### PR TITLE
fix(HomeMapView): clear vehicles list when leaving vehicles channel

### DIFF
--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -57,6 +57,7 @@ struct HomeMapView: View {
         viewportProvider: ViewportProvider,
         railRouteShapeRepository: IRailRouteShapeRepository = RepositoryDI().railRouteShapes,
         stopRepository: IStopRepository = RepositoryDI().stop,
+        vehiclesData: [Vehicle]? = nil,
         vehiclesRepository: IVehiclesRepository = RepositoryDI().vehicles,
         locationDataManager: LocationDataManager = .init(distanceFilter: 1),
         sheetHeight: Binding<CGFloat>,
@@ -68,6 +69,7 @@ struct HomeMapView: View {
         self.viewportProvider = viewportProvider
         self.railRouteShapeRepository = railRouteShapeRepository
         self.stopRepository = stopRepository
+        self.vehiclesData = vehiclesData
         self.vehiclesRepository = vehiclesRepository
         _locationDataManager = StateObject(wrappedValue: locationDataManager)
         _sheetHeight = sheetHeight

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -90,6 +90,7 @@ extension HomeMapView {
 
     func leaveVehiclesChannel() {
         vehiclesRepository.disconnect()
+        vehiclesData = []
     }
 
     func handleLastNavChange(oldNavEntry: SheetNavigationStackEntry?, nextNavEntry: SheetNavigationStackEntry?) {


### PR DESCRIPTION
### Summary

What is this PR for?

Fix for a bug likely introduced in [Investigate Sentry Phoenix Errors](https://app.asana.com/0/1205732265579288/1207900900515783/f). That included changes to how subscriptions to the vehicles channel works. Now, whenever a vehicle channel is left, the list of vehicles is also cleared.  This addresses the issue in [this video](https://mbta.slack.com/archives/C05QMG9GS9M/p1724274612282479) where vehicle icons remain on the map after navigating from from stop details => nearby transit

### Testing

What testing have you done?

Added a unit test for this fix and ran locally to confirm vehicles cleared as expected

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
