### PR TITLE
Jvc android tab navigation

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButtonTest.kt
@@ -1,0 +1,23 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class BottomNavIconButtonTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testBottomNavIconButton() {
+        val icon = 0
+        val label = "Hello World"
+        val active = false
+
+        composeTestRule.setContent {
+            BottomNavIconButton(onClick = {}, icon = icon, label = label, active = active)
+        }
+
+        composeTestRule.onNodeWithText("Hello World").assertExists()
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -1,6 +1,9 @@
 package com.mbta.tid.mbta_app.android
 
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
@@ -11,6 +14,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -19,6 +24,7 @@ import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.Backend
+import com.mbta.tid.mbta_app.android.component.BottomNavIconButton
 import com.mbta.tid.mbta_app.android.fetcher.fetchGlobalData
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
@@ -89,7 +95,21 @@ fun ContentView(
                     scaffoldState = scaffoldState,
                     mapViewportState = mapViewportState,
                     backend = backend
-                )
+                ),
+                bottomBar = {
+                    BottomAppBar(
+                        modifier = Modifier.height(83.dp),
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        actions = {
+                            BottomNavIconButton(
+                                onClick = { navController.navigate(Routes.nearbyTransit) },
+                                icon = R.drawable.map_pin,
+                                label = "Nearby",
+                                active = true,
+                            )
+                        }
+                    )
+                }
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MyApplicationTheme.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MyApplicationTheme.kt
@@ -59,7 +59,8 @@ fun MyApplicationTheme(
             headlineMedium = TextStyle(fontFamily = fontFamily, fontSize = 17.sp),
             headlineLarge = TextStyle(fontFamily = fontFamily, fontSize = 20.sp),
             titleLarge =
-                TextStyle(fontFamily = fontFamily, fontSize = 20.sp, fontWeight = FontWeight.Bold)
+                TextStyle(fontFamily = fontFamily, fontSize = 20.sp, fontWeight = FontWeight.Bold),
+            labelSmall = TextStyle(fontFamily = fontFamily, fontSize = 11.sp),
         )
     val shapes =
         Shapes(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButton.kt
@@ -1,0 +1,50 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun BottomNavIconButton(onClick: () -> Unit, icon: Int, label: String, active: Boolean) {
+    val iconButtonColors =
+        IconButtonColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            disabledContentColor = MaterialTheme.colorScheme.primary,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxSize(),
+        colors = iconButtonColors,
+        enabled = !active
+    ) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painterResource(icon),
+                contentDescription = "@null",
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(label, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,35 +42,40 @@ constructor(
 
 @OptIn(ExperimentalMaterial3Api::class, MapboxExperimental::class)
 @Composable
-fun NearbyTransitPage(nearbyTransit: NearbyTransit) {
-    BottomSheetScaffold(
-        sheetDragHandle = {
-            Column(
-                modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                BottomSheetDefaults.DragHandle()
-            }
-        },
-        sheetContent = {
-            NearbyTransitView(
-                Modifier.fillMaxSize().background(MaterialTheme.colorScheme.surface),
-                alertData = nearbyTransit.alertData,
+fun NearbyTransitPage(nearbyTransit: NearbyTransit, bottomBar: @Composable () -> Unit) {
+    Scaffold(bottomBar = bottomBar) { outerSheetPadding ->
+        BottomSheetScaffold(
+            sheetDragHandle = {
+                Column(
+                    modifier =
+                        Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    BottomSheetDefaults.DragHandle()
+                }
+            },
+            sheetContent = {
+                NearbyTransitView(
+                    Modifier.fillMaxSize()
+                        .padding(outerSheetPadding)
+                        .background(MaterialTheme.colorScheme.surface),
+                    alertData = nearbyTransit.alertData,
+                    globalData = nearbyTransit.globalData,
+                    targetLocation = nearbyTransit.mapCenter,
+                    setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
+                )
+            },
+            scaffoldState = nearbyTransit.scaffoldState,
+            sheetPeekHeight = 422.dp,
+        ) { sheetPadding ->
+            HomeMapView(
+                Modifier.padding(sheetPadding),
+                nearbyTransit.mapViewportState,
+                backend = nearbyTransit.backend,
                 globalData = nearbyTransit.globalData,
-                targetLocation = nearbyTransit.mapCenter,
-                setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
+                alertsData = nearbyTransit.alertData,
+                lastNearbyTransitLocation = nearbyTransit.lastNearbyTransitLocation
             )
-        },
-        scaffoldState = nearbyTransit.scaffoldState,
-        sheetPeekHeight = 339.dp,
-    ) { sheetPadding ->
-        HomeMapView(
-            Modifier.padding(sheetPadding),
-            nearbyTransit.mapViewportState,
-            backend = nearbyTransit.backend,
-            globalData = nearbyTransit.globalData,
-            alertsData = nearbyTransit.alertData,
-            lastNearbyTransitLocation = nearbyTransit.lastNearbyTransitLocation
-        )
+        }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[Android] Tab bar](https://app.asana.com/0/1205732265579288/1207729549786472/f)

What is this PR for?

This PR finishes the work started in #330, actually adding the navigation tabs to the Nearby Transit screen.

When the bottom sheet is peeking:
<img width="435" alt="Screenshot 2024-08-07 at 2 52 35 PM" src="https://github.com/user-attachments/assets/50617e0c-aec9-49c4-aa77-c24adbfe71a7">

When the sheet is extended:
<img width="424" alt="Screenshot 2024-08-07 at 2 52 51 PM" src="https://github.com/user-attachments/assets/f9e5628e-b936-4335-83c3-d8c20b62a127">


### Testing

What testing have you done?

The new component is unit tested. I'm thinking we should consider how to deal with the `nearbyTransit` directory - currently everything in it is untested, but whether we want to figure out how to test those views or refactor them into the more generic `components` directory seems like a good question for discussion.
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
