### PR TITLE
feat: show two predictions

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1,38 +1,19 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "%ld minutes" : {
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld minute"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld minutes"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "20+ minutes" : {
+    "%ld min" : {
 
     },
-    "Approaching" : {
+    "1 min" : {
 
     },
-    "Arriving" : {
+    "20+ min" : {
 
     },
-    "Boarding" : {
+    "ARR" : {
+
+    },
+    "BRD" : {
 
     },
     "Loading..." : {

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -154,6 +154,19 @@ final class NearbyTransitViewTests: XCTestCase {
                         vehicle: nil
                     ),
                     Prediction(
+                        id: "prediction-a-8552-1",
+                        arrivalTime: Date.now.addingTimeInterval(11 * 60).toKotlinInstant(),
+                        departureTime: Date.now.addingTimeInterval(15 * 60).toKotlinInstant(),
+                        directionId: 0,
+                        revenue: true,
+                        scheduleRelationship: .scheduled,
+                        status: "Overridden",
+                        stopSequence: 1,
+                        stopId: "8552",
+                        trip: Trip(id: "a", headsign: "Dedham Mall", routePatternId: "52-5-0", stops: nil),
+                        vehicle: nil
+                    ),
+                    Prediction(
                         id: "prediction-60451426-84791-18",
                         arrivalTime: Date.now.addingTimeInterval(1 * 60 + 1).toKotlinInstant(),
                         departureTime: Date.now.addingTimeInterval(2 * 60).toKotlinInstant(),
@@ -164,6 +177,19 @@ final class NearbyTransitViewTests: XCTestCase {
                         stopSequence: 18,
                         stopId: "84791",
                         trip: Trip(id: "60451426", headsign: "Watertown Yard", routePatternId: "52-5-1", stops: nil),
+                        vehicle: nil
+                    ),
+                    Prediction(
+                        id: "prediction-a-84791-1",
+                        arrivalTime: nil,
+                        departureTime: Date.now.addingTimeInterval(18 * 60).toKotlinInstant(),
+                        directionId: 1,
+                        revenue: true,
+                        scheduleRelationship: .scheduled,
+                        status: nil,
+                        stopSequence: 1,
+                        stopId: "84791",
+                        trip: Trip(id: "a", headsign: "Watertown Yard", routePatternId: "52-5-1", stops: nil),
                         vehicle: nil
                     ),
                 ]
@@ -182,10 +208,14 @@ final class NearbyTransitViewTests: XCTestCase {
             .parent().find(text: "No Predictions"))
 
         XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
-            .parent().find(text: "10 minutes"))
+            .parent().find(text: "10 min"))
+        XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
+            .parent().find(text: "Overridden"))
 
         XCTAssertNotNil(try stops[1].find(text: "Watertown Yard")
-            .parent().find(text: "1 minute"))
+            .parent().find(text: "1 min"))
+        XCTAssertNotNil(try stops[1].find(text: "Watertown Yard")
+            .parent().find(text: "18 min"))
     }
 
     func testRefetchesPredictionsOnNewStops() throws {
@@ -258,10 +288,10 @@ final class NearbyTransitViewTests: XCTestCase {
 
         predictionsFetcher.predictions = [prediction(minutesAway: 2)]
 
-        XCTAssertNotNil(try sut.inspect().find(text: "2 minutes"))
+        XCTAssertNotNil(try sut.inspect().find(text: "2 min"))
 
         predictionsFetcher.predictions = [prediction(minutesAway: 3)]
 
-        XCTAssertNotNil(try sut.inspect().find(text: "3 minutes"))
+        XCTAssertNotNil(try sut.inspect().find(text: "3 min"))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Show next two departures per destination](https://app.asana.com/0/1205425564113216/1206558617153664/f)

Shows two predictions instead of just one, with some refactoring to make that less redundant, and a random bonus localization feature I thought of while I was in here that probably doesn't make sense to split out as its own PR.

Stacked on #47 to ensure that predictions displayed aren't for the wrong stop.

### Testing

Manually verified functionality and updated tests to check for new predictions rendering behavior.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
