### PR TITLE
[wip] xcode cloud wrestling

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
 		8C0923A52C21054100813454 /* Inter.ttc in Resources */ = {isa = PBXBuildFile; fileRef = 8C0923A42C21054100813454 /* Inter.ttc */; };
 		8C0923A72C210C8C00813454 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C0923A62C210C8C00813454 /* Typography.swift */; };
+		8C10DE3C2C656DC20090EC23 /* EndToEndOpenStopDetailsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C10DE3B2C656DC20090EC23 /* EndToEndOpenStopDetailsTest.swift */; };
 		8C3D64102BE19DBA0026DD53 /* SettingsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3D640F2BE19DBA0026DD53 /* SettingsPage.swift */; };
 		8C5054582BB5EB6C00C6A51C /* StopDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5054572BB5EB6C00C6A51C /* StopDetailsPage.swift */; };
 		8C5F47662C40842200FB71DA /* TripDetailsStopViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5F47652C40842200FB71DA /* TripDetailsStopViewTests.swift */; };
@@ -276,6 +277,7 @@
 		84B5D164E49C6058407CC984 /* Pods-iosApp.stagingrelease.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.stagingrelease.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.stagingrelease.xcconfig"; sourceTree = "<group>"; };
 		8C0923A42C21054100813454 /* Inter.ttc */ = {isa = PBXFileReference; lastKnownFileType = file; path = Inter.ttc; sourceTree = "<group>"; };
 		8C0923A62C210C8C00813454 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
+		8C10DE3B2C656DC20090EC23 /* EndToEndOpenStopDetailsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndToEndOpenStopDetailsTest.swift; sourceTree = "<group>"; };
 		8C304C652B69C0C300263886 /* .swift-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".swift-version"; sourceTree = "<group>"; };
 		8C349BB72B754F2600AC7FFB /* 10 Park Plaza.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "10 Park Plaza.gpx"; sourceTree = "<group>"; };
 		8C3D640F2BE19DBA0026DD53 /* SettingsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPage.swift; sourceTree = "<group>"; };
@@ -487,6 +489,7 @@
 				6EED5E9B2B3DC6C10052A1B8 /* IosAppUITests.swift */,
 				6EED5E9D2B3DC6C10052A1B8 /* IosAppUITestsLaunchTests.swift */,
 				9ACA9DF22BA1EC8B003F0E9E /* HomeMapViewUITests.swift */,
+				8C10DE3B2C656DC20090EC23 /* EndToEndOpenStopDetailsTest.swift */,
 			);
 			path = iosAppUITests;
 			sourceTree = "<group>";
@@ -1187,6 +1190,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9ACA9DF32BA1EC8B003F0E9E /* HomeMapViewUITests.swift in Sources */,
+				8C10DE3C2C656DC20090EC23 /* EndToEndOpenStopDetailsTest.swift in Sources */,
 				6EED5E9E2B3DC6C10052A1B8 /* IosAppUITestsLaunchTests.swift in Sources */,
 				6EED5E9C2B3DC6C10052A1B8 /* IosAppUITests.swift in Sources */,
 			);

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -30,6 +30,9 @@ struct ProductionAppView: View {
         if CommandLine.arguments.contains("--default-mocks") {
             HelpersKt.startKoinIOSTestApp()
             self.init(socket: MockSocket())
+        } else if CommandLine.arguments.contains("--e2e-mocks") {
+            HelpersKt.startKoinE2E()
+            self.init(socket: MockSocket())
         } else {
             let socket = Self.initSocket()
             Self.initKoin(appCheck: AppCheckRepository(), socket: socket)

--- a/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
+++ b/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
@@ -1,0 +1,41 @@
+//
+//  EndToEndOpenStopDetailsTest.swift
+//  iosAppUITests
+//
+//  Created by Horn, Melody on 2024-08-08.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import XCTest
+
+final class EndToEndOpenStopDetailsTest: XCTestCase {
+    let app = XCUIApplication()
+
+    override func setUpWithError() throws {
+        app.launchArguments = ["--e2e-mocks"]
+        XCUIDevice.shared.location = XCUILocation(location: .init(latitude: 42.356395, longitude: -71.062424))
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
+        // before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testOpenStopDetails() throws {
+        // UI tests must launch the application that they test.
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        app.staticTexts["Alewife"].tap()
+
+        XCTAssertFalse(app.staticTexts["Nearby Transit"].exists)
+        XCTAssertTrue(app.staticTexts["Northbound to"].exists)
+        XCTAssertTrue(app.staticTexts["Southbound to"].exists)
+        XCTAssertTrue(app.staticTexts["Ashmont/Braintree"].exists)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -1,0 +1,190 @@
+package com.mbta.tid.mbta_app.endToEnd
+
+import com.mbta.tid.mbta_app.model.Coordinate
+import com.mbta.tid.mbta_app.model.NearbyStaticData
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Outcome
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.SocketError
+import com.mbta.tid.mbta_app.model.TripShape
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.model.response.StopMapResponse
+import com.mbta.tid.mbta_app.model.response.TripResponse
+import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.IAlertsRepository
+import com.mbta.tid.mbta_app.repositories.IAppCheckRepository
+import com.mbta.tid.mbta_app.repositories.IConfigRepository
+import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.INearbyRepository
+import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
+import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.IStopRepository
+import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.ITripRepository
+import com.mbta.tid.mbta_app.repositories.IVehicleRepository
+import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.IdleRailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
+import com.mbta.tid.mbta_app.repositories.MockAppCheckRepository
+import com.mbta.tid.mbta_app.repositories.MockConfigRepository
+import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
+import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.GetSettingUsecase
+import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+fun endToEndModule(): Module {
+    val now = Clock.System.now()
+    val objects = ObjectCollectionBuilder()
+    val lineRed = objects.line()
+    val routeRed =
+        objects.route {
+            color = "DA291C"
+            directionDestinations = listOf("Ashmont/Braintree", "Alewife")
+            directionNames = listOf("South", "North")
+            longName = "Red Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+            lineId = lineRed.id
+        }
+    val patternAlewife =
+        objects.routePattern(routeRed) {
+            directionId = 1
+            representativeTrip { headsign = "Alewife" }
+            typicality = RoutePattern.Typicality.Typical
+        }
+    val patternAshmont =
+        objects.routePattern(routeRed) {
+            directionId = 0
+            representativeTrip { headsign = "Ashmont" }
+            typicality = RoutePattern.Typicality.Typical
+        }
+    val stopParkStreet = objects.stop { name = "Park Street" }
+    val tripAlewife = objects.trip(patternAlewife)
+    val predictionAlewife =
+        objects.prediction {
+            trip = tripAlewife
+            stopId = stopParkStreet.id
+            departureTime = now + 10.minutes
+        }
+    return module {
+        single<IAppCheckRepository> { MockAppCheckRepository() }
+        single<IConfigRepository> { MockConfigRepository() }
+        single<IPinnedRoutesRepository> {
+            object : IPinnedRoutesRepository {
+                override suspend fun getPinnedRoutes() = emptySet<String>()
+
+                override suspend fun setPinnedRoutes(routes: Set<String>) {}
+            }
+        }
+        single<ISchedulesRepository> {
+            object : ISchedulesRepository {
+                override suspend fun getSchedule(stopIds: List<String>, now: Instant) =
+                    ScheduleResponse(objects)
+
+                override suspend fun getSchedule(stopIds: List<String>) =
+                    getSchedule(stopIds, Clock.System.now())
+            }
+        }
+        single<ISettingsRepository> { MockSettingsRepository() }
+        single<IStopRepository> {
+            object : IStopRepository {
+                override suspend fun getStopMapData(stopId: String): StopMapResponse =
+                    StopMapResponse(emptyList(), emptyMap())
+            }
+        }
+        single<ITripRepository> {
+            object : ITripRepository {
+                override suspend fun getTripSchedules(tripId: String): TripSchedulesResponse {
+                    TODO("Not yet implemented")
+                }
+
+                override suspend fun getTrip(tripId: String): ApiResult<TripResponse> {
+                    TODO("Not yet implemented")
+                }
+
+                override suspend fun getTripShape(tripId: String): ApiResult<TripShape> {
+                    TODO("Not yet implemented")
+                }
+            }
+        }
+        single<IPredictionsRepository> {
+            object : IPredictionsRepository {
+                override fun connect(
+                    stopIds: List<String>,
+                    onReceive: (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
+                ) {
+                    onReceive(Outcome(PredictionsStreamDataResponse(objects), null))
+                }
+
+                override fun disconnect() {}
+            }
+        }
+        single<IAlertsRepository> { MockAlertsRepository() }
+        single<INearbyRepository> {
+            object : INearbyRepository {
+                override suspend fun getNearby(global: GlobalResponse, location: Coordinate) =
+                    NearbyStaticData(global, NearbyResponse(listOf(stopParkStreet.id)))
+            }
+        }
+        single<ITripPredictionsRepository> {
+            object : ITripPredictionsRepository {
+                override fun connect(
+                    tripId: String,
+                    onReceive: (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
+                ) {
+                    TODO("Not yet implemented")
+                }
+
+                override fun disconnect() {
+                    TODO("Not yet implemented")
+                }
+            }
+        }
+        single<IVehicleRepository> {
+            object : IVehicleRepository {
+                override fun connect(
+                    vehicleId: String,
+                    onReceive: (Outcome<VehicleStreamDataResponse?, SocketError>) -> Unit
+                ) {
+                    TODO("Not yet implemented")
+                }
+
+                override fun disconnect() {
+                    TODO("Not yet implemented")
+                }
+            }
+        }
+        single<IGlobalRepository> {
+            object : IGlobalRepository {
+                override suspend fun getGlobalData() =
+                    GlobalResponse(
+                        objects,
+                        mapOf(stopParkStreet.id to listOf(patternAlewife.id, patternAshmont.id))
+                    )
+            }
+        }
+        single<ISearchResultRepository> { MockSearchResultRepository() }
+        single<IRailRouteShapeRepository> { IdleRailRouteShapeRepository() }
+        single<IVehiclesRepository> { MockVehiclesRepository() }
+        single { TogglePinnedRouteUsecase(get()) }
+        single { GetSettingUsecase(get()) }
+        single { ConfigUseCase(get(), get()) }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -119,6 +119,7 @@ class ObjectCollectionBuilder {
             set(trip) {
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it }
                 tripId = trip.id
+                directionId = trip.directionId
             }
 
         override fun built() =

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -6,6 +6,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import com.mbta.tid.mbta_app.dependencyInjection.appModule
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
+import com.mbta.tid.mbta_app.endToEnd.endToEndModule
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
@@ -57,4 +58,8 @@ subsequently load in specific modules to override these base definitions.
 fun startKoinIOSTestApp() {
     startKoin { modules(platformModule()) }
     loadDefaultRepoModules()
+}
+
+fun startKoinE2E() {
+    startKoin { modules(endToEndModule()) }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Name](URL)

I'm going to try rebasing the original commit from #344 against a couple different points on `main` so I can try to isolate where the problem actually came from.

- ✅ *working pointed here* ([build 554](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/3a5c0139-dba8-4a53-893e-49b9fbcb28de/summary))
- ❌ *failing pointed here again, but with [very slightly not the same changes](https://github.com/mbta/mobile_app/compare/bf67959bfe9169191e1c76fd00f38d96a585e2c4..634d69103b490c5d4f2b4ab97148ce841ea27aa5)* ([build 564](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/b79ef5ab-9c32-4021-9d7c-e834ae4ff96b/summary))
- ✅ *working pointed here once more with [actually the same changes this time](https://github.com/mbta/mobile_app/compare/bf67959..6a3a9e6)* ([build 567](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/27cbea85-ff5b-4acb-ab28-0cd23d53ebb7/summary))
- some android stuff
  - tab navigation
  - stop details ground work
  - stop details navigation
  - stop details structure
- iOS finish clean architecture
  - move search results
  - ✅ *working pointed here* ([build 568](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/6ba2d4a2-dfb8-4183-bebf-3a3f39dfcf93/summary))
  - move route shapes
    - cram new Repository into old Fetcher just to see
    - ❌ *failing pointed here* ([build 570](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/79e1117a-922c-4612-bb61-2094ae68c6f9/action/2e7e2714-9af8-4ada-a3d3-3b0f7aa36696/logs))
    - ✅ *working pointed here using IdleRailRouteShapeRepository instead of Mock* ([build 577](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/0225d424-de92-4933-8d76-91c402828cb4/summary))
    - replace old Fetcher with new Repository
    - ❌ *failing pointed here* ([build 569](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/8daf387e-2772-4372-b842-2260f0a7e128/summary))
  - move vehicles
- ❌ *failing pointed here* ([build 557](https://appstoreconnect.apple.com/teams/69a6de88-81a7-47e3-e053-5b8c7c11a4d1/apps/6499281036/ci/builds/f77eac29-a8bf-4cf4-9eb9-5d0e01047626/summary))
- ✅ *working pointed here with IdleRailRouteShapeRepository*
- alert parsing & dependency upgrades
- trip details & stop details work
- socket improvements
- vehicle halo & alerts stuff
- clean architecture cleanup

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
