### PR TITLE
feat: Tapping on stop search results navigates to stop page

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		9A3B09362B967CEC00691427 /* NonNilModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3B09352B967CEC00691427 /* NonNilModifier.swift */; };
 		9A3BAB722BEAB8E200DAFDE2 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A3BAB712BEAB8E200DAFDE2 /* Colors.xcassets */; };
 		9A3BAB742BEABADF00DAFDE2 /* ColorAssetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3BAB732BEABADF00DAFDE2 /* ColorAssetExtension.swift */; };
+		9A4DB7782C937EE300E8755B /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB7772C937EE300E8755B /* SearchViewModel.swift */; };
 		9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E8E582B7EC4B90066B936 /* RoutePill.swift */; };
 		9A4F3B9F2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */; };
 		9A52B3362C6A93390028EEAB /* AlertDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */; };
@@ -336,6 +337,7 @@
 		9A3B09352B967CEC00691427 /* NonNilModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonNilModifier.swift; sourceTree = "<group>"; };
 		9A3BAB712BEAB8E200DAFDE2 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		9A3BAB732BEABADF00DAFDE2 /* ColorAssetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAssetExtension.swift; sourceTree = "<group>"; };
+		9A4DB7772C937EE300E8755B /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		9A4E8E582B7EC4B90066B936 /* RoutePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePill.swift; sourceTree = "<group>"; };
 		9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsAlertHeaderTests.swift; sourceTree = "<group>"; };
 		9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsTests.swift; sourceTree = "<group>"; };
@@ -778,6 +780,7 @@
 			isa = PBXGroup;
 			children = (
 				9A887D562B683103006F5B80 /* SearchResultView.swift */,
+				9A4DB7772C937EE300E8755B /* SearchViewModel.swift */,
 			);
 			path = Search;
 			sourceTree = "<group>";
@@ -1285,6 +1288,7 @@
 				ED24EADC2C1A95A900A7BE4D /* StopDetailsAnalytics.swift in Sources */,
 				9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */,
 				9A9E3DC22C62AE12004AADC7 /* AlertDetailsPage.swift in Sources */,
+				9A4DB7782C937EE300E8755B /* SearchViewModel.swift in Sources */,
 				6E2027902BD989AC0037554F /* ProductionAppView.swift in Sources */,
 				6E04D4302C1A17340055FD99 /* StopDeparturesSummaryList.swift in Sources */,
 				9A74A2112BE2D71400E57102 /* AnnotationLabel.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -102,6 +102,7 @@ struct ContentView: View {
                 TextField("Find nearby transit", text: $searchObserver.searchText)
                 SearchView(
                     query: searchObserver.debouncedText,
+                    nearbyVM: nearbyVM,
                     searchVM: searchVM
                 )
             }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -98,7 +98,7 @@ struct ContentView: View {
     @ViewBuilder
     var nearbyTab: some View {
         VStack {
-            if contentVM.searchEnabled {
+            if contentVM.searchEnabled, nearbyVM.navigationStack.lastSafe() == .nearby {
                 TextField("Find nearby transit", text: $searchObserver.searchText)
                 SearchView(
                     query: searchObserver.debouncedText,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -17,8 +17,9 @@ struct ContentView: View {
     @ObservedObject var contentVM: ContentViewModel
 
     @State private var sheetHeight: CGFloat = UIScreen.main.bounds.height / 2
-    @StateObject var nearbyVM: NearbyViewModel = .init()
+    @StateObject var nearbyVM = NearbyViewModel()
     @StateObject var mapVM = MapViewModel()
+    @StateObject var searchVM = SearchViewModel()
     var screenTracker: ScreenTracker = AnalyticsProvider.shared
 
     let inspection = Inspection<Self>()
@@ -100,7 +101,8 @@ struct ContentView: View {
             if contentVM.searchEnabled {
                 TextField("Find nearby transit", text: $searchObserver.searchText)
                 SearchView(
-                    query: searchObserver.debouncedText
+                    query: searchObserver.debouncedText,
+                    searchVM: searchVM
                 )
             }
             locationAuthHeader

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -290,6 +290,9 @@
     "No Service" : {
 
     },
+    "Now" : {
+
+    },
     "Now at" : {
 
     },

--- a/iosApp/iosApp/Pages/Search/SearchResultView.swift
+++ b/iosApp/iosApp/Pages/Search/SearchResultView.swift
@@ -71,7 +71,6 @@ struct SearchView: View {
 
     func handleStopTap(stopId: String) {
         guard let stop = globalResponse?.stops[stopId] else { return }
-        nearbyVM.navigationStack.removeAll()
         nearbyVM.navigationStack.append(.stopDetails(stop, nil))
     }
 

--- a/iosApp/iosApp/Pages/Search/SearchResultView.swift
+++ b/iosApp/iosApp/Pages/Search/SearchResultView.swift
@@ -124,14 +124,15 @@ struct SearchResultView: View {
         if results == nil {
             Text("Loading...")
         } else {
-            if results!.stops.isEmpty, results!.routes.isEmpty {
+            if results!.stops.isEmpty, !showRoutes || results!.routes.isEmpty {
                 Text("No results found")
             } else {
                 List {
                     if !results!.stops.isEmpty {
                         Section(header: Text("Stops")) {
-                            ForEach(results!.stops, id: \.id) {
-                                StopResultView(stop: $0, handleStopTap: handleStopTap)
+                            ForEach(results!.stops, id: \.id) { stop in
+                                StopResultView(stop: stop)
+                                    .onTapGesture { handleStopTap(stop.id) }
                             }
                         }
                     }
@@ -150,12 +151,11 @@ struct SearchResultView: View {
 
 struct StopResultView: View {
     let stop: StopResult
-    let handleStopTap: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading) {
             Text(stop.name)
-        }.onTapGesture { handleStopTap(stop.id) }
+        }
     }
 }
 

--- a/iosApp/iosApp/Pages/Search/SearchViewModel.swift
+++ b/iosApp/iosApp/Pages/Search/SearchViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  SearchViewModel.swift
+//  iosApp
+//
+//  Created by esimon on 9/12/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import shared
+@_spi(Experimental) import MapboxMaps
+
+class SearchViewModel: ObservableObject {
+    @Published var routeResultsEnabled: Bool
+    private var settings: Set<Setting> = []
+
+    var settingsRepo: ISettingsRepository
+
+    init(
+        routeResultsEnabled: Bool = false,
+        settingsRepo: ISettingsRepository = RepositoryDI().settings
+    ) {
+        self.routeResultsEnabled = routeResultsEnabled
+        self.settingsRepo = settingsRepo
+    }
+
+    @MainActor func loadSettings() async {
+        do {
+            let settings = try await settingsRepo.getSettings()
+            routeResultsEnabled = settings.first(where: { $0.key == .searchRouteResults })?.isOn ?? false
+        } catch {}
+    }
+}

--- a/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
+++ b/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
@@ -18,6 +18,8 @@ extension Setting: Identifiable {
         switch key {
         case .search:
             "Search"
+        case .searchRouteResults:
+            "Search - Route Results"
         case .map:
             "Map Debug"
         }
@@ -27,6 +29,8 @@ extension Setting: Identifiable {
         switch key {
         case .search:
             "magnifyingglass"
+        case .searchRouteResults:
+            "point.topleft.down.to.point.bottomright.curvepath.fill"
         case .map:
             "location.magnifyingglass"
         }
@@ -35,6 +39,8 @@ extension Setting: Identifiable {
     var category: SettingsSection.Category {
         switch key {
         case .search:
+            .featureFlags
+        case .searchRouteResults:
             .featureFlags
         case .map:
             .debug

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -20,7 +20,7 @@ final class SearchResultViewTests: XCTestCase {
     }
 
     @MainActor func testPending() throws {
-        let sut = SearchResultView(results: nil)
+        let sut = SearchResultView(results: nil, handleStopTap: { _ in })
 
         XCTAssertEqual(try sut.inspect().view(SearchResultView.self).text().string(), "Loading...")
     }
@@ -43,6 +43,8 @@ final class SearchResultViewTests: XCTestCase {
 
         var sut = SearchView(
             query: "hay",
+            nearbyVM: NearbyViewModel(),
+            searchVM: SearchViewModel(),
             searchResultsRepository: FakeRepo(getSearchResultsExpectation: getSearchResultsExpectation)
         )
 
@@ -55,7 +57,8 @@ final class SearchResultViewTests: XCTestCase {
 
     @MainActor func testNoResults() throws {
         let sut = SearchResultView(
-            results: SearchResults(routes: [], stops: [])
+            results: SearchResults(routes: [], stops: []),
+            handleStopTap: { _ in }
         )
         XCTAssertEqual(try sut.inspect().view(SearchResultView.self).text().string(), "No results found")
     }
@@ -87,7 +90,9 @@ final class SearchResultViewTests: XCTestCase {
                         ]
                     ),
                 ]
-            )
+            ),
+            handleStopTap: { _ in },
+            showRoutes: true
         )
 
         XCTAssertNoThrow(try sut.inspect().find(text: "Stops"))
@@ -109,12 +114,35 @@ final class SearchResultViewTests: XCTestCase {
                     ),
                 ],
                 stops: []
-            )
+            ),
+            handleStopTap: { _ in },
+            showRoutes: true
         )
 
         XCTAssertNoThrow(try sut.inspect().find(text: "Routes"))
         XCTAssertNoThrow(try sut.inspect().find(text: "428 Oaklandvale - Haymarket Station"))
         XCTAssertThrowsError(try sut.inspect().find(text: "Stops"))
+    }
+
+    @MainActor func testRoutesHidden() throws {
+        let sut = SearchResultView(
+            results: SearchResults(
+                routes: [
+                    RouteResult(
+                        id: "428",
+                        rank: 5,
+                        longName: "Oaklandvale - Haymarket Station",
+                        shortName: "428",
+                        routeType: RouteType.bus
+                    ),
+                ],
+                stops: []
+            ),
+            handleStopTap: { _ in },
+            showRoutes: false
+        )
+
+        XCTAssertEqual(try sut.inspect().view(SearchResultView.self).text().string(), "No results found")
     }
 
     @MainActor func testOnlyStops() throws {
@@ -136,11 +164,49 @@ final class SearchResultViewTests: XCTestCase {
                         ]
                     ),
                 ]
-            )
+            ),
+            handleStopTap: { _ in }
         )
 
         XCTAssertNoThrow(try sut.inspect().find(text: "Stops"))
         XCTAssertNoThrow(try sut.inspect().find(text: "Haymarket"))
         XCTAssertThrowsError(try sut.inspect().find(text: "Routes"))
+    }
+
+    @MainActor func testStopTapping() async throws {
+        let tapStopExpectation = expectation(description: "stop was tapped")
+
+        let sut = SearchResultView(
+            results: SearchResults(
+                routes: [],
+                stops: [
+                    StopResult(
+                        id: "place-haecl",
+                        rank: 2,
+                        name: "Haymarket",
+                        zone: nil,
+                        isStation: true,
+                        routes: [
+                            StopResultRoute(
+                                type: .heavyRail,
+                                icon: "orange_line"
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            handleStopTap: { stopId in
+                XCTAssertEqual("place-haecl", stopId)
+                tapStopExpectation.fulfill()
+            }
+        )
+
+        XCTAssertNoThrow(
+            try sut.inspect()
+                .find(text: "Haymarket")
+                .find(StopResultView.self, relation: .parent)
+                .callOnTapGesture()
+        )
+        await fulfillment(of: [tapStopExpectation], timeout: 1)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -37,6 +37,7 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     Map(booleanPreferencesKey("map_debug")),
     Search(booleanPreferencesKey("search_featureFlag")),
+    SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
 }
 
 data class Setting(val key: Settings, var isOn: Boolean)


### PR DESCRIPTION
### Summary

_Ticket:_ [Tapping on stop search result goes to Stop Details](https://app.asana.com/0/1205732265579288/1208252548197529/f)

Make it so that stop search results navigate to the associated stop page. Also adds a new feature flag for hiding route search results, and makes it so that search is hidden everywhere except nearby transit.

### Testing

Added test for tapping stop result rows