### PR TITLE
fix(iOS): update current time in StopDetailsView

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -90,6 +90,9 @@ struct StopDetailsView: View {
                 }
             }
         }
+        .onReceive(timer) { input in
+            now = input
+        }
         .task {
             do {
                 globalResponse = try await globalRepository.getGlobalData()


### PR DESCRIPTION
### Summary

_Ticket:_ [Stop details predictions stale after backgrounding](https://app.asana.com/0/1205732265579288/1208092119023066/f)

On one hand, it's nice when bugs are this easy to fix; on the other hand, it's frustrating when bugs would've been this easy for me to catch in code review if I'd been paying slightly more attention when reviewing #241.

### Testing

Opened the stop details page and checked that the predictions count down correctly over time.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
