### PR TITLE
fix: Prevent map from shrinking when sheet is full

### DIFF
--- a/iosApp/iosApp/Utils/Backport/PartialSheetDetent.swift
+++ b/iosApp/iosApp/Utils/Backport/PartialSheetDetent.swift
@@ -13,7 +13,7 @@ public enum PartialSheetDetent: String, Comparable {
     @available(iOS 16, *)
     case small = "com.mbta.small"
     case medium = "com.apple.UIKit.medium"
-    case large = "com.apple.UIKit.large"
+    case large = "com.mbta.large"
 
     public static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.ordinal < rhs.ordinal
@@ -33,7 +33,15 @@ public enum PartialSheetDetent: String, Comparable {
         case .medium:
             return .medium()
         case .large:
-            return .large()
+            if #available(iOS 16, *) {
+                let largeDetentIdentifier = UISheetPresentationController.Detent.Identifier(Self.large.rawValue)
+                return UISheetPresentationController.Detent.custom(identifier: largeDetentIdentifier) { context in
+                    // Prevent the background content from shrinking underneath the expanded sheet
+                    context.maximumDetentValue - 1
+                }
+            } else {
+                return .large()
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

This was annoying me, and I was poking around in this file trying to debug a layout issue for the route pills anyway. The shrinking seems to happen when you're transitioning to the `maximumDetentValue`, but if it's less, no shrinking occurs.

| Before | After |
| ---- | ---- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-12 at 15 44 21](https://github.com/mbta/mobile_app/assets/12971446/ae75c594-517d-417e-a389-24fa5b6862ab) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-12 at 15 43 49](https://github.com/mbta/mobile_app/assets/12971446/4db228f6-3a94-49b2-bb26-25dc57fa3f70) |

It's more obvious in motion. As part of the UI passes we'll probably want the sheet bg color to expand up to touch the top of the screen, but I don't think we'd ever want the map shrinking that happens now.

### Testing

This doesn't really seem testable
