### PR TITLE
fix: prediction stop sequence is not nullable

### DIFF
--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
@@ -46,13 +46,13 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
             $0.trip = tripNorth
             $0.vehicleId = vehicleNorth.id
             $0.departureTime = now.toKotlinInstant()
-            $0.stopSequence = KotlinInt(int: Int32(stopSequence))
+            $0.stopSequence = Int32(stopSequence)
         }
         let tripSouth = objects.trip(routePattern: patternSouth)
         let predictionSouth = objects.prediction {
             $0.trip = tripSouth
             $0.departureTime = now.toKotlinInstant()
-            $0.stopSequence = KotlinInt(int: Int32(stopSequence))
+            $0.stopSequence = Int32(stopSequence)
         }
 
         let patternsByStop = PatternsByStop(route: route, stop: stop, patternsByHeadsign: [

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -80,7 +80,7 @@ class ObjectCollectionBuilder {
         var revenue = true
         var scheduleRelationship = Prediction.ScheduleRelationship.Scheduled
         var status: String? = null
-        var stopSequence: Int? = null
+        var stopSequence = 0
         var routeId = ""
         var stopId = ""
         var tripId = ""

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -20,7 +20,7 @@ data class Prediction(
     val revenue: Boolean,
     @SerialName("schedule_relationship") val scheduleRelationship: ScheduleRelationship,
     val status: String?,
-    @SerialName("stop_sequence") val stopSequence: Int?,
+    @SerialName("stop_sequence") val stopSequence: Int,
     @SerialName("route_id") val routeId: String,
     @SerialName("stop_id") val stopId: String,
     @SerialName("trip_id") val tripId: String,


### PR DESCRIPTION
### Summary

_Ticket:_ none

Ran into this as part of showing predictions in trip details.

### Testing

All tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
