### PR TITLE
fix: add color param to PinButtonTest

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/PinButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/PinButtonTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
@@ -13,7 +14,9 @@ class PinButtonTest {
     @Test
     fun callsAction() {
         var wasTapped = false
-        composeTestRule.setContent { PinButton(pinned = false) { wasTapped = true } }
+        composeTestRule.setContent {
+            PinButton(pinned = false, color = Color.Unspecified) { wasTapped = true }
+        }
 
         composeTestRule.onNodeWithContentDescription("pin route").performClick()
         assertTrue(wasTapped)


### PR DESCRIPTION
### Summary

_Ticket:_ none

I'm not in the habit of running the Android instrumented tests locally yet, which makes it easy to accidentally break them, and when they don't work in CI anyway it's harder to notice whether they failed for the same reason as usual or for a different reason too (especially when the tests still hang on exit whether they passed or failed).

### Testing

Ran the integration tests locally.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
