### PR TITLE
fix: unify screen tracking + pinned route tracking improvements

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		ED87C88F2C10F4B1009D398F /* SocketErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED87C88E2C10F4B1009D398F /* SocketErrorExtension.swift */; };
 		ED98F6332BD6E26F006EBDF5 /* MockPinnedRoutesRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED98F6322BD6E26F006EBDF5 /* MockPinnedRoutesRepository.swift */; };
 		EDC768C72BCF6FD6008BAE58 /* RouteCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDC768C62BCF6FD6008BAE58 /* RouteCard.swift */; };
+		EDE92FA62C3DD675007AD2F6 /* ScreenTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE92FA52C3DD675007AD2F6 /* ScreenTracker.swift */; };
 		EDEEFA9E2BEC5F6D007FDA06 /* PredictionsErrorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEEFA9D2BEC5F6D007FDA06 /* PredictionsErrorExtension.swift */; };
 /* End PBXBuildFile section */
 
@@ -390,6 +391,7 @@
 		ED87C88E2C10F4B1009D398F /* SocketErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketErrorExtension.swift; sourceTree = "<group>"; };
 		ED98F6322BD6E26F006EBDF5 /* MockPinnedRoutesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPinnedRoutesRepository.swift; sourceTree = "<group>"; };
 		EDC768C62BCF6FD6008BAE58 /* RouteCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteCard.swift; sourceTree = "<group>"; };
+		EDE92FA52C3DD675007AD2F6 /* ScreenTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTracker.swift; sourceTree = "<group>"; };
 		EDEEFA9D2BEC5F6D007FDA06 /* PredictionsErrorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionsErrorExtension.swift; sourceTree = "<group>"; };
 		F35CF19A11F0511AA7B2E080 /* Pods-iosApp.stagingdebug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.stagingdebug.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.stagingdebug.xcconfig"; sourceTree = "<group>"; };
 		F71252D2B68FF131F8E6BDE2 /* Pods-iosAppTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.release.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -869,6 +871,7 @@
 				ED24EAD72C1A941E00A7BE4D /* NearbyTransitAnalytics.swift */,
 				ED24EADB2C1A95A900A7BE4D /* StopDetailsAnalytics.swift */,
 				ED24EADD2C1A986900A7BE4D /* AnalyticsProvider.swift */,
+				EDE92FA52C3DD675007AD2F6 /* ScreenTracker.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -1286,6 +1289,7 @@
 				8C815AF32BF5257B009BB51C /* TripDetailsStopListView.swift in Sources */,
 				8C3D64102BE19DBA0026DD53 /* SettingsPage.swift in Sources */,
 				9A5B275A2BB22D91009A6FC6 /* StopLayerGenerator.swift in Sources */,
+				EDE92FA62C3DD675007AD2F6 /* ScreenTracker.swift in Sources */,
 				8CA1FB752BF7EB3500384658 /* TripDetailsStopListSplitView.swift in Sources */,
 				8CE014122BBDB96900918FAE /* StopDetailsRouteView.swift in Sources */,
 				ED87C88F2C10F4B1009D398F /* SocketErrorExtension.swift in Sources */,

--- a/iosApp/iosApp/Analytics/AnalyticsProvider.swift
+++ b/iosApp/iosApp/Analytics/AnalyticsProvider.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import AppcuesKit
 import FirebaseAnalytics
 import Foundation
 

--- a/iosApp/iosApp/Analytics/NearbyTransitAnalytics.swift
+++ b/iosApp/iosApp/Analytics/NearbyTransitAnalytics.swift
@@ -11,7 +11,7 @@ import Foundation
 
 protocol NearbyTransitAnalytics {
     func toggledPinnedRoute(pinned: Bool, routeId: String)
-    func tappedDeparture(routeId: String, stopId: String)
+    func tappedDeparture(routeId: String, stopId: String, pinned: Bool)
     func refetchedNearbyTransit()
     func tappedOnStop(stopId: String)
 }
@@ -26,12 +26,13 @@ extension AnalyticsProvider: NearbyTransitAnalytics {
         )
     }
 
-    func tappedDeparture(routeId: String, stopId: String) {
+    func tappedDeparture(routeId: String, stopId: String, pinned: Bool) {
         logEvent(
             "tapped_departure",
             parameters: [
                 "route_id": routeId,
                 "stop_id": stopId,
+                "pinned": pinned,
             ]
         )
     }

--- a/iosApp/iosApp/Analytics/ScreenTracker.swift
+++ b/iosApp/iosApp/Analytics/ScreenTracker.swift
@@ -1,0 +1,38 @@
+//
+//  ScreenTracker.swift
+//  iosApp
+//
+//  Created by Brandon Rodriguez on 7/9/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import AppcuesKit
+import FirebaseAnalytics
+import Foundation
+
+enum AnalyticsScreen: String {
+    case nearbyTransit = "NearbyTransitPage"
+    case tripDetails = "TripDetailsPage"
+    case stopDetails = "StopDetailsPage"
+    case settings = "SettingsPage"
+}
+
+protocol ScreenTracker {
+    func track(screen: AnalyticsScreen)
+}
+
+extension AnalyticsProvider: ScreenTracker {
+    private var appcues: Appcues? {
+        (UIApplication.shared.delegate as? AppDelegate)?.appcues
+    }
+
+    func track(screen: AnalyticsScreen) {
+        Analytics.logEvent(
+            AnalyticsEventScreenView,
+            parameters: [
+                AnalyticsParameterScreenName: screen.rawValue,
+            ]
+        )
+        appcues?.screen(title: screen.rawValue)
+    }
+}

--- a/iosApp/iosApp/Analytics/StopDetailsAnalytics.swift
+++ b/iosApp/iosApp/Analytics/StopDetailsAnalytics.swift
@@ -10,17 +10,18 @@ import FirebaseAnalytics
 import Foundation
 
 protocol StopDetailsAnalytics {
-    func tappedDepartureRow(routeId: String, stopId: String)
+    func tappedDepartureRow(routeId: String, stopId: String, pinned: Bool)
     func tappedRouteFilter(routeId: String, stopId: String)
 }
 
 extension AnalyticsProvider: StopDetailsAnalytics {
-    func tappedDepartureRow(routeId: String, stopId: String) {
+    func tappedDepartureRow(routeId: String, stopId: String, pinned: Bool) {
         logEvent(
             "tapped_departure",
             parameters: [
                 "route_id": routeId,
                 "stop_id": stopId,
+                "pinned": pinned,
             ]
         )
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -8,7 +8,6 @@ struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     let platform = Platform_iosKt.getPlatform().name
-    @EnvironmentObject var appcuesContainer: AppcuesContainer
     @EnvironmentObject var locationDataManager: LocationDataManager
     @EnvironmentObject var backendProvider: BackendProvider
     @EnvironmentObject var railRouteShapeFetcher: RailRouteShapeFetcher
@@ -18,6 +17,7 @@ struct ContentView: View {
     @State private var sheetHeight: CGFloat = UIScreen.main.bounds.height / 2
     @StateObject var nearbyVM: NearbyViewModel = .init()
     @StateObject var mapVM = MapViewModel()
+    var screenTracker: ScreenTracker = AnalyticsProvider()
 
     private enum SelectedTab: Hashable {
         case nearby
@@ -36,7 +36,7 @@ struct ContentView: View {
                     .tag(SelectedTab.settings)
                     .tabItem { Label("Settings", systemImage: "gear") }
                     .onAppear {
-                        appcuesContainer.appcues?.screen(title: "SettingsPage")
+                        screenTracker.track(screen: .settings)
                     }
             }
         } else {
@@ -115,7 +115,7 @@ struct ContentView: View {
                                 nearbyVM: nearbyVM
                             ).onAppear {
                                 visibleNearbySheet = entry
-                                appcuesContainer.appcues?.screen(title: "StopDetailsPage")
+                                screenTracker.track(screen: .stopDetails)
                             }
 
                         case let .tripDetails(
@@ -132,8 +132,7 @@ struct ContentView: View {
                                 nearbyVM: nearbyVM,
                                 mapVM: mapVM
                             ).onAppear {
-                                appcuesContainer.appcues?.screen(title: "TripDetailsPage")
-
+                                screenTracker.track(screen: .tripDetails)
                                 visibleNearbySheet = entry
                             }
 
@@ -141,7 +140,7 @@ struct ContentView: View {
                             nearbySheetContents
                                 .onAppear {
                                     visibleNearbySheet = entry
-                                    appcuesContainer.appcues?.screen(title: "NearbyTransitPage")
+                                    screenTracker.track(screen: .nearbyTransit)
                                 }
                         }
                     }

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -37,14 +37,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     }
 }
 
-class AppcuesContainer: ObservableObject {
-    var appcues: Appcues?
-
-    init(appcues: Appcues?) {
-        self.appcues = appcues
-    }
-}
-
 @main
 struct IOSApp: App {
     // register app delegate for Firebase setup
@@ -63,7 +55,6 @@ struct IOSApp: App {
                     .onAppear {
                         delegate.appcues?.anonymous()
                     }
-                    .environmentObject(AppcuesContainer(appcues: delegate.appcues))
             }
         }
     }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyRouteView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyRouteView.swift
@@ -20,7 +20,12 @@ struct NearbyRouteView: View {
         RouteCard(route: nearbyRoute.route, pinned: pinned, onPin: onPin) {
             ForEach(Array(nearbyRoute.patternsByStop.enumerated()), id: \.element.stop.id) { index, patternsAtStop in
                 VStack(spacing: 0) {
-                    NearbyStopView(patternsAtStop: patternsAtStop, now: now, pushNavEntry: pushNavEntry)
+                    NearbyStopView(
+                        patternsAtStop: patternsAtStop,
+                        now: now,
+                        pushNavEntry: pushNavEntry,
+                        pinned: pinned
+                    )
                     if index < nearbyRoute.patternsByStop.count - 1 {
                         Divider().background(Color.halo)
                     }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
@@ -15,17 +15,20 @@ struct NearbyStopView: View {
     let condenseHeadsignPredictions: Bool
     let now: Instant
     let pushNavEntry: (SheetNavigationStackEntry) -> Void
+    let pinned: Bool
 
     init(
         patternsAtStop: PatternsByStop,
         condenseHeadsignPredictions: Bool = false,
         now: Instant,
-        pushNavEntry: @escaping (SheetNavigationStackEntry) -> Void
+        pushNavEntry: @escaping (SheetNavigationStackEntry) -> Void,
+        pinned: Bool
     ) {
         self.patternsAtStop = patternsAtStop
         self.condenseHeadsignPredictions = condenseHeadsignPredictions
         self.now = now
         self.pushNavEntry = pushNavEntry
+        self.pinned = pinned
     }
 
     var body: some View {
@@ -42,7 +45,11 @@ struct NearbyStopView: View {
             now: now,
             pushNavEntry: { entry in
                 pushNavEntry(entry)
-                analytics.tappedDeparture(routeId: patternsAtStop.routeIdentifier, stopId: patternsAtStop.stop.id)
+                analytics.tappedDeparture(
+                    routeId: patternsAtStop.routeIdentifier,
+                    stopId: patternsAtStop.stop.id,
+                    pinned: pinned
+                )
             }
         )
     }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
@@ -16,6 +16,7 @@ struct StopDetailsFilteredRouteView: View {
     let now: Instant
     @Binding var filter: StopDetailsFilter?
     let pushNavEntry: (SheetNavigationStackEntry) -> Void
+    let pinned: Bool
 
     struct RowData {
         let tripId: String
@@ -53,15 +54,20 @@ struct StopDetailsFilteredRouteView: View {
 
     let rows: [RowData]
 
-    init(departures: StopDetailsDepartures, now: Instant, filter filterBinding: Binding<StopDetailsFilter?>,
-         pushNavEntry: @escaping (SheetNavigationStackEntry) -> Void) {
+    init(
+        departures: StopDetailsDepartures,
+        now: Instant,
+        filter filterBinding: Binding<StopDetailsFilter?>,
+        pushNavEntry: @escaping (SheetNavigationStackEntry) -> Void,
+        pinned: Bool
+    ) {
         _filter = filterBinding
         let filter = filterBinding.wrappedValue
         let patternsByStop = departures.routes.first(where: { $0.routeIdentifier == filter?.routeId })
         self.patternsByStop = patternsByStop
         self.now = now
         self.pushNavEntry = pushNavEntry
-
+        self.pinned = pinned
         let expectedDirection: Int32? = filter?.directionId
         if let patternsByStop {
             rows = patternsByStop.allUpcomingTrips().compactMap { upcoming in
@@ -114,7 +120,8 @@ struct StopDetailsFilteredRouteView: View {
                                             pushNavEntry(entry)
                                             analytics.tappedDepartureRow(
                                                 routeId: patternsByStop.routeIdentifier,
-                                                stopId: patternsByStop.stop.id
+                                                stopId: patternsByStop.stop.id,
+                                                pinned: pinned
                                             )
                                         }) {
                                             HeadsignRowView(

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
@@ -19,8 +19,14 @@ struct StopDetailsRoutesView: View {
     var pinnedRoutes: Set<String> = []
 
     var body: some View {
-        if filter != nil {
-            StopDetailsFilteredRouteView(departures: departures, now: now, filter: $filter, pushNavEntry: pushNavEntry)
+        if let filter {
+            StopDetailsFilteredRouteView(
+                departures: departures,
+                now: now,
+                filter: $filter,
+                pushNavEntry: pushNavEntry,
+                pinned: pinnedRoutes.contains(filter.routeId)
+            )
         } else {
             ZStack {
                 Color.fill1.ignoresSafeArea(.all)

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
@@ -164,7 +164,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
             departures: data.departures,
             now: data.now,
             filter: .constant(.init(routeId: data.routeId, directionId: 0)),
-            pushNavEntry: { _ in }
+            pushNavEntry: { _ in },
+            pinned: false
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "North"))
@@ -178,7 +179,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
             departures: data.departures,
             now: data.now,
             filter: .constant(.init(routeId: data.lineId, directionId: 0)),
-            pushNavEntry: { _ in }
+            pushNavEntry: { _ in },
+            pinned: false
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Trunk 1"))
@@ -209,7 +211,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
             departures: data.departures,
             now: data.now,
             filter: .constant(.init(routeId: data.routeId, directionId: 0)),
-            pushNavEntry: pushNavEntry
+            pushNavEntry: pushNavEntry,
+            pinned: false
         )
 
         try sut.inspect().find(button: "North").tap()

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -36,7 +36,6 @@ final class ContentViewTests: XCTestCase {
                                                     disconnectedExpectation: disconnectedExpectation)
 
         let sut = ContentView()
-            .environmentObject(AppcuesContainer(appcues: nil))
             .environmentObject(LocationDataManager(locationFetcher: MockLocationFetcher()))
             .environmentObject(BackendProvider(backend: IdleBackend()))
             .environmentObject(RailRouteShapeFetcher(backend: IdleBackend()))
@@ -62,7 +61,6 @@ final class ContentViewTests: XCTestCase {
                                                     disconnectedExpectation: disconnectedExpectation)
 
         let sut = ContentView()
-            .environmentObject(AppcuesContainer(appcues: nil))
             .environmentObject(LocationDataManager(locationFetcher: MockLocationFetcher()))
             .environmentObject(BackendProvider(backend: IdleBackend()))
             .environmentObject(RailRouteShapeFetcher(backend: IdleBackend()))

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -882,7 +882,8 @@ final class NearbyTransitViewTests: XCTestCase {
 
             ),
             now: Date.now.toKotlinInstant(),
-            pushNavEntry: pushNavEntry
+            pushNavEntry: pushNavEntry,
+            pinned: false
         )
 
         try sut.inspect().find(DestinationRowView.self).parent().parent().parent().button().tap()

--- a/iosApp/iosAppUITests/NearbyLineView.swift
+++ b/iosApp/iosAppUITests/NearbyLineView.swift
@@ -24,7 +24,8 @@ struct NearbyLineView: View {
                         patternsAtStop: patternsAtStop,
                         condenseHeadsignPredictions: nearbyLine.condensePredictions,
                         now: now,
-                        pushNavEntry: pushNavEntry
+                        pushNavEntry: pushNavEntry,
+                        pinned: pinned
                     )
                     if index < nearbyLine.patternsByStop.count - 1 {
                         Divider().background(Color.halo)


### PR DESCRIPTION
### Summary

_Tickets:_ 
[GA Tracking | Pinned routes](https://app.asana.com/0/1205425564113216/1207719928134874/f)
[GA screen tracking] (https://app.asana.com/0/1205425564113216/1207767703992795/f)

Unified the screen tracking for Appcues & GA. Updated tapped_departure event with pinned parameter.

### Testing

Manually tested code path to see that params are set properly