### PR TITLE
feat: bridge shared Mapbox styles to Android

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.kotlinAndroid)
     id("ios-assets")
+    id("check-mapbox-bridge")
 }
 
 android {
@@ -73,4 +74,5 @@ task("accessToken") {
 
 gradle.projectsEvaluated {
     tasks.getByPath("preBuild").dependsOn("accessToken", "convertIosIconsToAssets")
+    tasks.getByPath("check").dependsOn("checkMapboxBridge")
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapboxBridge.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapboxBridge.kt
@@ -1,0 +1,155 @@
+package com.mbta.tid.mbta_app.android.map
+
+import com.google.gson.JsonArray as MapboxJsonArray
+import com.google.gson.JsonElement as MapboxJsonElement
+import com.google.gson.JsonObject as MapboxJsonObject
+import com.google.gson.JsonPrimitive as MapboxJsonPrimitive
+import com.mapbox.geojson.Feature as MapboxFeature
+import com.mapbox.geojson.FeatureCollection as MapboxFeatureCollection
+import com.mapbox.geojson.Geometry as MapboxGeometry
+import com.mapbox.geojson.GeometryCollection as MapboxGeometryCollection
+import com.mapbox.geojson.LineString as MapboxLineString
+import com.mapbox.geojson.MultiLineString as MapboxMultiLineString
+import com.mapbox.geojson.MultiPoint as MapboxMultiPoint
+import com.mapbox.geojson.MultiPolygon as MapboxMultiPolygon
+import com.mapbox.geojson.Point as MapboxPoint
+import com.mapbox.geojson.Polygon as MapboxPolygon
+import com.mapbox.maps.extension.style.expressions.generated.Expression as MapboxExpression
+import com.mapbox.maps.extension.style.layers.generated.LineLayer as MapboxLineLayer
+import com.mapbox.maps.extension.style.layers.generated.SymbolLayer as MapboxSymbolLayer
+import com.mapbox.maps.extension.style.layers.properties.generated.LineJoin.Companion as MapboxLineJoin
+import com.mapbox.maps.extension.style.layers.properties.generated.TextJustify.Companion as MapboxTextJustify
+import com.mbta.tid.mbta_app.android.util.toPoint
+import com.mbta.tid.mbta_app.map.style.Exp
+import com.mbta.tid.mbta_app.map.style.Feature
+import com.mbta.tid.mbta_app.map.style.FeatureCollection
+import com.mbta.tid.mbta_app.map.style.JSONArray
+import com.mbta.tid.mbta_app.map.style.JSONObject
+import com.mbta.tid.mbta_app.map.style.JSONValue
+import com.mbta.tid.mbta_app.map.style.LineJoin
+import com.mbta.tid.mbta_app.map.style.LineLayer
+import com.mbta.tid.mbta_app.map.style.SymbolLayer
+import com.mbta.tid.mbta_app.map.style.TextAnchor
+import com.mbta.tid.mbta_app.map.style.TextJustify
+import io.github.dellisd.spatialk.geojson.Geometry
+import io.github.dellisd.spatialk.geojson.GeometryCollection
+import io.github.dellisd.spatialk.geojson.LineString
+import io.github.dellisd.spatialk.geojson.MultiLineString
+import io.github.dellisd.spatialk.geojson.MultiPoint
+import io.github.dellisd.spatialk.geojson.MultiPolygon
+import io.github.dellisd.spatialk.geojson.Point
+import io.github.dellisd.spatialk.geojson.Polygon
+import io.github.dellisd.spatialk.geojson.Position
+
+fun Position.toMapbox() = toPoint()
+
+@JvmName("listPositionToMapbox") fun List<Position>.toMapbox() = map { it.toMapbox() }
+
+@JvmName("listListPositionToMapbox") fun List<List<Position>>.toMapbox() = map { it.toMapbox() }
+
+fun Geometry.toMapbox(): MapboxGeometry =
+    when (this) {
+        is GeometryCollection ->
+            MapboxGeometryCollection.fromGeometries(this.geometries.map { it.toMapbox() })
+        is Point -> MapboxPoint.fromLngLat(this.coordinates.longitude, this.coordinates.latitude)
+        is MultiPoint -> MapboxMultiPoint.fromLngLats(this.coordinates.toMapbox())
+        is LineString -> MapboxLineString.fromLngLats(this.coordinates.toMapbox())
+        is MultiLineString -> MapboxMultiLineString.fromLngLats(this.coordinates.toMapbox())
+        is Polygon -> MapboxPolygon.fromLngLats(this.coordinates.toMapbox())
+        is MultiPolygon -> MapboxMultiPolygon.fromLngLats(this.coordinates.map { it.toMapbox() })
+    }
+
+fun JSONArray.toMapbox(): MapboxJsonArray =
+    MapboxJsonArray().apply {
+        for (el in this@toMapbox) {
+            add(el.toMapbox())
+        }
+    }
+
+fun JSONObject.toMapbox(): MapboxJsonObject =
+    MapboxJsonObject().apply {
+        for (el in this@toMapbox) {
+            add(el.key, el.value.toMapbox())
+        }
+    }
+
+fun JSONValue.toMapbox(): MapboxJsonElement =
+    when (this) {
+        is JSONValue.Array -> this.data.toMapbox()
+        is JSONValue.Boolean -> MapboxJsonPrimitive(this.data)
+        is JSONValue.Number -> MapboxJsonPrimitive(this.data)
+        is JSONValue.Object -> this.data.toMapbox()
+        is JSONValue.String -> MapboxJsonPrimitive(this.data)
+    }
+
+fun Feature.toMapbox(): MapboxFeature =
+    MapboxFeature.fromGeometry(this.geometry.toMapbox(), this.properties.data.toMapbox(), this.id)
+
+fun FeatureCollection.toMapbox(): MapboxFeatureCollection =
+    MapboxFeatureCollection.fromFeatures(this.features.map { it.toMapbox() })
+
+fun <T> Exp<T>.toMapbox() = MapboxExpression.fromRaw(this.toJsonString())
+
+fun LineJoin.toMapbox() =
+    when (this) {
+        LineJoin.Bevel -> MapboxLineJoin.BEVEL
+        LineJoin.Round -> MapboxLineJoin.ROUND
+        LineJoin.Miter -> MapboxLineJoin.MITER
+        LineJoin.None -> null
+    }
+
+fun TextAnchor.toMapbox() = this.name.lowercase().replace("_", "-")
+
+fun TextJustify.toMapbox() =
+    when (this) {
+        TextJustify.AUTO -> MapboxTextJustify.AUTO
+        TextJustify.LEFT -> MapboxTextJustify.LEFT
+        TextJustify.CENTER -> MapboxTextJustify.CENTER
+        TextJustify.RIGHT -> MapboxTextJustify.RIGHT
+    }
+
+fun LineLayer.toMapbox(): MapboxLineLayer {
+    val result = MapboxLineLayer(layerId = this.id, sourceId = this.source)
+
+    filter?.let { result.filter(it.toMapbox()) }
+    minZoom?.let { result.minZoom(it) }
+
+    lineColor?.let { result.lineColor(it.toMapbox()) }
+    lineDasharray?.let { result.lineDasharray(it) }
+    lineJoin?.toMapbox()?.let { result.lineJoin(it) }
+    lineOffset?.let { result.lineOffset(it.toMapbox()) }
+    lineSortKey?.let { result.lineSortKey(it.toMapbox()) }
+    lineWidth?.let { result.lineWidth(it.toMapbox()) }
+
+    return result
+}
+
+fun SymbolLayer.toMapbox(): MapboxSymbolLayer {
+    val result = MapboxSymbolLayer(layerId = this.id, sourceId = this.source)
+
+    filter?.let { result.filter(it.toMapbox()) }
+    minZoom?.let { result.minZoom(it) }
+
+    iconAllowOverlap?.let { result.iconAllowOverlap(it) }
+    iconImage?.let { result.iconImage(it.toMapbox()) }
+    iconOffset?.let { result.iconOffset(it.toMapbox()) }
+    iconPadding?.let { result.iconPadding(it) }
+    iconSize?.let { result.iconSize(it.toMapbox()) }
+
+    symbolSortKey?.let { result.symbolSortKey(it.toMapbox()) }
+
+    textAllowOverlap?.let { result.textAllowOverlap(it) }
+    textColor?.let { result.textColor(it.toMapbox()) }
+    textField?.let { result.textField(it.toMapbox()) }
+    textFont?.let { result.textFont(it) }
+    textHaloColor?.let { result.textHaloColor(it.toMapbox()) }
+    textHaloWidth?.let { result.textHaloWidth(it) }
+    textJustify?.let { result.textJustify(it.toMapbox()) }
+    textOffset?.let { result.textOffset(it.toMapbox()) }
+    textOptional?.let { result.textOptional(it) }
+    textRadialOffset?.let { result.textRadialOffset(it) }
+    textSize?.let { result.textSize(it) }
+    textVariableAnchor?.let { result.textVariableAnchor(it.map(TextAnchor::toMapbox)) }
+
+    return result
+}

--- a/androidApp/src/test/java/com/mbta/tid/mbta_app/android/map/MapboxBridgeTest.kt
+++ b/androidApp/src/test/java/com/mbta/tid/mbta_app/android/map/MapboxBridgeTest.kt
@@ -1,0 +1,22 @@
+package com.mbta.tid.mbta_app.android.map
+
+import com.mapbox.maps.extension.style.layers.generated.SymbolLayer as MapboxSymbolLayer
+import com.mbta.tid.mbta_app.map.style.Exp
+import com.mbta.tid.mbta_app.map.style.SymbolLayer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MapboxBridgeTest {
+    @Test
+    fun `symbol layer gets translated properly`() {
+        val symbolLayer = SymbolLayer(id = "symbol-layer", source = "stop-source")
+        symbolLayer.textField = Exp("this is text")
+
+        val bridgedSymbolLayer = symbolLayer.toMapbox()
+
+        val mapboxSymbolLayer =
+            MapboxSymbolLayer("symbol-layer", "stop-source").textField("this is text")
+
+        assertEquals(mapboxSymbolLayer.toString(), bridgedSymbolLayer.toString())
+    }
+}

--- a/buildSrc/src/main/kotlin/check-mapbox-bridge.gradle.kts
+++ b/buildSrc/src/main/kotlin/check-mapbox-bridge.gradle.kts
@@ -1,0 +1,63 @@
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.readText
+
+val layerProperty = Regex("va[lr] (?<name>\\w+): ")
+val identifier = Regex("\\w+")
+
+fun getPropertiesDeclaredInFile(file: Path) =
+    layerProperty
+        .findAll(file.readText())
+        .map { checkNotNull(it.groups["name"]).value }
+        .filter { it !in setOf("id", "type", "source") }
+
+fun identifiersInCode(code: String) = identifier.findAll(code).map { it.value }
+
+tasks.register("checkMapboxBridge") {
+    val mapboxBridgePath =
+        Path("$projectDir/src/main/java/com/mbta/tid/mbta_app/android/map/MapboxBridge.kt")
+    val mapboxBridgeSource = mapboxBridgePath.readText()
+
+    // \s is whitespace, \S is non-whitespace, (?=\S) is positive-lookahead non-whitespace
+    // so this splits on blank lines that are not followed by indentation
+    val mapboxBridgePieces = mapboxBridgeSource.split(Regex("\n\n(?=\\S)"))
+
+    val lineLayerBridge =
+        checkNotNull(mapboxBridgePieces.find { it.startsWith("fun LineLayer.toMapbox()") })
+    val lineLayerIdentifiers = identifiersInCode(lineLayerBridge)
+    val symbolLayerBridge =
+        checkNotNull(mapboxBridgePieces.find { it.startsWith("fun SymbolLayer.toMapbox()") })
+    val symbolLayerIdentifiers = identifiersInCode(symbolLayerBridge)
+
+    val sharedMapStylePackage =
+        Path("$projectDir/../shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style")
+
+    val sharedLayerPath = sharedMapStylePackage.resolve("Layer.kt")
+    val layerProperties = getPropertiesDeclaredInFile(sharedLayerPath)
+
+    val sharedLineLayerPath = sharedMapStylePackage.resolve("LineLayer.kt")
+    val lineLayerProperties = getPropertiesDeclaredInFile(sharedLineLayerPath)
+
+    val sharedSymbolLayerPath = sharedMapStylePackage.resolve("SymbolLayer.kt")
+    val symbolLayerProperties = getPropertiesDeclaredInFile(sharedSymbolLayerPath)
+
+    val badProperties = mutableListOf<Pair<String, Int>>()
+
+    for (property in layerProperties + lineLayerProperties) {
+        val references = lineLayerIdentifiers.count { it == property }
+        if (references != 2) {
+            badProperties.add("LineLayer.$property" to references)
+        }
+    }
+
+    for (property in layerProperties + symbolLayerProperties) {
+        val references = symbolLayerIdentifiers.count { it == property }
+        if (references != 2) {
+            badProperties.add("SymbolLayer.$property" to references)
+        }
+    }
+
+    if (badProperties.isNotEmpty()) {
+        throw IllegalStateException("Layer properties not referenced 2 times: $badProperties")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
@@ -37,12 +37,12 @@ object ChildStopLayerGenerator {
         layer.textFont = listOf("Inter Italic")
         layer.textHaloColor = Exp(colorPalette.fill3).downcastToColor()
         layer.textHaloWidth = 2.0
-        layer.textSize = 12
+        layer.textSize = 12.0
         layer.textVariableAnchor =
             listOf(TextAnchor.LEFT, TextAnchor.RIGHT, TextAnchor.BOTTOM, TextAnchor.TOP)
         layer.textJustify = TextJustify.AUTO
         layer.textOptional = true
-        layer.textRadialOffset = 1
+        layer.textRadialOffset = 1.0
         layer.iconAllowOverlap = true
         layer.textAllowOverlap = false
         layer.symbolSortKey = Exp.get(ChildStopFeaturesBuilder.propSortOrderKey)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
@@ -86,7 +86,7 @@ object StopLayerGenerator {
         stopLayer.textFont = listOf("Inter Regular")
         stopLayer.textHaloColor = Exp(colorPalette.fill3).downcastToColor()
         stopLayer.textHaloWidth = 2.0
-        stopLayer.textSize = 13
+        stopLayer.textSize = 13.0
         stopLayer.textVariableAnchor =
             listOf(TextAnchor.RIGHT, TextAnchor.BOTTOM, TextAnchor.TOP, TextAnchor.LEFT)
         stopLayer.textJustify = TextJustify.AUTO

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Layer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Layer.kt
@@ -10,7 +10,7 @@ sealed class Layer : MapboxStyleObject {
     abstract val filter: Exp<Boolean>?
     abstract val source: String?
 
-    var minZoom: Number? = null
+    var minZoom: Double? = null
 
     final override fun asJson() = buildJsonObject {
         put("id", id)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineLayer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineLayer.kt
@@ -9,7 +9,7 @@ data class LineLayer(override val id: String, override val source: String) : Lay
     override var filter: Exp<Boolean>? = null
 
     var lineColor: Exp<Color>? = null
-    var lineDasharray: List<Number>? = null
+    var lineDasharray: List<Double>? = null
     var lineJoin: LineJoin? = null
     var lineOffset: Exp<Number>? = null
     var lineSortKey: Exp<Number>? = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/SymbolLayer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/SymbolLayer.kt
@@ -12,7 +12,7 @@ data class SymbolLayer(override val id: String, override val source: String) : L
     var iconAllowOverlap: Boolean? = null
     var iconImage: Exp<ResolvedImage>? = null
     var iconOffset: Exp<List<Number>>? = null
-    var iconPadding: Number? = null
+    var iconPadding: Double? = null
     var iconSize: Exp<Number>? = null
 
     var symbolSortKey: Exp<Number>? = null
@@ -22,12 +22,12 @@ data class SymbolLayer(override val id: String, override val source: String) : L
     var textField: Exp<String>? = null
     var textFont: List<String>? = null
     var textHaloColor: Exp<Color>? = null
-    var textHaloWidth: Number? = null
+    var textHaloWidth: Double? = null
     var textJustify: TextJustify? = null
     var textOffset: Exp<List<Number>>? = null
     var textOptional: Boolean? = null
-    var textRadialOffset: Number? = null
-    var textSize: Number? = null
+    var textRadialOffset: Double? = null
+    var textSize: Double? = null
     var textVariableAnchor: List<TextAnchor>? = null
 
     override fun layoutAsJson() = buildJsonObject {


### PR DESCRIPTION
### Summary

_Ticket:_ [Use shared map logic on Android](https://app.asana.com/0/1201654106676769/1207898757421619/f)

Stacked on #316. Creates, but does not use, the logic that turns shared Mapbox style layers into real Android Mapbox style layers, with tests at compile time to ensure that we don't forget to add new properties to the bridge.

### Testing

Validated that the compile-time check works and that once we use these functions they cause the map to behave correctly.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
