### PR TITLE
feat: split up current Orange Line suspension/shuttle

### DIFF
--- a/iosApp/iosApp/Fetchers/AlertsFetcher.swift
+++ b/iosApp/iosApp/Fetchers/AlertsFetcher.swift
@@ -21,6 +21,9 @@ class AlertsFetcher: ObservableObject {
     @Published var socketError: Error?
     @Published var errorText: Text?
 
+    // TODO: remove after debugging mixed shuttle/suspension alerts
+    static let splitAlert566172 = true
+
     let socket: PhoenixSocket
     var channel: PhoenixChannel?
     var onMessageSuccessCallback: (() -> Void)?
@@ -76,7 +79,12 @@ class AlertsFetcher: ObservableObject {
                     .parseMessage(payload: stringPayload)
                 Logger().debug("Received \(newAlerts.alerts.count) alerts")
                 DispatchQueue.main.async {
-                    self.alerts = newAlerts
+                    let splitNewAlerts = if Self.splitAlert566172 {
+                        newAlerts.splitAlert566172()
+                    } else {
+                        newAlerts
+                    }
+                    self.alerts = splitNewAlerts
                     self.socketError = nil
                     self.errorText = nil
                     if let callback = self.onMessageSuccessCallback {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -7,4 +7,55 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AlertsStreamDataResponse(val alerts: Map<String, Alert>) {
     constructor(objects: ObjectCollectionBuilder) : this(objects.alerts)
+
+    // TODO remove after debugging mixed shuttle/suspension alerts
+    fun splitAlert566172(): AlertsStreamDataResponse =
+        when (val alert566172 = alerts["566172"]) {
+            null -> this
+            else -> {
+                val shuttledStops =
+                    setOf("place-welln", "70032", "70033") +
+                        setOf("place-astao", "70278", "70279") +
+                        setOf("place-sull", "70030", "70031") +
+                        setOf("place-ccmnl", "70028", "70029") +
+                        setOf("place-north", "70026", "70027")
+                val suspendedStops =
+                    setOf("place-north", "70026", "70027") +
+                        setOf("place-haecl", "70024", "70025") +
+                        setOf("place-state", "70022", "70023") +
+                        setOf("place-dwnxg", "70020", "70021") +
+                        setOf("place-chncl", "70018", "70019") +
+                        setOf("place-tumnl", "70016", "70017") +
+                        setOf("place-bbsta", "70014", "70015")
+                AlertsStreamDataResponse(
+                    alerts - listOf("566172") +
+                        mapOf(
+                            "566172.1" to
+                                Alert(
+                                    id = "566172.1",
+                                    activePeriod = alert566172.activePeriod,
+                                    effect = Alert.Effect.Shuttle,
+                                    effectName = null,
+                                    informedEntity =
+                                        alert566172.informedEntity.filter {
+                                            it.stop in shuttledStops
+                                        },
+                                    lifecycle = alert566172.lifecycle
+                                ),
+                            "566172.2" to
+                                Alert(
+                                    id = "566172.2",
+                                    activePeriod = alert566172.activePeriod,
+                                    effect = Alert.Effect.Suspension,
+                                    effectName = null,
+                                    informedEntity =
+                                        alert566172.informedEntity.filter {
+                                            it.stop in suspendedStops
+                                        },
+                                    lifecycle = alert566172.lifecycle
+                                )
+                        )
+                )
+            }
+        }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[UI] Update map line styles](https://app.asana.com/0/1201654106676769/1207335629929118/f)

Stacked on #202 (and #201 and #200). Splits up the ongoing Orange Line suspension with a partial shuttle into two separate alerts so that we can preview different handling for suspensions and shuttles. Will be easy to remove once we're finished with that task.

Making this an option on the settings page was annoying - either it requires Koin-ing the alerts fetcher or it requires passing the alerts fetcher into the settings page and mocking out everything that tests it - so I'm not doing it.

### Testing

Manually verified that Nearby Transit shows shuttle and suspension at stops on different sides of this split.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
