### PR TITLE
feat(UpcomingTrip): Only show BRD when <= 90 seconds

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.Serializable
 
 val ARRIVAL_CUTOFF = 30.seconds
 val APPROACH_CUTOFF = 60.seconds
+val BOARDING_CUTOFF = 90.seconds
 val DISTANT_FUTURE_CUTOFF = 60.minutes
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -123,7 +123,8 @@ data class UpcomingTrip(
         if (
             vehicle?.currentStatus == Vehicle.CurrentStatus.StoppedAt &&
                 vehicle.stopId == prediction.stopId &&
-                vehicle.tripId == prediction.tripId
+                vehicle.tripId == prediction.tripId &&
+                timeRemaining <= BOARDING_CUTOFF
         ) {
             return Format.Boarding
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -102,6 +102,30 @@ class UpcomingTripTest {
         }
 
         @Test
+        fun `not boarding when stopped at stop but more than 90 seconds until departure`() {
+            val now = Clock.System.now()
+            val vehicle = vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                stopId = "12345"
+                tripId = "trip1"
+            }
+            assertEquals(
+                Format.Minutes(2),
+                UpcomingTrip(
+                        trip {},
+                        prediction {
+                            departureTime = now.plus(95.seconds)
+                            stopId = "12345"
+                            tripId = "trip1"
+                            vehicleId = vehicle.id
+                        },
+                        vehicle
+                    )
+                    .format(now)
+            )
+        }
+
+        @Test
         fun `not boarding`() {
             val now = Clock.System.now()
             // wrong vehicle status


### PR DESCRIPTION
### Summary

_Ticket:_ [Update BRD display logic for predictions](https://app.asana.com/0/1205425564113216/1206779450869376/f)

What is this PR for?
Show BRD only if <= 90 seconds remaining, in line with the current API best practices documentation. A temporary solution until we receive a separate field that indicates boarding status.

### Testing

What testing have you done?
Added an additional unit test for the case where a vehicle is at a stop but it is more than 90 seconds until departure
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
