### PR TITLE
feat: parse stop vehicle type

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -264,6 +264,7 @@ struct NearbyTransitView_Previews: PreviewProvider {
             locationType: LocationType.stop,
             description: nil,
             platformName: nil,
+            vehicleType: .bus,
             childStopIds: [],
             connectingStopIds: [],
             parentStationId: nil
@@ -335,6 +336,7 @@ struct NearbyTransitView_Previews: PreviewProvider {
             locationType: LocationType.stop,
             description: nil,
             platformName: nil,
+            vehicleType: nil,
             childStopIds: [],
             connectingStopIds: [],
             parentStationId: nil

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -518,6 +518,7 @@ final class NearbyTransitViewTests: XCTestCase {
                     locationType: .station,
                     description: nil,
                     platformName: nil,
+                    vehicleType: nil,
                     childStopIds: [],
                     connectingStopIds: [],
                     parentStationId: nil

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -306,6 +306,7 @@ class ObjectCollectionBuilder {
         var locationType = LocationType.STOP
         var description: String? = null
         var platformName: String? = null
+        var vehicleType: RouteType? = null
         var childStopIds: List<String> = emptyList()
         var connectingStopIds: List<String> = emptyList()
         var parentStationId: String? = null
@@ -326,6 +327,7 @@ class ObjectCollectionBuilder {
                 locationType,
                 description,
                 platformName,
+                vehicleType,
                 childStopIds,
                 connectingStopIds,
                 parentStationId

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
@@ -13,6 +13,7 @@ data class Stop(
     @SerialName("location_type") val locationType: LocationType,
     val description: String? = null,
     @SerialName("platform_name") val platformName: String? = null,
+    @SerialName("vehicle_type") val vehicleType: RouteType? = null,
     @SerialName("child_stop_ids") val childStopIds: List<String> = emptyList(),
     @SerialName("connecting_stop_ids") val connectingStopIds: List<String> = emptyList(),
     @SerialName("parent_station_id") val parentStationId: String? = null

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -152,6 +152,7 @@ class GlobalRepositoryTest : KoinTest {
                     name = "S Franklin St @ Emery St",
                     longitude = -71.011556,
                     latitude = 42.125615,
+                    vehicleType = RouteType.BUS,
                     childStopIds = emptyList(),
                     connectingStopIds = emptyList(),
                     locationType = LocationType.STOP

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/StopRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/StopRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app
 
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.RouteSegment
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.SegmentedRouteShape
 import com.mbta.tid.mbta_app.model.Shape
 import com.mbta.tid.mbta_app.model.Stop
@@ -131,6 +132,7 @@ class StopRepositoryTest : KoinTest {
                                     latitude = 42.413361,
                                     longitude = -70.991685,
                                     platformName = "Exit Only",
+                                    vehicleType = RouteType.HEAVY_RAIL,
                                     parentStationId = "place-wondl"
                                 )
                             )


### PR DESCRIPTION
### Summary

_Ticket:_ [Move nearby transit logic to the frontend](https://app.asana.com/0/1205732265579288/1206614653454676/f)

We already fetch this field in the backend (it's already included in the test global response), and it's used in nearby transit on the backend, so we'll need it for nearby transit in the frontend.

### Testing

Updated unit tests to include this field.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
