### PR TITLE
refactor: explicitly use constructor to create platform default backend

### DIFF
--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -4,8 +4,14 @@ import SwiftUI
 @main
 struct IOSApp: App {
     @StateObject var locationDataManager = LocationDataManager()
-    @StateObject var nearbyFetcher = NearbyFetcher(backend: Backend.companion.platformDefault)
-    @StateObject var searchResultFetcher = SearchResultFetcher(backend: Backend.companion.platformDefault)
+    @StateObject var nearbyFetcher: NearbyFetcher
+    @StateObject var searchResultFetcher: SearchResultFetcher
+
+    init() {
+        let backend = Backend()
+        _nearbyFetcher = StateObject(wrappedValue: NearbyFetcher(backend: backend))
+        _searchResultFetcher = StateObject(wrappedValue: SearchResultFetcher(backend: backend))
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Backend.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Backend.kt
@@ -17,6 +17,8 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 
 class Backend(engine: HttpClientEngine) {
+    constructor() : this(getPlatform().httpClientEngine)
+
     private val mobileBackendBaseUrl = "https://mobile-app-backend-staging.mbtace.com"
     private val httpClient =
         HttpClient(engine) {
@@ -30,11 +32,6 @@ class Backend(engine: HttpClientEngine) {
             }
             defaultRequest { url(mobileBackendBaseUrl) }
         }
-
-    companion object {
-        val platformDefault
-            get() = Backend(getPlatform().httpClientEngine)
-    }
 
     @Throws(
         IOException::class,


### PR DESCRIPTION
### Summary

_Ticket:_ none

The fact that `Backend.platformDefault` constructs a new instance is counterintuitive; using a secondary constructor is much less confusing. This became an issue when constructing separate fetchers per request type in #30 and needing to avoid having separate backends.

### Testing

All the tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
