### PR TITLE
fix: Add handling for missing puck layer

### DIFF
--- a/iosApp/iosApp/HomeMapView.swift
+++ b/iosApp/iosApp/HomeMapView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import os
 import Polyline
 import shared
 import SwiftUI
@@ -70,9 +71,24 @@ struct HomeMapView: View {
                         // Create a GeoJSON data source for each typical route pattern shape in this route
                         var routeSource = GeoJSONSource(id: getRouteSourceId(route.id))
                         routeSource.data = createRouteSourceData(route: route)
-                        try? map.addSource(routeSource)
-                        // Create a line layer for each route
-                        try? map.addLayer(createRouteLayer(route: route), layerPosition: .below("puck"))
+                        do {
+                            try map.addSource(routeSource)
+                        } catch {
+                            let id = getRouteSourceId(route.id)
+                            Logger().error("Failed to add route source \(id)\n\(error)")
+                        }
+
+                        do {
+                            // Create a line layer for each route
+                            if map.layerExists(withId: "puck") {
+                                try map.addLayer(createRouteLayer(route: route), layerPosition: .below("puck"))
+                            } else {
+                                try map.addLayer(createRouteLayer(route: route))
+                            }
+                        } catch {
+                            let id = getRouteLayerId(route.id)
+                            Logger().error("Failed to add route layer \(id)\n\(error)")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display rail lines on map](https://app.asana.com/0/1205425564113216/1206467743054504/f)

There was a bug for displaying rail lines where if you didn't have permissions enabled and the puck didn't exist on the map, mapbox threw an error when the route layer was placed underneath it.
