### PR TITLE
chore: use Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: swift
-    directory: /iosApp/
-    schedule:
-      interval: weekly


### PR DESCRIPTION
### Summary

_Ticket:_ none

It seems like it'd be valuable to have up-to-date dependencies without manually checking everything ourselves.

There may be some setting somewhere in the GitHub repo settings that needs to be toggled before this will work; I can't quite tell, since I don't have access to the repo settings myself.

Dependabot doesn't support Swift updates in Xcode projects, and it looks like Renovate (which is similar but more flexible) doesn't, either, so if we want automated update checks for Swift dependencies, we'll need to get a little bit creative; if we decide we want that at all, it should be its own PR.

### Testing

This is difficult to test locally, and may not be straightforward to test except by merging, although GitHub [appears](https://github.com/mbta/mobile_app/runs/22950144252) to at least think the file is valid.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
