### PR TITLE
refactor(alertingSegments): consider stops by pairs

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
@@ -211,13 +211,12 @@ class RouteSegmentTest {
     }
 
     @Test
-    fun `alertingSegments when alerting segment at the ends splits so alert in each segment`() {
+    fun `alertingSegments ignores alert that only touches terminal`() {
 
         assertEquals(
             listOf(
                 Pair(true, listOf("alewife", "davis")),
-                Pair(false, listOf("davis", "porter", "harvard", "central")),
-                Pair(true, listOf("central"))
+                Pair(false, listOf("davis", "porter", "harvard", "central"))
             ),
             RouteSegment.alertingSegments(
                 listOf("alewife", "davis", "porter", "harvard", "central"),
@@ -311,70 +310,6 @@ class RouteSegmentTest {
                     stopIds = listOf("porter", "harvard", "central"),
                     otherPatternsByStopId = mapOf(),
                     isAlerting = false
-                ),
-            ),
-            routeSegment.splitAlertingSegments(alertsForStop)
-        )
-    }
-
-    @Test
-    fun `splitAlertingSegments when alerting segment at the ends splits so alert in each segment`() {
-        var routeSegment =
-            RouteSegment(
-                id = "id",
-                sourceRouteId = "sourceRoute",
-                sourceRoutePatternId = "sourceRoutePattern",
-                stopIds = listOf("alewife", "davis", "porter", "harvard", "central"),
-                otherPatternsByStopId =
-                    mapOf(
-                        "alewife" to
-                            listOf(
-                                RoutePatternKey(routeId = "otherRoute", routePatternId = "otherRp")
-                            )
-                    )
-            )
-
-        val alertsForStop =
-            mapOf(
-                "alewife" to serviceAlert("alewife", routeSegment.sourceRouteId),
-                "davis" to serviceAlert("davis", routeSegment.sourceRouteId),
-                "central" to serviceAlert("alewife", routeSegment.sourceRouteId)
-            )
-
-        assertEquals(
-            listOf(
-                AlertAwareRouteSegment(
-                    id = "id-0",
-                    sourceRoutePatternId = routeSegment.sourceRoutePatternId,
-                    sourceRouteId = routeSegment.sourceRouteId,
-                    stopIds = listOf("alewife", "davis"),
-                    otherPatternsByStopId =
-                        mapOf(
-                            "alewife" to
-                                listOf(
-                                    RoutePatternKey(
-                                        routeId = "otherRoute",
-                                        routePatternId = "otherRp"
-                                    )
-                                )
-                        ),
-                    isAlerting = true
-                ),
-                AlertAwareRouteSegment(
-                    id = "id-1",
-                    sourceRoutePatternId = routeSegment.sourceRoutePatternId,
-                    sourceRouteId = routeSegment.sourceRouteId,
-                    stopIds = listOf("davis", "porter", "harvard", "central"),
-                    otherPatternsByStopId = mapOf(),
-                    isAlerting = false
-                ),
-                AlertAwareRouteSegment(
-                    id = "id-2",
-                    sourceRoutePatternId = routeSegment.sourceRoutePatternId,
-                    sourceRouteId = routeSegment.sourceRouteId,
-                    stopIds = listOf("central"),
-                    otherPatternsByStopId = mapOf(),
-                    isAlerting = true
                 ),
             ),
             routeSegment.splitAlertingSegments(alertsForStop)


### PR DESCRIPTION
### Summary

_Ticket:_ [[UI] Update map line styles](https://app.asana.com/0/1201654106676769/1207335629929118/f)

Builds route segments up from pairs of adjacent stops directly.

### Testing

Updated unit tests to reflect new behavior around alerts that only exist at a terminal.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
