### PR TITLE
fix: don't filter out rare routes in stop details until all data is loaded

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -17,6 +17,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
         global.run {
             data class UpcomingTripKey(val routeId: String, val headsign: String?)
 
+            val loading = schedules == null || predictions == null
             val upcomingTripsByHeadsignAndStop =
                 UpcomingTrip.tripsMappedBy(
                     schedules,
@@ -69,8 +70,9 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                 PatternsByHeadsign(route, headsign, patterns, upcomingTrips)
                             }
                             .filter {
-                                (it.isTypical() || it.isUpcomingBefore(cutoffTime)) &&
-                                    !it.isArrivalOnly()
+                                loading ||
+                                    ((it.isTypical() || it.isUpcomingBefore(cutoffTime)) &&
+                                        !it.isArrivalOnly())
                             }
                             .sorted()
                     )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -5,6 +5,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 class StopDetailsDeparturesTest {
@@ -74,6 +75,132 @@ class StopDetailsDeparturesTest {
                 PredictionsStreamDataResponse(objects),
                 filterAtTime = time1
             )
+        )
+    }
+
+    @Test
+    fun `StopDetailsDepartures shows partial data and filters after loading`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+        val stop = objects.stop()
+
+        val time = Clock.System.now()
+
+        data class PatternInfo(
+            val headsign: String,
+            val routePattern: RoutePattern,
+            val scheduledTrip: UpcomingTrip?,
+            val predictedTrip: UpcomingTrip?,
+        ) {
+            fun patternsByHeadsign(trips: List<UpcomingTrip>?) =
+                PatternsByHeadsign(route, headsign, listOf(routePattern), trips)
+        }
+
+        fun buildPattern(scheduled: Boolean, predicted: Boolean): PatternInfo {
+            val headsign = buildString {
+                if (scheduled) {
+                    append("Scheduled")
+                } else {
+                    append("Unscheduled")
+                }
+                append(" & ")
+                if (predicted) {
+                    append("Predicted")
+                } else {
+                    append("Unpredicted")
+                }
+            }
+            val routePattern =
+                objects.routePattern(route) {
+                    typicality = RoutePattern.Typicality.Atypical
+                    representativeTrip { this.headsign = headsign }
+                }
+            val scheduledTrip =
+                if (scheduled) {
+                    val scheduledTrip = objects.trip(routePattern)
+                    val schedule =
+                        objects.schedule {
+                            trip = scheduledTrip
+                            stopId = stop.id
+                            departureTime = time
+                        }
+                    objects.upcomingTrip(schedule)
+                } else null
+            val predictedTrip =
+                if (predicted) {
+                    val predictedTrip = objects.trip(routePattern)
+                    val prediction =
+                        objects.prediction {
+                            trip = predictedTrip
+                            stopId = stop.id
+                            departureTime = time
+                        }
+                    objects.upcomingTrip(prediction)
+                } else null
+
+            return PatternInfo(headsign, routePattern, scheduledTrip, predictedTrip)
+        }
+
+        val scheduledPredicted = buildPattern(scheduled = true, predicted = true)
+        val scheduledUnpredicted = buildPattern(scheduled = true, predicted = false)
+        val unscheduledPredicted = buildPattern(scheduled = false, predicted = true)
+        val unscheduledUnpredicted = buildPattern(scheduled = false, predicted = false)
+
+        fun expected(vararg pattern: PatternsByHeadsign): StopDetailsDepartures =
+            StopDetailsDepartures(listOf(PatternsByStop(route, stop, pattern.toList())))
+
+        fun actual(includeSchedules: Boolean = true, includePredictions: Boolean = true) =
+            StopDetailsDepartures(
+                stop,
+                GlobalResponse(objects, mapOf(stop.id to objects.routePatterns.keys.toList())),
+                ScheduleResponse(objects).takeIf { includeSchedules },
+                PredictionsStreamDataResponse(objects).takeIf { includePredictions },
+                filterAtTime = time
+            )
+
+        assertEquals(
+            expected(
+                scheduledPredicted.patternsByHeadsign(null),
+                scheduledUnpredicted.patternsByHeadsign(null),
+                unscheduledPredicted.patternsByHeadsign(null),
+                unscheduledUnpredicted.patternsByHeadsign(null)
+            ),
+            actual(includeSchedules = false, includePredictions = false)
+        )
+
+        assertEquals(
+            expected(
+                scheduledPredicted.patternsByHeadsign(listOf(scheduledPredicted.predictedTrip!!)),
+                scheduledUnpredicted.patternsByHeadsign(emptyList()),
+                unscheduledPredicted.patternsByHeadsign(
+                    listOf(unscheduledPredicted.predictedTrip!!)
+                ),
+                unscheduledUnpredicted.patternsByHeadsign(emptyList())
+            ),
+            actual(includeSchedules = false, includePredictions = true)
+        )
+
+        assertEquals(
+            expected(
+                scheduledPredicted.patternsByHeadsign(listOf(scheduledPredicted.scheduledTrip!!)),
+                scheduledUnpredicted.patternsByHeadsign(
+                    listOf(scheduledUnpredicted.scheduledTrip!!)
+                ),
+                unscheduledPredicted.patternsByHeadsign(emptyList()),
+                unscheduledUnpredicted.patternsByHeadsign(emptyList())
+            ),
+            actual(includeSchedules = true, includePredictions = false)
+        )
+
+        assertEquals(
+            expected(
+                scheduledPredicted.patternsByHeadsign(
+                    listOf(scheduledPredicted.scheduledTrip, scheduledPredicted.predictedTrip)
+                ),
+                scheduledUnpredicted.patternsByHeadsign(listOf(scheduledUnpredicted.scheduledTrip)),
+                unscheduledPredicted.patternsByHeadsign(listOf(unscheduledPredicted.predictedTrip))
+            ),
+            actual(includeSchedules = true, includePredictions = true)
         )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1713379138768759)

The issue with the current Blue Line shuttles is caused by filtering out the target route before the filtered page state can retrieve it. It might be wise to robustly handle a bad route filter, but making sure that behaves correctly could have some architectural consequences (because it might involve putting the Route itself into the filter rather than just its ID), and filtering later in stop details is a lot easier.

### Testing

Added new unit test and manually verified that this fixes the crash Paul reported in Slack.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
