### PR TITLE
refactor: centralize route pill logic in shared code

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
@@ -6,9 +6,11 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
 
+@Composable fun routeIcon(route: Route) = routeIcon(route.type)
+
 @Composable
-fun routeIcon(route: Route) =
-    when (route.type) {
+fun routeIcon(routeType: RouteType) =
+    when (routeType) {
         RouteType.BUS -> Pair(painterResource(id = R.drawable.mode_bus), "Bus")
         RouteType.COMMUTER_RAIL -> Pair(painterResource(id = R.drawable.mode_cr), "Commuter Rail")
         RouteType.FERRY -> Pair(painterResource(id = R.drawable.mode_ferry), "Ferry")

--- a/iosApp/iosApp/ComponentViews/RouteIcon.swift
+++ b/iosApp/iosApp/ComponentViews/RouteIcon.swift
@@ -11,7 +11,11 @@ import shared
 import SwiftUI
 
 func routeIcon(_ route: Route) -> Image {
-    switch route.type {
+    routeIcon(route.type)
+}
+
+func routeIcon(_ routeType: RouteType) -> Image {
+    switch routeType {
     case .bus:
         Image(.modeBus)
     case .commuterRail:

--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -10,140 +10,40 @@ import shared
 import SwiftUI
 
 struct RoutePill: View {
-    enum `Type` {
-        case fixed
-        case flex
-    }
-
     let route: Route?
     let line: Line?
-    let type: `Type`
+    let type: RoutePillSpec.Type_
     let isActive: Bool
-    let textColor: Color?
-    let routeColor: Color?
+    let textColor: Color
+    let routeColor: Color
+    let spec: RoutePillSpec
 
-    init(route: Route?, line: Line? = nil, type: Type, isActive: Bool = true) {
+    init(route: Route?, line: Line? = nil, type: RoutePillSpec.Type_, isActive: Bool = true) {
         self.route = route
         self.line = line
         self.type = type
         self.isActive = isActive
-        guard let route else {
-            guard let line else {
-                textColor = nil
-                routeColor = nil
-                return
-            }
-            textColor = Color(hex: line.textColor)
-            routeColor = Color(hex: line.color)
-            return
-        }
-        if route.id.starts(with: "Shuttle"), let line {
-            textColor = Color(hex: line.textColor)
-            routeColor = Color(hex: line.color)
-        } else {
-            textColor = Color(hex: route.textColor)
-            routeColor = Color(hex: route.color)
-        }
-    }
-
-    private enum PillContent {
-        case empty
-        case text(String)
-        case image(ImageResource)
-    }
-
-    private func getPillContent() -> PillContent {
-        guard let route else {
-            guard let line else {
-                return .empty
-            }
-            return Self.linePillContent(line: line, type: type)
-        }
-        return switch route.type {
-        case .lightRail: Self.lightRailPillContent(route: route, type: type)
-        case .heavyRail: Self.heavyRailPillContent(route: route, type: type)
-        case .commuterRail: Self.commuterRailPillContent(route: route, type: type)
-        case .bus: Self.busPillContent(route: route, type: type)
-        case .ferry: Self.ferryPillContent(route: route, type: type)
-        }
-    }
-
-    private static func linePillContent(line: Line, type: Type) -> PillContent {
-        if line.longName == "Green Line", type == .fixed {
-            .text("GL")
-        } else {
-            .text(line.longName)
-        }
-    }
-
-    private static func lightRailPillContent(route: Route, type: Type) -> PillContent {
-        if route.longName.starts(with: "Green Line ") {
-            if type == .fixed {
-                .text(route.longName.replacing("Green Line ", with: "GL "))
-            } else {
-                .text(route.shortName)
-            }
-        } else if route.longName == "Mattapan Trolley", type == .fixed {
-            .text("M")
-        } else {
-            .text(route.longName)
-        }
-    }
-
-    private static func heavyRailPillContent(route: Route, type: Type) -> PillContent {
-        if type == .fixed {
-            .text(String(route.longName.split(separator: " ").compactMap(\.first)))
-        } else {
-            .text(route.longName)
-        }
-    }
-
-    private static func commuterRailPillContent(route: Route, type: Type) -> PillContent {
-        if type == .fixed {
-            .text("CR")
-        } else {
-            .text(route.longName.replacing(" Line", with: ""))
-        }
-    }
-
-    private static func busPillContent(route: Route, type: Type) -> PillContent {
-        if route.id.starts(with: "Shuttle"), type == .fixed {
-            .image(.modeBus)
-        } else {
-            .text(route.shortName)
-        }
-    }
-
-    private static func ferryPillContent(route: Route, type: Type) -> PillContent {
-        if type == .fixed {
-            .image(.modeFerry)
-        } else {
-            .text(route.longName)
-        }
+        spec = .init(route: route, line: line, type: type)
+        textColor = .init(hex: spec.textColor)
+        routeColor = .init(hex: spec.routeColor)
     }
 
     @ViewBuilder func getPillBase() -> some View {
-        switch getPillContent() {
+        switch onEnum(of: spec.content) {
         case .empty: EmptyView()
-        case let .text(text): Text(text)
-        case let .image(image): Image(image)
+        case let .text(text): Text(text.text)
+        case let .modeImage(mode): routeIcon(mode.mode)
         }
     }
 
-    private static func isRectangle(route: Route) -> Bool {
-        route.type == .bus && !route.id.starts(with: "Shuttle")
-    }
-
     private struct FramePaddingModifier: ViewModifier {
-        let pill: RoutePill
+        let spec: RoutePillSpec
 
         func body(content: Content) -> some View {
-            if pill.type == .fixed {
-                content.frame(width: 50, height: 24)
-            } else if pill.route?.longName.starts(with: "Green Line ") ?? false {
-                content.frame(width: 24, height: 24)
-            } else {
-                content.frame(height: 24).padding(.horizontal, 12)
+            switch spec.size {
+            case .fixedPill: content.frame(width: 50, height: 24)
+            case .circle: content.frame(width: 24, height: 24)
+            case .flexPill: content.frame(height: 24).padding(.horizontal, 12)
             }
         }
     }
@@ -156,26 +56,25 @@ struct RoutePill: View {
                 content
                     .foregroundColor(pill.textColor)
                     .background(pill.routeColor)
-            } else if let route = pill.route, RoutePill.isRectangle(route: route) {
+            } else if pill.spec.shape == .rectangle {
                 content.overlay(
-                    Rectangle().stroke(pill.routeColor ?? .deemphasized, lineWidth: 1).padding(1)
+                    Rectangle().stroke(pill.routeColor, lineWidth: 1).padding(1)
                 )
             } else {
                 content.overlay(
-                    Capsule().stroke(pill.routeColor ?? .deemphasized, lineWidth: 1).padding(1)
+                    Capsule().stroke(pill.routeColor, lineWidth: 1).padding(1)
                 )
             }
         }
     }
 
     private struct ClipShapeModifier: ViewModifier {
-        let pill: RoutePill
+        let spec: RoutePillSpec
 
         func body(content: Content) -> some View {
-            if let route = pill.route, RoutePill.isRectangle(route: route) {
-                content.clipShape(Rectangle())
-            } else {
-                content.clipShape(Capsule())
+            switch spec.shape {
+            case .rectangle: content.clipShape(Rectangle())
+            case .capsule: content.clipShape(Capsule())
             }
         }
     }
@@ -188,10 +87,10 @@ struct RoutePill: View {
                 .textCase(.uppercase)
                 .font(.custom("Helvetica Neue", size: 16).bold())
                 .tracking(0.5)
-                .modifier(FramePaddingModifier(pill: self))
+                .modifier(FramePaddingModifier(spec: spec))
                 .lineLimit(1)
                 .modifier(ColorModifier(pill: self))
-                .modifier(ClipShapeModifier(pill: self))
+                .modifier(ClipShapeModifier(spec: spec))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
@@ -1,0 +1,106 @@
+package com.mbta.tid.mbta_app.model
+
+data class RoutePillSpec(
+    val textColor: String,
+    val routeColor: String,
+    val content: Content,
+    val size: Size,
+    val shape: Shape
+) {
+    enum class Type {
+        Fixed,
+        Flex
+    }
+
+    sealed interface Content {
+        data object Empty : Content
+
+        data class Text(val text: String) : Content
+
+        data class ModeImage(val mode: RouteType) : Content
+    }
+
+    enum class Size {
+        FixedPill,
+        Circle,
+        FlexPill
+    }
+
+    enum class Shape {
+        Capsule,
+        Rectangle
+    }
+
+    constructor(
+        route: Route?,
+        line: Line?,
+        type: Type
+    ) : this(
+        route?.takeUnless { it.id.startsWith("Shuttle") }?.textColor ?: line?.textColor ?: "",
+        route?.takeUnless { it.id.startsWith("Shuttle") }?.color ?: line?.color ?: "",
+        when (route?.type) {
+            null -> if (line == null) Content.Empty else linePillContent(line, type)
+            RouteType.LIGHT_RAIL -> lightRailPillContent(route, type)
+            RouteType.HEAVY_RAIL -> heavyRailPillContent(route, type)
+            RouteType.COMMUTER_RAIL -> commuterRailPillContent(route, type)
+            RouteType.BUS -> busPillContent(route, type)
+            RouteType.FERRY -> ferryPillContent(route, type)
+        },
+        when {
+            type == Type.Fixed -> Size.FixedPill
+            route?.longName?.startsWith("Green Line ") ?: false -> Size.Circle
+            else -> Size.FlexPill
+        },
+        when {
+            route?.type == RouteType.BUS && !route.id.startsWith("Shuttle") -> Shape.Rectangle
+            else -> Shape.Capsule
+        }
+    )
+
+    companion object {
+        private fun linePillContent(line: Line, type: Type): Content =
+            if (line.longName == "Green Line" && type == Type.Fixed) {
+                Content.Text("GL")
+            } else {
+                Content.Text(line.longName)
+            }
+
+        private fun lightRailPillContent(route: Route, type: Type): Content =
+            if (route.longName.startsWith("Green Line ")) {
+                when (type) {
+                    Type.Fixed -> Content.Text(route.longName.replace("Green Line ", "GL "))
+                    Type.Flex -> Content.Text(route.shortName)
+                }
+            } else if (route.longName == "Mattapan Trolley" && type == Type.Fixed) {
+                Content.Text("M")
+            } else {
+                Content.Text(route.longName)
+            }
+
+        private fun heavyRailPillContent(route: Route, type: Type): Content =
+            when (type) {
+                Type.Fixed ->
+                    Content.Text(route.longName.split(" ").map { it.first() }.joinToString(""))
+                Type.Flex -> Content.Text(route.longName)
+            }
+
+        private fun commuterRailPillContent(route: Route, type: Type): Content =
+            when (type) {
+                Type.Fixed -> Content.Text("CR")
+                Type.Flex -> Content.Text(route.longName.removeSuffix(" Line"))
+            }
+
+        private fun busPillContent(route: Route, type: Type): Content =
+            if (route.id.startsWith("Shuttle") && type == Type.Fixed) {
+                Content.ModeImage(RouteType.BUS)
+            } else {
+                Content.Text(route.shortName)
+            }
+
+        private fun ferryPillContent(route: Route, type: Type): Content =
+            when (type) {
+                Type.Fixed -> Content.ModeImage(RouteType.FERRY)
+                Type.Flex -> Content.Text(route.longName)
+            }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpecTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpecTest.kt
@@ -1,0 +1,394 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.line
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.route
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoutePillSpecTest {
+    @Test
+    fun `test bus`() {
+        val busRoute = route {
+            type = RouteType.BUS
+            color = "FFC72C"
+            shortName = "62/76"
+            textColor = "000000"
+        }
+
+        val fixedPill = RoutePillSpec(busRoute, null, RoutePillSpec.Type.Fixed)
+        assertEquals(
+            RoutePillSpec(
+                "000000",
+                "FFC72C",
+                RoutePillSpec.Content.Text("62/76"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Rectangle
+            ),
+            fixedPill
+        )
+        val flexPill = RoutePillSpec(busRoute, null, RoutePillSpec.Type.Flex)
+        assertEquals(
+            RoutePillSpec(
+                "000000",
+                "FFC72C",
+                RoutePillSpec.Content.Text("62/76"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Rectangle
+            ),
+            flexPill
+        )
+    }
+
+    @Test
+    fun `test heavy rail`() {
+        val redLine = route {
+            type = RouteType.HEAVY_RAIL
+            color = "DA291C"
+            longName = "Red Line"
+            textColor = "FFFFFF"
+        }
+        val blueLine = route {
+            type = RouteType.HEAVY_RAIL
+            color = "003DA5"
+            longName = "Blue Line"
+            textColor = "FFFFFF"
+        }
+
+        val redLineFixed = RoutePillSpec(redLine, null, RoutePillSpec.Type.Fixed)
+        val redLineFlex = RoutePillSpec(redLine, null, RoutePillSpec.Type.Flex)
+        val blueLineFixed = RoutePillSpec(blueLine, null, RoutePillSpec.Type.Fixed)
+        val blueLineFlex = RoutePillSpec(blueLine, null, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("RL"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            redLineFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("Red Line"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            redLineFlex
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "003DA5",
+                RoutePillSpec.Content.Text("BL"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            blueLineFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "003DA5",
+                RoutePillSpec.Content.Text("Blue Line"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            blueLineFlex
+        )
+    }
+
+    @Test
+    fun `test light rail`() {
+        val greenLineC = route {
+            type = RouteType.LIGHT_RAIL
+            color = "00843D"
+            longName = "Green Line C"
+            shortName = "C"
+            textColor = "FFFFFF"
+        }
+        val mattapan = route {
+            type = RouteType.LIGHT_RAIL
+            color = "DA291C"
+            longName = "Mattapan Trolley"
+            textColor = "FFFFFF"
+        }
+
+        val greenLineCFixed = RoutePillSpec(greenLineC, null, RoutePillSpec.Type.Fixed)
+        val greenLineCFlex = RoutePillSpec(greenLineC, null, RoutePillSpec.Type.Flex)
+        val mattapanFixed = RoutePillSpec(mattapan, null, RoutePillSpec.Type.Fixed)
+        val mattapanFlex = RoutePillSpec(mattapan, null, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.Text("GL C"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            greenLineCFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.Text("C"),
+                RoutePillSpec.Size.Circle,
+                RoutePillSpec.Shape.Capsule
+            ),
+            greenLineCFlex
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("M"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            mattapanFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("Mattapan Trolley"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            mattapanFlex
+        )
+    }
+
+    @Test
+    fun `test commuter rail`() {
+        val middleborough = route {
+            type = RouteType.COMMUTER_RAIL
+            color = "80276C"
+            longName = "Middleborough/Lakeville Line"
+            textColor = "FFFFFF"
+        }
+        val providence = route {
+            type = RouteType.COMMUTER_RAIL
+            color = "80276C"
+            longName = "Providence/Stoughton Line"
+            textColor = "FFFFFF"
+        }
+
+        val middleboroughFixed = RoutePillSpec(middleborough, null, RoutePillSpec.Type.Fixed)
+        val middleboroughFlex = RoutePillSpec(middleborough, null, RoutePillSpec.Type.Flex)
+        val providenceFixed = RoutePillSpec(providence, null, RoutePillSpec.Type.Fixed)
+        val providenceFlex = RoutePillSpec(providence, null, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "80276C",
+                RoutePillSpec.Content.Text("CR"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            middleboroughFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "80276C",
+                RoutePillSpec.Content.Text("Middleborough/Lakeville"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            middleboroughFlex
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "80276C",
+                RoutePillSpec.Content.Text("CR"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            providenceFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "80276C",
+                RoutePillSpec.Content.Text("Providence/Stoughton"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            providenceFlex
+        )
+    }
+
+    @Test
+    fun `test ferry`() {
+        val ferry = route {
+            type = RouteType.FERRY
+            color = "008EAA"
+            longName = "Hingham/Hull Ferry"
+            textColor = "FFFFFF"
+        }
+
+        val ferryFixed = RoutePillSpec(ferry, null, RoutePillSpec.Type.Fixed)
+        val ferryFlex = RoutePillSpec(ferry, null, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "008EAA",
+                RoutePillSpec.Content.ModeImage(RouteType.FERRY),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            ferryFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "008EAA",
+                RoutePillSpec.Content.Text("Hingham/Hull Ferry"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            ferryFlex
+        )
+    }
+
+    @Test
+    fun `test shuttle`() {
+        val rlShuttle = route {
+            id = "Shuttle-BroadwayKendall"
+            type = RouteType.BUS
+            color = "FFC72C"
+            shortName = "Red Line Shuttle"
+            textColor = "000000"
+        }
+        val redLine = line {
+            color = "DA291C"
+            textColor = "FFFFFF"
+        }
+        val glShuttle = route {
+            id = "Shuttle-BrooklineHillsKenmore"
+            type = RouteType.BUS
+            color = "FFC72C"
+            shortName = "Green Line D Shuttle"
+            textColor = "000000"
+        }
+        val greenLine = line {
+            color = "00843D"
+            textColor = "FFFFFF"
+        }
+
+        val rlShuttleFixed = RoutePillSpec(rlShuttle, redLine, RoutePillSpec.Type.Fixed)
+        val rlShuttleFlex = RoutePillSpec(rlShuttle, redLine, RoutePillSpec.Type.Flex)
+        val glShuttleFixed = RoutePillSpec(glShuttle, greenLine, RoutePillSpec.Type.Fixed)
+        val glShuttleFlex = RoutePillSpec(glShuttle, greenLine, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.ModeImage(RouteType.BUS),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            rlShuttleFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("Red Line Shuttle"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            rlShuttleFlex
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.ModeImage(RouteType.BUS),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            glShuttleFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.Text("Green Line D Shuttle"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            glShuttleFlex
+        )
+    }
+
+    @Test
+    fun `test lines`() {
+        val redLine = line {
+            color = "DA291C"
+            longName = "Red Line"
+            textColor = "FFFFFF"
+        }
+        val greenLine = line {
+            color = "00843D"
+            longName = "Green Line"
+            textColor = "FFFFFF"
+        }
+
+        val rlFixed = RoutePillSpec(null, redLine, RoutePillSpec.Type.Fixed)
+        val rlFlex = RoutePillSpec(null, redLine, RoutePillSpec.Type.Flex)
+        val glFixed = RoutePillSpec(null, greenLine, RoutePillSpec.Type.Fixed)
+        val glFlex = RoutePillSpec(null, greenLine, RoutePillSpec.Type.Flex)
+
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("Red Line"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            rlFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "DA291C",
+                RoutePillSpec.Content.Text("Red Line"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            rlFlex
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.Text("GL"),
+                RoutePillSpec.Size.FixedPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            glFixed
+        )
+        assertEquals(
+            RoutePillSpec(
+                "FFFFFF",
+                "00843D",
+                RoutePillSpec.Content.Text("Green Line"),
+                RoutePillSpec.Size.FlexPill,
+                RoutePillSpec.Shape.Capsule
+            ),
+            glFlex
+        )
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Standardize pills in Stop Details / Trip Details](https://app.asana.com/0/1205732265579288/1208152137459416/f)

Moves the route pill logic to shared code.

### Testing

Copied the iOS RoutePill tests into shared code. Left the existing tests in place to make sure everything is actually integrated correctly - if we had none of them, it'd be silly to write this many, but since we already have all of them, I don't think we need to delete any of them.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
