### PR TITLE
test: extend timeout on flaky ContentView test

### DIFF
--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -126,7 +126,7 @@ final class ContentViewTests: XCTestCase {
             .environmentObject(ViewportProvider())
 
         ViewHosting.host(view: sut)
-        wait(for: [fetchesGlobalData], timeout: 1)
+        wait(for: [fetchesGlobalData], timeout: 2)
     }
 
     class FakeSocket: MockSocket {


### PR DESCRIPTION
### Summary

_Ticket:_ none

This test fails a lot in CI despite passing locally and occasionally passing in CI. I have no idea why this is the case, but since there's a timeout being hit, I'm hoping it'll suffice to extend the timeout.

### Testing

The test still passes locally (except the test suite is back to hanging if I run it on an iPhone 13 simulator for no discernible reason, but that was happening before, so it can't be caused by this).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
