### PR TITLE
feat: put nearby transit in sheet

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		9AF88E052B48913C00E08C7C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 9AF88E042B48913C00E08C7C /* Localizable.xcstrings */; };
 		A430D45FE0676C73075AB85B /* Pods_iosAppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED1649D982654BA7A4D2F2DC /* Pods_iosAppTests.framework */; };
 		A55C5596CDC797ED68F79279 /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C6BD892027AC258EE8F408D /* Pods_iosApp.framework */; };
+		ED3581662BB4706F005DDC34 /* PartialSheetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3581652BB4706F005DDC34 /* PartialSheetModifier.swift */; };
+		ED3581682BB470C4005DDC34 /* PartialSheetDetent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED3581672BB470C4005DDC34 /* PartialSheetDetent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -201,6 +203,8 @@
 		9ADB84A12BAE37C0006581CE /* StopExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopExtension.swift; sourceTree = "<group>"; };
 		9AF88E042B48913C00E08C7C /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		ED1649D982654BA7A4D2F2DC /* Pods_iosAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ED3581652BB4706F005DDC34 /* PartialSheetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialSheetModifier.swift; sourceTree = "<group>"; };
+		ED3581672BB470C4005DDC34 /* PartialSheetDetent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartialSheetDetent.swift; sourceTree = "<group>"; };
 		F71252D2B68FF131F8E6BDE2 /* Pods-iosAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.release.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -480,6 +484,7 @@
 		9AC10BD82B80060E00EA4605 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				EDB1F3DC2BB227160017D8F0 /* Backport */,
 				9AC10BD92B80067400EA4605 /* ColorHexExtension.swift */,
 				9AB44A122B911E6400E8FFB3 /* DateExtension.swift */,
 				9A3B09352B967CEC00691427 /* NonNilModifier.swift */,
@@ -500,6 +505,15 @@
 				9ADB849F2BAD1B84006581CE /* DebouncerTests.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		EDB1F3DC2BB227160017D8F0 /* Backport */ = {
+			isa = PBXGroup;
+			children = (
+				ED3581652BB4706F005DDC34 /* PartialSheetModifier.swift */,
+				ED3581672BB470C4005DDC34 /* PartialSheetDetent.swift */,
+			);
+			path = Backport;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -832,6 +846,7 @@
 				9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */,
 				9A5B27562BB221C1009A6FC6 /* RouteLayerGenerator.swift in Sources */,
 				9A9E05F42B6D6DEA0086B437 /* SearchResultFetcher.swift in Sources */,
+				ED3581682BB470C4005DDC34 /* PartialSheetDetent.swift in Sources */,
 				9A3B09362B967CEC00691427 /* NonNilModifier.swift in Sources */,
 				2152FB042600AC8F00CF470E /* IOSApp.swift in Sources */,
 				8CD1F8CD2B7164C100F419D4 /* PredictionsFetcher.swift in Sources */,
@@ -840,6 +855,7 @@
 				9A5B275A2BB22D91009A6FC6 /* StopLayerGenerator.swift in Sources */,
 				6E35D4D02B72C7B700A2BF95 /* HomeMapView.swift in Sources */,
 				8CC1BB402B59D1F6005386FE /* LocationDataManager.swift in Sources */,
+				ED3581662BB4706F005DDC34 /* PartialSheetModifier.swift in Sources */,
 				8C7FA8732B5F36D6009B699D /* Backend.swift in Sources */,
 				9A2005C72B97B63300F562E1 /* NearbyStopView.swift in Sources */,
 				9AC4FDF12BACE216004479BF /* NearbyTransitPageView.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import shared
 import SwiftPhoenixClient
 import SwiftUI
@@ -17,6 +18,15 @@ struct ContentView: View {
     @EnvironmentObject var searchResultFetcher: SearchResultFetcher
     @EnvironmentObject var socketProvider: SocketProvider
     @EnvironmentObject var viewportProvider: ViewportProvider
+    @State private var sheetHeight: CGFloat = .zero
+
+    private var sheetDetents: Set<PartialSheetDetent> {
+        if #available(iOS 16, *) {
+            [.small, .medium, .large]
+        } else {
+            [.medium, .large]
+        }
+    }
 
     var body: some View {
         NavigationView {
@@ -41,17 +51,24 @@ struct ContentView: View {
                     globalFetcher: globalFetcher,
                     nearbyFetcher: nearbyFetcher,
                     railRouteShapeFetcher: railRouteShapeFetcher,
-                    viewportProvider: viewportProvider
-                )
-                Spacer()
-                NearbyTransitPageView(
-                    currentLocation: locationDataManager.currentLocation?.coordinate,
-                    nearbyFetcher: nearbyFetcher,
-                    scheduleFetcher: scheduleFetcher,
-                    predictionsFetcher: predictionsFetcher,
                     viewportProvider: viewportProvider,
-                    alertsFetcher: alertsFetcher
+                    sheetHeight: $sheetHeight
                 )
+                .ignoresSafeArea(edges: .bottom)
+                .sheet(isPresented: .constant(true)) {
+                    /**
+                     NavigationView is only necessary as a workaround for the sheet automatically expanding
+                     https://www.hackingwithswift.com/forums/swiftui/bottom-sheet-resizing-bug/24155/24169
+                     **/
+                    NavigationView {
+                        nearbyTransit
+                            .navigationBarHidden(true)
+                    }
+                    .partialSheetDetents(
+                        sheetDetents,
+                        largestUndimmedDetent: .medium
+                    )
+                }
             }
         }
         .searchable(
@@ -67,6 +84,25 @@ struct ContentView: View {
                 socketProvider.socket.disconnect(code: .normal, reason: "backgrounded", callback: nil)
             }
         }.task { alertsFetcher.run() }
+    }
+
+    private var nearbyTransit: some View {
+        GeometryReader { proxy in
+            NearbyTransitPageView(
+                currentLocation: locationDataManager.currentLocation?.coordinate,
+                nearbyFetcher: nearbyFetcher,
+                scheduleFetcher: scheduleFetcher,
+                predictionsFetcher: predictionsFetcher,
+                viewportProvider: viewportProvider,
+                alertsFetcher: alertsFetcher
+            )
+            .onChange(of: proxy.size.height) { newValue in
+                // Not actually restricted to iOS 16, this just behaves terribly on iOS 15
+                if #available(iOS 16, *) {
+                    sheetHeight = newValue
+                }
+            }
+        }
     }
 }
 

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -24,18 +24,21 @@ struct HomeMapView: View {
     @State private var layerManager: MapLayerManager?
     @StateObject private var locationDataManager: LocationDataManager
     @State private var recenterButton: ViewAnnotation?
+    @Binding var sheetHeight: CGFloat
 
     init(
         globalFetcher: GlobalFetcher,
         nearbyFetcher: NearbyFetcher,
         railRouteShapeFetcher: RailRouteShapeFetcher,
         locationDataManager: LocationDataManager = .init(distanceFilter: 1),
-        viewportProvider: ViewportProvider
+        viewportProvider: ViewportProvider,
+        sheetHeight: Binding<CGFloat>
     ) {
         self.globalFetcher = globalFetcher
         self.nearbyFetcher = nearbyFetcher
         self.railRouteShapeFetcher = railRouteShapeFetcher
         self.viewportProvider = viewportProvider
+        _sheetHeight = sheetHeight
         _locationDataManager = StateObject(wrappedValue: locationDataManager)
     }
 
@@ -62,6 +65,7 @@ struct HomeMapView: View {
                 // print(feature.feature.identifier)
                 true
             }
+            .additionalSafeAreaInsets(.bottom, sheetHeight)
             .accessibilityIdentifier("transitMap")
             .onAppear { handleAppear(location: proxy.location, map: proxy.map) }
             .onChange(of: locationDataManager.authorizationStatus) { status in

--- a/iosApp/iosApp/Utils/Backport/PartialSheetDetent.swift
+++ b/iosApp/iosApp/Utils/Backport/PartialSheetDetent.swift
@@ -1,0 +1,50 @@
+//
+//  PartialSheetDetent.swift
+//  iosApp
+//
+//  Created by Brandon Rodriguez on 3/27/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import UIKit
+
+/// Replaces the use of PresentationDetent from the SwiftUI package as it's only available iOS 16+
+public enum PartialSheetDetent: String, Comparable {
+    @available(iOS 16, *)
+    case small = "com.mbta.small"
+    case medium = "com.apple.UIKit.medium"
+    case large = "com.apple.UIKit.large"
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.ordinal < rhs.ordinal
+    }
+
+    public var uiKitDetent: UISheetPresentationController.Detent {
+        switch self {
+        case .small:
+            if #available(iOS 16, *) {
+                let smallDetentIdentifier = UISheetPresentationController.Detent.Identifier(Self.small.rawValue)
+                return UISheetPresentationController.Detent.custom(identifier: smallDetentIdentifier) { _ in
+                    120
+                }
+            } else {
+                return .medium()
+            }
+        case .medium:
+            return .medium()
+        case .large:
+            return .large()
+        }
+    }
+
+    private var ordinal: Int {
+        switch self {
+        case .small:
+            0
+        case .medium:
+            1
+        case .large:
+            2
+        }
+    }
+}

--- a/iosApp/iosApp/Utils/Backport/PartialSheetModifier.swift
+++ b/iosApp/iosApp/Utils/Backport/PartialSheetModifier.swift
@@ -1,0 +1,117 @@
+//
+//  PartialSheetModifier.swift
+//  iosApp
+//
+//  Created by Brandon Rodriguez on 3/25/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+public extension View {
+    /**
+     Replaces the use of the presentationDetents & presentationBackgroundInteraction modifiers
+     as they're only available in iOS 16+ for SwiftUI
+     **/
+    func partialSheetDetents(
+        _ detents: Set<PartialSheetDetent>,
+        largestUndimmedDetent: PartialSheetDetent
+    ) -> some View {
+        background(
+            PartialSheetRepresentable(
+                detents: detents,
+                largestUndimmedDetent: largestUndimmedDetent
+            )
+        )
+    }
+}
+
+private struct PartialSheetRepresentable: UIViewControllerRepresentable {
+    let detents: Set<PartialSheetDetent>
+    let largestUndimmedDetent: PartialSheetDetent?
+
+    func makeUIViewController(context _: Context) -> Self.Controller {
+        Controller(
+            detents: detents,
+            largestUndimmedDetent: largestUndimmedDetent
+        )
+    }
+
+    func updateUIViewController(_ controller: Self.Controller, context _: Context) {
+        controller.update(
+            detents: detents,
+            largestUndimmedDetent: largestUndimmedDetent
+        )
+    }
+}
+
+private extension PartialSheetRepresentable {
+    final class Controller: UIViewController, UISheetPresentationControllerDelegate {
+        var detents: Set<PartialSheetDetent>
+        var largestUndimmedDetent: PartialSheetDetent?
+        weak var localDelegate: UISheetPresentationControllerDelegate?
+
+        init(
+            detents: Set<PartialSheetDetent>,
+            largestUndimmedDetent: PartialSheetDetent?
+        ) {
+            self.detents = detents
+            self.largestUndimmedDetent = largestUndimmedDetent
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder _: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func willMove(toParent parent: UIViewController?) {
+            super.willMove(toParent: parent)
+            if let controller = parent?.sheetPresentationController,
+               controller.delegate !== self,
+               localDelegate == nil
+            {
+                localDelegate = controller.delegate
+                controller.delegate = self
+            }
+            update(detents: detents, largestUndimmedDetent: largestUndimmedDetent)
+        }
+
+        override func willTransition(
+            to newCollection: UITraitCollection,
+            with coordinator: UIViewControllerTransitionCoordinator
+        ) {
+            super.willTransition(to: newCollection, with: coordinator)
+            update(detents: detents, largestUndimmedDetent: largestUndimmedDetent)
+        }
+
+        override func responds(to aSelector: Selector!) -> Bool {
+            if super.responds(to: aSelector) { return true }
+            if localDelegate?.responds(to: aSelector) == true { return true }
+            return false
+        }
+
+        override func forwardingTarget(for aSelector: Selector!) -> Any? {
+            if super.responds(to: aSelector) { return self }
+            return localDelegate
+        }
+
+        func update(
+            detents: Set<PartialSheetDetent>,
+            largestUndimmedDetent: PartialSheetDetent?
+        ) {
+            self.detents = detents
+
+            guard let controller = parent?.sheetPresentationController else { return }
+
+            controller.animateChanges {
+                controller.detents = detents.map(\.uiKitDetent)
+                controller.prefersScrollingExpandsWhenScrolledToEdge = true
+
+                if let largestUndimmedDetent {
+                    controller.largestUndimmedDetentIdentifier = .init(largestUndimmedDetent.rawValue)
+                }
+            }
+        }
+    }
+}

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -29,7 +29,8 @@ final class HomeMapViewTests: XCTestCase {
             nearbyFetcher: nearbyFetcher,
             railRouteShapeFetcher: railRouteShapeFetcher,
             locationDataManager: locationDataManager,
-            viewportProvider: ViewportProvider()
+            viewportProvider: ViewportProvider(),
+            sheetHeight: .constant(0)
         )
         XCTAssertEqual(sut.viewportProvider.viewport.camera?.center, ViewportProvider.defaultCenter)
     }
@@ -49,7 +50,8 @@ final class HomeMapViewTests: XCTestCase {
             nearbyFetcher: nearbyFetcher,
             railRouteShapeFetcher: railRouteShapeFetcher,
             locationDataManager: locationDataManager,
-            viewportProvider: ViewportProvider()
+            viewportProvider: ViewportProvider(),
+            sheetHeight: .constant(0)
         )
 
         let hasAppeared = sut.on(\.didAppear) { _ in
@@ -98,7 +100,8 @@ final class HomeMapViewTests: XCTestCase {
             globalFetcher: FakeGlobalFetcher(getGlobalExpectation: getGlobalExpectation),
             nearbyFetcher: NearbyFetcher(backend: IdleBackend()),
             railRouteShapeFetcher: FakeRailRouteShapeFetcher(getRailRouteShapeExpectation: getRailRouteShapeExpectation),
-            viewportProvider: ViewportProvider()
+            viewportProvider: ViewportProvider(),
+            sheetHeight: .constant(0)
         )
         let hasAppeared = sut.on(\.didAppear) { _ in }
         ViewHosting.host(view: sut)


### PR DESCRIPTION
### Summary
![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 11 26 10](https://github.com/mbta/mobile_app/assets/2722422/67e6b8b2-40ba-4073-bda2-02e843dcc066)

_Ticket:_ [Put nearby transit in a sheet over the map](https://app.asana.com/0/1205425564113216/1206776249230572/f)

Putting the existing nearby transit view into a sheet. With SwiftUI's partial sheet implementations only being available in iOS 16+ we needed to backport some functionality from UIKit where it's been available since iOS 15. The only thing not available in iOS 15 is the custom detent option, we are left with just having `.medium` and `.large`.

### Testing

Mostly manual testing and accessibility audit. Not sure how to best test this change from an automated standpoint as it's mostly native API interfacing.