### PR TITLE
fix: show correct alert icon on disruption boundary

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -298,7 +298,7 @@ class ObjectCollectionBuilder {
 
     fun shape(block: ShapeBuilder.() -> Unit = {}) = build(shapes, ShapeBuilder(), block)
 
-    class StopBuilder : ObjectBuilder<Stop> {
+    inner class StopBuilder : ObjectBuilder<Stop> {
         var id = uuid()
         var latitude = 1.2
         var longitude = 3.4
@@ -309,6 +309,13 @@ class ObjectCollectionBuilder {
         var childStopIds: List<String> = emptyList()
         var connectingStopIds: List<String> = emptyList()
         var parentStationId: String? = null
+
+        fun childStop(block: StopBuilder.() -> Unit = {}) =
+            this@ObjectCollectionBuilder.stop {
+                    parentStationId = this@StopBuilder.id
+                    block()
+                }
+                .also { childStopIds += listOf(it.id) }
 
         override fun built() =
             Stop(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
@@ -1,0 +1,54 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.datetime.Instant
+
+class AlertAssociatedStopTest {
+    @Test
+    fun `shows alert icon at boundary`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { id = "Red" }
+        val routePattern = objects.routePattern(route)
+        var platform1: Stop? = null
+        var platform2: Stop? = null
+        val stop =
+            objects.stop {
+                platform1 = childStop()
+                platform2 = childStop()
+            }
+        val alert =
+            objects.alert {
+                activePeriod(Instant.DISTANT_PAST, null)
+                effect = Alert.Effect.Shuttle
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = platform1!!.id
+                )
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = stop.id
+                )
+            }
+
+        val result =
+            AlertAssociatedStop(
+                stop,
+                mapOf(platform1!!.id to setOf(alert), stop.id to setOf(alert)),
+                setOf(),
+                GlobalResponse(
+                    objects,
+                    mapOf(
+                        platform1!!.id to listOf(routePattern.id),
+                        platform2!!.id to listOf(routePattern.id)
+                    )
+                )
+            )
+        assertEquals(mapOf(MapStopRoute.RED to StopAlertState.Shuttle), result.stateByRoute)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalResponseTest.kt
@@ -221,7 +221,7 @@ class GlobalResponseTest {
         val alertingParent = alertsByStop?.get(parentStop.id)
         assertNotNull(alertingParent)
         assertTrue(alertingParent.relevantAlerts.isEmpty())
-        assertEquals(StopAlertState.Issue, alertingParent.stateByRoute[routeType])
+        assertEquals(StopAlertState.Suspension, alertingParent.stateByRoute[routeType])
 
         val child1Alert = alertingParent.childAlerts[childStop1.id]
         assertNotNull(child1Alert)
@@ -366,6 +366,6 @@ class GlobalResponseTest {
 
         val boundaryParent = alertsByStop[parent3Stop.id]
         assertNotNull(boundaryParent)
-        assertEquals(StopAlertState.Issue, boundaryParent.stateByRoute[routeType])
+        assertEquals(StopAlertState.Suspension, boundaryParent.stateByRoute[routeType])
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Show alert effect icon at boundary](https://app.asana.com/0/1205732265579288/1207979990431082/f)

Shows the shuttle icon at the edge of a shuttle alert.

### Testing

Updated old unit tests and added a new unit test for this behavior. Manually verified that the icon now shows up correctly on both iOS and Android (as long as the Android app gets pointed to the staging backend instead of prod because https://github.com/mbta/mobile_app_backend/pull/173 isn't running in prod yet so the alerts don't parse).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
