### PR TITLE
fix(ci_post_clone): correct directory for archive

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -49,7 +49,7 @@ echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 # Skip adding mapbox API key when testing
 if [ $CI_XCODEBUILD_ACTION != "build-for-testing" ]; then
   echo "configuring mapbox public key"
-  cd iosApp
+  cd "${CI_PRIMARY_REPOSITORY_PATH}/iosApp"
   mkdir -p secrets
   cd secrets
   touch mapbox


### PR DESCRIPTION
…t read

### Summary

What is this PR for?

Fixes https://github.com/mbta/mobile_app/pull/34 and the incomplete fix https://github.com/mbta/mobile_app/pull/35. 

Using the full path to the `/iosApp` directory. https://github.com/mbta/mobile_app/pull/35 looked like it was a full fix when it was run from the branch, but that was because it was run from the `build-for-testing` action, which has a[ conditional call ](https://github.com/mbta/mobile_app/blob/28e17830b6f0051535fcfa043114859469c97d50/iosApp/ci_scripts/ci_post_clone.sh#L37)to `cd $CI_PRIMARY_REPOSISTORY_PATH`. Since that cd step is skipped for the archive action, `iosApp` couldn't be found in the pwd of the script. 

### Testing

What testing have you done?

Temporarily adding an archive step to the xcode cloud workflow to confirm it runs successfully (without distribution to users)
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
