### PR TITLE
fix(ci_post_clone): valid directory for mapbox

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -47,11 +47,11 @@ echo "login mapbox" >> ~/.netrc
 echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 
 # Skip adding mapbox API key when testing
-#if [ $CI_XCODEBUILD_ACTION != "build-for-testing" ]; then
+if [ $CI_XCODEBUILD_ACTION != "build-for-testing" ]; then
   echo "configuring mapbox public key"
   cd iosApp
   mkdir -p secrets
   cd secrets
   touch mapbox
   echo "${MAPBOX_PUBLIC_TOKEN}" >> mapbox
-#fi
+fi


### PR DESCRIPTION
### Summary

Follow-up to https://github.com/mbta/mobile_app/pull/34, which didn't appropriately test configuring the mapbox API key because we are skipping that step in testing.

I ran this with the conditional logic removed to confirm that the `ci_post_clone.sh` script successfully can populate the `/secrets/mapbox` file. That did work, but the tests hung, see [these run logs](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6472726821/ci/builds/7b8bc0fd-c736-4014-9635-2483e4777f27/action/19c2dced-1810-498e-8bf1-b0c8db72ebfa/logs). I don't think that matters though since tests all passed successfully in [this run](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6472726821/ci/builds/4bec6dd6-e0d3-4256-880c-49ee5fb3bc3d/summary) without the API configuration.


### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
