### PR TITLE
feat(HomeMapView): Filter shapes on map based on upcoming departures

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557BA273AAA24004C7B11 /* Assets.xcassets */; };
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* IOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* IOSApp.swift */; };
+		6E04E32F2BE95A8D006F8131 /* NearbyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E04E32E2BE95A8D006F8131 /* NearbyViewModel.swift */; };
 		6E20278E2BD989630037554F /* DummyTestAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20278D2BD989630037554F /* DummyTestAppView.swift */; };
 		6E2027902BD989AC0037554F /* ProductionAppView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E20278F2BD989AC0037554F /* ProductionAppView.swift */; };
 		6E35D4CE2B72C74500A2BF95 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 6E35D4CD2B72C74500A2BF95 /* MapboxMaps */; };
@@ -165,6 +166,7 @@
 		59BA20329B947F0211D70C0D /* Pods-iosAppTests.prodrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.prodrelease.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.prodrelease.xcconfig"; sourceTree = "<group>"; };
 		5D90749ECA9D2A48F600A230 /* Pods-iosAppTests.prod release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.prod release.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.prod release.xcconfig"; sourceTree = "<group>"; };
 		6C6BFDA87BC771B9484C9447 /* Pods-iosAppTests.stagingrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.stagingrelease.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.stagingrelease.xcconfig"; sourceTree = "<group>"; };
+		6E04E32E2BE95A8D006F8131 /* NearbyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyViewModel.swift; sourceTree = "<group>"; };
 		6E20278D2BD989630037554F /* DummyTestAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyTestAppView.swift; sourceTree = "<group>"; };
 		6E20278F2BD989AC0037554F /* ProductionAppView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductionAppView.swift; sourceTree = "<group>"; };
 		6E35D4CF2B72C7B700A2BF95 /* HomeMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMapView.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				7555FF82242A565900829871 /* ContentView.swift */,
 				8CC1BB3F2B59D1F6005386FE /* LocationDataManager.swift */,
 				058557D7273AAEEB004C7B11 /* Preview Content */,
+				6E04E32E2BE95A8D006F8131 /* NearbyViewModel.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -1039,6 +1042,7 @@
 				8CA485B62BDC610B00E84E1F /* VehiclesFetcher.swift in Sources */,
 				9A74A2112BE2D71400E57102 /* AnnotationLabel.swift in Sources */,
 				9A5B27562BB221C1009A6FC6 /* RouteLayerGenerator.swift in Sources */,
+				6E04E32F2BE95A8D006F8131 /* NearbyViewModel.swift in Sources */,
 				9A88AAC12BD0680C00A5BF88 /* StopDetailsRoutePills.swift in Sources */,
 				8CE0141B2BBF059B00918FAE /* SheetNavigationStackEntry.swift in Sources */,
 				9A7AC5C22BE139FB0036126F /* AnnotatedMap.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
   "pins" : [
     {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "748c7837511d0e6a507737353af268484e1745e2",
+        "version" : "1.2024011601.1"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "7d2688de038d5484866d835acb47b379722d610e",
+        "version" : "10.19.0"
+      }
+    },
+    {
       "identity" : "collectionconcurrencykit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
@@ -16,6 +34,78 @@
       "state" : {
         "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
         "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "97940381e57703c07f31a8058d8f39ec53b7c272",
+        "version" : "10.25.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "16244d177c4e989f87b25e9db1012b382cfedc55",
+        "version" : "10.25.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "8e5d57ed87057cd7b0e4e8f474d9e78f73eb85f7",
+        "version" : "7.13.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "e9fad491d0673bdda7063a0341fb6b47a30c5359",
+        "version" : "1.62.2"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "0382ca27f22fb3494cf657d8dc356dc282cd1193",
+        "version" : "3.4.1"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -46,12 +136,30 @@
       }
     },
     {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
       "identity" : "polyline",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/raphaelmor/Polyline.git",
       "state" : {
         "revision" : "353f80378dcd8f17eefe8550090c6b1ae3c9da23",
         "version" : "5.1.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -70,6 +178,15 @@
       "state" : {
         "revision" : "8f4d2753f0e4778c76d5f05ad16c74f707390531",
         "version" : "1.2.3"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "9f0c76544701845ad98716f3f6a774a892152bcb",
+        "version" : "1.26.0"
       }
     },
     {
@@ -131,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "67319287749b83f39dcc2f20edd520c610c012fd",
-        "version" : "0.9.10"
+        "revision" : "7b1732802ffe30e6a67754bda6c7819e5cb0eb70",
+        "version" : "0.9.11"
       }
     },
     {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @EnvironmentObject var viewportProvider: ViewportProvider
     @State private var sheetHeight: CGFloat = .zero
     @State private var navigationStack: [SheetNavigationStackEntry] = []
+    @StateObject var nearbyVM: NearbyViewModel = .init()
 
     private enum SelectedTab: Hashable {
         case nearby
@@ -71,6 +72,7 @@ struct ContentView: View {
                     alertsFetcher: alertsFetcher,
                     globalFetcher: globalFetcher,
                     nearbyFetcher: nearbyFetcher,
+                    nearbyVM: nearbyVM,
                     railRouteShapeFetcher: railRouteShapeFetcher,
                     vehiclesFetcher: vehiclesFetcher,
                     viewportProvider: viewportProvider,
@@ -143,7 +145,8 @@ struct ContentView: View {
                             socket: socketProvider.socket,
                             globalFetcher: globalFetcher,
                             viewportProvider: viewportProvider,
-                            stop: stop, filter: $navigationStack.lastStopDetailsFilter
+                            stop: stop, filter: $navigationStack.lastStopDetailsFilter,
+                            nearbyVM: nearbyVM
                         )
                     case let .tripDetails(tripId: tripId, vehicleId: vehicleId, target: target):
                         TripDetailsPage(tripId: tripId, vehicleId: vehicleId, target: target)

--- a/iosApp/iosApp/Fetchers/PredictionsFetcher.swift
+++ b/iosApp/iosApp/Fetchers/PredictionsFetcher.swift
@@ -74,6 +74,7 @@ class PredictionsFetcher: ObservableObject {
             if let stringPayload = rawPayload {
                 let newPredictions = try PredictionsForStopsChannel.companion
                     .parseMessage(payload: stringPayload)
+
                 Logger().debug("Received \(newPredictions.predictions.count) predictions")
                 DispatchQueue.main.async {
                     self.predictions = newPredictions

--- a/iosApp/iosApp/NearbyViewModel.swift
+++ b/iosApp/iosApp/NearbyViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  NearbyViewModel.swift
+//  iosApp
+//
+//  Created by Brady, Kayla on 5/6/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import shared
+import SwiftUI
+
+class NearbyViewModel: ObservableObject {
+    @Published var departures: StopDetailsDepartures?
+
+    func setDepartures(_ newDepartures: StopDetailsDepartures?) {
+        departures = newDepartures
+    }
+}

--- a/iosApp/iosApp/Pages/Map/RouteSourceGenerator.swift
+++ b/iosApp/iosApp/Pages/Map/RouteSourceGenerator.swift
@@ -164,29 +164,4 @@ class RouteSourceGenerator {
             alertsByStop: alertsByStop
         )
     }
-
-    static func forFilteredStop(_ stopShapes: [MapFriendlyRouteResponse.RouteWithSegmentedShapes],
-                                _ filter: StopDetailsFilter,
-                                _ routesById: [String: Route],
-                                _ stopsById: [String: Stop],
-                                _ alertsByStop: [String: AlertAssociatedStop]) -> RouteSourceGenerator {
-        let targetRouteData = stopShapes.first { $0.routeId == filter.routeId }
-        if let targetRouteData {
-            let targetDirectionShapes = targetRouteData.segmentedShapes.filter { $0.directionId == filter.directionId }
-            return RouteSourceGenerator(
-                routeData: [.init(routeId: targetRouteData.routeId, segmentedShapes: targetDirectionShapes)],
-                routesById: routesById,
-                stopsById: stopsById,
-                alertsByStop: alertsByStop
-            )
-
-        } else {
-            return RouteSourceGenerator(
-                routeData: [],
-                routesById: routesById,
-                stopsById: stopsById,
-                alertsByStop: alertsByStop
-            )
-        }
-    }
 }

--- a/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
+++ b/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
@@ -28,6 +28,7 @@ final class HomeMapViewTest: XCTestCase {
             alertsFetcher: .init(socket: MockSocket()),
             globalFetcher: .init(backend: IdleBackend()),
             nearbyFetcher: .init(backend: IdleBackend()),
+            nearbyVM: .init(),
             railRouteShapeFetcher: .init(backend: IdleBackend()),
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -61,7 +61,8 @@ final class StopDetailsPageTests: XCTestCase {
             schedulesRepository: FakeSchedulesRepository(callback: callback),
             viewportProvider: viewportProvider,
             stop: stop,
-            filter: filter
+            filter: filter,
+            nearbyVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -85,7 +86,8 @@ final class StopDetailsPageTests: XCTestCase {
             schedulesRepository: MockScheduleRepository(),
             viewportProvider: viewportProvider,
             stop: stop,
-            filter: filter
+            filter: filter,
+            nearbyVM: .init()
         )
 
         try sut.inspect().find(button: "Clear Filter").tap()
@@ -135,7 +137,8 @@ final class StopDetailsPageTests: XCTestCase {
             schedulesRepository: fakeSchedulesRepository(objects: objects, callback: { schedulesLoadedPublisher.send(true) }),
             viewportProvider: viewportProvider,
             stop: stop,
-            filter: filter
+            filter: filter,
+            nearbyVM: .init()
         )
 
         let exp = sut.inspection.inspect(onReceive: schedulesLoadedPublisher, after: 0.2) { view in

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -30,6 +30,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -55,6 +56,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -106,6 +108,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: FakeGlobalFetcher(),
             nearbyFetcher: NearbyFetcher(backend: IdleBackend()),
+            nearbyVM: .init(),
             railRouteShapeFetcher: FakeRailRouteShapeFetcher(getRailRouteShapeExpectation: getRailRouteShapeExpectation),
             vehiclesFetcher: VehiclesFetcher(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -134,6 +137,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -164,6 +168,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -241,6 +246,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -294,6 +300,80 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
+            railRouteShapeFetcher: railRouteShapeFetcher,
+            vehiclesFetcher: .init(socket: MockSocket()),
+            viewportProvider: ViewportProvider(),
+            locationDataManager: locationDataManager,
+            navigationStack: .constant([]),
+            sheetHeight: .constant(0),
+            layerManager: FakeLayerManager(updateRouteSourceCallback: olOnlyRouteSourceCheck)
+        )
+
+        let hasAppeared = sut.on(\.didAppear) { sut in
+            let newNavStackEntry: SheetNavigationStackEntry =
+                .stopDetails(stop, .init(routeId: MapTestDataHelper.routeOrange.id,
+                                         directionId: MapTestDataHelper.patternOrange30.directionId))
+            try sut.find(ProxyModifiedMap.self).callOnChange(newValue: newNavStackEntry)
+        }
+
+        ViewHosting.host(view: sut)
+        wait(for: [hasAppeared, olRouteSourceUpdateExpectation], timeout: 5)
+
+        addTeardownBlock {
+            HelpersKt.loadDefaultRepoModules()
+        }
+    }
+
+    func testUpdatesRouteSourceWhenStopSelectedWithRouteFilterAndUpcomingDepartures() throws {
+        class FakeStopRepository: IStopRepository {
+            func __getStopMapData(stopId _: String) async throws -> StopMapResponse {
+                StopMapResponse(routeShapes: MapTestDataHelper.routeResponse.routesWithSegmentedShapes, childStops: [:])
+            }
+        }
+        HelpersKt.loadKoinMocks(repositories: MockRepositories.companion.buildWithDefaults(stop: FakeStopRepository()))
+
+        let objectCollection = ObjectCollectionBuilder()
+        let stop = objectCollection.stop { stop in
+            stop.id = "1"
+            stop.latitude = 1
+            stop.longitude = 1
+        }
+        let trip = objectCollection.trip { trip in
+            trip.routePatternId = MapTestDataHelper.patternOrange30.id
+        }
+
+        let prediction = objectCollection.prediction { prediction in
+            prediction.trip = trip
+        }
+
+        let olRouteSourceUpdateExpectation = XCTestExpectation(description: "updateRouteSouce called for expected RP")
+        func olOnlyRouteSourceCheck(routeGenerator: RouteSourceGenerator) {
+            if routeGenerator.routeLines.allSatisfy({ $0.routePatternId == MapTestDataHelper.patternOrange30.id }) {
+                olRouteSourceUpdateExpectation.fulfill()
+            }
+        }
+
+        let alertsFetcher: AlertsFetcher = .init(socket: MockSocket())
+        let globalFetcher: GlobalFetcher = .init(backend: IdleBackend(), stops: [stop.id: stop], routes: [:])
+        let nearbyFetcher: NearbyFetcher = .init(backend: IdleBackend())
+        let nearbyVM: NearbyViewModel = .init()
+        nearbyVM.setDepartures(StopDetailsDepartures(routes:
+            [.init(route: MapTestDataHelper.routeOrange, stop: stop,
+                   patternsByHeadsign: [.init(route: MapTestDataHelper.routeOrange,
+                                              headsign: MapTestDataHelper.tripOrangeC1.headsign,
+                                              patterns: [MapTestDataHelper.patternOrange30],
+                                              upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
+                                              alertsHere: nil)])]))
+
+        let railRouteShapeFetcher: RailRouteShapeFetcher = .init(backend: IdleBackend())
+        railRouteShapeFetcher.response = MapTestDataHelper.routeResponse
+        let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
+        var sut = HomeMapView(
+            alertsFetcher: alertsFetcher,
+            globalFetcher: globalFetcher,
+            nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),
@@ -350,6 +430,7 @@ final class HomeMapViewTests: XCTestCase {
             alertsFetcher: alertsFetcher,
             globalFetcher: globalFetcher,
             nearbyFetcher: nearbyFetcher,
+            nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
             viewportProvider: ViewportProvider(),


### PR DESCRIPTION
### Summary

_Ticket:_ [Map shows selected route shape in filtered mode](https://app.asana.com/0/1205425564113216/1206911000924623/f)

What is this PR for?

This pulls up departures into a ViewModel that is shared between StopDetails and the HomeMap. I did this with the minimal change needed to do this filtering. We'll want to pull more into this view model, but I'm hesitant to go too far into that refactor in this ticket knowing that there will be more refactoring as part of [Stop details predictions don't update](https://app.asana.com/0/1205425564113216/1207247029232073/f), but I'm open to feedback that more of that should come in this PR! 

### Testing

What testing have you done?
* Added a unit test 
* Ran locally, confirmed only the upcoming 2 route patterns are shown for this stop on the 66 
![image](https://github.com/mbta/mobile_app/assets/31781298/ed53ca6f-7233-439a-9675-d70d6cc86dfa)

vs prod:
![IMG_0085](https://github.com/mbta/mobile_app/assets/31781298/359a2e48-2ec7-4a70-b604-7fb5a6d86344)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
