### PR TITLE
feat: add setting for debugging map camera

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		8CB823DD2BC5F432002C87E0 /* StopDetailsFilteredRouteViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823DC2BC5F432002C87E0 /* StopDetailsFilteredRouteViewTests.swift */; };
 		8CC1BB402B59D1F6005386FE /* LocationDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC1BB3F2B59D1F6005386FE /* LocationDataManager.swift */; };
 		8CD1F8CD2B7164C100F419D4 /* PredictionsFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD1F8CC2B7164C100F419D4 /* PredictionsFetcher.swift */; };
+		8CD81A242BE55B2C0090585F /* SettingsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD81A232BE55B2C0090585F /* SettingsPageTests.swift */; };
 		8CE0140E2BBDB7C300918FAE /* RoutePillSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE0140D2BBDB7C300918FAE /* RoutePillSection.swift */; };
 		8CE014102BBDB8DC00918FAE /* StopDetailsRoutesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE0140F2BBDB8DC00918FAE /* StopDetailsRoutesView.swift */; };
 		8CE014122BBDB96900918FAE /* StopDetailsRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CE014112BBDB96900918FAE /* StopDetailsRouteView.swift */; };
@@ -202,6 +203,7 @@
 		8CB823DC2BC5F432002C87E0 /* StopDetailsFilteredRouteViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsFilteredRouteViewTests.swift; sourceTree = "<group>"; };
 		8CC1BB3F2B59D1F6005386FE /* LocationDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDataManager.swift; sourceTree = "<group>"; };
 		8CD1F8CC2B7164C100F419D4 /* PredictionsFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionsFetcher.swift; sourceTree = "<group>"; };
+		8CD81A232BE55B2C0090585F /* SettingsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageTests.swift; sourceTree = "<group>"; };
 		8CE0140D2BBDB7C300918FAE /* RoutePillSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePillSection.swift; sourceTree = "<group>"; };
 		8CE0140F2BBDB8DC00918FAE /* StopDetailsRoutesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsRoutesView.swift; sourceTree = "<group>"; };
 		8CE014112BBDB96900918FAE /* StopDetailsRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsRouteView.swift; sourceTree = "<group>"; };
@@ -513,6 +515,14 @@
 			path = StopDetails;
 			sourceTree = "<group>";
 		};
+		8CD81A222BE55B150090585F /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				8CD81A232BE55B2C0090585F /* SettingsPageTests.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		9A2005C02B97B56100F562E1 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
@@ -577,6 +587,7 @@
 		9A5B275D2BB242EF009A6FC6 /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				8CD81A222BE55B150090585F /* Settings */,
 				8CB823D72BC5EDBF002C87E0 /* StopDetails */,
 				9A5B275E2BB24326009A6FC6 /* Map */,
 			);
@@ -927,6 +938,7 @@
 				9A6FA0252BC714360067769C /* HomeMapViewTest.swift in Sources */,
 				9AD1D1FE2BA4D5C600182060 /* ViewportProviderTest.swift in Sources */,
 				9A887D592B698EF1006F5B80 /* SearchResultViewTests.swift in Sources */,
+				8CD81A242BE55B2C0090585F /* SettingsPageTests.swift in Sources */,
 				9A5B27602BB31178009A6FC6 /* StopSourceGeneratorTests.swift in Sources */,
 				8CB823D62BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift in Sources */,
 				9A6FA0232BC70D0B0067769C /* InspectionEmissary.swift in Sources */,
@@ -1722,7 +1734,7 @@
 			repositoryURL = "https://github.com/nalexn/ViewInspector";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.9;
+				minimumVersion = 0.9.11;
 			};
 		};
 		8C42F06A2B87BCF700F9A77B /* XCRemoteSwiftPackageReference "SwiftLint" */ = {

--- a/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "67319287749b83f39dcc2f20edd520c610c012fd",
-        "version" : "0.9.10"
+        "revision" : "7b1732802ffe30e6a67754bda6c7819e5cb0eb70",
+        "version" : "0.9.11"
       }
     },
     {

--- a/iosApp/iosAppTests/Pages/Settings/SettingsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/Settings/SettingsPageTests.swift
@@ -1,0 +1,75 @@
+//
+//  SettingsPageTests.swift
+//  iosAppTests
+//
+//  Created by Horn, Melody on 2024-05-03.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Combine
+@testable import iosApp
+import shared
+import ViewInspector
+import XCTest
+
+final class SettingsPageTests: XCTestCase {
+    class FakeSettingsRepository: ISettingsRepository {
+        var mapDebug: Bool
+        let onGet: (() -> Void)?
+        let onSet: ((Bool) -> Void)?
+
+        init(mapDebug: Bool, onGet: (() -> Void)? = nil, onSet: ((Bool) -> Void)? = nil) {
+            self.mapDebug = mapDebug
+            self.onGet = onGet
+            self.onSet = onSet
+        }
+
+        func __getMapDebug() async throws -> KotlinBoolean {
+            onGet?()
+            return KotlinBoolean(bool: mapDebug)
+        }
+
+        func __setMapDebug(mapDebug: Bool) async throws {
+            onSet?(mapDebug)
+            self.mapDebug = mapDebug
+        }
+    }
+
+    func testLoadsState() throws {
+        let loadedPublisher = PassthroughSubject<Void, Never>()
+
+        let settingsRepository = FakeSettingsRepository(mapDebug: true, onGet: {
+            loadedPublisher.send(())
+        })
+        let sut = SettingsPage(settingsRepository: settingsRepository)
+
+        let exp = sut.inspection.inspect(onReceive: loadedPublisher, after: 0.01) { view in
+            XCTAssertTrue(try view.find(ViewType.Toggle.self).isOn())
+        }
+
+        ViewHosting.host(view: sut)
+
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testSavesState() throws {
+        let loadedPublisher = PassthroughSubject<Void, Never>()
+        let savedExp = expectation(description: "saved state")
+
+        let settingsRepository = FakeSettingsRepository(mapDebug: false, onGet: {
+            loadedPublisher.send(())
+        }, onSet: {
+            XCTAssertTrue($0)
+            savedExp.fulfill()
+        })
+        let sut = SettingsPage(settingsRepository: settingsRepository)
+
+        ViewHosting.host(view: sut)
+
+        let tapExp = sut.inspection.inspect(onReceive: loadedPublisher, after: 0.01) { view in
+            try view.find(ViewType.Toggle.self).tap()
+        }
+
+        wait(for: [tapExp, savedExp], timeout: 1)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import org.koin.core.module.Module
@@ -23,6 +24,7 @@ fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IPinnedRoutesRepository> { repositories.pinnedRoutesRepository }
         single<ISchedulesRepository> { repositories.schedules }
+        single<ISettingsRepository> { repositories.settings }
         single<IStopRepository> { repositories.stop }
 
         single { TogglePinnedRouteUsecase(get()) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -1,11 +1,13 @@
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
 import com.mbta.tid.mbta_app.repositories.IdleScheduleRepository
 import com.mbta.tid.mbta_app.repositories.IdleStopRepository
 import com.mbta.tid.mbta_app.repositories.PinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.SchedulesRepository
+import com.mbta.tid.mbta_app.repositories.SettingsRepository
 import com.mbta.tid.mbta_app.repositories.StopRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -13,24 +15,28 @@ import org.koin.core.component.inject
 interface IRepositories {
     val pinnedRoutesRepository: IPinnedRoutesRepository
     val schedules: ISchedulesRepository
+    val settings: ISettingsRepository
     val stop: IStopRepository
 }
 
-class RepositoryDI() : IRepositories, KoinComponent {
+class RepositoryDI : IRepositories, KoinComponent {
     override val pinnedRoutesRepository: IPinnedRoutesRepository by inject()
     override val schedules: ISchedulesRepository by inject()
+    override val settings: ISettingsRepository by inject()
     override val stop: IStopRepository by inject()
 }
 
 class RealRepositories : IRepositories {
     override val pinnedRoutesRepository = PinnedRoutesRepository()
     override val schedules = SchedulesRepository()
+    override val settings = SettingsRepository()
     override val stop = StopRepository()
 }
 
 class MockRepositories(
     override val pinnedRoutesRepository: IPinnedRoutesRepository,
     override val schedules: ISchedulesRepository,
+    override val settings: ISettingsRepository,
     override val stop: IStopRepository,
 ) : IRepositories {
     companion object {
@@ -38,11 +44,13 @@ class MockRepositories(
         fun buildWithDefaults(
             pinnedRoutesRepository: IPinnedRoutesRepository = PinnedRoutesRepository(),
             schedules: ISchedulesRepository = IdleScheduleRepository(),
+            settings: ISettingsRepository = SettingsRepository(),
             stop: IStopRepository = IdleStopRepository()
         ): MockRepositories {
             return MockRepositories(
                 pinnedRoutesRepository = pinnedRoutesRepository,
                 schedules = schedules,
+                settings = settings,
                 stop = stop
             )
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -1,0 +1,30 @@
+package com.mbta.tid.mbta_app.repositories
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface ISettingsRepository {
+    suspend fun getMapDebug(): Boolean
+
+    suspend fun setMapDebug(mapDebug: Boolean)
+}
+
+class SettingsRepository : ISettingsRepository, KoinComponent {
+    private val dataStore: DataStore<Preferences> by inject()
+
+    private val mapDebugKey = booleanPreferencesKey("map_debug")
+
+    override suspend fun getMapDebug(): Boolean {
+        return dataStore.data.map { it[mapDebugKey] ?: false }.first()
+    }
+
+    override suspend fun setMapDebug(mapDebug: Boolean) {
+        dataStore.edit { it[mapDebugKey] = mapDebug }
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up map debug mode which shows location & zoom level](https://app.asana.com/0/1205425564113216/1207114848419513/f)

Apparently, this is something Mapbox has built in. There are [several other things](https://docs.mapbox.com/ios/maps/api/11.3.0/documentation/mapboxmaps/mapviewdebugoptions) you can debug as well, but it seems like very few of those are likely to be useful for us, and if any are, we can add them when we need them.

### Testing

Manually verified that the state is retained and the debug view is drawn in the proper conditions, and added unit tests for the settings page interacting with the repository.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
