### PR TITLE
feat(ios): Decoder for swift phoenix messages

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,6 +14,11 @@
 		6E35D4D02B72C7B700A2BF95 /* HomeMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E35D4CF2B72C7B700A2BF95 /* HomeMapView.swift */; };
 		6E35D4D32B72CD3900A2BF95 /* HomeMapViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E35D4D22B72CD3900A2BF95 /* HomeMapViewTests.swift */; };
 		6E4EACFC2B7A82AC0011AB8B /* MockLocationFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E4EACFB2B7A82AC0011AB8B /* MockLocationFetcher.swift */; };
+		6EE7457E2B965ADE0052227E /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE7457D2B965ADE0052227E /* Socket.swift */; };
+		6EE745812B965AEA0052227E /* SwiftPhoenixClient in Frameworks */ = {isa = PBXBuildFile; productRef = 6EE745802B965AEA0052227E /* SwiftPhoenixClient */; };
+		6EE745842B965B9C0052227E /* SocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE745832B965B9C0052227E /* SocketTests.swift */; };
+		6EE745862B965C130052227E /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE745852B965C130052227E /* Message.swift */; };
+		6EE745882B965C2B0052227E /* MessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE745872B965C2B0052227E /* MessageTests.swift */; };
 		6EED5E8F2B3DC6A00052A1B8 /* IosAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EED5E8E2B3DC6A00052A1B8 /* IosAppTests.swift */; };
 		6EED5E9C2B3DC6C10052A1B8 /* IosAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EED5E9B2B3DC6C10052A1B8 /* IosAppUITests.swift */; };
 		6EED5E9E2B3DC6C10052A1B8 /* IosAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EED5E9D2B3DC6C10052A1B8 /* IosAppUITestsLaunchTests.swift */; };
@@ -78,6 +83,10 @@
 		6E35D4D22B72CD3900A2BF95 /* HomeMapViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMapViewTests.swift; sourceTree = "<group>"; };
 		6E4EACFB2B7A82AC0011AB8B /* MockLocationFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationFetcher.swift; sourceTree = "<group>"; };
 		6E9BCCE12B3F221A005FB96E /* iosApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = iosApp.xctestplan; sourceTree = "<group>"; };
+		6EE7457D2B965ADE0052227E /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
+		6EE745832B965B9C0052227E /* SocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTests.swift; sourceTree = "<group>"; };
+		6EE745852B965C130052227E /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		6EE745872B965C2B0052227E /* MessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageTests.swift; sourceTree = "<group>"; };
 		6EED5E8C2B3DC69F0052A1B8 /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EED5E8E2B3DC6A00052A1B8 /* IosAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosAppTests.swift; sourceTree = "<group>"; };
 		6EED5E992B3DC6C10052A1B8 /* iosAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -130,6 +139,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A8B34B02B892C810018412C /* Polyline in Frameworks */,
+				6EE745812B965AEA0052227E /* SwiftPhoenixClient in Frameworks */,
 				6E35D4CE2B72C74500A2BF95 /* MapboxMaps in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -153,9 +163,28 @@
 			path = Mocks;
 			sourceTree = "<group>";
 		};
+		6EE7457C2B965AD40052227E /* Phoenix */ = {
+			isa = PBXGroup;
+			children = (
+				6EE7457D2B965ADE0052227E /* Socket.swift */,
+				6EE745852B965C130052227E /* Message.swift */,
+			);
+			path = Phoenix;
+			sourceTree = "<group>";
+		};
+		6EE745822B965B8D0052227E /* Phoenix */ = {
+			isa = PBXGroup;
+			children = (
+				6EE745832B965B9C0052227E /* SocketTests.swift */,
+				6EE745872B965C2B0052227E /* MessageTests.swift */,
+			);
+			path = Phoenix;
+			sourceTree = "<group>";
+		};
 		6EED5E8D2B3DC69F0052A1B8 /* iosAppTests */ = {
 			isa = PBXGroup;
 			children = (
+				6EE745822B965B8D0052227E /* Phoenix */,
 				6E4EACFA2B7A829C0011AB8B /* Mocks */,
 				6EED5EA92B3DF1BF0052A1B8 /* Views */,
 				6EED5E8E2B3DC6A00052A1B8 /* IosAppTests.swift */,
@@ -213,6 +242,7 @@
 		7555FF7D242A565900829871 /* iosApp */ = {
 			isa = PBXGroup;
 			children = (
+				6EE7457C2B965AD40052227E /* Phoenix */,
 				9AC10BD82B80060E00EA4605 /* Utils */,
 				9A4E8E572B7EC49A0066B936 /* ComponentViews */,
 				9A9E05F22B6D6D9F0086B437 /* Fetchers */,
@@ -332,6 +362,7 @@
 			packageProductDependencies = (
 				6E35D4CD2B72C74500A2BF95 /* MapboxMaps */,
 				9A8B34AF2B892C810018412C /* Polyline */,
+				6EE745802B965AEA0052227E /* SwiftPhoenixClient */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
@@ -375,6 +406,7 @@
 				6E35D4CC2B72C74500A2BF95 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */,
 				8C42F06A2B87BCF700F9A77B /* XCRemoteSwiftPackageReference "SwiftLint" */,
 				9A8B34AE2B892C810018412C /* XCRemoteSwiftPackageReference "Polyline" */,
+				6EE7457F2B965AEA0052227E /* XCRemoteSwiftPackageReference "SwiftPhoenixClient" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -475,6 +507,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9A887D592B698EF1006F5B80 /* SearchResultViewTests.swift in Sources */,
+				6EE745842B965B9C0052227E /* SocketTests.swift in Sources */,
 				6EED5EAB2B3E1B550052A1B8 /* ContentViewTests.swift in Sources */,
 				9A60E8E72B8501BD008A8D5C /* RoutePillTests.swift in Sources */,
 				6E35D4D32B72CD3900A2BF95 /* HomeMapViewTests.swift in Sources */,
@@ -482,6 +515,7 @@
 				6EED5E8F2B3DC6A00052A1B8 /* IosAppTests.swift in Sources */,
 				8C7FA8712B5F2EF2009B699D /* NearbyTransitViewTests.swift in Sources */,
 				6E4EACFC2B7A82AC0011AB8B /* MockLocationFetcher.swift in Sources */,
+				6EE745882B965C2B0052227E /* MessageTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,8 +532,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EE7457E2B965ADE0052227E /* Socket.swift in Sources */,
 				9A8B34AD2B88E5090018412C /* RailRouteShapeFetcher.swift in Sources */,
 				9AB44A132B911E6400E8FFB3 /* DateExtension.swift in Sources */,
+				6EE745862B965C130052227E /* Message.swift in Sources */,
 				9A9E05F62B6D6EF70086B437 /* NearbyFetcher.swift in Sources */,
 				9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */,
 				9A9E05F42B6D6DEA0086B437 /* SearchResultFetcher.swift in Sources */,
@@ -880,6 +916,14 @@
 				minimumVersion = 11.0.0;
 			};
 		};
+		6EE7457F2B965AEA0052227E /* XCRemoteSwiftPackageReference "SwiftPhoenixClient" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/davidstump/SwiftPhoenixClient";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.3.2;
+			};
+		};
 		6EED5EAC2B3E1BA80052A1B8 /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
@@ -911,6 +955,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6E35D4CC2B72C74500A2BF95 /* XCRemoteSwiftPackageReference "mapbox-maps-ios" */;
 			productName = MapboxMaps;
+		};
+		6EE745802B965AEA0052227E /* SwiftPhoenixClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6EE7457F2B965AEA0052227E /* XCRemoteSwiftPackageReference "SwiftPhoenixClient" */;
+			productName = SwiftPhoenixClient;
 		};
 		6EED5EAD2B3E1BA80052A1B8 /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -91,6 +91,15 @@
       }
     },
     {
+      "identity" : "swiftphoenixclient",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/davidstump/SwiftPhoenixClient",
+      "state" : {
+        "revision" : "588bf6baab5d049752748e19a4bff32421ea40ec",
+        "version" : "5.3.2"
+      }
+    },
+    {
       "identity" : "swiftytexttable",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",

--- a/iosApp/iosApp/Phoenix/Message.swift
+++ b/iosApp/iosApp/Phoenix/Message.swift
@@ -1,0 +1,16 @@
+//
+//  Message.swift
+//  iosApp
+//
+//  Created by Brady, Kayla on 3/4/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import SwiftPhoenixClient
+
+extension Message {
+    func jsonPayload() -> String? {
+        payload["jsonPayload"] as? String
+    }
+}

--- a/iosApp/iosApp/Phoenix/Socket.swift
+++ b/iosApp/iosApp/Phoenix/Socket.swift
@@ -1,0 +1,92 @@
+//
+//  Socket.swift
+//  iosApp
+//
+//  Created by Brady, Kayla on 3/4/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import os
+import SwiftPhoenixClient
+
+/*
+ Return the decoded message in the expected [Any?] format:
+ [joinReference, messageReference, topic, eventName, eventPayload]
+ where eventPayload has type
+ ["jsonPayload": String, "payload": Any?] or
+ ["response": ["jsonPayload": String, "payload": Any?], "status": String]
+ "jsonPayload" is the raw payload string, and "payload" contains the decoded json payload object.
+ */
+func decodeWithRawMessage(data: Data) -> Any? {
+    let messageParts = decodeMessageParts(data: data)
+
+    guard let data = messageParts.rawEventString?.data(using: String.Encoding.utf8),
+          let eventPayload = Defaults.decode(data)
+    else {
+        Logger().warning("unable to parse raw payload \(messageParts.rawEventString ?? "")")
+        return nil
+    }
+
+    var event: [String: Any?] = [:]
+
+    if let eventPayloadMap = eventPayload as? [String: Any?], isResponseEvent(payload: eventPayloadMap) {
+        let existingResponse = eventPayloadMap["response"]!
+        event = eventPayloadMap
+        // Include the jsonPayload on the response
+        event["response"] = ["jsonPayload": String(data: Defaults.encode(existingResponse!),
+                                                   encoding: String.Encoding.utf8), "payload": existingResponse]
+    } else {
+        event = ["jsonPayload": messageParts.rawEventString, "payload": eventPayload]
+    }
+
+    return [messageParts.joinRef as Any, messageParts.messageRef as Any, messageParts.topic, messageParts.eventName, event]
+}
+
+struct DecodedMessageParts {
+    var joinRef: String?
+    var messageRef: String?
+    var topic: String
+    var eventName: String
+    var rawEventString: String?
+}
+
+private func decodeMessageParts(data: Data) -> DecodedMessageParts {
+    // Parsing based on
+    // https://github.com/dsrees/JavaPhoenixClient/blob/master/src/main/kotlin/org/phoenixframework/Defaults.kt#L68
+    var rawStringMessage = String(data: data, encoding: .utf8)!
+
+    rawStringMessage.removeFirst(1) // remove '['
+    let joinRef = String(rawStringMessage.prefix(while: { $0 != "," })) // take join ref, 'null' or '5'
+
+    rawStringMessage.removeFirst(joinRef.count) // remove join ref
+    rawStringMessage.removeFirst(1) // remove ','
+
+    let messageRef = String(rawStringMessage.prefix(while: { $0 != "," })) // take ref, 'null' or '5'
+    rawStringMessage.removeFirst(messageRef.count) // remove ref
+    rawStringMessage.removeFirst(2) // remove ',"'
+
+    let topic = String(rawStringMessage.prefix(while: { $0 != "\"" }))
+    rawStringMessage.removeFirst(topic.count)
+    rawStringMessage.removeFirst(3) // remove '","'
+
+    let eventName = String(rawStringMessage.prefix(while: { $0 != "\"" }))
+    rawStringMessage.removeFirst(eventName.count)
+    rawStringMessage.removeFirst(2) // remove '",'
+
+    let rawEventString = String(rawStringMessage.dropLast()) // remove ]
+
+    return .init(joinRef: parseValue(str: joinRef), messageRef: parseValue(str: messageRef), topic: topic, eventName: eventName, rawEventString: rawEventString)
+}
+
+private func parseValue(str: String) -> String? {
+    if str == "null" {
+        nil
+    } else {
+        str.replacingOccurrences(of: "\"", with: "")
+    }
+}
+
+private func isResponseEvent(payload: [String: Any?]) -> Bool {
+    payload["response"] != nil
+}

--- a/iosApp/iosAppTests/Phoenix/MessageTests.swift
+++ b/iosApp/iosAppTests/Phoenix/MessageTests.swift
@@ -1,0 +1,30 @@
+//
+//  MessageTests.swift
+//  iosAppTests
+//
+//  Created by Brady, Kayla on 3/4/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+@testable import iosApp
+@testable import SwiftPhoenixClient
+import XCTest
+
+final class MessageTest: XCTestCase {
+    override func setUp() {
+        executionTimeAllowance = 60
+    }
+
+    func testDecodesJsonPayload() {
+        let message = Message(ref: "ref", topic: "topic", event: "event", payload: ["jsonPayload": "{\"user_id\":\"abc123\"}", "payload": ["user_id": "abc123"]], joinRef: "join_ref")
+
+        XCTAssertEqual(message.jsonPayload(), "{\"user_id\":\"abc123\"}")
+    }
+
+    func testDecodesJsonPayloadNestedInResponse() {
+        let message = Message(ref: "ref", topic: "topic", event: "event", payload: ["response": ["jsonPayload": "{\"user_id\":\"abc123\"}", "payload": ["user_id": "abc123"]], "status": "ok"], joinRef: "join_ref")
+
+        XCTAssertEqual(message.jsonPayload(), "{\"user_id\":\"abc123\"}")
+    }
+}

--- a/iosApp/iosAppTests/Phoenix/SocketTests.swift
+++ b/iosApp/iosAppTests/Phoenix/SocketTests.swift
@@ -1,0 +1,49 @@
+//
+//  SocketTests.swift
+//  iosAppTests
+//
+//  Created by Brady, Kayla on 3/4/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+@testable import SwiftPhoenixClient
+import XCTest
+
+final class SocketTests: XCTestCase {
+    override func setUp() {
+        executionTimeAllowance = 60
+    }
+
+    func testDecodeMessageWithObjectEvent() {
+        let body: [Any] = ["join_ref", "ref", "topic", "event", ["user_id": "abc123"]]
+        let data = Defaults.encode(body)
+        let jsonParts = decodeWithRawMessage(data: data) as? [Any]
+
+        let message = Message(json: jsonParts!)
+        XCTAssertEqual(message?.joinRef, "join_ref")
+        XCTAssertEqual(message?.ref, "ref")
+        XCTAssertEqual(message?.topic, "topic")
+        XCTAssertEqual(message?.event, "event")
+
+        let payload = message?.payload as? [String: Any]
+        XCTAssertEqual(payload?["payload"] as? [String: String], ["user_id": "abc123"])
+        XCTAssertEqual(payload?["jsonPayload"] as? String, "{\"user_id\":\"abc123\"}")
+    }
+
+    func testDecodeMessageWithResponseBody() {
+        let body: [Any] = ["join_ref", "ref", "topic", "event", ["status": "ok", "response": ["user_id": "abc123"]]]
+        let data = Defaults.encode(body)
+        let jsonParts = decodeWithRawMessage(data: data) as? [Any]
+
+        let message = Message(json: jsonParts!)
+        XCTAssertEqual(message?.joinRef, "join_ref")
+        XCTAssertEqual(message?.ref, "ref")
+        XCTAssertEqual(message?.topic, "topic")
+        XCTAssertEqual(message?.event, "event")
+
+        let payload = message?.payload as? [String: Any]
+        XCTAssertEqual(payload?["payload"] as? [String: String], ["user_id": "abc123"])
+        XCTAssertEqual(payload?["jsonPayload"] as? String, "{\"user_id\":\"abc123\"}")
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Imporve socket conneciton management](https://app.asana.com/0/1205732265579288/1206547428606969/f)

What is this PR for?

This PR is a small precursor to switching over to using the [SwiftPhoenixClient](https://github.com/davidstump/SwiftPhoenixClient). 

We are moving towards using SwiftPhoenixClient and the analogous [JavaPhoenixClient](https://github.com/dsrees/JavaPhoenixClient) with parsing logic shared in the common code. In order to do so, we need to preserve the phoenix channel event body as a string so that it can be decoded by the common code without type coercion errors. 

This PR implements a custom decoder for a phoenix socket to preserve the event body string as `jsonPayload`. 

I also considered making an upstream change to SwiftPhoenixClient to preserve the `jsonPayload` as a field on [Message](https://github.com/davidstump/SwiftPhoenixClient/blob/master/Sources/SwiftPhoenixClient/Message.swift), but my changes seemed a bit in conflict with the ability to override the default `decoder` function used [here](https://github.com/davidstump/SwiftPhoenixClient/blob/588bf6baab5d049752748e19a4bff32421ea40ec/Sources/SwiftPhoenixClient/Socket.swift#L699), so I went the route of just using the existing decoder customization functionality instead.

### Testing

What testing have you done?

Added some unit tests. I've also been using this over in [kb-swift-phoenix-client](https://github.com/mbta/mobile_app/tree/kb-swift-phoenix-client). Still working on getting the sockets/channels mocked correctly in that PR, so figured I'd shared this smaller chunk of the approach first for early feedback.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
