### PR TITLE
test(map): evaluate expressions in style tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
@@ -1,5 +1,13 @@
 package com.mbta.tid.mbta_app.map
 
+import com.mbta.tid.mbta_app.map.style.evaluate
+import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.MapStop
+import com.mbta.tid.mbta_app.model.MapStopRoute
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.StopAlertState
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -20,5 +28,224 @@ class StopLayerGeneratorTest {
         assertEquals(StopLayerGenerator.getAlertLayerId(1), stopLayers[8].id)
         assertEquals(StopLayerGenerator.getAlertLayerId(2), stopLayers[9].id)
         assertEquals(StopLayerGenerator.stopLayerSelectedPinId, stopLayers[10].id)
+    }
+
+    @Test
+    fun `North Station with alerts has correct properties`() {
+        val northStation =
+            Stop(
+                id = "place-north",
+                latitude = 42.365577,
+                longitude = -71.06129,
+                name = "North Station",
+                locationType = LocationType.STATION,
+                description = null,
+                platformName = null,
+                childStopIds =
+                    listOf(
+                        "70026",
+                        "70027",
+                        "70205",
+                        "70206",
+                        "BNT-0000",
+                        "BNT-0000-01",
+                        "BNT-0000-02",
+                        "BNT-0000-03",
+                        "BNT-0000-04",
+                        "BNT-0000-05",
+                        "BNT-0000-06",
+                        "BNT-0000-07",
+                        "BNT-0000-08",
+                        "BNT-0000-09",
+                        "BNT-0000-10",
+                        "BNT-0000-B1",
+                        "BNT-0000-B2",
+                        "door-north-causewaye",
+                        "door-north-causeways",
+                        "door-north-crcanal",
+                        "door-north-crcauseway",
+                        "door-north-crnashua",
+                        "door-north-tdgarden",
+                        "door-north-valenti"
+                    ),
+                connectingStopIds = listOf("9070026", "114", "113"),
+                parentStationId = null
+            )
+        val routes =
+            mapOf(
+                MapStopRoute.ORANGE to
+                    listOf(
+                        Route(
+                            id = "Orange",
+                            type = RouteType.HEAVY_RAIL,
+                            color = "ED8B00",
+                            directionNames = listOf("South", "North"),
+                            directionDestinations = listOf("Forest Hills", "Oak Grove"),
+                            longName = "Orange Line",
+                            shortName = "",
+                            sortOrder = 10020,
+                            textColor = "FFFFFF",
+                            lineId = "line-Orange",
+                            routePatternIds = null
+                        )
+                    ),
+                MapStopRoute.GREEN to
+                    listOf(
+                        Route(
+                            id = "Green-D",
+                            type = RouteType.LIGHT_RAIL,
+                            color = "00843D",
+                            directionNames = listOf("West", "East"),
+                            directionDestinations = listOf("Riverside", "Union Square"),
+                            longName = "Green Line D",
+                            shortName = "D",
+                            sortOrder = 10034,
+                            textColor = "FFFFFF",
+                            lineId = "line-Green",
+                            routePatternIds = null
+                        ),
+                        Route(
+                            id = "Green-E",
+                            type = RouteType.LIGHT_RAIL,
+                            color = "00843D",
+                            directionNames = listOf("West", "East"),
+                            directionDestinations = listOf("Heath Street", "Medford/Tufts"),
+                            longName = "Green Line E",
+                            shortName = "E",
+                            sortOrder = 10035,
+                            textColor = "FFFFFF",
+                            lineId = "line-Green",
+                            routePatternIds = null
+                        )
+                    ),
+                MapStopRoute.COMMUTER to
+                    listOf(
+                        Route(
+                            id = "CR-Fitchburg",
+                            type = RouteType.COMMUTER_RAIL,
+                            color = "80276C",
+                            directionNames = listOf("Outbound", "Inbound"),
+                            directionDestinations = listOf("Wachusett", "North Station"),
+                            longName = "Fitchburg Line",
+                            shortName = "",
+                            sortOrder = 20002,
+                            textColor = "FFFFFF",
+                            lineId = "line-Fitchburg",
+                            routePatternIds = null
+                        ),
+                        Route(
+                            id = "CR-Haverhill",
+                            type = RouteType.COMMUTER_RAIL,
+                            color = "80276C",
+                            directionNames = listOf("Outbound", "Inbound"),
+                            directionDestinations = listOf("Haverhill", "North Station"),
+                            longName = "Haverhill Line",
+                            shortName = "",
+                            sortOrder = 20006,
+                            textColor = "FFFFFF",
+                            lineId = "line-Haverhill",
+                            routePatternIds = null
+                        ),
+                        Route(
+                            id = "CR-Lowell",
+                            type = RouteType.COMMUTER_RAIL,
+                            color = "80276C",
+                            directionNames = listOf("Outbound", "Inbound"),
+                            directionDestinations = listOf("Lowell", "North Station"),
+                            longName = "Lowell Line",
+                            shortName = "",
+                            sortOrder = 20008,
+                            textColor = "FFFFFF",
+                            lineId = "line-Lowell",
+                            routePatternIds = null
+                        ),
+                        Route(
+                            id = "CR-Newburyport",
+                            type = RouteType.COMMUTER_RAIL,
+                            color = "80276C",
+                            directionNames = listOf("Outbound", "Inbound"),
+                            directionDestinations =
+                                listOf("Newburyport or Rockport", "North Station"),
+                            longName = "Newburyport/Rockport Line",
+                            shortName = "",
+                            sortOrder = 20011,
+                            textColor = "FFFFFF",
+                            lineId = "line-Newburyport",
+                            routePatternIds = null
+                        )
+                    )
+            )
+
+        val mapStops =
+            mapOf(
+                northStation.id to
+                    MapStop(
+                        stop = northStation,
+                        routes = routes,
+                        routeTypes =
+                            listOf(MapStopRoute.ORANGE, MapStopRoute.GREEN, MapStopRoute.COMMUTER),
+                        isTerminal = true,
+                        alerts =
+                            mapOf(
+                                MapStopRoute.ORANGE to StopAlertState.Shuttle,
+                                MapStopRoute.GREEN to StopAlertState.Suspension,
+                                MapStopRoute.COMMUTER to StopAlertState.Normal,
+                                MapStopRoute.BUS to StopAlertState.Normal
+                            )
+                    )
+            )
+
+        val feature =
+            StopFeaturesBuilder.buildCollection(StopSourceData(), mapStops, emptyList())
+                .features
+                .single()
+
+        val stopLayers = StopLayerGenerator.createStopLayers(ColorPalette.light)
+
+        val busLayer = stopLayers[1]
+        val busAlertLayer = stopLayers[2]
+        val stopLayer = stopLayers[3]
+        val transferLayer0 = stopLayers[4]
+        val transferLayer1 = stopLayers[5]
+        val transferLayer2 = stopLayers[6]
+        val alertLayer0 = stopLayers[7]
+        val alertLayer1 = stopLayers[8]
+        val alertLayer2 = stopLayers[9]
+
+        assertEquals("", busLayer.iconImage!!.evaluate(feature.properties, zoom = 14.0))
+        assertEquals("", busLayer.textField!!.evaluate(feature.properties, zoom = 14.0))
+        assertEquals("", busAlertLayer.iconImage!!.evaluate(feature.properties, zoom = 14.0))
+
+        assertEquals(
+            "map-stop-container-wide-3",
+            stopLayer.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+        assertEquals(
+            "North Station",
+            stopLayer.textField!!.evaluate(feature.properties, zoom = 14.0)
+        )
+
+        assertEquals(
+            "map-stop-wide-ORANGE",
+            transferLayer0.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+        assertEquals(
+            "map-stop-wide-GREEN",
+            transferLayer1.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+        assertEquals(
+            "map-stop-wide-COMMUTER",
+            transferLayer2.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+
+        assertEquals(
+            "alert-small-orange-shuttle",
+            alertLayer0.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+        assertEquals(
+            "alert-small-green-suspension",
+            alertLayer1.iconImage!!.evaluate(feature.properties, zoom = 14.0)
+        )
+        assertEquals("", alertLayer2.iconImage!!.evaluate(feature.properties, zoom = 14.0))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
@@ -1,0 +1,193 @@
+package com.mbta.tid.mbta_app.map.style
+
+import kotlin.jvm.JvmName
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private fun JSONValue.toKotlin(): JsonElement =
+    when (this) {
+        is JSONValue.Array -> JsonArray(this.data.map { it.toKotlin() })
+        is JSONValue.Boolean -> JsonPrimitive(this.data)
+        is JSONValue.Number -> JsonPrimitive(this.data)
+        is JSONValue.Object -> JsonObject(this.data.mapValues { it.value.toKotlin() })
+        is JSONValue.String -> JsonPrimitive(this.data)
+    }
+
+private data class EvaluationContext(val featureProperties: FeatureProperties, val zoom: Double) {
+    fun evaluate(json: JsonElement): JsonElement {
+        return if (json is JsonArray) {
+            when (val operator = (json.firstOrNull() as? JsonPrimitive)?.contentOrNull) {
+                "boolean" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.boolean)
+                "string" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.content)
+                "at" -> {
+                    val index = evaluate(json[1]).jsonPrimitive.int
+                    val array = evaluate(json[2]).jsonArray
+                    array[index]
+                }
+                "get" -> {
+                    val property = evaluate(json[1]).jsonPrimitive.content
+                    if (json.size == 2) {
+                        featureProperties.data.getValue(property).toKotlin()
+                    } else {
+                        evaluate(json[2]).jsonObject.getValue(property)
+                    }
+                }
+                "has" -> {
+                    val property = evaluate(json[1]).jsonPrimitive.content
+                    if (json.size == 2) {
+                        JsonPrimitive(featureProperties.data.containsKey(property))
+                    } else {
+                        JsonPrimitive(evaluate(json[2]).jsonObject.containsKey(property))
+                    }
+                }
+                "length" ->
+                    when (val target = evaluate(json[1])) {
+                        is JsonArray -> JsonPrimitive(target.size)
+                        is JsonPrimitive -> JsonPrimitive(target.content.length)
+                        else -> throw IllegalArgumentException("can't take length of $target")
+                    }
+                "!" -> JsonPrimitive(!evaluate(json[1]).jsonPrimitive.boolean)
+                "==" -> JsonPrimitive(evaluate(json[1]) == evaluate(json[2]))
+                ">=" -> {
+                    val lhs = evaluate(json[1])
+                    val rhs = evaluate(json[2])
+                    if (lhs.jsonPrimitive.isString) {
+                        JsonPrimitive(lhs.jsonPrimitive.content >= rhs.jsonPrimitive.content)
+                    } else {
+                        JsonPrimitive(lhs.jsonPrimitive.double >= rhs.jsonPrimitive.double)
+                    }
+                }
+                "all" -> JsonPrimitive(json.drop(1).all { evaluate(it).jsonPrimitive.boolean })
+                "any" -> JsonPrimitive(json.drop(1).any { evaluate(it).jsonPrimitive.boolean })
+                "case" -> {
+                    for ((condition, output) in
+                        json.drop(1).dropLast(1).windowed(size = 2, step = 2)) {
+                        if (evaluate(condition).jsonPrimitive.boolean) {
+                            return evaluate(output)
+                        }
+                    }
+                    evaluate(json.last())
+                }
+                "step" -> {
+                    val input = evaluate(json[1]).jsonPrimitive.double
+                    var previousOutput = evaluate(json[2])
+                    for ((stopInput, stopOutput) in json.drop(3).windowed(size = 2, step = 2)) {
+                        if (input < evaluate(stopInput).jsonPrimitive.double) break
+                        previousOutput = evaluate(stopOutput)
+                    }
+                    return previousOutput
+                }
+                "concat" ->
+                    JsonPrimitive(
+                        buildString {
+                            for (input in json.drop(1)) {
+                                append(evaluate(input).jsonPrimitive.content)
+                            }
+                        }
+                    )
+                "downcase" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.content.lowercase())
+                "zoom" -> JsonPrimitive(zoom)
+                "array",
+                "collator",
+                "format",
+                "image",
+                "literal",
+                "number",
+                "number-format",
+                "object",
+                "to-boolean",
+                "to-color",
+                "to-number",
+                "to-string",
+                "typeof",
+                "accumulated",
+                "feature-state",
+                "geometry-type",
+                "id",
+                "line-progress",
+                "properties",
+                "config",
+                "in",
+                "index-of",
+                "measure-light",
+                "slice",
+                "!=",
+                "<",
+                "<=",
+                ">",
+                "coalesce",
+                "match",
+                "within",
+                "interpolate",
+                "interpolate-hcl",
+                "interpolate-lab",
+                "let",
+                "var",
+                "downcase",
+                "is-supported-script",
+                "resolved-locale",
+                "upcase",
+                "hsl",
+                "hsla",
+                "rgb",
+                "rgba",
+                "to-rgba",
+                "-",
+                "*",
+                "/",
+                "%",
+                "^",
+                "+",
+                "abs",
+                "acos",
+                "asin",
+                "atan",
+                "ceil",
+                "cos",
+                "distance",
+                "e",
+                "floor",
+                "ln",
+                "ln2",
+                "log10",
+                "log2",
+                "max",
+                "min",
+                "pi",
+                "random",
+                "round",
+                "sin",
+                "sqrt",
+                "tan",
+                "distance-from-center",
+                "pitch",
+                "heatmap-density" ->
+                    throw NotImplementedError("operation $operator not implemented in ExpEval")
+                else -> json
+            }
+        } else {
+            json
+        }
+    }
+}
+
+@JvmName("evaluateResolvedImage")
+fun Exp<ResolvedImage>.evaluate(featureProperties: FeatureProperties, zoom: Double): String {
+    val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
+    return result.jsonPrimitive.content
+}
+
+@JvmName("evaluateString")
+fun Exp<String>.evaluate(featureProperties: FeatureProperties, zoom: Double): String {
+    val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
+    return result.jsonPrimitive.content
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Move map logic towards shared code](https://app.asana.com/0/1201654106676769/1207789718623665/f)

Adds a bit of extra logic to let us actually test that our expressions will work correctly. Stacked on #305.

I've only bothered to implement the expressions that this test actually touches, so if anyone in the future adds tests that use expressions I haven't implemented here, they'll need to implement those expressions; if it'd make more sense to go ahead and eagerly implement all the expressions we've got helper functions to create, I can do that.

### Testing

Copied in the real route mapping from North Station for this unit test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
