### PR TITLE
refactor(map): add types for feature properties

### DIFF
--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -142,7 +142,7 @@ extension HomeMapView {
     }
 
     func handleTapStopLayer(feature: QueriedFeature, _: MapContentGestureContext) -> Bool {
-        guard case let .string(stopId) = feature.feature.properties?[StopFeaturesBuilder.shared.propIdKey] else {
+        guard case let .string(stopId) = feature.feature.properties?[StopFeaturesBuilder.shared.propIdKey.key] else {
             let featureId = feature.feature.identifier.debugDescription
             log.error("""
                 Stop icon featureId=`\(featureId)` was tapped, but had invalid stop id prop. sourceId=\(feature.source)

--- a/iosApp/iosApp/Pages/Map/MapLayerManager.swift
+++ b/iosApp/iosApp/Pages/Map/MapLayerManager.swift
@@ -14,9 +14,9 @@ import SwiftUI
 protocol IMapLayerManager {
     func addLayers(colorScheme: ColorScheme)
 
-    func updateSourceData(routeData: FeatureCollection)
-    func updateSourceData(stopData: FeatureCollection)
-    func updateSourceData(childStopData: FeatureCollection)
+    func updateSourceData(routeData: MapboxMaps.FeatureCollection)
+    func updateSourceData(stopData: MapboxMaps.FeatureCollection)
+    func updateSourceData(childStopData: MapboxMaps.FeatureCollection)
 }
 
 struct MapImageError: Error {}
@@ -72,7 +72,7 @@ class MapLayerManager: IMapLayerManager {
         }
     }
 
-    func updateSourceData(sourceId: String, data: FeatureCollection) {
+    func updateSourceData(sourceId: String, data: MapboxMaps.FeatureCollection) {
         if map.sourceExists(withId: sourceId) {
             map.updateGeoJSONSource(withId: sourceId, data: .featureCollection(data))
         } else {
@@ -82,15 +82,15 @@ class MapLayerManager: IMapLayerManager {
         }
     }
 
-    func updateSourceData(routeData: FeatureCollection) {
+    func updateSourceData(routeData: MapboxMaps.FeatureCollection) {
         updateSourceData(sourceId: RouteFeaturesBuilder.shared.routeSourceId, data: routeData)
     }
 
-    func updateSourceData(stopData: FeatureCollection) {
+    func updateSourceData(stopData: MapboxMaps.FeatureCollection) {
         updateSourceData(sourceId: StopFeaturesBuilder.shared.stopSourceId, data: stopData)
     }
 
-    func updateSourceData(childStopData: FeatureCollection) {
+    func updateSourceData(childStopData: MapboxMaps.FeatureCollection) {
         updateSourceData(sourceId: ChildStopFeaturesBuilder.shared.childStopSourceId, data: childStopData)
     }
 }

--- a/iosApp/iosApp/Pages/Map/MapViewModel.swift
+++ b/iosApp/iosApp/Pages/Map/MapViewModel.swift
@@ -32,11 +32,11 @@ class MapViewModel: ObservableObject {
             .updateSourceData(routeData: RouteFeaturesBuilder.shared.buildCollection(routeLines: routeLines).toMapbox())
     }
 
-    func updateStopSource(_ stopData: FeatureCollection) {
+    func updateStopSource(_ stopData: MapboxMaps.FeatureCollection) {
         layerManager?.updateSourceData(stopData: stopData)
     }
 
-    func updateChildStopSource(_ childStopData: FeatureCollection) {
+    func updateChildStopSource(_ childStopData: MapboxMaps.FeatureCollection) {
         layerManager?.updateSourceData(childStopData: childStopData)
     }
 

--- a/iosApp/iosApp/Utils/MapboxBridge.swift
+++ b/iosApp/iosApp/Utils/MapboxBridge.swift
@@ -9,6 +9,12 @@
 import MapboxMaps
 import shared
 
+private func bridgeStyleObject<T: Decodable>(_ object: MapboxStyleObject) -> T {
+    // the json is supposed to be valid
+    // swiftlint:disable:next force_try
+    try! JSONDecoder().decode(T.self, from: Data(object.toJsonString().utf8))
+}
+
 extension GeojsonPosition {
     func toMapbox() -> LocationCoordinate2D {
         .init(latitude: latitude, longitude: longitude)
@@ -17,6 +23,18 @@ extension GeojsonPosition {
 
 extension [GeojsonPosition] {
     func toMapbox() -> [LocationCoordinate2D] {
+        map { $0.toMapbox() }
+    }
+}
+
+extension [[GeojsonPosition]] {
+    func toMapbox() -> [[LocationCoordinate2D]] {
+        map { $0.toMapbox() }
+    }
+}
+
+extension [[[GeojsonPosition]]] {
+    func toMapbox() -> [[[LocationCoordinate2D]]] {
         map { $0.toMapbox() }
     }
 }
@@ -31,9 +49,8 @@ extension GeojsonGeometry {
         case let .lineString(lineString): .lineString(LineString(lineString.coordinates.toMapbox()))
         case let .multiLineString(multiLineString): .multiLineString(MultiLineString(multiLineString.coordinates
                     .map { $0.toMapbox() }))
-        case let .polygon(polygon): .polygon(Polygon(polygon.coordinates.map { $0.toMapbox() }))
-        case let .multiPolygon(multiPolygon): .multiPolygon(MultiPolygon(multiPolygon.coordinates
-                    .map { polygonCoordinates in polygonCoordinates.map { $0.toMapbox() }}))
+        case let .polygon(polygon): .polygon(Polygon(polygon.coordinates.toMapbox()))
+        case let .multiPolygon(multiPolygon): .multiPolygon(MultiPolygon(multiPolygon.coordinates.toMapbox()))
         }
     }
 }
@@ -44,51 +61,49 @@ extension GeojsonLineString {
     }
 }
 
-extension GeojsonFeature {
-    func toMapbox() -> Feature {
-        var result = Feature(geometry: geometry?.toMapbox())
+extension shared.JSONValue {
+    func toMapbox() -> MapboxMaps.JSONValue {
+        switch onEnum(of: self) {
+        case let .array(data): .array(data.data.map { $0.toMapbox() })
+        case let .boolean(data): .boolean(data.data)
+        case let .number(data): .number(data.data)
+        case let .object(data): .object(data.data.mapValues { $0.toMapbox() })
+        case let .string(data): .string(data.data)
+        }
+    }
+}
+
+extension shared.Feature {
+    func toMapbox() -> MapboxMaps.Feature {
+        var result = Feature(geometry: geometry.toMapbox())
         if let id {
             result.identifier = .string(id)
         }
-        // the json is supposed to be valid
-        // swiftlint:disable:next force_try
-        result.properties = try! JSONDecoder().decode(JSONObject.self, from: Data(propertiesToString().utf8))
+        result.properties = properties.data.mapValues { $0.toMapbox() }
         return result
     }
 }
 
-extension GeojsonFeatureCollection {
-    func toMapbox() -> FeatureCollection {
-        FeatureCollection(features: features.map { $0.toMapbox() })
+extension shared.FeatureCollection {
+    func toMapbox() -> MapboxMaps.FeatureCollection {
+        MapboxMaps.FeatureCollection(features: features.map { $0.toMapbox() })
     }
 }
 
 extension shared.Exp {
     func toMapbox() -> MapboxMaps.Exp {
-        // the json is supposed to be valid
-        // swiftlint:disable:next force_try
-        try! JSONDecoder().decode(MapboxMaps.Exp.self, from: Data(toJsonString().utf8))
+        bridgeStyleObject(self)
     }
 }
 
 extension shared.LineLayer {
     func toMapbox() -> MapboxMaps.LineLayer {
-        // the json is supposed to be valid
-        // swiftlint:disable:next force_try
-        try! JSONDecoder().decode(
-            MapboxMaps.LineLayer.self,
-            from: Data(toJsonString().utf8)
-        )
+        bridgeStyleObject(self)
     }
 }
 
 extension shared.SymbolLayer {
     func toMapbox() -> MapboxMaps.SymbolLayer {
-        // the json is supposed to be valid
-        // swiftlint:disable:next force_try
-        try! JSONDecoder().decode(
-            MapboxMaps.SymbolLayer.self,
-            from: Data(toJsonString().utf8)
-        )
+        bridgeStyleObject(self)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/AlertIcons.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/AlertIcons.kt
@@ -25,16 +25,13 @@ object AlertIcons {
     // Expression that's true if the specified route index has no service status set
     private fun alertEmpty(index: Int): Exp<Boolean> {
         return Exp.not(
-            Exp.has(MapExp.routeAt(index), Exp.get(Exp(StopFeaturesBuilder.propServiceStatusKey)))
+            Exp.has(MapExp.routeAt(index), Exp.get(StopFeaturesBuilder.propServiceStatusKey))
         )
     }
 
     // Expression that returns the alert status string for the given route index
     private fun alertStatus(index: Int): Exp<String> {
-        return Exp.get(
-            MapExp.routeAt(index),
-            Exp.get(Exp(StopFeaturesBuilder.propServiceStatusKey))
-        )
+        return Exp.get(MapExp.routeAt(index), Exp.get(StopFeaturesBuilder.propServiceStatusKey))
     }
 
     private fun getAlertIconName(zoomPrefix: String, index: Int, forBus: Boolean): Exp<String> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilder.kt
@@ -1,20 +1,20 @@
 package com.mbta.tid.mbta_app.map
 
+import com.mbta.tid.mbta_app.map.style.Feature
+import com.mbta.tid.mbta_app.map.style.FeatureCollection
+import com.mbta.tid.mbta_app.map.style.FeatureProperties
+import com.mbta.tid.mbta_app.map.style.FeatureProperty
+import com.mbta.tid.mbta_app.map.style.buildFeatureProperties
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.Stop
-import io.github.dellisd.spatialk.geojson.Feature
-import io.github.dellisd.spatialk.geojson.FeatureCollection
 import io.github.dellisd.spatialk.geojson.Point
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 
 object ChildStopFeaturesBuilder {
     val childStopSourceId = "child-stop-source"
 
-    val propNameKey = "name"
-    val propLocationTypeKey = "locationType"
-    val propSortOrderKey = "sortOrder"
+    val propNameKey = FeatureProperty<String>("name")
+    val propLocationTypeKey = FeatureProperty<String>("locationType")
+    val propSortOrderKey = FeatureProperty<Number>("sortOrder")
 
     fun generateChildStopFeatures(childStops: Map<String, Stop>?): FeatureCollection {
         if (childStops != null) {
@@ -30,7 +30,7 @@ object ChildStopFeaturesBuilder {
     }
 
     fun generateChildStopFeature(childStop: Stop, index: Int): Feature? {
-        var feature =
+        val feature =
             Feature(
                 id = childStop.id,
                 geometry = Point(childStop.position),
@@ -39,16 +39,17 @@ object ChildStopFeaturesBuilder {
         return feature
     }
 
-    fun generateChildStopProperties(childStop: Stop, index: Int): JsonObject? = buildJsonObject {
-        when (childStop.locationType) {
-            LocationType.ENTRANCE_EXIT ->
-                put(propNameKey, childStop.name.split(" - ").lastOrNull() ?: "")
-            LocationType.BOARDING_AREA,
-            LocationType.STOP -> put(propNameKey, childStop.platformName ?: childStop.name)
-            else -> return null
-        }
+    fun generateChildStopProperties(childStop: Stop, index: Int): FeatureProperties? =
+        buildFeatureProperties {
+            when (childStop.locationType) {
+                LocationType.ENTRANCE_EXIT ->
+                    put(propNameKey, childStop.name.split(" - ").lastOrNull() ?: "")
+                LocationType.BOARDING_AREA,
+                LocationType.STOP -> put(propNameKey, childStop.platformName ?: childStop.name)
+                else -> return null
+            }
 
-        put(propLocationTypeKey, childStop.locationType.name)
-        put(propSortOrderKey, index)
-    }
+            put(propLocationTypeKey, childStop.locationType.name)
+            put(propSortOrderKey, index)
+        }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
@@ -18,7 +18,7 @@ object ChildStopLayerGenerator {
             SymbolLayer(id = childStopLayerId, source = ChildStopFeaturesBuilder.childStopSourceId)
         layer.iconImage =
             Exp.match(
-                    Exp.get<String>(Exp(ChildStopFeaturesBuilder.propLocationTypeKey)),
+                    Exp.get(ChildStopFeaturesBuilder.propLocationTypeKey),
                     Exp(LocationType.ENTRANCE_EXIT.name) to Exp(ChildStopIcons.entranceIcon),
                     Exp.Bare.arrayOf(LocationType.BOARDING_AREA.name, LocationType.STOP.name) to
                         Exp(ChildStopIcons.platformIcon),
@@ -29,8 +29,7 @@ object ChildStopLayerGenerator {
             Exp.step(
                 Exp.zoom(),
                 Exp(""),
-                Exp(annotationTextZoomThreshold) to
-                    Exp.get(Exp(ChildStopFeaturesBuilder.propNameKey))
+                Exp(annotationTextZoomThreshold) to Exp.get(ChildStopFeaturesBuilder.propNameKey)
             )
 
         // TODO actually pick a color
@@ -46,7 +45,7 @@ object ChildStopLayerGenerator {
         layer.textRadialOffset = 1
         layer.iconAllowOverlap = true
         layer.textAllowOverlap = false
-        layer.symbolSortKey = Exp.get(Exp(ChildStopFeaturesBuilder.propSortOrderKey))
+        layer.symbolSortKey = Exp.get(ChildStopFeaturesBuilder.propSortOrderKey)
         layer.minZoom = MapDefaults.closeZoomThreshold
         return layer
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapExp.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapExp.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.json.buildJsonArray
 
 object MapExp {
     // Get the array of MapStopRoute string values from a stop feature
-    val routesExp: Exp<List<String>> = Exp.get(Exp(StopFeaturesBuilder.propMapRoutesKey))
+    val routesExp = Exp.get(StopFeaturesBuilder.propMapRoutesKey)
 
     // Returns true if there is only a single type of route served at this stop
     val singleRouteTypeExp = Exp.eq(Exp(1), Exp.length(routesExp))
@@ -27,12 +27,7 @@ object MapExp {
             singleRouteTypeExp,
             Exp.eq(
                 Exp(1),
-                Exp.length(
-                    Exp.get<List<String>>(
-                        topRouteExp,
-                        Exp.get(Exp(StopFeaturesBuilder.propRouteIdsKey))
-                    )
-                )
+                Exp.length(Exp.get(topRouteExp, Exp.get(StopFeaturesBuilder.propRouteIdsKey)))
             )
         )
 
@@ -51,7 +46,7 @@ object MapExp {
     fun routeAt(index: Int) = Exp.string(Exp.at(Exp(index), routesExp))
 
     // Returns true if you're currently on the stop page for this stop
-    val selectedExp = Exp.boolean(Exp.get(Exp(StopFeaturesBuilder.propIsSelectedKey)))
+    val selectedExp = Exp.boolean(Exp.get(StopFeaturesBuilder.propIsSelectedKey))
 
     // Returns the iconSize of the stop icon, interpolated by zoom level, and sized differently
     // depending on the route served by the stop.
@@ -123,14 +118,14 @@ object MapExp {
                 // the additional branch indicator
                 branchedRouteExp to
                     Exp.case(
-                        Exp.get<Boolean>(Exp(StopFeaturesBuilder.propIsTerminalKey)) to
+                        Exp.get(StopFeaturesBuilder.propIsTerminalKey) to
                             xyExp(branchTerminalWidth, height),
                         xyExp(branchStopWidth, height)
                     ),
                 // Ferry terminals have a special larger icon at the wide zoom level
                 Exp.all(
                     Exp.eq(topRouteExp, Exp(MapStopRoute.FERRY.name)),
-                    Exp.get(Exp(StopFeaturesBuilder.propIsTerminalKey))
+                    Exp.get(StopFeaturesBuilder.propIsTerminalKey)
                 ) to xyExp(terminalFerryWidth, height),
                 // Buses have an extra small dot at wide zoom, and at close zoom, the height is
                 // slightly repositioned to center the alert on the tombstone, ignoring the small
@@ -138,7 +133,7 @@ object MapExp {
                 Exp.eq(topRouteExp, Exp(MapStopRoute.BUS.name)) to
                     xyExp(busStopWidth, height - (if (closeZoom) 2 else 0)),
                 // Rail terminals at wide zoom have a special pill icon rather than the usual dot
-                Exp.get<Boolean>(Exp(StopFeaturesBuilder.propIsTerminalKey)) to
+                Exp.get(StopFeaturesBuilder.propIsTerminalKey) to
                     xyExp(terminalRailStopWidth, height),
                 // Regular rail stops, have a basic pill at close zoom and a dot at wide
                 fallback = xyExp(railStopWidth, height)
@@ -169,7 +164,7 @@ object MapExp {
                 // Ferry terminals have a special larger icon at the wide zoom level
                 Exp.all(
                     Exp.eq(topRouteExp, Exp(MapStopRoute.FERRY.name)),
-                    Exp.get(Exp(StopFeaturesBuilder.propIsTerminalKey))
+                    Exp.get(StopFeaturesBuilder.propIsTerminalKey)
                 ) to xyExp(0, -singleRouteOffset - (if (closeZoom) 0 else 2)),
                 // Buses have an extra small dot at wide zoom, and at close zoom, the height is
                 // slightly repositioned to center the alert on the tombstone, ignoring the small
@@ -177,7 +172,7 @@ object MapExp {
                 Exp.eq(topRouteExp, Exp(MapStopRoute.BUS.name)) to
                     xyExp(0, -singleRouteOffset - (if (closeZoom) 2 else 0)),
                 // Rail terminals at wide zoom have a special pill icon rather than the usual dot
-                Exp.get<Boolean>(Exp(StopFeaturesBuilder.propIsTerminalKey)) to
+                Exp.get(StopFeaturesBuilder.propIsTerminalKey) to
                     xyExp(0, -singleRouteOffset - (if (closeZoom) 0 else 2)),
                 // Regular rail stops, have a basic pill at close zoom and a dot at wide
                 fallback = xyExp(0, -singleRouteOffset)
@@ -196,11 +191,10 @@ object MapExp {
             Exp.zoom(),
             Exp(MapDefaults.midZoomThreshold) to
                 Exp.step(
-                    Exp.length(Exp.get(Exp(StopFeaturesBuilder.propMapRoutesKey))),
+                    Exp.length(Exp.get(StopFeaturesBuilder.propMapRoutesKey)),
                     Exp.case(
                         branchedRouteExp to xyExp(1.15, 0.75),
-                        Exp.get<Boolean>(Exp(StopFeaturesBuilder.propIsTerminalKey)) to
-                            xyExp(1, 0.75),
+                        Exp.get(StopFeaturesBuilder.propIsTerminalKey) to xyExp(1, 0.75),
                         fallback = xyExp(0.75, 0.5)
                     ),
                     Exp(2) to xyExp(0.5, 1.25),
@@ -208,7 +202,7 @@ object MapExp {
                 ),
             Exp(MapDefaults.closeZoomThreshold) to
                 Exp.step(
-                    Exp.length(Exp.get(Exp(StopFeaturesBuilder.propMapRoutesKey))),
+                    Exp.length(Exp.get(StopFeaturesBuilder.propMapRoutesKey)),
                     Exp.case(branchedRouteExp to xyExp(2.5, 1.5), xyExp(2, 1.5)),
                     Exp(2) to xyExp(2, 2),
                     Exp(3) to xyExp(2, 2.5)
@@ -262,18 +256,15 @@ object MapExp {
             Exp(MapDefaults.midZoomThreshold) to
                 Exp.case(
                     Exp.eq(topRouteExp, Exp(MapStopRoute.FERRY.name)) to Exp(""),
-                    Exp.get<Boolean>(Exp(StopFeaturesBuilder.propIsTerminalKey)) to
-                        busSwitchExp(
-                            forBus = forBus,
-                            Exp.get(Exp(StopFeaturesBuilder.propNameKey))
-                        ),
+                    Exp.get(StopFeaturesBuilder.propIsTerminalKey) to
+                        busSwitchExp(forBus = forBus, Exp.get(StopFeaturesBuilder.propNameKey)),
                     fallback = Exp("")
                 ),
             // At close zoom, display labels for all non-bus stops
             Exp(MapDefaults.closeZoomThreshold) to
                 Exp.case(
                     Exp.eq(topRouteExp, Exp(MapStopRoute.BUS.name)) to Exp(""),
-                    busSwitchExp(forBus = forBus, Exp.get(Exp(StopFeaturesBuilder.propNameKey)))
+                    busSwitchExp(forBus = forBus, Exp.get(StopFeaturesBuilder.propNameKey))
                 )
         )
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
@@ -1,5 +1,10 @@
 package com.mbta.tid.mbta_app.map
 
+import com.mbta.tid.mbta_app.map.style.Color
+import com.mbta.tid.mbta_app.map.style.Feature
+import com.mbta.tid.mbta_app.map.style.FeatureCollection
+import com.mbta.tid.mbta_app.map.style.FeatureProperty
+import com.mbta.tid.mbta_app.map.style.buildFeatureProperties
 import com.mbta.tid.mbta_app.model.AlertAssociatedStop
 import com.mbta.tid.mbta_app.model.AlertAwareRouteSegment
 import com.mbta.tid.mbta_app.model.Route
@@ -10,12 +15,9 @@ import com.mbta.tid.mbta_app.model.SegmentedRouteShape
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.model.response.ShapeWithStops
-import io.github.dellisd.spatialk.geojson.Feature
-import io.github.dellisd.spatialk.geojson.FeatureCollection
 import io.github.dellisd.spatialk.geojson.LineString
 import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
 import io.github.dellisd.spatialk.turf.lineSlice
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 data class RouteLineData(
@@ -35,11 +37,11 @@ data class RouteLineData(
 object RouteFeaturesBuilder {
     val routeSourceId = "route-source"
 
-    val propRouteId = "routeId"
-    val propRouteType = "routeType"
-    val propRouteSortKey = "routeSortKey"
-    val propRouteColor = "routeColor"
-    val propAlertStateKey = "alertState"
+    val propRouteId = FeatureProperty<String>("routeId")
+    val propRouteType = FeatureProperty<String>("routeType")
+    val propRouteSortKey = FeatureProperty<Number>("routeSortKey")
+    val propRouteColor = FeatureProperty<Color>("routeColor")
+    val propAlertStateKey = FeatureProperty<String>("alertState")
 
     fun generateRouteLines(
         routeData: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
@@ -123,7 +125,7 @@ object RouteFeaturesBuilder {
         Feature(
             geometry = routeLineData.line,
             properties =
-                buildJsonObject {
+                buildFeatureProperties {
                     put(propRouteId, routeLineData.routeId)
                     routeLineData.routeType?.let { put(propRouteType, it) }
                     routeLineData.color?.let { put(propRouteColor, it) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
@@ -37,7 +37,7 @@ object RouteLayerGenerator {
         val shuttledLayer = baseRouteLayer(shuttledRouteLayerId)
         shuttledLayer.filter =
             Exp.eq(
-                Exp.get(Exp(RouteFeaturesBuilder.propAlertStateKey)),
+                Exp.get(RouteFeaturesBuilder.propAlertStateKey),
                 Exp(SegmentAlertState.Shuttle.name)
             )
         shuttledLayer.lineWidth = Exp.step(Exp.zoom(), Exp(4), Exp(closeZoomCutoff) to Exp(6))
@@ -46,7 +46,7 @@ object RouteLayerGenerator {
         val suspendedLayer = baseRouteLayer(suspendedRouteLayerId)
         suspendedLayer.filter =
             Exp.eq(
-                Exp.get(Exp(RouteFeaturesBuilder.propAlertStateKey)),
+                Exp.get(RouteFeaturesBuilder.propAlertStateKey),
                 Exp(SegmentAlertState.Suspension.name)
             )
         suspendedLayer.lineWidth = Exp.step(Exp.zoom(), Exp(4), Exp(closeZoomCutoff) to Exp(6))
@@ -56,7 +56,7 @@ object RouteLayerGenerator {
         val alertBackgroundLayer = baseRouteLayer(alertingBgRouteLayerId)
         alertBackgroundLayer.filter =
             Exp.`in`(
-                Exp.get(Exp(RouteFeaturesBuilder.propAlertStateKey)),
+                Exp.get(RouteFeaturesBuilder.propAlertStateKey),
                 Exp.Bare.arrayOf(SegmentAlertState.Suspension.name, SegmentAlertState.Shuttle.name)
             )
         alertBackgroundLayer.lineWidth =
@@ -68,10 +68,10 @@ object RouteLayerGenerator {
 
     fun baseRouteLayer(layerId: String): LineLayer {
         val layer = LineLayer(id = layerId, source = RouteFeaturesBuilder.routeSourceId)
-        layer.lineColor = Exp.get(Exp(RouteFeaturesBuilder.propRouteColor))
+        layer.lineColor = Exp.get(RouteFeaturesBuilder.propRouteColor)
         layer.lineJoin = LineJoin.Round
         layer.lineOffset = lineOffsetExp()
-        layer.lineSortKey = Exp.get(Exp(RouteFeaturesBuilder.propRouteSortKey))
+        layer.lineSortKey = Exp.get(RouteFeaturesBuilder.propRouteSortKey)
         checkNotNull(layer.id)
         return layer
     }
@@ -85,17 +85,16 @@ object RouteLayerGenerator {
 
         return Exp.case(
             Exp.`in`(
-                Exp.get(Exp(RouteFeaturesBuilder.propRouteId)),
+                Exp.get(RouteFeaturesBuilder.propRouteId),
                 Exp.Bare.arrayOf("CR-Lowell", "CR-Fitchburg")
             ) to Exp(0),
             Exp.`in`(
-                Exp.get(Exp(RouteFeaturesBuilder.propRouteId)),
+                Exp.get(RouteFeaturesBuilder.propRouteId),
                 Exp.Bare.arrayOf("CR-Greenbush", "CR-Kingston", "CR-Middleborough")
             ) to Exp(maxLineWidth * 1.5),
-            Exp.eq(Exp.get(Exp(RouteFeaturesBuilder.propRouteType)), Exp("COMMUTER_RAIL")) to
+            Exp.eq(Exp.get(RouteFeaturesBuilder.propRouteType), Exp("COMMUTER_RAIL")) to
                 Exp(-maxLineWidth),
-            Exp.`in`(Exp("Green"), Exp.get(Exp(RouteFeaturesBuilder.propRouteId))) to
-                Exp(maxLineWidth),
+            Exp.`in`(Exp("Green"), Exp.get(RouteFeaturesBuilder.propRouteId)) to Exp(maxLineWidth),
             // Default to no offset
             fallback = Exp(0)
         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopIcons.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopIcons.kt
@@ -69,10 +69,7 @@ object StopIcons {
                     Exp("-"),
                     Exp.at(
                         Exp(0),
-                        Exp.get(
-                            MapExp.topRouteExp,
-                            Exp.get(Exp(StopFeaturesBuilder.propRouteIdsKey))
-                        )
+                        Exp.get(MapExp.topRouteExp, Exp.get(StopFeaturesBuilder.propRouteIdsKey))
                     )
                 ),
             Exp("")
@@ -93,7 +90,7 @@ object StopIcons {
             Exp.case(
                 // If at wide zoom, give terminal stops with no transfers distinct icons
                 Exp.all(
-                    Exp.get(Exp(StopFeaturesBuilder.propIsTerminalKey)),
+                    Exp.get(StopFeaturesBuilder.propIsTerminalKey),
                     MapExp.singleRouteTypeExp,
                     Exp.boolean(Exp(zoomPrefix == stopZoomWidePrefix))
                 ) to Exp.concat(Exp(stopTerminalSuffix), branchingRouteSuffixExp),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
@@ -103,7 +103,7 @@ object StopLayerGenerator {
 
         layer.iconAllowOverlap = true
         layer.minZoom = stopZoomThreshold
-        layer.symbolSortKey = Exp.get(Exp(StopFeaturesBuilder.propSortOrderKey))
+        layer.symbolSortKey = Exp.get(StopFeaturesBuilder.propSortOrderKey)
     }
 
     fun offsetAlertValue(index: Int): Exp<List<Number>> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Color.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Color.kt
@@ -1,4 +1,3 @@
 package com.mbta.tid.mbta_app.map.style
 
-/** Represents a color in the [Exp] type checking system. Does not contain a value. */
-typealias Color = Nothing
+typealias Color = String

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
@@ -4,7 +4,6 @@ import kotlin.jvm.JvmName
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonArrayBuilder
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
@@ -72,16 +71,20 @@ sealed interface Exp<T> : MapboxStyleObject {
 
         fun <T> at(index: Exp<Number>, array: Exp<List<T>>): Exp<T> = op("at", index, array)
 
-        fun <T> get(property: Exp<String>, inObject: Exp<JsonObject>? = null): Exp<T> =
+        fun <T> get(property: FeatureProperty<T>): Exp<T> = op("get") { add(property.key) }
+
+        fun <K, V> get(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<V> =
             op("get") {
                 add(property)
-                inObject?.let { add(it) }
+                add(inObject)
             }
 
-        fun has(property: Exp<String>, inObject: Exp<JsonObject>? = null): Exp<Boolean> =
+        fun has(property: FeatureProperty<*>): Exp<Boolean> = op("has") { add(property.key) }
+
+        fun <K, V> has(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<Boolean> =
             op("has") {
                 add(property)
-                inObject?.let { add(it) }
+                add(inObject)
             }
 
         @JvmName("inArray")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Feature.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Feature.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.map.style
+
+import io.github.dellisd.spatialk.geojson.Geometry
+
+data class Feature(
+    val id: String? = null,
+    val geometry: Geometry,
+    val properties: FeatureProperties
+)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureCollection.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureCollection.kt
@@ -1,0 +1,3 @@
+package com.mbta.tid.mbta_app.map.style
+
+data class FeatureCollection(val features: List<Feature>)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
@@ -1,0 +1,123 @@
+package com.mbta.tid.mbta_app.map.style
+
+import kotlin.jvm.JvmName
+
+/**
+ * [kotlinx.serialization.json.JsonPrimitive] stores values as strings, which makes sense when
+ * actually round tripping to JSON but is too expensive if merely passing back and forth in memory.
+ * Mapbox for Android uses GSON, which stores primitives as a boxed Java Object, which is nice but a
+ * bit of a nuisance to work with in a more type-safe language like Kotlin. Mapbox for iOS defines
+ * an enum like this.
+ */
+sealed interface JSONValue {
+    data class Array(val data: JSONArray) : JSONValue
+
+    data class Boolean(val data: kotlin.Boolean) : JSONValue
+
+    data class Number(val data: Double) : JSONValue
+
+    data class Object(val data: JSONObject) : JSONValue
+
+    data class String(val data: kotlin.String) : JSONValue
+}
+
+val JSONValue.array: JSONArray
+    get() {
+        check(this is JSONValue.Array)
+        return this.data
+    }
+
+val JSONValue.boolean: Boolean
+    get() {
+        check(this is JSONValue.Boolean)
+        return this.data
+    }
+
+val JSONValue.number: Number
+    get() {
+        check(this is JSONValue.Number)
+        return this.data
+    }
+
+val JSONValue.`object`: JSONObject
+    get() {
+        check(this is JSONValue.Object)
+        return this.data
+    }
+val JSONValue.string: String
+    get() {
+        check(this is JSONValue.String)
+        return this.data
+    }
+
+typealias JSONArray = List<JSONValue>
+
+typealias JSONObject = Map<String, JSONValue>
+
+data class FeatureProperties(val data: JSONObject) {
+    operator fun get(property: FeatureProperty<Boolean>): Boolean =
+        data.getValue(property.key).boolean
+
+    operator fun get(property: FeatureProperty<Number>): Number = data.getValue(property.key).number
+
+    operator fun get(property: FeatureProperty<String>): String = data.getValue(property.key).string
+
+    operator fun get(property: FeatureProperty<List<String>>): List<String> =
+        data.getValue(property.key).array.map { it.string }
+
+    @JvmName("getMapStringString")
+    operator fun get(property: FeatureProperty<Map<String, String>>): Map<String, String> =
+        data.getValue(property.key).`object`.mapValues { it.value.string }
+
+    @JvmName("getMapStringListString")
+    operator fun get(
+        property: FeatureProperty<Map<String, List<String>>>
+    ): Map<String, List<String>> =
+        data.getValue(property.key).`object`.mapValues { it.value.array.map { it.string } }
+}
+
+class FeaturePropertiesBuilder(private val data: MutableMap<String, JSONValue> = mutableMapOf()) {
+    fun put(property: FeatureProperty<Boolean>, value: Boolean) {
+        data[property.key] = JSONValue.Boolean(value)
+    }
+
+    fun put(property: FeatureProperty<Number>, value: Double) {
+        data[property.key] = JSONValue.Number(value)
+    }
+
+    fun put(property: FeatureProperty<Number>, value: Int) {
+        data[property.key] = JSONValue.Number(value.toDouble())
+    }
+
+    fun put(property: FeatureProperty<String>, value: String) {
+        data[property.key] = JSONValue.String(value)
+    }
+
+    fun put(property: FeatureProperty<List<String>>, value: List<String>) {
+        data[property.key] = JSONValue.Array(value.map(JSONValue::String))
+    }
+
+    @JvmName("putMapStringString")
+    fun put(property: FeatureProperty<Map<String, String>>, value: Map<String, String>) {
+        data[property.key] = JSONValue.Object(value.mapValues { JSONValue.String(it.value) })
+    }
+
+    @JvmName("putMapStringListString")
+    fun put(
+        property: FeatureProperty<Map<String, List<String>>>,
+        value: Map<String, List<String>>
+    ) {
+        data[property.key] =
+            JSONValue.Object(
+                value.mapValues { JSONValue.Array(it.value.map { JSONValue.String(it) }) }
+            )
+    }
+
+    fun built() = FeatureProperties(data)
+}
+
+inline fun buildFeatureProperties(block: FeaturePropertiesBuilder.() -> Unit): FeatureProperties {
+    val builder = FeaturePropertiesBuilder()
+    builder.block()
+    return builder.built()
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperty.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperty.kt
@@ -1,0 +1,3 @@
+package com.mbta.tid.mbta_app.map.style
+
+data class FeatureProperty<T>(val key: String)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilderTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.map
 
+import com.mbta.tid.mbta_app.map.style.buildFeatureProperties
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 class ChildStopFeaturesBuilderTest {
@@ -60,7 +60,7 @@ class ChildStopFeaturesBuilderTest {
 
             assertEquals(platform.id, collection.features[0].id)
             assertEquals(
-                buildJsonObject {
+                buildFeatureProperties {
                     put(ChildStopFeaturesBuilder.propNameKey, "Headsign")
                     put(ChildStopFeaturesBuilder.propLocationTypeKey, LocationType.STOP.name)
                     put(ChildStopFeaturesBuilder.propSortOrderKey, 0)
@@ -70,7 +70,7 @@ class ChildStopFeaturesBuilderTest {
 
             assertEquals(entrance.id, collection.features[1].id)
             assertEquals(
-                buildJsonObject {
+                buildFeatureProperties {
                     put(ChildStopFeaturesBuilder.propNameKey, ("Entrance"))
                     put(
                         ChildStopFeaturesBuilder.propLocationTypeKey,
@@ -83,7 +83,7 @@ class ChildStopFeaturesBuilderTest {
 
             assertEquals(boardingArea.id, collection.features[2].id)
             assertEquals(
-                buildJsonObject {
+                buildFeatureProperties {
                     put(ChildStopFeaturesBuilder.propNameKey, "Other Headsign")
                     put(
                         ChildStopFeaturesBuilder.propLocationTypeKey,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -18,7 +18,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
-import kotlinx.serialization.json.JsonPrimitive
 
 @OptIn(ExperimentalTurfApi::class)
 class RouteFeaturesBuilderTest {
@@ -46,8 +45,7 @@ class RouteFeaturesBuilderTest {
             2,
             collection.features
                 .filter {
-                    it.properties[RouteFeaturesBuilder.propRouteId] ==
-                        JsonPrimitive(MapTestDataHelper.routeRed.id)
+                    it.properties[RouteFeaturesBuilder.propRouteId] == MapTestDataHelper.routeRed.id
                 }
                 .size
         )
@@ -56,7 +54,7 @@ class RouteFeaturesBuilderTest {
             collection.features
                 .filter {
                     it.properties[RouteFeaturesBuilder.propRouteId] ==
-                        JsonPrimitive(MapTestDataHelper.routeOrange.id)
+                        MapTestDataHelper.routeOrange.id
                 }
                 .size
         )
@@ -69,8 +67,7 @@ class RouteFeaturesBuilderTest {
             ),
             collection.features
                 .first {
-                    it.properties[RouteFeaturesBuilder.propRouteId] ==
-                        JsonPrimitive(MapTestDataHelper.routeRed.id)
+                    it.properties[RouteFeaturesBuilder.propRouteId] == MapTestDataHelper.routeRed.id
                 }
                 .geometry
         )
@@ -84,7 +81,7 @@ class RouteFeaturesBuilderTest {
             collection.features
                 .first {
                     it.properties[RouteFeaturesBuilder.propRouteId] ==
-                        JsonPrimitive(MapTestDataHelper.routeOrange.id)
+                        MapTestDataHelper.routeOrange.id
                 }
                 .geometry
         )
@@ -112,22 +109,12 @@ class RouteFeaturesBuilderTest {
         val firstRedFeature =
             collection.features
                 .filter {
-                    it.properties[RouteFeaturesBuilder.propRouteId] ==
-                        JsonPrimitive(MapTestDataHelper.routeRed.id)
+                    it.properties[RouteFeaturesBuilder.propRouteId] == MapTestDataHelper.routeRed.id
                 }[0]
 
-        assertEquals(
-            JsonPrimitive("#DA291C"),
-            firstRedFeature.properties[RouteFeaturesBuilder.propRouteColor]
-        )
-        assertEquals(
-            JsonPrimitive("HEAVY_RAIL"),
-            firstRedFeature.properties[RouteFeaturesBuilder.propRouteType]
-        )
-        assertEquals(
-            JsonPrimitive(-10010),
-            firstRedFeature.properties[RouteFeaturesBuilder.propRouteSortKey]
-        )
+        assertEquals("#DA291C", firstRedFeature.properties[RouteFeaturesBuilder.propRouteColor])
+        assertEquals("HEAVY_RAIL", firstRedFeature.properties[RouteFeaturesBuilder.propRouteType])
+        assertEquals(-10010.0, firstRedFeature.properties[RouteFeaturesBuilder.propRouteSortKey])
     }
 
     @Test
@@ -187,14 +174,13 @@ class RouteFeaturesBuilderTest {
 
         val redFeatures =
             collection.features.filter {
-                it.properties[RouteFeaturesBuilder.propRouteId] ==
-                    JsonPrimitive(MapTestDataHelper.routeRed.id)
+                it.properties[RouteFeaturesBuilder.propRouteId] == MapTestDataHelper.routeRed.id
             }
 
         assertEquals(3, redFeatures.size)
         assertEquals(
-            JsonPrimitive(SegmentAlertState.Normal.name),
-            redFeatures[0].properties[RouteFeaturesBuilder.propAlertStateKey]!!
+            SegmentAlertState.Normal.name,
+            redFeatures[0].properties[RouteFeaturesBuilder.propAlertStateKey]
         )
         assertEquals(
             lineSlice(
@@ -206,8 +192,8 @@ class RouteFeaturesBuilderTest {
         )
 
         assertEquals(
-            JsonPrimitive(SegmentAlertState.Shuttle.name),
-            redFeatures[1].properties[RouteFeaturesBuilder.propAlertStateKey]!!
+            SegmentAlertState.Shuttle.name,
+            redFeatures[1].properties[RouteFeaturesBuilder.propAlertStateKey]
         )
         assertEquals(
             lineSlice(
@@ -218,8 +204,8 @@ class RouteFeaturesBuilderTest {
             redFeatures[1].geometry,
         )
         assertEquals(
-            JsonPrimitive(SegmentAlertState.Normal.name),
-            redFeatures[2].properties[RouteFeaturesBuilder.propAlertStateKey]!!
+            SegmentAlertState.Normal.name,
+            redFeatures[2].properties[RouteFeaturesBuilder.propAlertStateKey]
         )
         assertEquals(
             lineSlice(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGeneratorTest.kt
@@ -52,7 +52,7 @@ class RouteLayerGeneratorTest {
         assertEquals(
             buildJsonArray {
                 add("get")
-                add(RouteFeaturesBuilder.propRouteColor)
+                add(RouteFeaturesBuilder.propRouteColor.key)
             },
             baseRouteLayer.lineColor!!.asJson()
         )
@@ -66,7 +66,7 @@ class RouteLayerGeneratorTest {
         assertEquals(
             buildJsonArray {
                 add("get")
-                add(RouteFeaturesBuilder.propRouteSortKey)
+                add(RouteFeaturesBuilder.propRouteSortKey.key)
             },
             baseRouteLayer.lineSortKey!!.asJson()
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -1,21 +1,17 @@
 package com.mbta.tid.mbta_app.map
 
-import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.map.MapTestDataHelper.routesById
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.MapStop
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.StopAlertState
-import io.github.dellisd.spatialk.geojson.Feature
 import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.decodeFromJsonElement
 
 class StopFeaturesBuilderTest {
     @Test
@@ -214,12 +210,9 @@ class StopFeaturesBuilderTest {
         val selectedFeature = collection.features.find { it.id == selectedStop.id }
         val otherFeature = collection.features.find { it.id == otherStop.id }
         assertNotNull(selectedFeature)
-        assertEquals(
-            true,
-            selectedFeature.getBooleanProperty(StopFeaturesBuilder.propIsSelectedKey)
-        )
+        assertEquals(true, selectedFeature.properties[StopFeaturesBuilder.propIsSelectedKey])
 
-        assertEquals(false, otherFeature?.getBooleanProperty(StopFeaturesBuilder.propIsSelectedKey))
+        assertEquals(false, otherFeature?.properties?.get(StopFeaturesBuilder.propIsSelectedKey))
     }
 
     @Test
@@ -330,15 +323,18 @@ class StopFeaturesBuilderTest {
 
         val alewifeFeature = collection.features.find { it.id == "place-alfcl" }
         assertNotNull(alewifeFeature)
-        val alewifeServiceStatus: Map<MapStopRoute, StopAlertState> =
-            alewifeFeature.getDecodedJsonProperty(StopFeaturesBuilder.propServiceStatusKey)
-        assertEquals(StopAlertState.Shuttle, alewifeServiceStatus[MapStopRoute.RED])
+        val alewifeServiceStatus =
+            alewifeFeature.properties.get(StopFeaturesBuilder.propServiceStatusKey)
+        assertEquals(StopAlertState.Shuttle.name, alewifeServiceStatus[MapStopRoute.RED.name])
 
         val assemblyFeature = collection.features.find { it.id == "place-astao" }
         assertNotNull(assemblyFeature)
-        val assemblyServiceStatus: Map<MapStopRoute, StopAlertState> =
-            assemblyFeature.getDecodedJsonProperty(StopFeaturesBuilder.propServiceStatusKey)
-        assertEquals(StopAlertState.Suspension, assemblyServiceStatus[MapStopRoute.ORANGE])
+        val assemblyServiceStatus =
+            assemblyFeature.properties.get(StopFeaturesBuilder.propServiceStatusKey)
+        assertEquals(
+            StopAlertState.Suspension.name,
+            assemblyServiceStatus[MapStopRoute.ORANGE.name]
+        )
     }
 
     @Test
@@ -369,21 +365,18 @@ class StopFeaturesBuilderTest {
         val assemblyFeature =
             collection.features.find { it.id == MapTestDataHelper.stopAssembly.id }
 
-        val assemblyRoutes: List<MapStopRoute>? =
-            assemblyFeature?.getDecodedJsonProperty(StopFeaturesBuilder.propMapRoutesKey)
-        assertEquals(listOf(MapStopRoute.ORANGE), assemblyRoutes)
+        val assemblyRoutes = assemblyFeature?.properties?.get(StopFeaturesBuilder.propMapRoutesKey)
+        assertEquals(listOf(MapStopRoute.ORANGE.name), assemblyRoutes)
 
         val alewifeFeature = collection.features.find { it.id == MapTestDataHelper.stopAlewife.id }
 
-        val alewifeRoutes: List<MapStopRoute>? =
-            alewifeFeature?.getDecodedJsonProperty(StopFeaturesBuilder.propMapRoutesKey)
-        assertEquals(listOf(MapStopRoute.RED, MapStopRoute.BUS), alewifeRoutes)
-        val alewifeRouteIds: Map<MapStopRoute, List<String>>? =
-            alewifeFeature?.getDecodedJsonProperty(StopFeaturesBuilder.propRouteIdsKey)
+        val alewifeRoutes = alewifeFeature?.properties?.get(StopFeaturesBuilder.propMapRoutesKey)
+        assertEquals(listOf(MapStopRoute.RED.name, MapStopRoute.BUS.name), alewifeRoutes)
+        val alewifeRouteIds = alewifeFeature?.properties?.get(StopFeaturesBuilder.propRouteIdsKey)
         assertEquals(
             mapOf(
-                MapStopRoute.RED to listOf(MapTestDataHelper.routeRed.id),
-                MapStopRoute.BUS to listOf(MapTestDataHelper.route67.id)
+                MapStopRoute.RED.name to listOf(MapTestDataHelper.routeRed.id),
+                MapStopRoute.BUS.name to listOf(MapTestDataHelper.route67.id)
             ),
             alewifeRouteIds
         )
@@ -408,12 +401,12 @@ class StopFeaturesBuilderTest {
         val assemblyFeature =
             collection.features.find { it.id == MapTestDataHelper.stopAssembly.id }
 
-        val assemblyName = assemblyFeature?.getStringProperty(StopFeaturesBuilder.propNameKey)
+        val assemblyName = assemblyFeature?.properties?.get(StopFeaturesBuilder.propNameKey)
         assertEquals(MapTestDataHelper.stopAssembly.name, assemblyName)
 
         val alewifeFeature = collection.features.find { it.id == MapTestDataHelper.stopAlewife.id }
 
-        val alewifeName = alewifeFeature?.getStringProperty(StopFeaturesBuilder.propNameKey)
+        val alewifeName = alewifeFeature?.properties?.get(StopFeaturesBuilder.propNameKey)
         assertEquals(MapTestDataHelper.stopAlewife.name, alewifeName)
     }
 
@@ -436,16 +429,12 @@ class StopFeaturesBuilderTest {
         val alewifeFeature = collection.features.find { it.id == MapTestDataHelper.stopAlewife.id }
 
         val alewifeIsTerminal =
-            alewifeFeature?.getBooleanProperty(StopFeaturesBuilder.propIsTerminalKey)
+            alewifeFeature?.properties?.get(StopFeaturesBuilder.propIsTerminalKey)
         assertEquals(MapTestDataHelper.mapStopAlewife.isTerminal, alewifeIsTerminal)
 
         val davisFeature = collection.features.find { it.id == MapTestDataHelper.stopDavis.id }
 
-        val davisIsTerminal =
-            davisFeature?.getBooleanProperty(StopFeaturesBuilder.propIsTerminalKey)
+        val davisIsTerminal = davisFeature?.properties?.get(StopFeaturesBuilder.propIsTerminalKey)
         assertEquals(MapTestDataHelper.mapStopDavis.isTerminal, davisIsTerminal)
     }
-
-    private inline fun <reified T> Feature.getDecodedJsonProperty(key: String) =
-        json.decodeFromJsonElement<T>(getJsonProperty(key) ?: JsonNull)
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Move map logic towards shared code](https://app.asana.com/0/1201654106676769/1207789718623665/f)

Adds type information to feature properties at both write time and `Exp.get` time, and stores feature properties in a way that lets us convert to Mapbox feature properties at runtime without JSON round trips or the potential for conversion errors.

Stacked on #303.

### Testing

Updated all unit tests and manually verified that everything still works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
