### PR TITLE
feat: show future rare patterns in stop details

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -219,15 +219,15 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
             ?: false
 
     /**
-     * Checks if a trip exists after the given cutoff time.
+     * Checks if a trip exists.
      *
      * If [upcomingTrips] are unavailable (i.e. null), returns false, since non-typical patterns
      * should be hidden until data is available.
      */
-    fun isUpcomingAfter(cutoffTime: Instant) =
+    fun isUpcoming() =
         upcomingTrips?.any {
             val tripTime = it.time
-            tripTime != null && tripTime > cutoffTime
+            tripTime != null
         }
             ?: false
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -55,7 +55,6 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                             tripMapByHeadsignOrDirection(tripMapByHeadsign, schedules, predictions),
                             allStopIds,
                             loading,
-                            filterAtTime,
                             global,
                             activeRelevantAlerts
                         )
@@ -68,7 +67,6 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                         tripMapByHeadsign,
                         allStopIds,
                         loading,
-                        filterAtTime,
                         global,
                         activeRelevantAlerts
                     )
@@ -153,7 +151,6 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             tripMap: Map<RealtimePatterns.UpcomingTripKey.ByHeadsign, List<UpcomingTrip>>?,
             allStopIds: Set<String>,
             loading: Boolean,
-            filterAtTime: Instant,
             global: GlobalResponse,
             alerts: Collection<Alert>?
         ): PatternsByStop {
@@ -201,9 +198,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                             )
                         }
                         .filter {
-                            loading ||
-                                ((it.isTypical() || it.isUpcomingAfter(filterAtTime)) &&
-                                    !it.isArrivalOnly())
+                            loading || ((it.isTypical() || it.isUpcoming()) && !it.isArrivalOnly())
                         }
                         .sorted(),
                     Direction.getDirections(global, stop, route, routePatterns)
@@ -218,7 +213,6 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             tripMap: Map<RealtimePatterns.UpcomingTripKey, List<UpcomingTrip>>?,
             allStopIds: Set<String>,
             loading: Boolean,
-            filterAtTime: Instant,
             global: GlobalResponse,
             alerts: Collection<Alert>?
         ): PatternsByStop {
@@ -245,9 +239,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                             }
                         }
                         .filter {
-                            loading ||
-                                ((it.isTypical() || it.isUpcomingAfter(filterAtTime)) &&
-                                    !it.isArrivalOnly())
+                            loading || ((it.isTypical() || it.isUpcoming()) && !it.isArrivalOnly())
                         }
                         .sorted()
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -415,7 +415,6 @@ class StopDetailsDeparturesTest {
 
     @Test
     fun `StopDetailsDepartures keeps late patterns but drops early patterns after loading`() {
-        val early = Instant.parse("2024-08-16T08:00:00-04:00")
         val now = Instant.parse("2024-08-16T10:32:38-04:00")
         val late = Instant.parse("2024-08-16T20:00:00-04:00")
 
@@ -433,13 +432,8 @@ class StopDetailsDeparturesTest {
                 representativeTrip { headsign = "Late" }
             }
 
-        val earlyTrip = objects.trip(earlyPattern)
-        val earlyPrediction =
-            objects.prediction {
-                trip = earlyTrip
-                stopId = stop.id
-                departureTime = early
-            }
+        // since we only request schedules in the future and predictions get removed once they're
+        // far enough in the past, there will be no schedule or prediction for the early pattern
         val lateTrip = objects.trip(latePattern)
         val latePrediction =
             objects.prediction {
@@ -449,13 +443,7 @@ class StopDetailsDeparturesTest {
             }
 
         val expectedEarly =
-            RealtimePatterns.ByHeadsign(
-                route,
-                "Early",
-                null,
-                listOf(earlyPattern),
-                listOf(UpcomingTrip(earlyTrip, earlyPrediction))
-            )
+            RealtimePatterns.ByHeadsign(route, "Early", null, listOf(earlyPattern), emptyList())
         val expectedLate =
             RealtimePatterns.ByHeadsign(
                 route,
@@ -484,7 +472,7 @@ class StopDetailsDeparturesTest {
                 null,
                 PredictionsStreamDataResponse(objects),
                 null,
-                setOf(),
+                emptySet(),
                 now
             )
         assertEquals(expectedBeforeLoaded, actualBeforeLoaded)


### PR DESCRIPTION
### Summary

_Ticket:_ [Don't filter out future rare patterns in Stop Details](https://app.asana.com/0/1201654106676769/1207813918309495/f)

Doesn't filter out rare route patterns in Stop Details as long as they're coming up later in the day.

### Testing

Manually checked that future rare route patterns now show up in Stop Details but still don't show up in Nearby Transit and that past rare route patterns still don't show up in Stop Details. Added a unit test for this behavior.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
