### PR TITLE
feat(android): blank stop details page

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
@@ -1,0 +1,14 @@
+package com.mbta.tid.mbta_app.android
+
+import kotlinx.serialization.Serializable
+
+object SheetRoutes {
+    @Serializable object NearbyTransit
+
+    @Serializable
+    data class StopDetails(
+        val stopId: String,
+        val filterRouteId: String?,
+        val filterDirectionId: Int?
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.model.Alert
@@ -17,9 +18,14 @@ import kotlinx.datetime.Clock
 fun DirectionRowView(
     direction: Direction,
     predictions: RealtimePatterns.Format,
+    modifier: Modifier = Modifier,
     pillDecoration: PillDecoration? = null
 ) {
-    PredictionRowView(predictions = predictions, pillDecoration = pillDecoration) {
+    PredictionRowView(
+        predictions = predictions,
+        modifier = modifier,
+        pillDecoration = pillDecoration
+    ) {
         DirectionLabel(direction)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopDeparturesSummaryList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopDeparturesSummaryList.kt
@@ -1,8 +1,10 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.model.PatternsByStop
 import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
@@ -14,6 +16,7 @@ fun StopDeparturesSummaryList(
     condenseHeadsignPredictions: Boolean,
     now: Instant,
     context: TripInstantDisplay.Context,
+    onClick: (RealtimePatterns) -> Unit
 ) {
     for (patterns in patternsAtStop.patterns) {
         when (patterns) {
@@ -21,6 +24,7 @@ fun StopDeparturesSummaryList(
                 HeadsignRowView(
                     patterns.headsign,
                     patterns.format(now, if (condenseHeadsignPredictions) 1 else 2, context),
+                    modifier = Modifier.clickable { onClick(patterns) },
                     pillDecoration =
                         if (patternsAtStop.line != null) PillDecoration.OnRow(patterns.route)
                         else null
@@ -30,6 +34,7 @@ fun StopDeparturesSummaryList(
                 DirectionRowView(
                     patterns.direction,
                     patterns.format(now, context),
+                    modifier = Modifier.clickable { onClick(patterns) },
                     pillDecoration = PillDecoration.OnPrediction(patterns.routesByTrip)
                 )
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyLineView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyLineView.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import androidx.compose.runtime.Composable
 import com.mbta.tid.mbta_app.android.component.LineCard
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopsAssociated
 import kotlinx.datetime.Instant
 
@@ -10,14 +11,16 @@ fun NearbyLineView(
     nearbyLine: StopsAssociated.WithLine,
     pinned: Boolean,
     onPin: (String) -> Unit,
-    now: Instant
+    now: Instant,
+    onOpenStopDetails: (String, StopDetailsFilter?) -> Unit
 ) {
     LineCard(nearbyLine.line, nearbyLine.routes, pinned, onPin) {
         for (patternsAtStop in nearbyLine.patternsByStop) {
             NearbyStopView(
                 patternsAtStop,
                 condenseHeadsignPredictions = nearbyLine.condensePredictions,
-                now
+                now,
+                onOpenStopDetails
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyRouteView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyRouteView.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import androidx.compose.runtime.Composable
 import com.mbta.tid.mbta_app.android.component.RouteCard
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopsAssociated
 import kotlinx.datetime.Instant
 
@@ -11,10 +12,11 @@ fun NearbyRouteView(
     pinned: Boolean,
     onPin: (String) -> Unit,
     now: Instant,
+    onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
 ) {
     RouteCard(nearbyRoute.route, pinned, onPin) {
         for (patternsAtStop in nearbyRoute.patternsByStop) {
-            NearbyStopView(patternsAtStop, now = now)
+            NearbyStopView(patternsAtStop, now = now, onOpenStopDetails = onOpenStopDetails)
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,6 +13,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.StopDeparturesSummaryList
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.PatternsByStop
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import kotlinx.datetime.Instant
@@ -21,8 +23,14 @@ fun NearbyStopView(
     patternsAtStop: PatternsByStop,
     condenseHeadsignPredictions: Boolean = false,
     now: Instant,
+    onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
 ) {
-    Row(modifier = Modifier.background(colorResource(id = R.color.fill2)).fillMaxWidth()) {
+    Row(
+        modifier =
+            Modifier.clickable { onOpenStopDetails(patternsAtStop.stop.id, null) }
+                .background(colorResource(id = R.color.fill2))
+                .fillMaxWidth()
+    ) {
         Text(
             text = patternsAtStop.stop.name,
             modifier = Modifier.padding(top = 11.dp, bottom = 11.dp, start = 16.dp, end = 8.dp),
@@ -35,5 +43,10 @@ fun NearbyStopView(
         condenseHeadsignPredictions,
         now,
         TripInstantDisplay.Context.NearbyTransit
-    )
+    ) { patterns ->
+        onOpenStopDetails(
+            patternsAtStop.stop.id,
+            StopDetailsFilter(patternsAtStop.routeIdentifier, patterns.directionId())
+        )
+    }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.fetcher.GlobalData
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
 import com.mbta.tid.mbta_app.android.util.getSchedule
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.android.util.subscribeToPredictions
@@ -35,6 +36,7 @@ fun NearbyTransitView(
     globalData: GlobalData,
     targetLocation: Position,
     setLastLocation: (Position) -> Unit,
+    onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
     nearbyRepository: INearbyRepository = koinInject(),
 ) {
     var nearby: NearbyStaticData? by remember { mutableStateOf(null) }
@@ -88,14 +90,16 @@ fun NearbyTransitView(
                             it,
                             pinnedRoutes.orEmpty().contains(it.id),
                             togglePinnedRoute,
-                            now
+                            now,
+                            onOpenStopDetails
                         )
                     is StopsAssociated.WithLine ->
                         NearbyLineView(
                             it,
                             pinnedRoutes.orEmpty().contains(it.id),
                             togglePinnedRoute,
-                            now
+                            now,
+                            onOpenStopDetails
                         )
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -12,15 +12,23 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.toRoute
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.Backend
+import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.fetcher.GlobalData
 import com.mbta.tid.mbta_app.android.map.HomeMapView
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitView
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import io.github.dellisd.spatialk.geojson.Position
 
@@ -41,6 +49,7 @@ constructor(
 @OptIn(ExperimentalMaterial3Api::class, MapboxExperimental::class)
 @Composable
 fun NearbyTransitPage(nearbyTransit: NearbyTransit, bottomBar: @Composable () -> Unit) {
+    val navController = rememberNavController()
     Scaffold(bottomBar = bottomBar) { outerSheetPadding ->
         BottomSheetScaffold(
             sheetDragHandle = {
@@ -53,15 +62,57 @@ fun NearbyTransitPage(nearbyTransit: NearbyTransit, bottomBar: @Composable () ->
                 }
             },
             sheetContent = {
-                NearbyTransitView(
-                    Modifier.fillMaxSize()
-                        .padding(outerSheetPadding)
-                        .background(MaterialTheme.colorScheme.surface),
-                    alertData = nearbyTransit.alertData,
-                    globalData = nearbyTransit.globalData,
-                    targetLocation = nearbyTransit.mapCenter,
-                    setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
-                )
+                NavHost(
+                    navController,
+                    startDestination = SheetRoutes.NearbyTransit,
+                    modifier =
+                        Modifier.fillMaxSize()
+                            .padding(outerSheetPadding)
+                            .background(MaterialTheme.colorScheme.surface)
+                ) {
+                    composable<SheetRoutes.NearbyTransit> {
+                        NearbyTransitView(
+                            alertData = nearbyTransit.alertData,
+                            globalData = nearbyTransit.globalData,
+                            targetLocation = nearbyTransit.mapCenter,
+                            setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
+                            onOpenStopDetails = { stopId, filter ->
+                                navController.navigate(
+                                    SheetRoutes.StopDetails(
+                                        stopId,
+                                        filter?.routeId,
+                                        filter?.directionId
+                                    )
+                                )
+                            }
+                        )
+                    }
+                    composable<SheetRoutes.StopDetails> { backStackEntry ->
+                        val navRoute: SheetRoutes.StopDetails = backStackEntry.toRoute()
+                        val stop = nearbyTransit.globalData.stops[navRoute.stopId]
+                        val filterState = remember {
+                            val filter =
+                                if (
+                                    navRoute.filterRouteId != null &&
+                                        navRoute.filterDirectionId != null
+                                )
+                                    StopDetailsFilter(
+                                        navRoute.filterRouteId,
+                                        navRoute.filterDirectionId
+                                    )
+                                else null
+                            mutableStateOf(filter)
+                        }
+                        if (stop != null) {
+                            StopDetailsPage(
+                                stop,
+                                filterState,
+                                nearbyTransit.alertData,
+                                onClose = { navController.popBackStack() }
+                            )
+                        }
+                    }
+                }
             },
             scaffoldState = nearbyTransit.scaffoldState,
             sheetPeekHeight = 422.dp,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -1,0 +1,15 @@
+package com.mbta.tid.mbta_app.android.pages
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import com.mbta.tid.mbta_app.android.util.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+
+@Composable
+fun StopDetailsPage(
+    stop: Stop,
+    filterState: MutableState<StopDetailsFilter?>,
+    alertData: AlertsStreamDataResponse?,
+    onClose: () -> Unit
+) {}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/StopDetailsFilter.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/StopDetailsFilter.kt
@@ -1,0 +1,5 @@
+package com.mbta.tid.mbta_app.android.util
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class StopDetailsFilter(val routeId: String, val directionId: Int)


### PR DESCRIPTION
### Summary

_Ticket:_ [[Android] Placeholder stop details page](https://app.asana.com/0/1205732265579288/1207729547484454/f)

Adds all the navigation and inbound links for a blank stop details page. Stacked on #334.

### Testing

Manually verified that the page opens and the Back button works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
