### PR TITLE
feat: restore nearby transit viewport when going back

### DIFF
--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -70,6 +70,9 @@ extension HomeMapView {
     }
 
     func handleLastNavChange(oldNavEntry: SheetNavigationStackEntry?, nextNavEntry: SheetNavigationStackEntry?) {
+        if oldNavEntry == nil {
+            viewportProvider.saveNearbyTransitViewport()
+        }
         if case let .stopDetails(stop, filter) = nextNavEntry {
             if oldNavEntry?.stop()?.id == stop.id {
                 handleRouteFilterChange(filter)
@@ -78,6 +81,9 @@ extension HomeMapView {
             }
         } else {
             clearSelectedStop()
+        }
+        if nextNavEntry == nil {
+            viewportProvider.restoreNearbyTransitViewport()
         }
     }
 

--- a/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
+++ b/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
@@ -52,4 +52,38 @@ final class ViewportProviderTest: XCTestCase {
         XCTAssertEqual(provider.viewport.camera?.center, .init(latitude: 1, longitude: 1))
         XCTAssertEqual(provider.viewport.camera?.zoom, 17.0)
     }
+
+    func testSaveFollowing() throws {
+        let provider = ViewportProvider(viewport: .followPuck(zoom: 16.0))
+
+        provider.saveNearbyTransitViewport()
+        provider.animateTo(coordinates: .init(latitude: 1, longitude: 1), zoom: 17.0)
+        provider.restoreNearbyTransitViewport()
+
+        XCTAssertEqual(provider.viewport.followPuck?.zoom, 16.0)
+    }
+
+    func testSavePanned() throws {
+        let provider = ViewportProvider(viewport: .idle)
+
+        let center = CLLocationCoordinate2D(latitude: 1, longitude: 2)
+        let zoom = 16.0
+        provider.updateCameraState(.init(center: center, padding: .zero, zoom: zoom, bearing: .zero, pitch: .zero))
+        provider.saveNearbyTransitViewport()
+        provider.animateTo(coordinates: .init(latitude: 3, longitude: 4), zoom: 17.0)
+        provider.restoreNearbyTransitViewport()
+
+        XCTAssertEqual(provider.viewport.camera?.center, center)
+        XCTAssertEqual(provider.viewport.camera?.zoom, zoom)
+    }
+
+    func testRestoreWithoutSave() throws {
+        // this shouldn't be possible, but if we implement e.g. deep linking in a way that makes this possible,
+        // it's important that this not crash
+        let provider = ViewportProvider(viewport: .camera(center: .init(latitude: 0, longitude: 0)))
+
+        provider.restoreNearbyTransitViewport()
+
+        XCTAssertEqual(provider.viewport.camera?.center, .init(latitude: 0, longitude: 0))
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [When going back from stop details to Nearby Transit, reset location](https://app.asana.com/0/1205732265579288/1207355892523286/f)

Persists the viewport when exiting nearby transit so that it can be restored when returning to nearby transit.

### Testing

Added unit tests for the new logic and manually verified that it's called correctly and that restoring a `followPuck` will properly show a new location instead.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
