### PR TITLE
feat(HomeMapView): Filter stops in trip details view

### DIFF
--- a/iosApp/iosApp/Pages/Map/StopSourceGenerator.swift
+++ b/iosApp/iosApp/Pages/Map/StopSourceGenerator.swift
@@ -16,6 +16,7 @@ struct StopFeatureData {
 }
 
 struct StopSourceData: Equatable {
+    var filteredStopIds: [String]?
     var selectedStopId: String?
 }
 
@@ -38,7 +39,12 @@ enum StopSourceGenerator {
         stops: [String: MapStop],
         linesToSnap: [RouteLineData]
     ) -> GeoJSONSource {
-        let stopFeatures = generateStopFeatures(stopData, stops, linesToSnap)
+        let filteredStops = if let filteredStopIds = stopData.filteredStopIds {
+            stops.filter { filteredStopIds.contains($0.key) }
+        } else {
+            stops
+        }
+        let stopFeatures = generateStopFeatures(stopData, filteredStops, linesToSnap)
         return generateStopSource(stopFeatures: stopFeatures)
     }
 

--- a/iosApp/iosAppTests/Pages/Map/MapTestDataHelper.swift
+++ b/iosApp/iosAppTests/Pages/Map/MapTestDataHelper.swift
@@ -136,6 +136,14 @@ enum MapTestDataHelper {
         stop.locationType = LocationType.station
     }
 
+    static let stopAssemblyChild = objects.stop { stop in
+        stop.id = "70279"
+        stop.latitude = 42.392811
+        stop.longitude = -71.077257
+        stop.locationType = LocationType.stop
+        stop.parentStationId = stopAssembly.id
+    }
+
     static let mapStopAssembly: MapStop = .init(
         stop: stopAssembly,
         routes: [MapStopRoute.orange: [routeOrange]],

--- a/iosApp/iosAppTests/Pages/Map/StopSourceGeneratorTests.swift
+++ b/iosApp/iosAppTests/Pages/Map/StopSourceGeneratorTests.swift
@@ -214,6 +214,32 @@ final class StopSourceGeneratorTests: XCTestCase {
         }
     }
 
+    func testFilteredStopIds() {
+        let source = StopSourceGenerator.generateStopSource(stopData:
+            .init(filteredStopIds: [MapTestDataHelper.stopAlewife.id], selectedStopId: nil),
+            stops: [MapTestDataHelper.stopAlewife.id: MapTestDataHelper.stopAlewife,
+                    MapTestDataHelper.stopDavis.id: MapTestDataHelper.stopDavis].mapValues { stop in
+                MapStop(
+                    stop: stop,
+                    routes: [.red: [MapTestDataHelper.routeRed]],
+                    routeTypes: [.red],
+                    isTerminal: false,
+                    alerts: nil
+                )
+            },
+            linesToSnap: [])
+
+        if case let .featureCollection(collection) = source.data.unsafelyUnwrapped {
+            XCTAssertEqual(collection.features.count, 1)
+
+            XCTAssertNotNil(collection.features.first { feat in
+                feat.identifier == FeatureIdentifier(MapTestDataHelper.stopAlewife.id)
+            })
+        } else {
+            XCTFail("Station source had no features")
+        }
+    }
+
     func testStopsFeaturesHaveServiceStatus() {
         let objects = MapTestDataHelper.objects
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Display route shape and stops on map](https://app.asana.com/0/1205732265579288/1207160272394267/f)

What is this PR for?
Filters out stops so that only the stops for the given trip are displayed in the trip details page.

Note: The ticket references displaying child stops - opting not to for now following up on standup discussion. 
This also omits any changes to the stop labels, which can be deferred for the trip details UI work.
### Testing
* Added unit tests
* Ran locally and confirm stops filtered / unfiltered as expected 
![IMG_0117](https://github.com/mbta/mobile_app/assets/31781298/e8d29ead-02bc-4686-a676-6f2348bd4806)
![IMG_0118](https://github.com/mbta/mobile_app/assets/31781298/5ecc94f9-3522-4577-8549-acd0f2edd3a7)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
