### PR TITLE
fix: Include connecting children in transfers

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -249,7 +249,12 @@ data class TripDetailsStopList(val stops: List<Entry>) {
                 globalData.routes[entry.prediction?.routeId ?: entry.schedule?.routeId]
 
             val transferStopIds =
-                listOf(selfOrParent.id) + selfOrParent.connectingStopIds + selfOrParent.childStopIds
+                listOf(selfOrParent.id) +
+                    selfOrParent.childStopIds +
+                    selfOrParent.connectingStopIds +
+                    selfOrParent.connectingStopIds.flatMap {
+                        globalData.stops[it]?.childStopIds ?: emptyList()
+                    }
 
             val transferRoutes =
                 transferStopIds

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -411,7 +411,8 @@ class TripDetailsStopListTest {
         val stopC = stop("C", listOf("C1"))
         val stopA1 = stop("A1")
         val stopA2 = stop("A2")
-        val stopA3 = stop("A3")
+        val stopA3 = stop("A3", listOf("A4"))
+        val stopA4 = stop("A4")
         val stopB1 = stop("B1")
         val stopC1 = stop("C1")
 
@@ -473,7 +474,7 @@ class TripDetailsStopListTest {
                     vehicle = vehicle,
                     schedule = sched1,
                     prediction = pred1,
-                    routes = listOf(routeW, routeX, routeZ)
+                    routes = listOf(routeW, routeX, routeY, routeZ)
                 ),
                 entry(
                     "B1",
@@ -500,6 +501,7 @@ class TripDetailsStopListTest {
                     Pair(stopA1.id, listOf(patternCurrent1.id, patternW1.id)),
                     Pair(stopA2.id, listOf(patternZ1.id, patternExcluded.id)),
                     Pair(stopA3.id, listOf(patternX1.id)),
+                    Pair(stopA4.id, listOf(patternY1.id)),
                     Pair(stopB1.id, listOf(patternZ1.id, patternCurrent2.id)),
                     Pair(stopC.id, listOf(patternW2.id, patternY1.id, patternExcluded.id)),
                     Pair(stopC1.id, listOf(patternY1.id, patternCurrent1.id, patternCurrent2.id))


### PR DESCRIPTION
### Summary

_Ticket:_ [Show connecting routes for each future stop](https://app.asana.com/0/1205732265579288/1207160272394261/f)

Hotfix for missing connecting stop children. Bug report [on slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1716405253201309).

### Testing

Added connecting stop child ID to test.