### PR TITLE
fix(HomeMapViewTests): Fix flaky testUpdatesSourcesWhenTripSelected

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -48,9 +48,13 @@ class MockGlobalRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     val response: GlobalResponse =
-        GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap())
+        GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),
+    val onGet: () -> Unit = {}
 ) : IGlobalRepository {
-    override suspend fun getGlobalData() = response
+    override suspend fun getGlobalData(): GlobalResponse {
+        onGet()
+        return response
+    }
 }
 
 class IdleGlobalRepository : IGlobalRepository {


### PR DESCRIPTION
### Summary

No ticket, a fix to a test that was made flaky in https://github.com/mbta/mobile_app/pull/279. Caught by @boringcactus.

Determining which stops to filter to is dependent on global data, so we should wait for global data to load before making assertions.

### Testing
Updated test. It is passing locally, but the old version also passed locally, so seems like the real test will be passing in CI.
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
