### PR TITLE
ci: skip Google Play upload if running as Dependabot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,11 +63,13 @@ jobs:
           echo "java-version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS Credentials
+        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
       - name: Configure GCP Credentials
+        if: github.actor != 'dependabot[bot]'
         uses: google-github-actions/auth@v1
         with:
           create_credentials_file: true
@@ -101,21 +103,26 @@ jobs:
           path: androidApp/build/reports
 
       - name: Fetch AWS secrets
+        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
           secret-ids: |
             mobile-app-android-upload-key-passphrase
       - name: Load code signing key
+        if: github.actor != 'dependabot[bot]'
         run: |
           cd androidApp
           aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks
       - name: Set up Ruby
+        if: github.actor != 'dependabot[bot]'
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Patch Fastlane to pick up application default credentials
+        if: github.actor != 'dependabot[bot]'
         run: bin/patch-fastlane.sh
       - name: Build and ${{ github.event_name == 'pull_request' && 'validate on' || 'upload to' }} Google Play
+        if: github.actor != 'dependabot[bot]'
         env:
           KEYSTORE_FILE: "${{ github.workspace }}/androidApp/upload-keystore.jks"
           KEYSTORE_PASSWORD: ${{ env.MOBILE_APP_ANDROID_UPLOAD_KEY_PASSPHRASE }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

Dependabot has its own disjoint secrets config, and I don't know if we want to have to deal with configuring all the CI secrets a second time over, so it seems simpler to just skip all the secrets-dependent pieces in CI jobs that don't have access to the secrets.

### Testing

This is not straightforward to test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
