### PR TITLE
feat(UpcomingTripView): Include vehicle type in voice over

### DIFF
--- a/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
+++ b/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
@@ -28,18 +28,29 @@ struct HeadsignRowView: View {
                     let restTrips = trips.trips.dropFirst()
 
                     if let firstTrip {
-                        UpcomingTripView(prediction: .some(firstTrip.format), isFirst: true)
+                        UpcomingTripView(prediction: .some(firstTrip.format),
+                                         routeType: routeType,
+                                         isFirst: true,
+                                         isOnly: restTrips.isEmpty)
                         ForEach(restTrips, id: \.id) { prediction in
-                            UpcomingTripView(prediction: .some(prediction.format))
+                            UpcomingTripView(prediction: .some(prediction.format),
+                                             routeType: routeType,
+                                             isFirst: false,
+                                             isOnly: false)
                         }
                     }
                 }
             case let .noService(alert):
-                UpcomingTripView(prediction: .noService(alert.alert.effect))
+                UpcomingTripView(
+                    prediction: .noService(alert.alert.effect),
+                    routeType: routeType,
+                    isFirst: true,
+                    isOnly: true
+                )
             case .none:
-                UpcomingTripView(prediction: .none)
+                UpcomingTripView(prediction: .none, routeType: routeType, isFirst: true, isOnly: true)
             case .loading:
-                UpcomingTripView(prediction: .loading)
+                UpcomingTripView(prediction: .loading, routeType: routeType, isFirst: true, isOnly: true)
             }
         }
         .accessibilityInputLabels([headsign])

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1,6 +1,42 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "%@ arriving at %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ arriving at %2$@"
+          }
+        }
+      }
+    },
+    "%@ arriving at %@ scheduled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ arriving at %2$@ scheduled"
+          }
+        }
+      }
+    },
+    "%@ arriving in %@ min" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ arriving in %2$@ min"
+          }
+        }
+      }
+    },
+    "%@ arriving now" : {
+
+    },
+    "%@ boarding now" : {
+
+    },
     "%@ Bus" : {
       "extractionState" : "manual"
     },
@@ -54,23 +90,14 @@
     "ARR" : {
 
     },
-    "arriving at %@" : {
-
-    },
-    "arriving at %@ scheduled" : {
-
-    },
-    "arriving in %@ min" : {
-
-    },
-    "arriving now" : {
-
-    },
-    "boarding now" : {
-
-    },
     "BRD" : {
 
+    },
+    "bus" : {
+      "comment" : "bus"
+    },
+    "buses" : {
+      "comment" : "buses"
     },
     "Clear Filter" : {
 
@@ -122,6 +149,12 @@
     },
     "Failed to load vehicles, could not connect to the server" : {
 
+    },
+    "ferries" : {
+      "comment" : "ferries"
+    },
+    "ferry" : {
+      "comment" : "ferry"
     },
     "last updated %.0fs ago" : {
 
@@ -188,6 +221,12 @@
     },
     "This vehicle is completing another trip." : {
 
+    },
+    "train" : {
+      "comment" : "train"
+    },
+    "trains" : {
+      "comment" : "trains"
     }
   },
   "version" : "1.0"

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -47,10 +47,11 @@ struct TripDetailsPage: View {
     var body: some View {
         VStack {
             if let globalData = globalFetcher.response {
+                let vehicle = vehicleFetcher.response?.vehicle
                 if let stops = TripDetailsStopList.companion.fromPieces(
                     tripSchedules: tripSchedulesResponse,
                     tripPredictions: tripPredictionsFetcher.predictions,
-                    vehicle: vehicleFetcher.response?.vehicle, globalData: globalData
+                    vehicle: vehicle, globalData: globalData
                 ) {
                     vehicleCardView
                     if let target, let splitStops = stops.splitForTarget(

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -18,7 +18,7 @@ struct TripDetailsStopView: View {
             HStack {
                 Text(stop.stop.name)
                 Spacer()
-                UpcomingTripView(prediction: .some(stop.format(now: now)))
+                UpcomingTripView(prediction: .some(stop.format(now: now)), routeType: nil)
             }
             scrollRoutes
         }

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -19,37 +19,53 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testFirstBoardingAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatBoarding()), isFirst: true)
-        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "boarding now"))
+        let sut = UpcomingTripView(
+            prediction: .some(UpcomingTrip.FormatBoarding()),
+            routeType: .heavyRail,
+            isFirst: true
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "train boarding now"))
     }
 
     func testBoardingAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatBoarding()), isFirst: false)
+        let sut = UpcomingTripView(
+            prediction: .some(UpcomingTrip.FormatBoarding()),
+            routeType: .heavyRail,
+            isFirst: false
+        )
         XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "and boarding now"))
     }
 
     func testFirstArrivingAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatArriving()), isFirst: true)
-        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "arriving now"))
+        let sut = UpcomingTripView(
+            prediction: .some(UpcomingTrip.FormatArriving()),
+            routeType: .heavyRail,
+            isFirst: true
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "train arriving now"))
     }
 
     func testArrivingAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatArriving()), isFirst: false)
+        let sut = UpcomingTripView(
+            prediction: .some(UpcomingTrip.FormatArriving()),
+            routeType: .heavyRail,
+            isFirst: false
+        )
         XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "and arriving now"))
     }
 
     func testFirstDistantAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().distantFuture(date: date, isFirst: true)
+        let text: any View = UpcomingTripAccessibilityFormatters().distantFutureFirst(date: date, vehicleText: "trains")
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 
-        XCTAssertEqual("arriving at 4:00 PM", foundText)
+        XCTAssertEqual("trains arriving at 4:00 PM", foundText)
     }
 
     func testDistantAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().distantFuture(date: date, isFirst: false)
+        let text: any View = UpcomingTripAccessibilityFormatters().distantFutureOther(date: date)
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 
@@ -58,16 +74,16 @@ final class UpcomingTripViewTests: XCTestCase {
 
     func testFirstScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().scheduled(date: date, isFirst: true)
+        let text: any View = UpcomingTripAccessibilityFormatters().scheduledFirst(date: date, vehicleText: "buses")
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 
-        XCTAssertEqual("arriving at 4:00 PM scheduled", foundText)
+        XCTAssertEqual("buses arriving at 4:00 PM scheduled", foundText)
     }
 
     func testScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().scheduled(date: date, isFirst: false)
+        let text: any View = UpcomingTripAccessibilityFormatters().scheduledOther(date: date)
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 
@@ -75,10 +91,13 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testFirstPredictedAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatMinutes(minutes: 5)), isFirst: true)
+        let sut = UpcomingTripView(prediction: .some(UpcomingTrip.FormatMinutes(minutes: 5)),
+                                   routeType: .heavyRail,
+                                   isFirst: true,
+                                   isOnly: false)
         let predictionView = try sut.inspect().find(PredictionText.self)
         XCTAssertEqual(
-            "arriving in 5 min",
+            "trains arriving in 5 min",
             try predictionView.accessibilityLabel().string(locale: Locale(identifier: "en"))
         )
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [VoiceOver text for the Nearby Transit sheet](https://app.asana.com/0/1205732265579288/1207335629929153/f)

What is this PR for?

Follow-up to https://github.com/mbta/mobile_app/pull/199. This adds the vehicle type to the accessibility label so that nearby transit reads "trains arriving in 5 minutes and in 6 minutes".

I had some challenges getting the pluralization to work nicely with future localization in mind. 

### Testing

What testing have you done?
Updated unit tests & ran locally with accessibility inspector
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
