### PR TITLE
fix(NearbyTransit): Preserve nearby sort order

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Route.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Route.kt
@@ -32,12 +32,10 @@ data class Route(
             }
 
         /*
-        Sort by pinned status first, then subway first, defaulting to route sort order.
+        Sort by pinned status first, then subway first, then given sort order.
          */
         fun relevanceComparator(pinnedRoutes: Set<String>): Comparator<Route> {
-            return compareBy<Route> { !pinnedRoutes.contains(it.id) }
-                .then(subwayFirstComparator)
-                .thenBy { it.sortOrder }
+            return compareBy<Route> { !pinnedRoutes.contains(it.id) }.then(subwayFirstComparator)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -79,7 +79,12 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                     )
                 }
                 .filterNot { it.patternsByHeadsign.isEmpty() }
-                .sortedWith(compareBy(Route.relevanceComparator(pinnedRoutes)) { it.route })
+                .sortedWith(
+                    compareBy<PatternsByStop, Route>(Route.relevanceComparator(pinnedRoutes)) {
+                            it.route
+                        }
+                        .thenBy { it.route }
+                )
         }
     )
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -824,31 +824,35 @@ class NearbyResponseTest {
                 longitude = closeBusStop.longitude + 0.3
             }
 
-        val closeBusRoute = objects.route { type = RouteType.BUS }
-        val farBusRoute = objects.route { type = RouteType.BUS }
-        val closeSubwayRoute = objects.route { type = RouteType.LIGHT_RAIL }
-        val farSubwayRoute = objects.route { type = RouteType.LIGHT_RAIL }
+        val closeBusRoute =
+            objects.route {
+                type = RouteType.BUS
+                sortOrder = 4
+            }
+        val farBusRoute =
+            objects.route {
+                type = RouteType.BUS
+                sortOrder = 3
+            }
+        val closeSubwayRoute =
+            objects.route {
+                type = RouteType.LIGHT_RAIL
+                sortOrder = 2
+            }
+        val farSubwayRoute =
+            objects.route {
+                type = RouteType.LIGHT_RAIL
+                sortOrder = 1
+            }
 
         val closeSubwayPattern =
-            objects.routePattern(closeSubwayRoute) {
-                sortOrder = 1
-                representativeTrip { headsign = "Alewife" }
-            }
+            objects.routePattern(closeSubwayRoute) { representativeTrip { headsign = "Alewife" } }
         val farSubwayPattern =
-            objects.routePattern(farSubwayRoute) {
-                sortOrder = 1
-                representativeTrip { headsign = "Oak Grove" }
-            }
+            objects.routePattern(farSubwayRoute) { representativeTrip { headsign = "Oak Grove" } }
         val closeBusPattern =
-            objects.routePattern(closeBusRoute) {
-                sortOrder = 1
-                representativeTrip { headsign = "Nubian" }
-            }
+            objects.routePattern(closeBusRoute) { representativeTrip { headsign = "Nubian" } }
         val farBusPattern =
-            objects.routePattern(farBusRoute) {
-                sortOrder = 1
-                representativeTrip { headsign = "Malden Center" }
-            }
+            objects.routePattern(farBusRoute) { representativeTrip { headsign = "Malden Center" } }
 
         val staticData =
             NearbyStaticData.build {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteTest.kt
@@ -43,33 +43,28 @@ class RouteTest {
     }
 
     @Test
-    fun `relevanceComparator sorts pinned then subway then rest`() {
+    fun `relevanceComparator sorts pinned then subway then rest in original order`() {
         val pinnedSubway: Route = route {
             type = RouteType.HEAVY_RAIL
             id = "pinned_subway"
-            sortOrder = 5
         }
         val subway = route {
             type = RouteType.HEAVY_RAIL
             id = "subway"
-            sortOrder = 4
         }
 
         val pinnedBus = route {
             type = RouteType.BUS
             id = "pinned_bus"
-            sortOrder = 3
         }
         val bus = route {
             type = RouteType.BUS
             id = "bus"
-            sortOrder = 2
         }
 
         val cr = route {
             type = RouteType.COMMUTER_RAIL
             id = "cr"
-            sortOrder = 1
         }
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -218,10 +218,17 @@ class StopDetailsDeparturesTest {
             }
 
         val routeNotPinned = objects.route { sortOrder = 1 }
-        val routePattern2 =
+        val routeNotPinnedPattern =
             objects.routePattern(routeNotPinned) {
                 typicality = RoutePattern.Typicality.Typical
                 representativeTrip { headsign = "B" }
+            }
+
+        val routeNotPinned2 = objects.route { sortOrder = 2 }
+        val routeNotPinnedPattern2 =
+            objects.routePattern(routeNotPinned2) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "C" }
             }
 
         val stop = objects.stop()
@@ -245,7 +252,19 @@ class StopDetailsDeparturesTest {
                             PatternsByHeadsign(
                                 routeNotPinned,
                                 "B",
-                                listOf(routePattern2),
+                                listOf(routeNotPinnedPattern),
+                                listOf()
+                            ),
+                        )
+                    ),
+                    PatternsByStop(
+                        routeNotPinned2,
+                        stop,
+                        listOf(
+                            PatternsByHeadsign(
+                                routeNotPinned2,
+                                "C",
+                                listOf(routeNotPinnedPattern2),
                                 listOf()
                             ),
                         )
@@ -256,7 +275,14 @@ class StopDetailsDeparturesTest {
                 stop,
                 GlobalResponse(
                     objects,
-                    mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    mapOf(
+                        stop.id to
+                            listOf(
+                                routePattern1.id,
+                                routeNotPinnedPattern2.id,
+                                routeNotPinnedPattern.id
+                            )
+                    )
                 ),
                 ScheduleResponse(objects),
                 PredictionsStreamDataResponse(objects),


### PR DESCRIPTION
### Summary

A fix for https://github.com/mbta/mobile_app/pull/241. That PR included a change to default sort on route `sortOrder`, which was the desired behavior for the Stop Details page. That is *not* the desired behavior for the Nearby Transit page where this logic also applied. This resulted in the Nearby Page showing routes in `sortOrder` rather than from closest to furthest as expected.

### Testing
Updated unit tests, confirmed the modified `NearbyResponseTest` test fails without the change to `relevanceComparator` applied.

Ran locally for the case identified in [this slack thread](https://mbta.slack.com/archives/C06LDM085DZ/p1719150086745729) and confirmed routes displayed in the expected order.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
