### PR TITLE
build(deps): upgrade Android Gradle plugin to 8.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.1.2"
+agp = "8.2.2"
 kotlin = "1.9.23"
 compose = "1.5.3"
 compose-compiler = "1.5.11-dev-k1.9.23-96ef9dc6af1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary

_Ticket:_ none

The Android Gradle plugin has more specific Gradle requirements than most other things, which is why #86 isn't working. Furthermore, Kotlin Multiplatform has its own supported range of Android Gradle plugin versions, which 8.3.x isn't in, which is why I've stopped at 8.2.

### Testing

Verified that the Android code still runs.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
