### PR TITLE
feat: reset nearby transit scroll position

### DIFF
--- a/iosApp/iosApp/Utils/Backport/PartialSheetModifier.swift
+++ b/iosApp/iosApp/Utils/Backport/PartialSheetModifier.swift
@@ -106,6 +106,7 @@ private extension PartialSheetRepresentable {
             controller.animateChanges {
                 controller.detents = detents.map(\.uiKitDetent)
                 controller.prefersScrollingExpandsWhenScrolledToEdge = true
+                controller.prefersGrabberVisible = true
 
                 if let largestUndimmedDetent {
                     controller.largestUndimmedDetentIdentifier = .init(largestUndimmedDetent.rawValue)


### PR DESCRIPTION
### Summary

_Ticket:_ [Nearby Transit scroll position shouldn't always persist](https://app.asana.com/0/1205425564113216/1206808633100154/f)

Reset the nearby transit scroll position when the map is panned or the app returns from the background. The solution isn't entirely ideal. I would've liked to use a `PassthroughSubject` so that we don't have to clear a state after it is consumed but since `NearbyTransitView` is re-initialized several times a second the `.onReceive` modifier was not getting the ID from the publisher. There was also an issue where the `.top` anchor was not actually scrolling to the top of the view but a custom `UnitPoint` does.

### Testing

Added `ViewInspector` unit tests to ensure `scrollPosition` is being set when expected.
