### PR TITLE
fix: show now instead of arr/brd for bus in trip details

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -229,12 +229,13 @@ struct ContentView: View {
                 tripId: tripId,
                 vehicleId: vehicleId,
                 target: target,
-                routeId: _,
+                routeId: routeId,
                 directionId: _
             ):
                 TripDetailsPage(
                     tripId: tripId,
                     vehicleId: vehicleId,
+                    routeId: routeId,
                     target: target,
                     nearbyVM: nearbyVM,
                     mapVM: mapVM

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -290,6 +290,9 @@
     "No Service" : {
 
     },
+    "Now" : {
+
+    },
     "Now at" : {
 
     },

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -205,7 +205,7 @@ extension HomeMapView {
         })
         let stopSequence = trip?.stopSequence?.intValue
 
-        guard let routeId = vehicle.routeId ?? trip?.trip.id else {
+        guard let routeId = trip?.trip.routeId ?? vehicle.routeId else {
             // TODO: figure out something to do if this is nil
             return
         }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct TripDetailsPage: View {
     let tripId: String
     let vehicleId: String
+    let routeId: String
     let target: TripDetailsTarget?
 
     @ObservedObject var nearbyVM: NearbyViewModel
@@ -34,9 +35,14 @@ struct TripDetailsPage: View {
 
     let inspection = Inspection<Self>()
 
+    private var routeType: RouteType? {
+        globalResponse?.routes[routeId]?.type
+    }
+
     init(
         tripId: String,
         vehicleId: String,
+        routeId: String,
         target: TripDetailsTarget?,
         nearbyVM: NearbyViewModel,
         mapVM: MapViewModel,
@@ -48,6 +54,7 @@ struct TripDetailsPage: View {
     ) {
         self.tripId = tripId
         self.vehicleId = vehicleId
+        self.routeId = routeId
         self.target = target
         self.nearbyVM = nearbyVM
         self.mapVM = mapVM
@@ -75,9 +82,14 @@ struct TripDetailsPage: View {
                         targetStopSequence: Int32(stopSequence),
                         globalData: globalResponse
                     ) {
-                        TripDetailsStopListSplitView(splitStops: splitStops, now: now, onTapLink: onTapStop)
+                        TripDetailsStopListSplitView(
+                            splitStops: splitStops,
+                            now: now,
+                            onTapLink: onTapStop,
+                            routeType: routeType
+                        )
                     } else {
-                        TripDetailsStopListView(stops: stops, now: now, onTapLink: onTapStop)
+                        TripDetailsStopListView(stops: stops, now: now, onTapLink: onTapStop, routeType: routeType)
                     }
                 } else {
                     Text("Couldn't load stop list")

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
@@ -13,20 +13,21 @@ struct TripDetailsStopListSplitView: View {
     let splitStops: TripDetailsStopList.TargetSplit
     let now: Instant
     let onTapLink: (SheetNavigationStackEntry, TripDetailsStopList.Entry, String?) -> Void
+    let routeType: RouteType?
 
     var body: some View {
         List {
             if !splitStops.collapsedStops.isEmpty {
                 DisclosureGroup(LocalizedStringKey("\(splitStops.collapsedStops.count, specifier: "%ld") stops")) {
                     ForEach(splitStops.collapsedStops, id: \.stopSequence) { stop in
-                        TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink)
+                        TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink, routeType: routeType)
                     }
                 }
             }
-            TripDetailsStopView(stop: splitStops.targetStop, now: now, onTapLink: onTapLink)
+            TripDetailsStopView(stop: splitStops.targetStop, now: now, onTapLink: onTapLink, routeType: routeType)
                 .listRowBackground(Color.keyInverse.opacity(0.15))
             ForEach(splitStops.followingStops, id: \.stopSequence) { stop in
-                TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink)
+                TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink, routeType: routeType)
             }
         }
     }
@@ -61,6 +62,7 @@ struct TripDetailsStopListSplitView: View {
             followingStops: [entry(stop3, 30, pred3)]
         ),
         now: Date.now.toKotlinInstant(),
-        onTapLink: { _, _, _ in }
+        onTapLink: { _, _, _ in },
+        routeType: nil
     ).font(Typography.body)
 }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListView.swift
@@ -13,10 +13,11 @@ struct TripDetailsStopListView: View {
     let stops: TripDetailsStopList
     let now: Instant
     let onTapLink: (SheetNavigationStackEntry, TripDetailsStopList.Entry, String?) -> Void
+    let routeType: RouteType?
 
     var body: some View {
         List(stops.stops, id: \.stopSequence) { stop in
-            TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink)
+            TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink, routeType: routeType)
         }
     }
 }
@@ -53,6 +54,7 @@ struct TripDetailsStopListView: View {
             ),
         ]),
         now: Date.now.toKotlinInstant(),
-        onTapLink: { _, _, _ in }
+        onTapLink: { _, _, _ in },
+        routeType: nil
     ).font(Typography.body)
 }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -13,6 +13,7 @@ struct TripDetailsStopView: View {
     let stop: TripDetailsStopList.Entry
     let now: Instant
     let onTapLink: (SheetNavigationStackEntry, TripDetailsStopList.Entry, String?) -> Void
+    let routeType: RouteType?
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -23,7 +24,7 @@ struct TripDetailsStopView: View {
                     HStack {
                         Text(stop.stop.name).foregroundStyle(Color.text)
                         Spacer()
-                        UpcomingTripView(prediction: upcomingTripViewState, routeType: nil)
+                        UpcomingTripView(prediction: upcomingTripViewState, routeType: routeType)
                     }
                 }
             )
@@ -35,7 +36,7 @@ struct TripDetailsStopView: View {
         if let alert = stop.alert {
             .noService(alert.effect)
         } else {
-            .some(stop.format(now: now, routeType: nil))
+            .some(stop.format(now: now, routeType: routeType))
         }
     }
 
@@ -83,6 +84,7 @@ struct TripDetailsStopView: View {
             ]
         ),
         now: Date.now.toKotlinInstant(),
-        onTapLink: { _, _, _ in }
+        onTapLink: { _, _, _ in },
+        routeType: .lightRail
     ).font(Typography.body)
 }

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -46,6 +46,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: trip.routeId,
             target: nil,
             nearbyVM: .init(),
             mapVM: .init(),
@@ -109,6 +110,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: route.id,
             target: nil,
             nearbyVM: .init(),
             mapVM: .init(),
@@ -152,6 +154,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: trip.routeId,
             target: .init(stopId: stop1.id, stopSequence: 998),
             nearbyVM: .init(),
             mapVM: .init(),
@@ -261,6 +264,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: trip.routeId,
             target: nil,
             nearbyVM: .init(),
             mapVM: .init(),
@@ -320,6 +324,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: trip.routeId,
             target: nil,
             nearbyVM: .init(),
             mapVM: .init(),
@@ -361,6 +366,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: "tripId",
             vehicleId: "veicleId",
+            routeId: "routeId",
             target: nil,
             nearbyVM: FakeNearbyVM(backExp),
             mapVM: .init(),
@@ -396,6 +402,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
+            routeId: trip.routeId,
             target: nil,
             nearbyVM: .init(),
             mapVM: mapVM,
@@ -442,6 +449,7 @@ final class TripDetailsPageTests: XCTestCase {
         let sut = TripDetailsPage(
             tripId: trip.id,
             vehicleId: vehicle.id,
+            routeId: route.id,
             target: nil,
             nearbyVM: nearbyVM,
             mapVM: .init(),

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopListSplitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopListSplitViewTests.swift
@@ -41,7 +41,8 @@ final class TripDetailsStopListSplitViewTests: XCTestCase {
                 followingStops: [entry(stop2, 20, pred2), entry(stop3, 30, pred3)]
             ),
             now: Date.now.toKotlinInstant(),
-            onTapLink: { _, _, _ in }
+            onTapLink: { _, _, _ in },
+            routeType: nil
         )
 
         XCTAssertNil(try? sut.inspect().find(ViewType.DisclosureGroup.self))
@@ -55,7 +56,8 @@ final class TripDetailsStopListSplitViewTests: XCTestCase {
                 followingStops: []
             ),
             now: Date.now.toKotlinInstant(),
-            onTapLink: { _, _, _ in }
+            onTapLink: { _, _, _ in },
+            routeType: nil
         )
 
         XCTAssertNotNil(try sut.inspect().find(ViewType.DisclosureGroup.self))

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
@@ -35,7 +35,8 @@ final class TripDetailsStopViewTests: XCTestCase {
             stop: .init(stop: stop, stopSequence: 1, alert: alert, schedule: nil, prediction: prediction, vehicle: nil,
                         routes: []),
             now: Date.now.toKotlinInstant(),
-            onTapLink: { _, _, _ in }
+            onTapLink: { _, _, _ in },
+            routeType: nil
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Stop Closed"))
@@ -69,7 +70,8 @@ final class TripDetailsStopViewTests: XCTestCase {
                 XCTAssertEqual(stopListEntry, actualStopListEntry)
                 XCTAssertNil(connectingRoute)
                 exp.fulfill()
-            }
+            },
+            routeType: nil
         )
 
         try sut.inspect().find(button: "Boylston").tap()
@@ -107,10 +109,36 @@ final class TripDetailsStopViewTests: XCTestCase {
                 XCTAssertEqual(stopListEntry, actualStopListEntry)
                 XCTAssertEqual(connectingRouteId, connectingRoute.id)
                 exp.fulfill()
-            }
+            },
+            routeType: nil
         )
 
         try sut.inspect().find(text: "28").find(RoutePill.self, relation: .parent).callOnTapGesture()
         wait(for: [exp], timeout: 5)
+    }
+
+    func testShowsNowForBus() throws {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let prediction = objects.prediction { prediction in
+            prediction.arrivalTime = now.addingTimeInterval(15).toKotlinInstant()
+        }
+        let sut = TripDetailsStopView(
+            stop: .init(
+                stop: stop,
+                stopSequence: 1,
+                alert: nil,
+                schedule: nil,
+                prediction: prediction,
+                vehicle: nil,
+                routes: []
+            ),
+            now: now.toKotlinInstant(),
+            onTapLink: { _, _, _ in },
+            routeType: .bus
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Now"))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [For bus, use Now instead of ARR/BRD](https://app.asana.com/0/1205732265579288/1207678190799457/f)

Missed changing this for trip details. Turns out we're not passing in `RouteType` to the format function there.

### Testing

Added a unit test on the affected view for good measure.
