### PR TITLE
feat: leave predictions channel when backgrounded

### DIFF
--- a/iosApp/iosApp/NearbyTransitView.swift
+++ b/iosApp/iosApp/NearbyTransitView.swift
@@ -15,6 +15,7 @@ public func == (lhs: CLLocationCoordinate2D, rhs: CLLocationCoordinate2D) -> Boo
 }
 
 struct NearbyTransitView: View {
+    @Environment(\.scenePhase) private var scenePhase
     let location: CLLocationCoordinate2D?
     @ObservedObject var nearbyFetcher: NearbyFetcher
     @ObservedObject var predictionsFetcher: PredictionsFetcher
@@ -77,6 +78,15 @@ struct NearbyTransitView: View {
         }
         .onChange(of: nearbyFetcher.nearbyByRouteAndStop) { _ in
             joinPredictions()
+        }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .inactive {
+                leavePredictions()
+            } else if newPhase == .active {
+                joinPredictions()
+            } else if newPhase == .background {
+                leavePredictions()
+            }
         }
         .onReceive(timer) { input in
             now = input

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -309,4 +309,124 @@ final class NearbyTransitViewTests: XCTestCase {
 
         XCTAssertNotNil(try sut.inspect().find(text: "3 min"))
     }
+
+    func testLeavesChannelWhenBackgrounded() throws {
+        let joinExpectation = expectation(description: "joins predictions")
+        let leaveExpectation = expectation(description: "leaves predictions")
+
+        class FakePredictionsFetcher: PredictionsFetcher {
+            let joinExpectation: XCTestExpectation
+            let leaveExpectation: XCTestExpectation
+
+            init(joinExpectation: XCTestExpectation, leaveExpectation: XCTestExpectation) {
+                self.joinExpectation = joinExpectation
+                self.leaveExpectation = leaveExpectation
+                super.init(backend: IdleBackend())
+            }
+
+            override func run(stopIds _: [String]) async {
+                joinExpectation.fulfill()
+            }
+
+            override func leave() async {
+                leaveExpectation.fulfill()
+            }
+        }
+
+        let nearbyFetcher = Route52NearbyFetcher()
+        let predictionsFetcher = FakePredictionsFetcher(joinExpectation: joinExpectation, leaveExpectation: leaveExpectation)
+        let sut = NearbyTransitView(
+            location: .init(latitude: 12.34, longitude: -56.78),
+            nearbyFetcher: nearbyFetcher, predictionsFetcher: predictionsFetcher
+        )
+
+        ViewHosting.host(view: sut)
+
+        wait(for: [joinExpectation], timeout: 1)
+        try sut.inspect().vStack().callOnChange(newValue: ScenePhase.background)
+
+        wait(for: [leaveExpectation], timeout: 1)
+    }
+
+    func testLeavesChannelWhenInactive() throws {
+        let joinExpectation = expectation(description: "joins predictions")
+        let leaveExpectation = expectation(description: "leaves predictions")
+
+        class FakePredictionsFetcher: PredictionsFetcher {
+            let joinExpectation: XCTestExpectation
+            let leaveExpectation: XCTestExpectation
+
+            init(joinExpectation: XCTestExpectation, leaveExpectation: XCTestExpectation) {
+                self.joinExpectation = joinExpectation
+                self.leaveExpectation = leaveExpectation
+                super.init(backend: IdleBackend())
+            }
+
+            override func run(stopIds _: [String]) async {
+                joinExpectation.fulfill()
+            }
+
+            override func leave() async {
+                leaveExpectation.fulfill()
+            }
+        }
+
+        let nearbyFetcher = Route52NearbyFetcher()
+        let predictionsFetcher = FakePredictionsFetcher(joinExpectation: joinExpectation, leaveExpectation: leaveExpectation)
+        let sut = NearbyTransitView(
+            location: .init(latitude: 12.34, longitude: -56.78),
+            nearbyFetcher: nearbyFetcher, predictionsFetcher: predictionsFetcher
+        )
+
+        ViewHosting.host(view: sut)
+
+        wait(for: [joinExpectation], timeout: 1)
+        try sut.inspect().vStack().callOnChange(newValue: ScenePhase.background)
+
+        wait(for: [leaveExpectation], timeout: 1)
+    }
+
+    func testRejoinsChannelWhenReactivated() throws {
+        let joinExpectation = expectation(description: "joins predictions")
+        joinExpectation.expectedFulfillmentCount = 2
+        joinExpectation.assertForOverFulfill = true
+
+        let leaveExpectation = expectation(description: "leaves predictions")
+
+        class FakePredictionsFetcher: PredictionsFetcher {
+            let joinExpectation: XCTestExpectation
+            let leaveExpectation: XCTestExpectation
+
+            init(joinExpectation: XCTestExpectation, leaveExpectation: XCTestExpectation) {
+                self.joinExpectation = joinExpectation
+                self.leaveExpectation = leaveExpectation
+                super.init(backend: IdleBackend())
+            }
+
+            override func run(stopIds _: [String]) async {
+                joinExpectation.fulfill()
+            }
+
+            override func leave() async {
+                leaveExpectation.fulfill()
+            }
+        }
+
+        let nearbyFetcher = Route52NearbyFetcher()
+        let predictionsFetcher = FakePredictionsFetcher(joinExpectation: joinExpectation, leaveExpectation: leaveExpectation)
+        let sut = NearbyTransitView(
+            location: .init(latitude: 12.34, longitude: -56.78),
+            nearbyFetcher: nearbyFetcher, predictionsFetcher: predictionsFetcher
+        )
+
+        ViewHosting.host(view: sut)
+
+        try sut.inspect().vStack().callOnChange(newValue: ScenePhase.background)
+
+        wait(for: [leaveExpectation], timeout: 1)
+
+        try sut.inspect().vStack().callOnChange(newValue: ScenePhase.active)
+
+        wait(for: [joinExpectation], timeout: 1)
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve socket connection management](https://app.asana.com/0/1205732265579288/1206547428606969/f)

What is this PR for?

### Testing

What testing have you done?
* Added unit tests
* Ran locally and confirmed predictions are refetched after backgrounding

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
