### PR TITLE
refactor(android): match iOS component structure

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RouteHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RouteHeaderTest.kt
@@ -9,13 +9,13 @@ import com.mbta.tid.mbta_app.model.RouteType
 import org.junit.Rule
 import org.junit.Test
 
-class RouteCardHeaderTest {
+class RouteHeaderTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testRouteCardHeaderForBus() {
+    fun testRouteHeaderForBus() {
         composeTestRule.setContent {
-            RouteCardHeader(
+            RouteHeader(
                 route =
                     Route(
                         "a",
@@ -28,18 +28,16 @@ class RouteCardHeaderTest {
                         1,
                         "000000"
                     )
-            ) {
-                // Empty
-            }
+            )
         }
         composeTestRule.onNodeWithText("Short name").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Bus").assertIsDisplayed()
     }
 
     @Test
-    fun testRouteCardHeaderForFerry() {
+    fun testRouteHeaderForFerry() {
         composeTestRule.setContent {
-            RouteCardHeader(
+            RouteHeader(
                 route =
                     Route(
                         "a",
@@ -52,18 +50,16 @@ class RouteCardHeaderTest {
                         1,
                         "000000"
                     )
-            ) {
-                // Empty
-            }
+            )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Ferry").assertIsDisplayed()
     }
 
     @Test
-    fun testRouteCardHeaderForCommuterRail() {
+    fun testRouteHeaderForCommuterRail() {
         composeTestRule.setContent {
-            RouteCardHeader(
+            RouteHeader(
                 route =
                     Route(
                         "a",
@@ -76,18 +72,16 @@ class RouteCardHeaderTest {
                         1,
                         "000000"
                     )
-            ) {
-                // Empty
-            }
+            )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Commuter Rail").assertIsDisplayed()
     }
 
     @Test
-    fun testRouteCardHeaderForSubway() {
+    fun testRouteHeaderForSubway() {
         composeTestRule.setContent {
-            RouteCardHeader(
+            RouteHeader(
                 route =
                     Route(
                         "a",
@@ -100,9 +94,7 @@ class RouteCardHeaderTest {
                         1,
                         "000000"
                     )
-            ) {
-                // Empty
-            }
+            )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Subway").assertIsDisplayed()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
@@ -1,25 +1,13 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
-import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
 import com.mbta.tid.mbta_app.model.RealtimePatterns
@@ -31,54 +19,12 @@ fun HeadsignRowView(
     predictions: RealtimePatterns.Format,
     modifier: Modifier = Modifier
 ) {
-    Row(
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = 74.dp)
-            .background(color = MaterialTheme.colorScheme.background),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Column(modifier = Modifier.weight(1f).padding(16.dp)) {
-            Text(
-                headsign,
-                style = MaterialTheme.typography.headlineMedium,
-                fontWeight = FontWeight.Bold
-            )
-        }
-        Row(
-            modifier = Modifier.weight(1f),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.End,
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                when (predictions) {
-                    is RealtimePatterns.Format.Some ->
-                        for (prediction in predictions.trips) {
-                            UpcomingTripView(UpcomingTripViewState.Some(prediction.format))
-                        }
-                    is RealtimePatterns.Format.NoService ->
-                        UpcomingTripView(UpcomingTripViewState.NoService(predictions.alert.effect))
-                    is RealtimePatterns.Format.None -> UpcomingTripView(UpcomingTripViewState.None)
-                    is RealtimePatterns.Format.Loading ->
-                        UpcomingTripView(UpcomingTripViewState.Loading)
-                }
-            }
-
-            Column(
-                modifier = Modifier.padding(8.dp).widthIn(max = 8.dp),
-            ) {
-                Icon(
-                    painterResource(id = R.drawable.baseline_chevron_right_24),
-                    contentDescription = "Arrow Right",
-                    tint = MaterialTheme.colorScheme.tertiary
-                )
-            }
-        }
+    PredictionRowView(predictions = predictions, modifier = modifier) {
+        Text(
+            headsign,
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
     }
 }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -1,0 +1,70 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.RealtimePatterns
+
+@Composable
+fun PredictionRowView(
+    predictions: RealtimePatterns.Format,
+    modifier: Modifier = Modifier,
+    destination: @Composable () -> Unit
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = 74.dp)
+            .background(color = MaterialTheme.colorScheme.background),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f).padding(16.dp)) { destination() }
+        Row(
+            modifier = Modifier.weight(1f),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.End,
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                when (predictions) {
+                    is RealtimePatterns.Format.Some ->
+                        for (prediction in predictions.trips) {
+                            UpcomingTripView(UpcomingTripViewState.Some(prediction.format))
+                        }
+                    is RealtimePatterns.Format.NoService ->
+                        UpcomingTripView(UpcomingTripViewState.NoService(predictions.alert.effect))
+                    is RealtimePatterns.Format.None -> UpcomingTripView(UpcomingTripViewState.None)
+                    is RealtimePatterns.Format.Loading ->
+                        UpcomingTripView(UpcomingTripViewState.Loading)
+                }
+            }
+
+            Column(
+                modifier = Modifier.padding(8.dp).widthIn(max = 8.dp),
+            ) {
+                Icon(
+                    painterResource(id = R.drawable.baseline_chevron_right_24),
+                    contentDescription = "Arrow Right",
+                    tint = MaterialTheme.colorScheme.tertiary
+                )
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteCard.kt
@@ -1,0 +1,17 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.runtime.Composable
+import com.mbta.tid.mbta_app.model.Route
+
+@Composable
+fun RouteCard(
+    route: Route,
+    pinned: Boolean,
+    onPin: (String) -> Unit,
+    content: @Composable () -> Unit
+) {
+    TransitCard(
+        header = { RouteHeader(route) { PinButton(pinned = pinned) { onPin(route.id) } } },
+        content = content
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteHeader.kt
@@ -1,0 +1,26 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteType
+
+@Composable
+fun RouteHeader(route: Route, rightContent: (@Composable () -> Unit)? = null) {
+    val routeName =
+        when (route.type) {
+            RouteType.BUS -> route.shortName
+            RouteType.COMMUTER_RAIL -> route.longName.replace("/", " / ")
+            else -> route.longName
+        }
+    val (modeIcon, modeDescription) = routeIcon(route)
+    TransitHeader(
+        routeName,
+        backgroundColor = Color.fromHex(route.color),
+        textColor = Color.fromHex(route.textColor),
+        modeIcon = modeIcon,
+        modeDescription = modeDescription,
+        rightContent
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
@@ -1,0 +1,16 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteType
+
+@Composable
+fun routeIcon(route: Route) =
+    when (route.type) {
+        RouteType.BUS -> Pair(painterResource(id = R.drawable.mode_bus), "Bus")
+        RouteType.COMMUTER_RAIL -> Pair(painterResource(id = R.drawable.mode_cr), "Commuter Rail")
+        RouteType.FERRY -> Pair(painterResource(id = R.drawable.mode_ferry), "Ferry")
+        else -> Pair(painterResource(id = R.drawable.mode_subway), "Subway")
+    }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitCard.kt
@@ -1,0 +1,25 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun TransitCard(header: @Composable () -> Unit, content: @Composable () -> Unit) {
+    Card(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+        shape = MaterialTheme.shapes.medium,
+        colors = CardDefaults.cardColors(containerColor = colorResource(id = R.color.fill3)),
+        border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outline)
+    ) {
+        header()
+        content()
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitHeader.kt
@@ -16,66 +16,37 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.android.util.fromHex
-import com.mbta.tid.mbta_app.model.Route
-import com.mbta.tid.mbta_app.model.RouteType
 
 @Composable
-fun RouteCardHeader(
-    route: Route,
-    rightContent: (@Composable () -> Unit)? = null,
-    body: @Composable () -> Unit
+fun TransitHeader(
+    name: String,
+    backgroundColor: Color,
+    textColor: Color,
+    modeIcon: Painter,
+    modeDescription: String,
+    rightContent: (@Composable () -> Unit)? = null
 ) {
     Column(
         modifier =
-            Modifier.heightIn(min = 44.dp)
-                .background(color = Color.fromHex(route.color))
-                .fillMaxWidth(),
+            Modifier.heightIn(min = 44.dp).background(color = backgroundColor).fillMaxWidth(),
         verticalArrangement = Arrangement.Center
     ) {
-        val textColor = route.textColor
-        val routeName =
-            when (route.type) {
-                RouteType.BUS -> route.shortName
-                else -> route.longName
-            }
-
-        val routeIconResource =
-            when (route.type) {
-                RouteType.BUS -> painterResource(R.drawable.bus)
-                RouteType.FERRY -> painterResource(R.drawable.ferry)
-                RouteType.COMMUTER_RAIL -> painterResource(R.drawable.commuter_rail)
-                else -> painterResource(R.drawable.subway)
-            }
-
-        val routeIconDescription =
-            when (route.type) {
-                RouteType.BUS -> "Bus"
-                RouteType.FERRY -> "Ferry"
-                RouteType.COMMUTER_RAIL -> "Commuter Rail"
-                else -> "Subway"
-            }
         Row(
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                routeIconResource,
-                contentDescription = routeIconDescription,
-                tint = Color.fromHex(textColor)
-            )
+            Icon(modeIcon, contentDescription = modeDescription, tint = textColor)
             Spacer(modifier = Modifier.width(8.dp))
             Text(
-                text = routeName,
+                text = name,
                 maxLines = 1,
                 style =
                     LocalTextStyle.current.copy(
-                        color = Color.fromHex(textColor),
+                        color = textColor,
                         fontSize = 17.sp,
                         fontWeight = FontWeight.Bold
                     )
@@ -86,5 +57,4 @@ fun RouteCardHeader(
             }
         }
     }
-    body()
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyRouteView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyRouteView.kt
@@ -1,15 +1,7 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.mbta.tid.mbta_app.android.component.PinButton
-import com.mbta.tid.mbta_app.android.component.RouteCardHeader
+import com.mbta.tid.mbta_app.android.component.RouteCard
 import com.mbta.tid.mbta_app.model.StopsAssociated
 import kotlinx.datetime.Instant
 
@@ -20,22 +12,9 @@ fun NearbyRouteView(
     onPin: (String) -> Unit,
     now: Instant,
 ) {
-    Card(
-        modifier =
-            Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
-                .border(
-                    BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.outline),
-                    shape = MaterialTheme.shapes.medium
-                ),
-        shape = MaterialTheme.shapes.medium
-    ) {
-        RouteCardHeader(
-            nearbyRoute.route,
-            rightContent = { PinButton(pinned = pinned) { onPin(nearbyRoute.id) } }
-        ) {
-            for (patternsAtStop in nearbyRoute.patternsByStop) {
-                NearbyStopView(patternsAtStop, now)
-            }
+    RouteCard(nearbyRoute.route, pinned, onPin) {
+        for (patternsAtStop in nearbyRoute.patternsByStop) {
+            NearbyStopView(patternsAtStop, now)
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
@@ -1,12 +1,17 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HeadsignRowView
 import com.mbta.tid.mbta_app.model.PatternsByStop
 import com.mbta.tid.mbta_app.model.RealtimePatterns
@@ -18,11 +23,13 @@ fun NearbyStopView(
     patternsAtStop: PatternsByStop,
     now: Instant,
 ) {
-    Text(
-        text = patternsAtStop.stop.name,
-        modifier = Modifier.padding(top = 11.dp, bottom = 11.dp, start = 16.dp, end = 8.dp),
-        style = MaterialTheme.typography.headlineSmall
-    )
+    Row(modifier = Modifier.background(colorResource(id = R.color.fill2)).fillMaxWidth()) {
+        Text(
+            text = patternsAtStop.stop.name,
+            modifier = Modifier.padding(top = 11.dp, bottom = 11.dp, start = 16.dp, end = 8.dp),
+            style = MaterialTheme.typography.headlineSmall
+        )
+    }
 
     for (patterns in patternsAtStop.patterns) {
         when (patterns) {


### PR DESCRIPTION
### Summary

_Ticket:_ [[Android] Green Line grouping](https://app.asana.com/0/1205732265579288/1207953370146533/f)

Rearranges some of our Android component structure to more closely resemble the iOS side. The iOS abstractions were mostly introduced to support Green Line grouping, and this will help with that on the Android side.

### Testing

Manually verified that the nearby transit panel looks the same before and after this refactor.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
