### PR TITLE
feat: use prod backend for prod app variant

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -2,8 +2,7 @@ package com.mbta.tid.mbta_app
 
 enum class AppVariant(val backendHost: String) {
     Staging("mobile-app-backend-staging.mbtace.com"),
-    // TODO use prod backend once created
-    Prod("mobile-app-backend-staging.mbtace.com");
+    Prod("mobile-app-backend.mbtace.com");
 
     val backendRoot = "https://$backendHost"
     val socketUrl = "wss://$backendHost/socket"


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up prod application deployments › Mobile app points to prod backend](https://app.asana.com/0/1205732265579288/1207590058465517/f)

During the interval where the prod frontend is still auto deployed from main but pointed at the manually-released prod backend, we need to keep an eye out for changes to the backend, because if we, for example, add a non-optional field in the frontend that hasn't been released yet in the backend, the app doesn't work. This is already the case - https://github.com/mbta/mobile_app_backend/pull/149 isn't running on the prod backend yet, so https://github.com/mbta/mobile_app/pull/232 crashes at parse time - so hopefully we remember to run a prod deploy before we merge this PR.

### Testing

Manually verified that the prod app build uses the prod backend and the staging app build still uses the staging frontend.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
