### PR TITLE
fix(android): accept user-trusted root certificates in debug builds

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="MBTA Transit"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity

--- a/androidApp/src/main/res/xml/network_security_config.xml
+++ b/androidApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added CAs while debuggable only -->
+            <certificates src="user" />
+            <certificates src="system" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1722278776214579?thread_ts=1721846672.319229&cid=C062QNAJZ2M)

I don't understand why Android is designed this way.

### Testing

Validated that this makes the app work behind an enterprise MITM layer if the root CA is marked as trusted in the OS.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
