### PR TITLE
build: use original Android app ID

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,7 +29,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace "com.mbta.tid.mbtaapp"
+    namespace "com.mbta.tid.mbta_app"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
@@ -47,7 +47,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.mbta.tid.mbtaapp"
+        applicationId "com.mbta.tid.mbta_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdkVersion flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="mbtaapp"
+        android:label="mbta_app"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/kotlin/com/mbta/tid/mbta_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/mbta/tid/mbta_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.mbta.tid.mbtaapp
+package com.mbta.tid.mbta_app
 
 import io.flutter.embedding.android.FlutterActivity
 


### PR DESCRIPTION
### Summary

*Ticket:* none

#5 fails because #6 changed the Android app ID but that's actually immutable once the listing exists and the first app bundle has been uploaded.

### Testing

Validated locally.
