### PR TITLE
build: time android instrumented tests out after 30 minutes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,6 +108,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 30
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

The Android instrumented tests have started hanging on exit sometimes, and we don't want to pay for a runner to idle for [two hours](https://github.com/mbta/mobile_app/actions/runs/10687051954/job/29623758898) because we didn't manually cancel the job.

### Testing

Not tested.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
