### PR TITLE
fix: preserve stops with no route patterns

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -53,10 +53,6 @@ data class NearbyStaticData(val data: List<RouteWithStops>) {
                         .map { patternId -> response.routePatterns.getValue(patternId) }
                         .groupBy { it.routeId }
 
-                if (newPatternsByRoute.isEmpty()) {
-                    return@forEach
-                }
-
                 val stopKey =
                     stop.parentStationId?.let { parentStationId ->
                         fullStopIds

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -368,6 +368,53 @@ class NearbyResponseTest {
     }
 
     @Test
+    fun `byRouteAndStop preserves unscheduled physical platform`() {
+        val objects = ObjectCollectionBuilder()
+
+        val parentStation = objects.stop { id = "place-forhl" }
+
+        val logicalPlatform =
+            objects.stop {
+                id = "70001"
+                parentStationId = parentStation.id
+            }
+        val physicalPlatform =
+            objects.stop {
+                id = "Forest Hills-01"
+                parentStationId = parentStation.id
+            }
+
+        val route = objects.route { id = "Orange" }
+
+        val routePattern =
+            objects.routePattern(route) { representativeTrip { headsign = "Oak Grove" } }
+
+        val response =
+            StopAndRoutePatternResponse(
+                objects,
+                patternIdsByStop =
+                    mapOf(
+                        logicalPlatform.id to
+                            listOf(
+                                routePattern.id,
+                            ),
+                    ),
+                parentStops = mapOf(parentStation.id to parentStation),
+            )
+
+        assertEquals(
+            NearbyStaticData.build {
+                route(route) {
+                    stop(parentStation, listOf(logicalPlatform.id, physicalPlatform.id)) {
+                        headsign("Oak Grove", listOf(routePattern))
+                    }
+                }
+            },
+            NearbyStaticData(response)
+        )
+    }
+
+    @Test
     fun `withRealtimeInfo includes predictions filtered to the correct stop and pattern`() {
         val objects = ObjectCollectionBuilder()
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: reports that predictions don't match countdown clocks](https://app.asana.com/0/1205425564113216/1206846399376954/f)

In conjunction with https://github.com/mbta/mobile_app_backend/pull/104, fixes the issue of Forest Hills predictions on physical platforms disappearing from the app.

### Testing

Added a new unit test and manually verified that the relevant predictions aren't lost.

(In this specific case, and most likely in other cases, since the stop in question is a terminal and we don't have special terminal handling logic, we show BRD for these predictions when the signs still say N min, but that's a separate issue.)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
