### PR TITLE
build: remove temporary `iosApp` alias for `Prod`

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -64,9 +64,6 @@ if [ $CI_XCODEBUILD_ACTION != "build-for-testing" ]; then
   echo "${MAPBOX_PUBLIC_TOKEN}" >> mapbox
 fi
 
-echo "Creating temporary iosApp scheme to preserve existing Xcode Cloud CI setup"
-ln -s "${CI_PRIMARY_REPOSITORY_PATH}/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/Prod.xcscheme" "${CI_PRIMARY_REPOSITORY_PATH}/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme"
-
 echo "Adding build environment variables"
 cd ${CI_PRIMARY_REPOSITORY_PATH}
 touch .envrc


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up prod application deployments › Manual mobile app prod deploys](https://app.asana.com/0/1205732265579288/1207590058465518/f)

This was created when we first set up the separate staging and prod apps, and it should stop being necessary once we switch over to CD on staging and manual deploys for prod.

### Testing

Not tested.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
