### PR TITLE
refactor: move headsign predictions selection to Kotlin

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyStopRoutePatternView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyStopRoutePatternView.swift
@@ -11,57 +11,19 @@ import SwiftUI
 
 struct NearbyStopRoutePatternView: View {
     let headsign: String
-    let predictions: PredictionState
-
-    struct TripWithFormat: Identifiable {
-        let trip: UpcomingTrip
-        let format: UpcomingTrip.Format
-
-        var id: String { trip.id }
-
-        init(_ trip: UpcomingTrip, now: Instant) {
-            self.trip = trip
-            format = trip.format(now: now)
-        }
-
-        func isHidden() -> Bool {
-            format is UpcomingTrip.FormatHidden
-        }
-    }
-
-    enum PredictionState {
-        case loading
-        case none
-        case some([TripWithFormat])
-        case noService(shared.Alert)
-
-        static func from(upcomingTrips: [UpcomingTrip]?, alertsHere: [shared.Alert]?, now: Instant) -> Self {
-            guard let upcomingTrips else { return .loading }
-            let tripsToShow = upcomingTrips
-                .map { TripWithFormat($0, now: now) }
-                .filter { !$0.isHidden() }
-                .prefix(2)
-            if tripsToShow.isEmpty {
-                if let alert = alertsHere?.first {
-                    return .noService(alert)
-                }
-                return .none
-            }
-            return .some(Array(tripsToShow))
-        }
-    }
+    let predictions: PatternsByHeadsign.Format
 
     var body: some View {
         HStack {
             Text(headsign)
             Spacer()
-            switch predictions {
-            case let .some(predictions):
-                ForEach(predictions) { prediction in
+            switch onEnum(of: predictions) {
+            case let .some(trips):
+                ForEach(trips.trips, id: \.id) { prediction in
                     UpcomingTripView(prediction: .some(prediction.format))
                 }
             case let .noService(alert):
-                UpcomingTripView(prediction: .noService(alert.effect))
+                UpcomingTripView(prediction: .noService(alert.alert.effect))
             case .none:
                 UpcomingTripView(prediction: .none)
             case .loading:
@@ -75,14 +37,14 @@ struct NearbyStopRoutePatternView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .trailing) {
             let now = Date.now
-            NearbyStopRoutePatternView(headsign: "Some", predictions: .some([
-                .init(.init(prediction: ObjectCollectionBuilder.Single.shared.prediction { prediction in
+            NearbyStopRoutePatternView(headsign: "Some", predictions: PatternsByHeadsign.FormatSome(trips: [
+                .init(trip: .init(prediction: ObjectCollectionBuilder.Single.shared.prediction { prediction in
                     prediction.departureTime = now.addingTimeInterval(5 * 60).toKotlinInstant()
                 }), now: now.toKotlinInstant()),
             ]))
-            NearbyStopRoutePatternView(headsign: "None", predictions: .none)
-            NearbyStopRoutePatternView(headsign: "Loading", predictions: .loading)
-            NearbyStopRoutePatternView(headsign: "No Service", predictions: .noService(
+            NearbyStopRoutePatternView(headsign: "None", predictions: PatternsByHeadsign.FormatNone.shared)
+            NearbyStopRoutePatternView(headsign: "Loading", predictions: PatternsByHeadsign.FormatLoading.shared)
+            NearbyStopRoutePatternView(headsign: "No Service", predictions: PatternsByHeadsign.FormatNoService(alert:
                 ObjectCollectionBuilder.Single.shared.alert { alert in
                     alert.effect = .suspension
                 }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
@@ -21,8 +21,7 @@ struct NearbyStopView: View {
                 ForEach(patternsAtStop.patternsByHeadsign, id: \.headsign) { patternsByHeadsign in
                     NearbyStopRoutePatternView(
                         headsign: patternsByHeadsign.headsign,
-                        predictions: .from(upcomingTrips: patternsByHeadsign.upcomingTrips,
-                                           alertsHere: patternsByHeadsign.alertsHere, now: now)
+                        predictions: patternsByHeadsign.format(now: now)
                     )
                 }
             }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByHeadsignTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByHeadsignTest.kt
@@ -1,0 +1,77 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+
+class PatternsByHeadsignTest {
+    @Test
+    fun `formats as loading when null trips`() {
+        val now = Clock.System.now()
+
+        assertEquals(
+            PatternsByHeadsign.Format.Loading,
+            PatternsByHeadsign("", emptyList(), null, null).format(now)
+        )
+    }
+
+    @Test
+    fun `formats as alert with no trips and alert`() {
+        val now = Clock.System.now()
+
+        val alert = alert {}
+
+        assertEquals(
+            PatternsByHeadsign.Format.NoService(alert),
+            PatternsByHeadsign("", emptyList(), emptyList(), listOf(alert)).format(now)
+        )
+    }
+
+    @Test
+    fun `formats as none with no trips and no alert`() {
+        val now = Clock.System.now()
+
+        assertEquals(
+            PatternsByHeadsign.Format.None,
+            PatternsByHeadsign("", emptyList(), emptyList(), emptyList()).format(now)
+        )
+    }
+
+    @Test
+    fun `skips trips that should be hidden`() {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+
+        val prediction1 =
+            objects.prediction {
+                trip = trip1
+                departureTime = null
+            }
+        val prediction2 =
+            objects.prediction {
+                trip = trip2
+                departureTime = now + 5.minutes
+            }
+
+        val upcomingTrip1 = UpcomingTrip(prediction1)
+        val upcomingTrip2 = UpcomingTrip(prediction2)
+
+        assertEquals(
+            PatternsByHeadsign.Format.Some(
+                listOf(
+                    PatternsByHeadsign.Format.Some.FormatWithId(
+                        trip2.id,
+                        UpcomingTrip.Format.Minutes(5)
+                    )
+                )
+            ),
+            PatternsByHeadsign("", emptyList(), listOf(upcomingTrip1, upcomingTrip2)).format(now)
+        )
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Omit all subway & light rail schedules in Nearby Transit](https://app.asana.com/0/1205425564113216/1206860816616693/f) (tangentially)

This is the place where I want to drop scheduled subway trips, and I'd rather not have to redo it when we add Android support.

### Testing

Maintained existing and added new unit tests, and manually verified that everything still works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
