### PR TITLE
ci: make deployment to Google Play a separate job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,13 +42,11 @@ jobs:
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
-  android:
-    name: Analyze, test, build, and ${{ github.event_name == 'pull_request' && 'validate on' || 'upload to' }} Google Play
+  test-android:
+    name: Test for Android
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Read asdf versions
@@ -61,20 +59,6 @@ jobs:
           VERSION=(`echo ${{steps.asdf.outputs.java}} | cut -d - -f2`)
           echo "java-distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
           echo "java-version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Configure AWS Credentials
-        if: github.actor != 'dependabot[bot]'
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Configure GCP Credentials
-        if: github.actor != 'dependabot[bot]'
-        uses: google-github-actions/auth@v2
-        with:
-          create_credentials_file: true
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -101,28 +85,69 @@ jobs:
         with:
           name: android-android-reports
           path: androidApp/build/reports
-
+  deploy-android:
+    name: ${{ github.event_name == 'pull_request' && 'Validate on' || 'Upload to' }} Google Play
+    if: github.actor != 'dependabot[bot]'
+    needs:
+      - test-android
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    concurrency:
+      group: deploy-android
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read asdf versions
+        id: asdf
+        run: cat .tool-versions | sed 's/ /=/' | tee -a "$GITHUB_OUTPUT"
+      - name: Parse java version
+        id: java-spec
+        run: |
+          DISTRIBUTION=(`echo ${{steps.asdf.outputs.java}} | cut -d - -f1`)
+          VERSION=(`echo ${{steps.asdf.outputs.java}} | cut -d - -f2`)
+          echo "java-distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
+          echo "java-version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Configure GCP Credentials
+        uses: google-github-actions/auth@v2
+        with:
+          create_credentials_file: true
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: ${{steps.java-spec.outputs.java-distribution}}
+          java-version: ${{steps.java-spec.outputs.java-version}}
+          cache: gradle
+      - uses: actions/cache@v4
+        with:
+          path: ~/.konan
+          key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
+          restore-keys: konan-${{ runner.os }}
       - name: Fetch AWS secrets
-        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             mobile-app-android-upload-key-passphrase
       - name: Load code signing key
-        if: github.actor != 'dependabot[bot]'
         run: |
           cd androidApp
           aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks
       - name: Set up Ruby
-        if: github.actor != 'dependabot[bot]'
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Patch Fastlane to pick up application default credentials
-        if: github.actor != 'dependabot[bot]'
         run: bin/patch-fastlane.sh
       - name: Build and ${{ github.event_name == 'pull_request' && 'validate on' || 'upload to' }} Google Play
-        if: github.actor != 'dependabot[bot]'
         env:
           KEYSTORE_FILE: "${{ github.workspace }}/androidApp/upload-keystore.jks"
           KEYSTORE_PASSWORD: ${{ env.MOBILE_APP_ANDROID_UPLOAD_KEY_PASSPHRASE }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

It looks like if multiple PRs are trying to validate on Google Play at the same time, they use the same version code and trample each other; it seems like the solution is to only let one PR at a time be deploying. This also lets us clean up #96 somewhat, since all the secrets-based steps are a separate job.

### Testing

It's hard to test CI changes.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
