### PR TITLE
fix(NearbySheet): don't pop new sheet every time stop details filter changes

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -87,18 +87,22 @@ struct ContentView: View {
                 viewportProvider: viewportProvider,
                 sheetHeight: $sheetHeight
             )
-            .sheet(item: .constant($nearbyVM.navigationStack.wrappedValue.lastSafe()), onDismiss: {
-                selectedDetent = .halfScreen
+            .sheet(
+                item: .constant($nearbyVM.navigationStack.wrappedValue.lastSafe().sheetItemIdentifiable()),
+                onDismiss: {
+                    selectedDetent = .halfScreen
 
-                if visibleNearbySheet == nearbyVM.navigationStack.last {
-                    // When the visible sheet matches the last nav entry, then a dismissal indicates
-                    // an intentional action remove the sheet and replace it with the previous one.
+                    if visibleNearbySheet == nearbyVM.navigationStack.last {
+                        // When the visible sheet matches the last nav entry, then a dismissal indicates
+                        // an intentional action remove the sheet and replace it with the previous one.
 
-                    // When the visible sheet *doesn't* match the latest item in the nav stack, it is
-                    // being dismissed so that it can be automatically replaced with the new one.
-                    nearbyVM.goBack()
-                } else {}
-            }) { entry in
+                        // When the visible sheet *doesn't* match the latest item in the nav stack, it is
+                        // being dismissed so that it can be automatically replaced with the new one.
+                        nearbyVM.goBack()
+                    } else {}
+                }
+            ) { sheetIdentityEntry in
+                let entry = sheetIdentityEntry.stackEntry
                 GeometryReader { proxy in
                     NavigationStack {
                         switch entry {

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -34,6 +34,27 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         case _: nil
         }
     }
+
+    func sheetItemIdentifiable() -> NearbySheetItem {
+        NearbySheetItem(stackEntry: self)
+    }
+}
+
+/// Struct that holds a SheetNavigationStackEntry. To be used with `sheet(item:onDismiss:content:)`
+/// the ids of two `NearbySheetItem`s will differ only if a new sheet should be opened when switching from one to
+/// the other.
+/// For example, if switching between two `.stopDetails` entries, a new sheet should only be opened if the stop ID
+/// changes.
+struct NearbySheetItem: Identifiable {
+    let stackEntry: SheetNavigationStackEntry
+
+    var id: String {
+        switch stackEntry {
+        case let .stopDetails(stop, _): stop.id
+        case let .tripDetails(tripId, _, _): tripId
+        case .nearby: "nearby"
+        }
+    }
 }
 
 extension [SheetNavigationStackEntry] {

--- a/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
+++ b/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
@@ -76,4 +76,16 @@ final class SheetNavigationStackEntryTests: XCTestCase {
 
         XCTAssertEqual(stack, prevStack)
     }
+
+    func testNearbySheetItemIdentifable() throws {
+        let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
+        let stopEntry: SheetNavigationStackEntry = .stopDetails(stop, .init(routeId: "A", directionId: 1))
+        let tripEntry: SheetNavigationStackEntry = .tripDetails(tripId: "tripId", vehicleId: "vehicleId", target: nil)
+
+        let nearbyEntry: SheetNavigationStackEntry = .nearby
+
+        XCTAssertEqual(stopEntry.sheetItemIdentifiable().id, stop.id)
+        XCTAssertEqual(tripEntry.sheetItemIdentifiable().id, "tripId")
+        XCTAssertEqual(nearbyEntry.sheetItemIdentifiable().id, "nearby")
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[UI] Stop details sheet](https://app.asana.com/0/1205732265579288/1207471186968037/f)
Follow-up to https://github.com/mbta/mobile_app/pull/220.


What is this PR for?

When applying a route filter in the Stop Details page, the current sheet should stay open rather than closing & opening a new sheet with the filter applied.
### Testing

Added unit tests & ran locally to confirm stop details page stays open when changing the route filter.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
