### PR TITLE
feat: rethink location spoofing

### DIFF
--- a/iosApp/10 Park Plaza.gpx
+++ b/iosApp/10 Park Plaza.gpx
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="https://gpx.studio">
+<wpt lat="42.3513706803105" lon="-71.06649626809957" />
+</gpx>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8C304C652B69C0C300263886 /* .swift-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".swift-version"; sourceTree = "<group>"; };
+		8C349BB72B754F2600AC7FFB /* 10 Park Plaza.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "10 Park Plaza.gpx"; sourceTree = "<group>"; };
 		8C7FA86E2B5EEA34009B699D /* LocationDataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataManagerTests.swift; sourceTree = "<group>"; };
 		8C7FA8702B5F2EF2009B699D /* NearbyTransitViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyTransitViewTests.swift; sourceTree = "<group>"; };
 		8C7FA8722B5F36D6009B699D /* Backend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backend.swift; sourceTree = "<group>"; };
@@ -162,6 +163,7 @@
 			children = (
 				8C304C652B69C0C300263886 /* .swift-version */,
 				6E9BCCE12B3F221A005FB96E /* iosApp.xctestplan */,
+				8C349BB72B754F2600AC7FFB /* 10 Park Plaza.gpx */,
 				7555FF7D242A565900829871 /* iosApp */,
 				6EED5E8D2B3DC69F0052A1B8 /* iosAppTests */,
 				6EED5E9A2B3DC6C10052A1B8 /* iosAppUITests */,

--- a/iosApp/iosApp/LocationDataManager.swift
+++ b/iosApp/iosApp/LocationDataManager.swift
@@ -33,15 +33,6 @@ public class LocationDataManager: NSObject, LocationFetcherDelegate, ObservableO
 
     public func locationFetcher(_: LocationFetcher, didUpdateLocations locations: [CLLocation]) {
         currentLocation = locations.last
-
-        // spoof coordinates if not near MBTA system (useful for remote work)
-        guard let coordinate = locations.last?.coordinate else { return }
-        if !((41 ... 43).contains(coordinate.latitude) && (-72 ... -70).contains(coordinate.longitude)) {
-            currentLocation = CLLocation(
-                latitude: .random(in: 42.31 ... 42.38),
-                longitude: .random(in: -71.24 ... -71.05)
-            )
-        }
     }
 }
 

--- a/iosApp/iosAppTests/LocationDataManagerTests.swift
+++ b/iosApp/iosAppTests/LocationDataManagerTests.swift
@@ -67,7 +67,7 @@ final class LocationDataManagerTests: XCTestCase {
         XCTAssertNil(manager.currentLocation)
         XCTAssertEqual(locationFetcher.distanceFilter, 100)
 
-        let location = CLLocation(latitude: 42, longitude: -71)
+        let location = CLLocation(latitude: 1.2, longitude: 3.4)
 
         locationFetcher.updateLocations(locations: [location])
 


### PR DESCRIPTION
### Summary

_Ticket:_ none

Adding a fixed offset to the user's actual coordinates turns out to be surprisingly ineffective; using [Xcode's location spoofing functionality](https://stackoverflow.com/a/26689515) lets us avoid crowding the actual code base with things we can't ship.

### Testing

Manually verified functionality.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
