### PR TITLE
fix: Use now instead of ARR/BRD for bus

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -39,6 +39,14 @@ class UpcomingTripViewTest {
     }
 
     @Test
+    fun testUpcomingTripViewWithSomeNow() {
+        composeTestRule.setContent {
+            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Now))
+        }
+        composeTestRule.onNodeWithText("Now").assertIsDisplayed()
+    }
+
+    @Test
     fun testUpcomingTripViewWithSomeBoarding() {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Boarding))

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyLineViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyLineViewTest.kt
@@ -107,6 +107,6 @@ class NearbyLineViewTest {
         composeTestRule.onNodeWithText("Sample Line Long Name").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sample Stop").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ARR").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Now").assertIsDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopViewTest.kt
@@ -101,6 +101,6 @@ class NearbyStopViewTest {
 
         composeTestRule.onNodeWithText("Sample Stop").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("ARR").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Now").assertIsDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -74,6 +74,14 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold
                     )
+                is TripInstantDisplay.Now ->
+                    Text(
+                        stringResource(R.string.now),
+                        modifier,
+                        textAlign = TextAlign.End,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold
+                    )
                 is TripInstantDisplay.Approaching ->
                     BoldedTripStatus(
                         text = stringResource(R.string.approaching_abbr),

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="hello_platform">Hello, %1$s!</string>
     <string name="boarding_abbr">BRD</string>
     <string name="arriving_abbr">ARR</string>
+    <string name="now">Now</string>
     <string name="minutes_abbr">%1$s min</string>
     <string name="approaching_abbr">1 min</string>
     <string name="detour">Detour</string>

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -68,6 +68,8 @@ struct UpcomingTripView: View {
             case .hidden, .skipped:
                 // should have been filtered out already
                 Text(verbatim: "")
+            case .now:
+                Text("Now").font(Typography.headlineBold)
             case .boarding:
                 Text("BRD").font(Typography.headlineBold)
                     .accessibilityLabel(isFirst

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -70,6 +70,9 @@ struct UpcomingTripView: View {
                 Text(verbatim: "")
             case .now:
                 Text("Now").font(Typography.headlineBold)
+                    .accessibilityLabel(isFirst
+                        ? accessibilityFormatters.arrivingFirst(vehicleText: vehicleTypeText)
+                        : accessibilityFormatters.arrivingOther())
             case .boarding:
                 Text("BRD").font(Typography.headlineBold)
                     .accessibilityLabel(isFirst

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -142,7 +142,7 @@ class RealtimePatternsTest {
                     RealtimePatterns.Format.Some.FormatWithId(
                         trip.id,
                         route.type,
-                        TripInstantDisplay.Approaching
+                        TripInstantDisplay.Minutes(1)
                     )
                 ),
                 RealtimePatterns.Format.SecondaryAlert(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -587,6 +587,34 @@ class TripInstantDisplayTest {
     fun `minutes less than 20 in trip details`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(
+            TripInstantDisplay.Now,
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = now.plus(15.seconds)
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = TripInstantDisplay.Context.TripDetails
+            )
+        )
+        assertEquals(
+            TripInstantDisplay.Minutes(1),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = now.plus(31.seconds)
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = TripInstantDisplay.Context.TripDetails
+            )
+        )
+        assertEquals(
             TripInstantDisplay.AsTime(now + 90.seconds),
             TripInstantDisplay.from(
                 prediction =
@@ -595,7 +623,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )
@@ -610,7 +638,7 @@ class TripInstantDisplayTest {
                 schedule = null,
                 vehicle = null,
                 now = now,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
                 context = TripInstantDisplay.Context.TripDetails
             )
         )
@@ -623,7 +651,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -21,7 +21,7 @@ class UpcomingTripTest {
         private fun ParametricTest.anyContext() =
             anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
 
-        private fun ParametricTest.anyNonCommuterRailOrBus() =
+        private fun ParametricTest.subwayOrFerry() =
             anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS)
 
         @Test
@@ -29,7 +29,7 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Overridden("Custom Text"),
                 UpcomingTrip(trip {}, prediction { status = "Custom Text" })
-                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
+                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
             )
         }
 
@@ -45,7 +45,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         },
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -59,7 +59,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         }
                     )
-                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
+                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
             )
         }
 
@@ -68,12 +68,12 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, prediction { departureTime = null })
-                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
+                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, schedule { departureTime = null })
-                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
+                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
             )
         }
 
@@ -83,7 +83,7 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Schedule(now + 15.minutes),
                 UpcomingTrip(trip {}, schedule { departureTime = now + 15.minutes })
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -99,7 +99,7 @@ class UpcomingTripTest {
                             departureTime = now.minus(2.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -147,7 +147,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(10.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -171,7 +171,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -196,7 +196,7 @@ class UpcomingTripTest {
                             },
                             vehicle
                         )
-                        .format(now, anyNonCommuterRailOrBus(), anyContext())
+                        .format(now, subwayOrFerry(), anyContext())
                 )
             }
 
@@ -221,7 +221,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
             // wrong stop ID
             vehicle = vehicle {
@@ -241,7 +241,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
             // wrong trip ID
             vehicle = vehicle {
@@ -261,7 +261,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -277,12 +277,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(20.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Arriving,
                 UpcomingTrip(trip {}, prediction { departureTime = now.plus(15.seconds) })
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -298,12 +298,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(50.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Approaching,
                 UpcomingTrip(trip {}, (prediction { departureTime = now.plus(40.seconds) }))
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
@@ -322,7 +322,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(futureMinutes.minutes).plus(1.minutes)
                         }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Minutes(moreFutureMinutes),
@@ -330,14 +330,14 @@ class UpcomingTripTest {
                         trip {},
                         prediction { departureTime = now.plus(moreFutureMinutes.minutes) }
                     )
-                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+                    .format(now, subwayOrFerry(), anyContext())
             )
         }
 
         @Test
         fun `minutes less than 20`() = parametricTest {
             val now = Clock.System.now()
-            val routeType = anyNonCommuterRailOrBus()
+            val routeType = subwayOrFerry()
             val context = anyContext()
             assertEquals(
                 TripInstantDisplay.Minutes(1),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -21,15 +21,15 @@ class UpcomingTripTest {
         private fun ParametricTest.anyContext() =
             anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
 
-        private fun ParametricTest.anyNonCommuterRail() =
-            anyEnumValueExcept(RouteType.COMMUTER_RAIL)
+        private fun ParametricTest.anyNonCommuterRailOrBus() =
+            anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS)
 
         @Test
         fun `status is non-null`() = parametricTest {
             assertEquals(
                 TripInstantDisplay.Overridden("Custom Text"),
                 UpcomingTrip(trip {}, prediction { status = "Custom Text" })
-                    .format(Clock.System.now(), anyNonCommuterRail(), anyContext())
+                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -45,7 +45,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         },
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -59,7 +59,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         }
                     )
-                    .format(Clock.System.now(), anyNonCommuterRail(), anyContext())
+                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -68,12 +68,12 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, prediction { departureTime = null })
-                    .format(Clock.System.now(), anyNonCommuterRail(), anyContext())
+                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, schedule { departureTime = null })
-                    .format(Clock.System.now(), anyNonCommuterRail(), anyContext())
+                    .format(Clock.System.now(), anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -83,7 +83,7 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Schedule(now + 15.minutes),
                 UpcomingTrip(trip {}, schedule { departureTime = now + 15.minutes })
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -99,7 +99,39 @@ class UpcomingTripTest {
                             departureTime = now.minus(2.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
+            )
+        }
+
+        @Test
+        fun `bus arriving now`() = parametricTest {
+            val now = Clock.System.now()
+            assertEquals(
+                TripInstantDisplay.Now,
+                UpcomingTrip(
+                        trip {},
+                        prediction {
+                            arrivalTime = now
+                            departureTime = now.plus(10.seconds)
+                        }
+                    )
+                    .format(now, RouteType.BUS, anyContext())
+            )
+        }
+
+        @Test
+        fun `bus more than 30 seconds away`() = parametricTest {
+            val now = Clock.System.now()
+            assertEquals(
+                TripInstantDisplay.Minutes(2),
+                UpcomingTrip(
+                        trip {},
+                        prediction {
+                            arrivalTime = now.plus(2.minutes)
+                            departureTime = now.plus(3.minutes)
+                        }
+                    )
+                    .format(now, RouteType.BUS, anyContext())
             )
         }
 
@@ -115,7 +147,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(10.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -139,7 +171,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -164,7 +196,7 @@ class UpcomingTripTest {
                             },
                             vehicle
                         )
-                        .format(now, anyNonCommuterRail(), anyContext())
+                        .format(now, anyNonCommuterRailOrBus(), anyContext())
                 )
             }
 
@@ -189,7 +221,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
             // wrong stop ID
             vehicle = vehicle {
@@ -209,7 +241,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
             // wrong trip ID
             vehicle = vehicle {
@@ -229,7 +261,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -245,12 +277,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(20.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Arriving,
                 UpcomingTrip(trip {}, prediction { departureTime = now.plus(15.seconds) })
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -266,12 +298,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(50.seconds)
                         }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Approaching,
                 UpcomingTrip(trip {}, (prediction { departureTime = now.plus(40.seconds) }))
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
@@ -290,7 +322,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(futureMinutes.minutes).plus(1.minutes)
                         }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Minutes(moreFutureMinutes),
@@ -298,14 +330,14 @@ class UpcomingTripTest {
                         trip {},
                         prediction { departureTime = now.plus(moreFutureMinutes.minutes) }
                     )
-                    .format(now, anyNonCommuterRail(), anyContext())
+                    .format(now, anyNonCommuterRailOrBus(), anyContext())
             )
         }
 
         @Test
         fun `minutes less than 20`() = parametricTest {
             val now = Clock.System.now()
-            val routeType = anyNonCommuterRail()
+            val routeType = anyNonCommuterRailOrBus()
             val context = anyContext()
             assertEquals(
                 TripInstantDisplay.Minutes(1),


### PR DESCRIPTION
### Summary

_Ticket:_ [For bus, use Now instead of ARR/BRD](https://app.asana.com/0/1205732265579288/1207678190799457/f)

For bus, don't show `ARR` or `BRD` if the trip is less than or equal to 30 seconds away,  instead show `Now`. Otherwise round to nearest minute.

### Testing
Added some unit tests, tweaked existing tests, and added a UI test for Android. 
