### PR TITLE
fix: show alert instead of trips if both exist

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopAssociatedRoute.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopAssociatedRoute.kt
@@ -128,6 +128,8 @@ data class PatternsByHeadsign(
     }
 
     fun format(now: Instant): Format {
+        val alert = alertsHere?.firstOrNull()
+        if (alert != null) return Format.NoService(alert)
         if (this.upcomingTrips == null) return Format.Loading
         val tripsToShow =
             upcomingTrips
@@ -138,12 +140,7 @@ data class PatternsByHeadsign(
                         (this.route.type.isSubway() && it.format is UpcomingTrip.Format.Schedule)
                 }
                 .take(2)
-        if (tripsToShow.isEmpty()) {
-            this.alertsHere?.firstOrNull()?.let {
-                return Format.NoService(it)
-            }
-            return Format.None
-        }
+        if (tripsToShow.isEmpty()) return Format.None
         return Format.Some(tripsToShow)
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByHeadsignTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByHeadsignTest.kt
@@ -36,6 +36,30 @@ class PatternsByHeadsignTest {
     }
 
     @Test
+    fun `formats as alert with trip and alert`() {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+
+        val trip = objects.trip()
+        val prediction =
+            objects.prediction {
+                this.trip = trip
+                departureTime = now + 1.minutes
+            }
+        val upcomingTrip = objects.upcomingTrip(prediction)
+
+        val alert = objects.alert {}
+
+        assertEquals(
+            PatternsByHeadsign.Format.NoService(alert),
+            PatternsByHeadsign(route, "", emptyList(), listOf(upcomingTrip), listOf(alert))
+                .format(now)
+        )
+    }
+
+    @Test
     fun `formats as none with no trips and no alert`() {
         val now = Clock.System.now()
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: schedules appearing during stop closure alert](https://app.asana.com/0/1205425564113216/1206983965658527/f)

Since alerts are manually maintained in real time, they are more trustworthy than schedules or predictions, so an alert that indicates no service at the stop should override old or automated claims that there is in fact service at that stop.

### Testing

Manually verified that the stop in the Asana ticket correctly shows as closed now, and added a new unit test that fails with the old implementation and succeeds with the new implementation.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
