### PR TITLE
feat: retain predictions sent on channel join

### DIFF
--- a/iosApp/iosApp/Fetchers/PredictionsFetcher.swift
+++ b/iosApp/iosApp/Fetchers/PredictionsFetcher.swift
@@ -55,6 +55,7 @@ class PredictionsFetcher: ObservableObject {
         }
         channel?.join().receive("ok") { message in
             Logger().debug("joined channel \(message.topic)")
+            self.handleNewDataMessage(message: message)
         }.receive("error", callback: { message in
             DispatchQueue.main.async {
                 self.socketError = PhoenixChannelError.channelError("B: \(message.payload)")

--- a/iosApp/iosAppTests/Fetchers/PredictionsFetcherTests.swift
+++ b/iosApp/iosAppTests/Fetchers/PredictionsFetcherTests.swift
@@ -58,6 +58,24 @@ final class PredictionsFetcherTests: XCTestCase {
         XCTAssertNil(predictionsFetcher.channel)
     }
 
+    func testSetsPredictionsOnJoinResponse() {
+        let mockSocket = MockSocket()
+        let messageSuccessExpectation = expectation(description: "got initial payload")
+
+        let predictionsFetcher = PredictionsFetcher(socket: mockSocket, onMessageSuccessCallback: {
+            messageSuccessExpectation.fulfill()
+        })
+
+        XCTAssertNil(predictionsFetcher.predictions)
+        predictionsFetcher.run(stopIds: ["1"])
+
+        predictionsFetcher.channel!.joinPush.trigger("ok", payload: ["jsonPayload": "{\"predictions\": {}, \"trips\": {}, \"vehicles\": {}}"])
+
+        wait(for: [messageSuccessExpectation], timeout: 1)
+
+        XCTAssertEqual(predictionsFetcher.predictions, .init(predictions: [:], trips: [:], vehicles: [:]))
+    }
+
     func testSetsPredictionsWhenMessageReceived() {
         let mockSocket = MockSocket()
         let messageSuccessExpectation = expectation(description: "parsed prediction payload prediction payload")

--- a/iosApp/iosAppTests/Mocks/MockSocket.swift
+++ b/iosApp/iosAppTests/Mocks/MockSocket.swift
@@ -12,9 +12,11 @@ import Foundation
 
 open class MockSocket: PhoenixSocket {
     public var channels: [SwiftPhoenixClient.Channel] = []
+    // Channel.socket is weak, so we need to maintain a reference to the Socket
+    private let socket = Socket(endPoint: "/socket", transport: { _ in PhoenixTransportMock() })
 
     public func channel(_ topic: String, params _: [String: Any]) -> Channel {
-        let channel = Channel(topic: topic, socket: Socket(endPoint: "/socket", transport: { _ in PhoenixTransportMock() }))
+        let channel = Channel(topic: topic, socket: socket)
         channels.append(channel)
         return channel
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve scalability of predictions streaming](https://app.asana.com/0/1205425564113216/1206467839191098/f)

Now that we're sending potential preexisting predictions as a response to the channel join, we need to actually parse those.

### Testing

Manually validated functionality and added a new unit test (which was really annoying to debug!).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
