### PR TITLE
feat(RouteLayerGenerator): Hardcoded offsets for certain routes

### DIFF
--- a/iosApp/iosApp/Pages/Map/RouteLayerGenerator.swift
+++ b/iosApp/iosApp/Pages/Map/RouteLayerGenerator.swift
@@ -17,7 +17,7 @@ class RouteLayerGenerator {
 
     static let routeLayerId = "route-layer"
     static func getRouteLayerId(_ routeId: String) -> String { "\(routeLayerId)-\(routeId)" }
-    static let lineWidth = 4.0
+    private static let lineWidth = 4.0
 
     init(mapFriendlyRoutesResponse: MapFriendlyRouteResponse, routesById: [String: Route]) {
         self.mapFriendlyRoutesResponse = mapFriendlyRoutesResponse
@@ -81,8 +81,8 @@ class RouteLayerGenerator {
      Hardcoding offsets based on route properties to minimize the occurences of overlapping rail lines when drawn on the map
      */
     private static func lineOffset(_ route: Route) -> Double {
-        var greenOverlappingCR: Set = ["CR-Lowell", "CR-Fitchburg"]
-        var redOverlappingCR: Set = ["CR-Greenbush", "CR-Kingston", "CR-Middleborough"]
+        let greenOverlappingCR: Set = ["CR-Lowell", "CR-Fitchburg"]
+        let redOverlappingCR: Set = ["CR-Greenbush", "CR-Kingston", "CR-Middleborough"]
 
         return if route.type == RouteType.commuterRail {
             if greenOverlappingCR.contains(route.id) {


### PR DESCRIPTION
### Summary

_Ticket:_ [Improve alert styling for overlapping routes ](https://app.asana.com/0/1205425564113216/1206923917064606/f)

What is this PR for?

Manually offsets the GL & CR lines to minimize the occurrence of overlapping lines on the map. These offsets and the alerting style will likely be further adjusted based on map UI work.

I explored some other options for handling overlapping lines [here](https://www.notion.so/mbta-downtown-crossing/Live-Alerts-Map-Experiment-Notes-a531a799ba3747e9a3e815de925cc59f?pvs=4#e32b45ad50b044e7b1bf3f2c235dca16) which all have a higher level of complexity than this approach. They typically involve breaking lines down into smaller segments offsetting those segments. 

### Testing

What testing have you done?

Tested on locally running device. This seems ideal to screenshot test in the future.
<img width="340" alt="image" src="https://github.com/mbta/mobile_app/assets/31781298/de5a06ed-4899-4332-8218-9c29db7a1d1d">

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
