### PR TITLE
fix(iOS): upgrade deps for Xcode 16 support

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Sentry (8.26.0):
-    - Sentry/Core (= 8.26.0)
-  - Sentry/Core (8.26.0)
+  - Sentry (8.36.0):
+    - Sentry/Core (= 8.36.0)
+  - Sentry/Core (8.36.0)
   - shared (1.0):
-    - Sentry (~> 8.26.0)
+    - Sentry (~> 8.36.0)
 
 DEPENDENCIES:
   - shared (from `../shared/`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../shared/"
 
 SPEC CHECKSUMS:
-  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
-  shared: 3feb3c866b91cde11fd8e459d237a2cc925cd032
+  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
+  shared: 19e2aa6dcc6627fddba6b8c32232f932ea8b8cc2
 
 PODFILE CHECKSUM: 32413a7fdb16d40c9f57cf8da0c74d4507ff5f90
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -2026,7 +2026,7 @@
 			repositoryURL = "https://github.com/mapbox/mapbox-maps-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.3.0;
+				minimumVersion = 11.6.1;
 			};
 		};
 		6E55C1802C2489030086A424 /* XCRemoteSwiftPackageReference "swift-collections" */ = {
@@ -2058,7 +2058,7 @@
 			repositoryURL = "https://github.com/appcues/appcues-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 3.2.0;
+				minimumVersion = 3.3.1;
 			};
 		};
 		9AB3F50B2BE44B49008D9E40 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/appcues/appcues-ios-sdk",
       "state" : {
-        "revision" : "5b3668a18154dcfc37a5b551658c29985a5f80e1",
-        "version" : "3.2.0"
+        "revision" : "14ec15534547f6be480a8aa8a627a7988a3c093e",
+        "version" : "3.3.1"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "15aed0b292a0fe0672113c1b69be04bd350c8bb3",
-        "version" : "24.3.1"
+        "revision" : "3cbd3eba5a316e4213b4860db398d5777f9de957",
+        "version" : "24.6.1"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "3638d2841f8a2ef6a995c659457d6133a6f0d1be",
-        "version" : "11.3.0"
+        "revision" : "80f08d877ff8a6ba1ad46d357e7863bb0a98f414",
+        "version" : "11.6.1"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "935c658a4d4d454de0e81e0b49ed291bd2c756a9",
-        "version" : "11.3.0"
+        "revision" : "c502416eaadd90891cb2a1d2d62f57a52dcfbfa5",
+        "version" : "11.6.1"
       }
     },
     {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,9 +1,9 @@
 import AppcuesKit
 import CoreLocation
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 struct ContentView: View {
     @Environment(\.scenePhase) private var scenePhase

--- a/iosApp/iosApp/ContentViewModel.swift
+++ b/iosApp/iosApp/ContentViewModel.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import MapboxMaps
 import shared
-@_spi(Experimental) import MapboxMaps
 
 class ContentViewModel: ObservableObject {
     @Published var configResponse: ApiResult<ConfigResponse>?

--- a/iosApp/iosApp/Fetchers/ViewportProvider.swift
+++ b/iosApp/iosApp/Fetchers/ViewportProvider.swift
@@ -7,10 +7,9 @@
 //
 
 import Combine
+import MapboxMaps
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
-import shared
 
 class ViewportProvider: ObservableObject {
     enum Defaults {

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 struct AnnotatedMap: View {
     static let annotationTextZoomThreshold = 19.0

--- a/iosApp/iosApp/Pages/Map/AnnotationLabel.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotationLabel.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 extension View {
     func annotationLabel<Content: View>(_ content: Content) -> ModifiedContent<Self, FloatingLabel<Content>> {

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import os
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 struct HomeMapView: View {
     var analytics: NearbyTransitAnalytics = AnalyticsProvider.shared

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 /*
  Functions for handling interactions with the map, like prop change, navigation, and tapping.

--- a/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 /*
  Functions for manipulating the layers displayed on the map.

--- a/iosApp/iosApp/Pages/Map/MapHttpInterceptor.swift
+++ b/iosApp/iosApp/Pages/Map/MapHttpInterceptor.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-@_spi(Experimental) import MapboxMaps
+import MapboxMaps
 
 class MapHttpInterceptor: HttpServiceInterceptorInterface {
     var updateLastErrorTimestamp: () -> Void

--- a/iosApp/iosApp/Pages/Map/MapLayerManager.swift
+++ b/iosApp/iosApp/Pages/Map/MapLayerManager.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import MapboxMaps
 import os
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 protocol IMapLayerManager {
     var currentScheme: ColorScheme? { get }

--- a/iosApp/iosApp/Pages/Map/MapViewModel.swift
+++ b/iosApp/iosApp/Pages/Map/MapViewModel.swift
@@ -8,8 +8,8 @@
 
 import Combine
 import Foundation
+import MapboxMaps
 import shared
-@_spi(Experimental) import MapboxMaps
 
 class MapViewModel: ObservableObject {
     @Published var childStops: [String: Stop]?

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
@@ -8,10 +8,10 @@
 
 import Combine
 import CoreLocation
+import MapboxMaps
 import os
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 struct NearbyTransitPageView: View {
     @ObservedObject var nearbyVM: NearbyViewModel

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -9,10 +9,10 @@
 import Combine
 import CoreLocation
 import FirebaseAnalytics
+import MapboxMaps
 import os
 import shared
 import SwiftUI
-@_spi(Experimental) import MapboxMaps
 
 struct NearbyTransitView: View {
     var analytics: NearbyTransitAnalytics = AnalyticsProvider.shared

--- a/iosApp/iosApp/Utils/ViewportExtension.swift
+++ b/iosApp/iosApp/Utils/ViewportExtension.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
-@_spi(Experimental) import MapboxMaps
+import MapboxMaps
 
 extension Viewport {
     var isFollowing: Bool {

--- a/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
+++ b/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
@@ -7,8 +7,8 @@
 //
 
 @testable import iosApp
+import MapboxMaps
 import shared
-@_spi(Experimental) import MapboxMaps
 import XCTest
 
 final class ViewportProviderTest: XCTestCase {

--- a/iosApp/iosAppTests/Mocks/MockLayerManager.swift
+++ b/iosApp/iosAppTests/Mocks/MockLayerManager.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 @testable import iosApp
-@_spi(Experimental) import MapboxMaps
+import MapboxMaps
 import SwiftUI
 
 class MockLayerManager: IMapLayerManager {

--- a/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
+++ b/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
@@ -7,12 +7,12 @@
 //
 
 @testable import iosApp
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
 import ViewInspector
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 final class HomeMapViewTest: XCTestCase {
     override func setUp() {

--- a/iosApp/iosAppTests/Pages/Map/MapHttpInterceptorTests.swift
+++ b/iosApp/iosAppTests/Pages/Map/MapHttpInterceptorTests.swift
@@ -7,8 +7,8 @@
 //
 
 @testable import iosApp
+import MapboxMaps
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 final class MapHttpInterceptorTests: XCTestCase {
     override func setUp() {

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
@@ -9,12 +9,12 @@
 import Combine
 import CoreLocation
 @testable import iosApp
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
 import ViewInspector
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 // swiftlint:disable:next type_body_length
 final class NearbyTransitPageViewTests: XCTestCase {

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -8,12 +8,12 @@
 
 import Combine
 @testable import iosApp
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
 import ViewInspector
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 final class StopDetailsPageTests: XCTestCase {
     override func setUp() {

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -8,12 +8,12 @@
 import Combine
 import Foundation
 @testable import iosApp
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
 import ViewInspector
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 final class ContentViewTests: XCTestCase {
     struct NotUnderTestError: Error {}

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -8,10 +8,10 @@
 
 import Combine
 @testable import iosApp
-import ViewInspector
-@_spi(Experimental) import MapboxMaps
+import MapboxMaps
 import shared
 import SwiftUI
+import ViewInspector
 import XCTest
 
 // swiftlint:disable:next type_body_length

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -9,12 +9,12 @@
 import Combine
 import CoreLocation
 @testable import iosApp
+import MapboxMaps
 import shared
 import SwiftPhoenixClient
 import SwiftUI
 import ViewInspector
 import XCTest
-@_spi(Experimental) import MapboxMaps
 
 // swiftlint:disable:next type_body_length
 final class NearbyTransitViewTests: XCTestCase {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -86,4 +86,7 @@ android {
 
 skie { features { group { DefaultArgumentInterop.MaximumDefaultArgumentCount(8) } } }
 
-sentryKmp { autoInstall.commonMain.enabled = false }
+sentryKmp {
+    autoInstall.commonMain.enabled = false
+    autoInstall.cocoapods.sentryCocoaVersion = "~> 8.36.0"
+}

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target    = '15.0'
-    spec.dependency 'Sentry', '~> 8.26.0'
+    spec.dependency 'Sentry', '~> 8.36.0'
 
     if !Dir.exist?('build/cocoapods/framework/shared.framework') || Dir.empty?('build/cocoapods/framework/shared.framework')
         raise "


### PR DESCRIPTION
### Summary

_Ticket:_ none

Since Xcode Cloud has started running our builds in Xcode 16 RC, we may as well go ahead and upgrade our dependencies to be compatible with Xcode 16.

### Testing

Checked locally in Xcode 16 that the app builds and runs successfully.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
