### PR TITLE
fix: always ignore unknown keys in JSON

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Backend.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Backend.kt
@@ -21,7 +21,6 @@ import io.ktor.utils.io.errors.IOException
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.json.Json
 
 class Backend(engine: HttpClientEngine) {
     constructor() : this(getPlatform().httpClientEngine)
@@ -29,7 +28,6 @@ class Backend(engine: HttpClientEngine) {
     private val mobileBackendHost = "mobile-app-backend-staging.mbtace.com"
     private val httpClient =
         HttpClient(engine) {
-            val json = Json { ignoreUnknownKeys = true }
             install(ContentNegotiation) { json(json) }
             install(WebSockets) { contentConverter = KotlinxWebsocketSerializationConverter(json) }
             defaultRequest { url("https://$mobileBackendHost") }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Json.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Json.kt
@@ -1,0 +1,5 @@
+package com.mbta.tid.mbta_app
+
+import kotlinx.serialization.json.Json
+
+val json = Json { ignoreUnknownKeys = true }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/PredictionsStopsChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/PredictionsStopsChannel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.addAll
 import kotlinx.serialization.json.buildJsonObject
@@ -32,7 +31,7 @@ class PredictionsStopsChannel(socket: PhoenixSocket, stopIds: List<String>) :
             "phx_join" -> {}
             "stream_data" -> {
                 val predictions: List<Prediction> =
-                    Json.decodeFromJsonElement(payload["predictions"]!!)
+                    json.decodeFromJsonElement(payload["predictions"]!!)
                 _predictionsChannel.send(predictions)
             }
             "phx_leave",

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/PhoenixSocketTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/PhoenixSocketTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.phoenix
 
 import com.mbta.tid.mbta_app.PredictionsStopsChannel
+import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.Prediction
 import com.mbta.tid.mbta_app.model.Trip
 import kotlin.test.Test
@@ -12,7 +13,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Instant
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -49,7 +49,7 @@ class PhoenixSocketTest {
                     event = "stream_data",
                     payload =
                         buildJsonObject {
-                            put("predictions", Json.encodeToJsonElement(listOf(prediction)))
+                            put("predictions", json.encodeToJsonElement(listOf(prediction)))
                         }
                 )
                 expectSend(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/RawPhoenixChannelMessageTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/RawPhoenixChannelMessageTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.phoenix
 
+import com.mbta.tid.mbta_app.json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
@@ -66,7 +66,7 @@ class RawPhoenixChannelMessageTest {
     }
 
     private fun testPair(string: String, rawPhoenixChannelMessage: RawPhoenixChannelMessage) {
-        assertEquals(string, Json.encodeToString(rawPhoenixChannelMessage))
-        assertEquals(rawPhoenixChannelMessage, Json.decodeFromString(string))
+        assertEquals(string, json.encodeToString(rawPhoenixChannelMessage))
+        assertEquals(rawPhoenixChannelMessage, json.decodeFromString(string))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none

Caught [in Slack](https://mbta.slack.com/archives/C062QNAJZ2M/p1708023634023349?thread_ts=1708023539.353589&cid=C062QNAJZ2M).

### Testing

Manually validated functionality as part of a different change.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
