### PR TITLE
fix: Fix Bundle Identifier for AppFrameworkInfo.plist

### DIFF
--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>App</string>
   <key>CFBundleIdentifier</key>
-  <string>com.mbta.tid.mbta_app</string>
+  <string>io.flutter.flutter.app</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
### Summary

No ticket, found while porting localization code from maple flutter.

What is this PR for?

### Testing

This fixes an issue with iOS builds. I was overzealous in find/replacing bundle identifiers, and mistakenly updated the bundle ID specified in `AppFrameworkInfo.plist`, which should be set to `io.flutter.flutter.app`, which is the default when initializing a new app. [This](https://github.com/flutter/flutter/issues/113923#issuecomment-1309376323) github issue suggestion helped me track down that problem.

What testing have you done?

* Confirmed the app will build and run on an iPhone simulator
