### PR TITLE
feat(iOS): use customizable map styles

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		8C0923A52C21054100813454 /* Inter.ttc in Resources */ = {isa = PBXBuildFile; fileRef = 8C0923A42C21054100813454 /* Inter.ttc */; };
 		8C0923A72C210C8C00813454 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0923A62C210C8C00813454 /* Typography.swift */; };
+		8C1587042C76524600AB5036 /* AppVariantExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C1587032C76524600AB5036 /* AppVariantExtension.swift */; };
 		8C2752EF2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2752EE2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift */; };
 		8C3D64102BE19DBA0026DD53 /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3D640F2BE19DBA0026DD53 /* SettingsPage.swift */; };
 		8C5054582BB5EB6C00C6A51C /* StopDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5054572BB5EB6C00C6A51C /* StopDetailsPage.swift */; };
@@ -285,6 +286,7 @@
 		84B5D164E49C6058407CC984 /* Pods-iosApp.stagingrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.stagingrelease.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.stagingrelease.xcconfig"; sourceTree = "<group>"; };
 		8C0923A42C21054100813454 /* Inter.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; path = Inter.ttc; sourceTree = "<group>"; };
 		8C0923A62C210C8C00813454 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
+		8C1587032C76524600AB5036 /* AppVariantExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVariantExtension.swift; sourceTree = "<group>"; };
 		8C2752EE2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailsAnalytics.swift; sourceTree = "<group>"; };
 		8C304C652B69C0C300263886 /* .swift-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".swift-version"; sourceTree = "<group>"; };
 		8C349BB72B754F2600AC7FFB /* 10 Park Plaza.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "10 Park Plaza.gpx"; sourceTree = "<group>"; };
@@ -881,6 +883,7 @@
 				6EA231702C21BF8900789173 /* RoundedBorderModifier.swift */,
 				8C0923A62C210C8C00813454 /* Typography.swift */,
 				8CD79F102C46F6E200AFF17D /* MapboxBridge.swift */,
+				8C1587032C76524600AB5036 /* AppVariantExtension.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1249,6 +1252,7 @@
 				9A5B275C2BB237DE009A6FC6 /* RecenterButton.swift in Sources */,
 				6E99CBB72B9892C80047E78D /* SocketProvider.swift in Sources */,
 				ED5C93F42C496FB90086D017 /* TripDetailsHeader.swift in Sources */,
+				8C1587042C76524600AB5036 /* AppVariantExtension.swift in Sources */,
 				9A15DA3F2BF51BB7003A861C /* HomeMapViewHandlerExtension.swift in Sources */,
 				9A9E7DD12C2200F4000DA1FD /* TransitHeader.swift in Sources */,
 				8CB28DB92C2CC5AD0036258E /* MapViewModel.swift in Sources */,

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -39,7 +39,7 @@ struct AnnotatedMap: View {
     var body: some View {
         map
             .gestureOptions(.init(rotateEnabled: false, pitchEnabled: false))
-            .mapStyle(colorScheme == .light ? .light : .dark)
+            .mapStyle(.init(uri: appVariant.styleUri(colorScheme: colorScheme)))
             .debugOptions(mapDebug ? .camera : [])
             .onCameraChanged { change in handleCameraChange(change) }
             .ornamentOptions(.init(scaleBar: .init(visibility: .hidden)))

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -159,6 +159,7 @@ struct HomeMapView: View {
             mapContent: AnyView(annotatedMap),
             handleAppear: handleAppear,
             handleTryLayerInit: handleTryLayerInit,
+            handleAccessTokenLoaded: handleAccessTokenLoaded,
             globalMapData: globalMapData
         )
         .onChange(of: globalData) { _ in
@@ -211,6 +212,7 @@ struct ProxyModifiedMap: View {
     var mapContent: AnyView
     var handleAppear: (_ location: LocationManager?, _ map: MapboxMap?) -> Void
     var handleTryLayerInit: (_ map: MapboxMap?) -> Void
+    var handleAccessTokenLoaded: (_ map: MapboxMap?) -> Void
     var globalData: GlobalResponse?
     var railRouteShapes: MapFriendlyRouteResponse?
     var globalMapData: GlobalMapData?
@@ -229,6 +231,9 @@ struct ProxyModifiedMap: View {
                 }
                 .onChange(of: globalMapData) { _ in
                     handleTryLayerInit(proxy.map)
+                }
+                .onChange(of: MapboxOptions.accessToken) { _ in
+                    handleAccessTokenLoaded(proxy.map)
                 }
         }
     }

--- a/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
@@ -26,6 +26,10 @@ extension HomeMapView {
         handleLayerInit(map)
     }
 
+    func handleAccessTokenLoaded(_ map: MapboxMap?) {
+        map?.mapStyle = .init(uri: appVariant.styleUri(colorScheme: colorScheme))
+    }
+
     func handleLayerInit(_ map: MapboxMap) {
         let layerManager = MapLayerManager(map: map)
         initializeLayers(layerManager)

--- a/iosApp/iosApp/Utils/AppVariantExtension.swift
+++ b/iosApp/iosApp/Utils/AppVariantExtension.swift
@@ -1,0 +1,21 @@
+//
+//  AppVariantExtension.swift
+//  iosApp
+//
+//  Created by Horn, Melody on 2024-08-21.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import MapboxMaps
+import shared
+import SwiftUI
+
+extension AppVariant {
+    func styleUri(colorScheme: ColorScheme) -> StyleURI {
+        if colorScheme == .light {
+            .init(rawValue: lightMapStyle) ?? .light
+        } else {
+            .init(rawValue: darkMapStyle) ?? .dark
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -1,8 +1,20 @@
 package com.mbta.tid.mbta_app
 
-enum class AppVariant(val backendHost: String) {
-    Staging("mobile-app-backend-staging.mbtace.com"),
-    Prod("mobile-app-backend.mbtace.com");
+enum class AppVariant(
+    val backendHost: String,
+    val lightMapStyle: String,
+    val darkMapStyle: String
+) {
+    Staging(
+        "mobile-app-backend-staging.mbtace.com",
+        "mapbox://styles/mbtamobileapp/cm02vf0cf00cu01pnfgnu5onh",
+        "mapbox://styles/mbtamobileapp/cm02vgvsp003c01ombyewgu70"
+    ),
+    Prod(
+        "mobile-app-backend.mbtace.com",
+        "mapbox://styles/mbtamobileapp/cm02vja9z00dz01psa55ba0ew",
+        "mapbox://styles/mbtamobileapp/cm02vjs2000e001psbu2v10p9"
+    );
 
     val backendRoot = "https://$backendHost"
     val socketUrl = "wss://$backendHost/socket"


### PR DESCRIPTION
### Summary

_Ticket:_ [Short-lived mapbox tokens](https://app.asana.com/0/1201654106676769/1206545972237191/f)

Uses custom Mapbox styles owned by the mobile app team Mapbox account. (Doesn't do that on Android because we still haven't set up App Check on Android.)

These are unmodified copies of the template styles we were already using.

### Testing

Checked that the new styles are loaded successfully (by changing a font somewhere and then changing it back afterwards).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
