### PR TITLE
fix: add nil secondaryAlert to realtime format in filtered stop details

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
@@ -42,9 +42,9 @@ struct StopDetailsFilteredRouteView: View {
                 context: .stopDetailsFiltered,
                 isSubway: route.type.isSubway()
             ) {
-                RealtimePatterns.FormatSome(trips: [formattedUpcomingTrip])
+                RealtimePatterns.FormatSome(trips: [formattedUpcomingTrip], secondaryAlert: nil)
             } else {
-                RealtimePatterns.FormatNone()
+                RealtimePatterns.FormatNone(secondaryAlert: nil)
             }
 
             if let vehicleId = upcoming.prediction?.vehicleId, let stopSequence = upcoming.stopSequence {


### PR DESCRIPTION
### Summary

_Ticket:_ none

The iOS build on `main` is broken right now because of a logical merge conflict.

### Testing

Ran the tests locally.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
