### PR TITLE
feat: draw vehicles on trip details map

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		8CB28DB02C29EE1F0036258E /* ChildStopIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DAF2C29EE1F0036258E /* ChildStopIcons.swift */; };
 		8CB28DB22C2A288E0036258E /* ChildStopSourceGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DB12C2A288E0036258E /* ChildStopSourceGeneratorTests.swift */; };
 		8CB28DB52C2B2DEC0036258E /* AppcuesKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8CB28DB42C2B2DEC0036258E /* AppcuesKit */; };
+		8CB28DB92C2CC5AD0036258E /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DB82C2CC5AD0036258E /* MapViewModel.swift */; };
 		8CB823D62BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D52BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift */; };
 		8CB823D92BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D82BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift */; };
 		8CB823DB2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823DA2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift */; };
@@ -279,6 +280,7 @@
 		8CB28DAD2C29DCBF0036258E /* ChildStopLayerGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildStopLayerGenerator.swift; sourceTree = "<group>"; };
 		8CB28DAF2C29EE1F0036258E /* ChildStopIcons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildStopIcons.swift; sourceTree = "<group>"; };
 		8CB28DB12C2A288E0036258E /* ChildStopSourceGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChildStopSourceGeneratorTests.swift; sourceTree = "<group>"; };
+		8CB28DB82C2CC5AD0036258E /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		8CB823D52BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetNavigationStackEntryTests.swift; sourceTree = "<group>"; };
 		8CB823D82BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsRouteViewTests.swift; sourceTree = "<group>"; };
 		8CB823DA2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsRoutesViewTests.swift; sourceTree = "<group>"; };
@@ -719,6 +721,7 @@
 				8CB28DAB2C29D6240036258E /* ChildStopSourceGenerator.swift */,
 				8CB28DAD2C29DCBF0036258E /* ChildStopLayerGenerator.swift */,
 				8CB28DAF2C29EE1F0036258E /* ChildStopIcons.swift */,
+				8CB28DB82C2CC5AD0036258E /* MapViewModel.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -1197,6 +1200,7 @@
 				9A5B275C2BB237DE009A6FC6 /* RecenterButton.swift in Sources */,
 				6E99CBB72B9892C80047E78D /* SocketProvider.swift in Sources */,
 				9A15DA3F2BF51BB7003A861C /* HomeMapViewHandlerExtension.swift in Sources */,
+				8CB28DB92C2CC5AD0036258E /* MapViewModel.swift in Sources */,
 				9A17D42C2C0A4F8100F4A745 /* MapDefaults.swift in Sources */,
 				8CB28DB02C29EE1F0036258E /* ChildStopIcons.swift in Sources */,
 				9A6DDF912B976FDF004D141A /* EmptyWhenModifier.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @EnvironmentObject var viewportProvider: ViewportProvider
     @State private var sheetHeight: CGFloat = UIScreen.main.bounds.height / 2
     @StateObject var nearbyVM: NearbyViewModel = .init()
+    @StateObject var mapVM = MapViewModel()
 
     private enum SelectedTab: Hashable {
         case nearby
@@ -79,6 +80,7 @@ struct ContentView: View {
             }
             HomeMapView(
                 globalFetcher: globalFetcher,
+                mapVM: mapVM,
                 nearbyVM: nearbyVM,
                 railRouteShapeFetcher: railRouteShapeFetcher,
                 vehiclesFetcher: vehiclesFetcher,
@@ -114,13 +116,20 @@ struct ContentView: View {
                                 visibleNearbySheet = entry
                             }
 
-                        case let .tripDetails(tripId: tripId, vehicleId: vehicleId, target: target):
+                        case let .tripDetails(
+                            tripId: tripId,
+                            vehicleId: vehicleId,
+                            target: target,
+                            routeId: _,
+                            directionId: _
+                        ):
                             TripDetailsPage(
                                 tripId: tripId,
                                 vehicleId: vehicleId,
                                 target: target,
                                 globalFetcher: globalFetcher,
-                                nearbyVM: nearbyVM
+                                nearbyVM: nearbyVM,
+                                mapVM: mapVM
                             ).onAppear {
                                 visibleNearbySheet = entry
                             }

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct HomeMapView: View {
     var analytics: NearbyTransitAnalytics = AnalyticsProvider()
     @ObservedObject var globalFetcher: GlobalFetcher
+    @ObservedObject var mapVM: MapViewModel
     @ObservedObject var nearbyVM: NearbyViewModel
     @ObservedObject var railRouteShapeFetcher: RailRouteShapeFetcher
     @ObservedObject var vehiclesFetcher: VehiclesFetcher
@@ -44,6 +45,7 @@ struct HomeMapView: View {
 
     init(
         globalFetcher: GlobalFetcher,
+        mapVM: MapViewModel,
         nearbyVM: NearbyViewModel,
         railRouteShapeFetcher: RailRouteShapeFetcher,
         vehiclesFetcher: VehiclesFetcher,
@@ -54,6 +56,7 @@ struct HomeMapView: View {
         layerManager: IMapLayerManager? = nil
     ) {
         self.globalFetcher = globalFetcher
+        self.mapVM = mapVM
         self.nearbyVM = nearbyVM
         self.railRouteShapeFetcher = railRouteShapeFetcher
         self.vehiclesFetcher = vehiclesFetcher
@@ -123,13 +126,18 @@ struct HomeMapView: View {
 
     @ViewBuilder
     var annotatedMap: some View {
+        let selectedVehicle: Vehicle? = if case .tripDetails = nearbyVM.navigationStack.last {
+            mapVM.selectedVehicle
+        } else { nil }
+        let vehicles: [Vehicle]? = vehiclesFetcher.vehicles?.filter { $0.id != selectedVehicle?.id }
         AnnotatedMap(
             stopMapData: stopMapData,
             filter: nearbyVM.navigationStack.lastStopDetailsFilter,
             nearbyLocation: isNearbyNotFollowing ? nearbyVM.nearbyState.loadedLocation : nil,
             routes: globalFetcher.routes,
+            selectedVehicle: selectedVehicle,
             sheetHeight: sheetHeight,
-            vehicles: vehiclesFetcher.vehicles,
+            vehicles: vehicles,
             viewportProvider: viewportProvider,
             handleCameraChange: handleCameraChange,
             handleTapStopLayer: handleTapStopLayer,

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -71,7 +71,12 @@ extension HomeMapView {
 
     func handleNavStackChange(navigationStack: [SheetNavigationStackEntry]) {
         if let filter = navigationStack.lastStopDetailsFilter {
+            vehiclesFetcher.leave()
             vehiclesFetcher.run(routeId: filter.routeId, directionId: Int(filter.directionId))
+        } else if case let .tripDetails(tripId: _, vehicleId: _, target: _, routeId: routeId,
+                                        directionId: directionId) = navigationStack.last {
+            vehiclesFetcher.leave()
+            vehiclesFetcher.run(routeId: routeId, directionId: Int(directionId))
         } else {
             vehiclesFetcher.leave()
         }
@@ -168,7 +173,10 @@ extension HomeMapView {
             nearbyVM.navigationStack.append(.tripDetails(
                 tripId: tripId,
                 vehicleId: vehicle.id,
-                target: nil
+                target: nil,
+                // TODO: figure out something to do if this is nil
+                routeId: vehicle.routeId!,
+                directionId: vehicle.directionId
             ))
             return
         }
@@ -179,7 +187,9 @@ extension HomeMapView {
             target: .init(
                 stopId: patterns.stop.id,
                 stopSequence: stopSequence
-            )
+            ),
+            routeId: trip.trip.routeId,
+            directionId: trip.trip.directionId
         ))
     }
 }

--- a/iosApp/iosApp/Pages/Map/MapViewModel.swift
+++ b/iosApp/iosApp/Pages/Map/MapViewModel.swift
@@ -1,0 +1,14 @@
+//
+//  MapViewModel.swift
+//  iosApp
+//
+//  Created by Horn, Melody on 2024-06-26.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import shared
+
+class MapViewModel: ObservableObject {
+    @Published var selectedVehicle: Vehicle?
+}

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
@@ -37,7 +37,8 @@ struct StopDetailsFilteredRouteView: View {
 
             if let vehicleId = upcoming.prediction?.vehicleId, let stopSequence = upcoming.stopSequence {
                 navigationTarget = .tripDetails(tripId: tripId, vehicleId: vehicleId,
-                                                target: .init(stopId: stopId, stopSequence: stopSequence.intValue))
+                                                target: .init(stopId: stopId, stopSequence: stopSequence.intValue),
+                                                routeId: upcoming.trip.routeId, directionId: upcoming.trip.directionId)
             } else {
                 navigationTarget = nil
             }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -18,6 +18,7 @@ struct TripDetailsPage: View {
 
     @ObservedObject var globalFetcher: GlobalFetcher
     @ObservedObject var nearbyVM: NearbyViewModel
+    @ObservedObject var mapVM: MapViewModel
     @State var tripPredictionsRepository: ITripPredictionsRepository
     @State var tripPredictions: PredictionsStreamDataResponse?
     @State var tripSchedulesRepository: ITripSchedulesRepository
@@ -35,6 +36,7 @@ struct TripDetailsPage: View {
         target: TripDetailsTarget?,
         globalFetcher: GlobalFetcher,
         nearbyVM: NearbyViewModel,
+        mapVM: MapViewModel,
         tripPredictionsRepository: ITripPredictionsRepository = RepositoryDI().tripPredictions,
         tripSchedulesRepository: ITripSchedulesRepository = RepositoryDI().tripSchedules,
         vehicleRepository: IVehicleRepository = RepositoryDI().vehicle
@@ -44,6 +46,7 @@ struct TripDetailsPage: View {
         self.target = target
         self.globalFetcher = globalFetcher
         self.nearbyVM = nearbyVM
+        self.mapVM = mapVM
         self.tripPredictionsRepository = tripPredictionsRepository
         self.tripSchedulesRepository = tripSchedulesRepository
         self.vehicleRepository = vehicleRepository
@@ -140,6 +143,7 @@ struct TripDetailsPage: View {
             DispatchQueue.main.async {
                 if let data = outcome.data {
                     vehicleResponse = data
+                    mapVM.selectedVehicle = data.vehicle
                 } else {
                     vehicleResponse = nil
                 }
@@ -149,6 +153,9 @@ struct TripDetailsPage: View {
 
     private func leaveVehicle() {
         vehicleRepository.disconnect()
+        if mapVM.selectedVehicle?.id == vehicleId {
+            mapVM.selectedVehicle = nil
+        }
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -21,7 +21,7 @@ struct TripDetailsTarget: Hashable {
 
 enum SheetNavigationStackEntry: Hashable, Identifiable {
     case stopDetails(Stop, StopDetailsFilter?)
-    case tripDetails(tripId: String, vehicleId: String, target: TripDetailsTarget?)
+    case tripDetails(tripId: String, vehicleId: String, target: TripDetailsTarget?, routeId: String, directionId: Int32)
     case nearby
 
     var id: Int {
@@ -51,7 +51,7 @@ struct NearbySheetItem: Identifiable {
     var id: String {
         switch stackEntry {
         case let .stopDetails(stop, _): stop.id
-        case let .tripDetails(tripId, _, _): tripId
+        case let .tripDetails(tripId, _, _, _, _): tripId
         case .nearby: "nearby"
         }
     }

--- a/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
+++ b/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
@@ -25,6 +25,7 @@ final class HomeMapViewTest: XCTestCase {
 
         let sut = HomeMapView(
             globalFetcher: .init(backend: IdleBackend()),
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: .init(backend: IdleBackend()),
             vehiclesFetcher: .init(socket: MockSocket()),

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
@@ -111,7 +111,9 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
         let expected = SheetNavigationStackEntry.tripDetails(
             tripId: data.tripNorthId,
             vehicleId: data.vehicleNorthId,
-            target: .init(stopId: data.stopId, stopSequence: data.stopSequence)
+            target: .init(stopId: data.stopId, stopSequence: data.stopSequence),
+            routeId: data.routeId,
+            directionId: 0
         )
 
         func pushNavEntry(entry: SheetNavigationStackEntry) {

--- a/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
+++ b/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
@@ -44,7 +44,13 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         let previousEntries: [SheetNavigationStackEntry] = [
             .stopDetails(otherStop, .init(routeId: "A", directionId: 1)),
             .stopDetails(otherStop, .init(routeId: "B", directionId: 1)),
-            .tripDetails(tripId: "345", vehicleId: "abc", target: .init(stopId: "999", stopSequence: 111)),
+            .tripDetails(
+                tripId: "345",
+                vehicleId: "abc",
+                target: .init(stopId: "999", stopSequence: 111),
+                routeId: "Z",
+                directionId: 1
+            ),
             .stopDetails(otherStop, .init(routeId: "C", directionId: 0)),
             .stopDetails(otherStop, .init(routeId: "D", directionId: 0)),
         ]
@@ -66,7 +72,7 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         var stack: [SheetNavigationStackEntry] = [
             .stopDetails(stop, .init(routeId: "A", directionId: 1)),
             .stopDetails(stop, .init(routeId: "B", directionId: 0)),
-            .tripDetails(tripId: "a", vehicleId: "1", target: nil),
+            .tripDetails(tripId: "a", vehicleId: "1", target: nil, routeId: "C", directionId: 1),
         ]
 
         XCTAssertEqual(stack.lastStopDetailsFilter, nil)
@@ -80,7 +86,13 @@ final class SheetNavigationStackEntryTests: XCTestCase {
     func testNearbySheetItemIdentifable() throws {
         let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         let stopEntry: SheetNavigationStackEntry = .stopDetails(stop, .init(routeId: "A", directionId: 1))
-        let tripEntry: SheetNavigationStackEntry = .tripDetails(tripId: "tripId", vehicleId: "vehicleId", target: nil)
+        let tripEntry: SheetNavigationStackEntry = .tripDetails(
+            tripId: "tripId",
+            vehicleId: "vehicleId",
+            target: nil,
+            routeId: "routeId",
+            directionId: 0
+        )
 
         let nearbyEntry: SheetNavigationStackEntry = .nearby
 

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -27,6 +27,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         let sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -48,6 +49,7 @@ final class HomeMapViewTests: XCTestCase {
 
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -96,6 +98,7 @@ final class HomeMapViewTests: XCTestCase {
 
         var sut = HomeMapView(
             globalFetcher: FakeGlobalFetcher(),
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: FakeRailRouteShapeFetcher(
                 getRailRouteShapeExpectation: getRailRouteShapeExpectation
@@ -122,6 +125,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(navigationStack: [.stopDetails(stop, nil)]),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -148,6 +152,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -239,6 +244,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -288,6 +294,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -359,6 +366,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -436,6 +444,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: nearbyVM,
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket(), vehicles: [vehicle]),
@@ -450,7 +459,9 @@ final class HomeMapViewTests: XCTestCase {
             XCTAssertEqual(nearbyVM.navigationStack.last, .tripDetails(
                 tripId: trip.id,
                 vehicleId: vehicle.id,
-                target: .init(stopId: stop.id, stopSequence: Int(prediction.stopSequence))
+                target: .init(stopId: stop.id, stopSequence: Int(prediction.stopSequence)),
+                routeId: trip.routeId,
+                directionId: trip.directionId
             ))
         }
 
@@ -496,6 +507,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         var sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(navigationStack: [.stopDetails(stop, nil)]),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),
@@ -537,6 +549,7 @@ final class HomeMapViewTests: XCTestCase {
         let viewportProvider: ViewportProvider = FakeViewportProvider(updateCameraExpectation: updateCameraExpectation)
         let sut = HomeMapView(
             globalFetcher: globalFetcher,
+            mapVM: .init(),
             nearbyVM: .init(),
             railRouteShapeFetcher: railRouteShapeFetcher,
             vehiclesFetcher: .init(socket: MockSocket()),

--- a/iosApp/iosAppTests/Views/OptionalNavigationLinkTests.swift
+++ b/iosApp/iosAppTests/Views/OptionalNavigationLinkTests.swift
@@ -13,7 +13,13 @@ import XCTest
 
 final class OptionalNavigationLinkTests: XCTestCase {
     func testIsLink() throws {
-        let target = SheetNavigationStackEntry.tripDetails(tripId: "1", vehicleId: "a", target: nil)
+        let target = SheetNavigationStackEntry.tripDetails(
+            tripId: "1",
+            vehicleId: "a",
+            target: nil,
+            routeId: "Z",
+            directionId: 1
+        )
 
         let tappedExp = XCTestExpectation(description: "Nav link button tapped with target")
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Display vehicle positions on map](https://app.asana.com/0/1205732265579288/1207160272394269/f)

Stacked on #259. Draws the selected vehicle at a larger scale (acceptance criteria call for a different icon but I don't want to make a different icon myself), and draws all vehicles on the selected trip's route and direction.

### Testing

Added a test to ensure that the page will keep the map view model up to date with the selected vehicle's information.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
