### PR TITLE
build: actually fix android instrumented tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,25 +87,6 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          target: ${{ matrix.target }}
-          arch: ${{ matrix.arch }}
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
         timeout-minutes: 30
@@ -114,7 +95,6 @@ jobs:
           target: ${{ matrix.target }}
           arch: ${{ matrix.arch }}
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: ./bin/android-instrumented-test-ci.sh
         env:

--- a/bin/android-instrumented-test-ci.sh
+++ b/bin/android-instrumented-test-ci.sh
@@ -12,9 +12,4 @@ if [ $GRADLE_EXIT_CODE -ne 0 ]; then
   /usr/local/lib/android/sdk/platform-tools/adb -s emulator-5554 logcat -d '*:S' ci-keep
 fi
 
-# https://github.com/ReactiveCircus/android-emulator-runner/issues/385#issuecomment-2234309549
-pkill -SIGTERM crashpad_handler || true
-sleep 5
-pkill -SIGKILL crashpad_handler || true
-
 exit $GRADLE_EXIT_CODE


### PR DESCRIPTION
### Summary

_Ticket:_ none

Skips the recommended AVD snapshot caching for (what appears to me to be) a nine second performance hit in exchange for actually working correctly.

Moves the logcat setup into a separate shell script for clarity (and because an earlier draft had more going on in that script which might've helped but didn't).

### Testing

Ran the CI.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
