### PR TITLE
feat: add Appcues integration

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -10,3 +10,7 @@ export FIREBASE_KEY=
 # Find DSN under the Client Keys settings of the mobile_app_ios project in Sentry
 export SENTRY_DSN=
 export SENTRY_ENVIRONMENT=debug
+
+# Appcues - needed only to show surveys via Appcues
+export APPCUES_ACCOUNT_ID=
+export APPCUES_APP_ID=

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -70,3 +70,5 @@ touch .envrc
 echo "export SENTRY_DSN=${SENTRY_DSN}" >> .envrc
 echo "export SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}" >> .envrc
 echo "export FIREBASE_KEY=${FIREBASE_KEY}" >> .envrc
+echo "export APPCUES_ACCOUNT_ID=${APPCUES_ACCOUNT_ID}" >> .envrc
+echo "export APPCUES_APP_ID=${APPCUES_APP_ID}" >> .envrc

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		8CB28DAE2C29DCBF0036258E /* ChildStopLayerGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DAD2C29DCBF0036258E /* ChildStopLayerGenerator.swift */; };
 		8CB28DB02C29EE1F0036258E /* ChildStopIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DAF2C29EE1F0036258E /* ChildStopIcons.swift */; };
 		8CB28DB22C2A288E0036258E /* ChildStopSourceGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DB12C2A288E0036258E /* ChildStopSourceGeneratorTests.swift */; };
+		8CB28DB52C2B2DEC0036258E /* AppcuesKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CB28DB42C2B2DEC0036258E /* AppcuesKit */; };
 		8CB823D62BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D52BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift */; };
 		8CB823D92BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D82BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift */; };
 		8CB823DB2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823DA2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift */; };
@@ -398,6 +399,7 @@
 			files = (
 				6E55C1822C2489030086A424 /* Collections in Frameworks */,
 				9A8B34B02B892C810018412C /* Polyline in Frameworks */,
+				8CB28DB52C2B2DEC0036258E /* AppcuesKit in Frameworks */,
 				9AB3F50D2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */,
 				6EE745812B965AEA0052227E /* SwiftPhoenixClient in Frameworks */,
 				6E35D4CE2B72C74500A2BF95 /* MapboxMaps in Frameworks */,
@@ -916,6 +918,7 @@
 				6EE745802B965AEA0052227E /* SwiftPhoenixClient */,
 				9AB3F50C2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport */,
 				6E55C1812C2489030086A424 /* Collections */,
+				8CB28DB42C2B2DEC0036258E /* AppcuesKit */,
 			);
 			productName = iosApp;
 			productReference = 7555FF7B242A565900829871 /* iosApp.app */;
@@ -961,6 +964,7 @@
 				6EE7457F2B965AEA0052227E /* XCRemoteSwiftPackageReference "SwiftPhoenixClient" */,
 				9AB3F50B2BE44B49008D9E40 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				6E55C1802C2489030086A424 /* XCRemoteSwiftPackageReference "swift-collections" */,
+				8CB28DB32C2B2DEC0036258E /* XCRemoteSwiftPackageReference "appcues-ios-sdk" */,
 			);
 			productRefGroup = 7555FF7C242A565900829871 /* Products */;
 			projectDirPath = "";
@@ -1983,6 +1987,14 @@
 				minimumVersion = 0.9.11;
 			};
 		};
+		8CB28DB32C2B2DEC0036258E /* XCRemoteSwiftPackageReference "appcues-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/appcues/appcues-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.2.0;
+			};
+		};
 		9A8B34AE2B892C810018412C /* XCRemoteSwiftPackageReference "Polyline" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/raphaelmor/Polyline.git";
@@ -2021,6 +2033,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6EED5EAC2B3E1BA80052A1B8 /* XCRemoteSwiftPackageReference "ViewInspector" */;
 			productName = ViewInspector;
+		};
+		8CB28DB42C2B2DEC0036258E /* AppcuesKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8CB28DB32C2B2DEC0036258E /* XCRemoteSwiftPackageReference "appcues-ios-sdk" */;
+			productName = AppcuesKit;
 		};
 		9A8B34AF2B892C810018412C /* Polyline */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "appcues-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appcues/appcues-ios-sdk",
+      "state" : {
+        "revision" : "5b3668a18154dcfc37a5b551658c29985a5f80e1",
+        "version" : "3.2.0"
+      }
+    },
+    {
       "identity" : "firebase-ios-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",


### PR DESCRIPTION
### Summary

_Ticket:_ [Add Appcues to iOS app](https://app.asana.com/0/1205732265579288/1207114848419517/f)

Adds Appcues integration. I've set up the Xcode Cloud environment for the deploy-`main`-to-staging and deploy-tags-to-prod workflows and specifically not for the PR review workflow; the PR workflow should only run the app in debug mode, so that shouldn't waste any resources even if it had the config, but there's no point giving it the config anyway.

### Testing

Manually validated that local release builds with the `.envrc` properly configured show the test survey. To make a local release build, edit the Staging scheme and change the build configuration from `StagingDebug` to `StagingRelease`.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
