### PR TITLE
feat: rewrite trips and collapse route patterns during temporary terminals

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -54,8 +54,18 @@ fun NearbyTransitView(
     val (pinnedRoutes, togglePinnedRoute) = managePinnedRoutes()
 
     val nearbyWithRealtimeInfo =
-        remember(nearby, targetLocation, schedules, predictions, alertData, now, pinnedRoutes) {
+        remember(
+            nearby,
+            globalResponse,
+            targetLocation,
+            schedules,
+            predictions,
+            alertData,
+            now,
+            pinnedRoutes
+        ) {
             nearby?.withRealtimeInfo(
+                globalData = globalResponse,
                 sortByDistanceFrom = targetLocation,
                 schedules,
                 predictions,

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -241,6 +241,7 @@ struct NearbyTransitView: View {
     ) -> [StopsAssociated]? {
         guard let loadedLocation = state.loadedLocation else { return nil }
         return state.nearbyByRouteAndStop?.withRealtimeInfo(
+            globalData: globalData,
             sortByDistanceFrom: .init(longitude: loadedLocation.longitude, latitude: loadedLocation.latitude),
             schedules: schedules,
             predictions: predictions,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -569,14 +569,14 @@ private fun NearbyStaticData.rewrittenForTemporaryTerminals(
 
     fun NearbyStaticData.StopPatterns.withTruncatedPatterns(): NearbyStaticData.StopPatterns {
         for (fullPattern in this.patterns.flatMap { it.patterns }) {
-            val fullPatternTrip = globalData.trips[fullPattern.representativeTripId] ?: continue
-            checkNotNull(fullPatternTrip.stopIds) { fetchedWithoutStopIds(fullPattern) }
+            val fullPatternStopIds =
+                globalData.trips[fullPattern.representativeTripId]?.stopIds ?: continue
 
             for (stopId in this.allStopIds) {
-                if (!fullPatternTrip.stopIds.contains(stopId)) continue
+                if (!fullPatternStopIds.contains(stopId)) continue
 
                 truncatedPatternByFullPatternAndStop[Pair(fullPattern.id, stopId)] =
-                    rewriter.truncatedPattern(fullPattern, fullPatternTrip.stopIds, stopId)?.id
+                    rewriter.truncatedPattern(fullPattern, fullPatternStopIds, stopId)?.id
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -228,8 +228,6 @@ class ObjectCollectionBuilder {
         var id = uuid()
         var arrivalTime: Instant? = null
         var departureTime: Instant? = null
-        var dropOffType = Schedule.StopEdgeType.Regular
-        var pickUpType = Schedule.StopEdgeType.Regular
         var stopSequence = 0
         var routeId = ""
         var stopId = ""
@@ -247,8 +245,14 @@ class ObjectCollectionBuilder {
                 id,
                 arrivalTime,
                 departureTime,
-                dropOffType,
-                pickUpType,
+                when (arrivalTime) {
+                    null -> Schedule.StopEdgeType.Unavailable
+                    else -> Schedule.StopEdgeType.Regular
+                },
+                when (departureTime) {
+                    null -> Schedule.StopEdgeType.Unavailable
+                    else -> Schedule.StopEdgeType.Regular
+                },
                 stopSequence,
                 routeId,
                 stopId,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -348,19 +348,21 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
             directionId: Int? = null,
             alerts: Collection<Alert>
         ): List<Alert> =
-            stopIds.flatMap { stopId ->
-                alerts.filter { alert ->
-                    alert.anyInformedEntity {
-                        routes.any { route ->
-                            it.appliesTo(
-                                directionId = directionId,
-                                routeId = route.id,
-                                stopId = stopId
-                            )
-                        } && it.activities.contains(Alert.InformedEntity.Activity.Board)
+            stopIds
+                .flatMap { stopId ->
+                    alerts.filter { alert ->
+                        alert.anyInformedEntity {
+                            routes.any { route ->
+                                it.appliesTo(
+                                    directionId = directionId,
+                                    routeId = route.id,
+                                    stopId = stopId
+                                )
+                            } && it.activities.contains(Alert.InformedEntity.Activity.Board)
+                        }
                     }
                 }
-            }
+                .distinct()
 
         fun formatUpcomingTrip(
             now: Instant,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
@@ -80,10 +80,10 @@ class TemporaryTerminalRewriter(
     ): Boolean {
         if (typicality == RoutePattern.Typicality.Typical) return false
         if (directionId != fullPattern.directionId) return false
-        val truncatedPatternTrip = globalData.trips[representativeTripId] ?: return false
-        checkNotNull(truncatedPatternTrip.stopIds) { fetchedWithoutStopIds(this) }
-        return truncatedPatternTrip.stopIds.contains(stopId) &&
-            fullPatternStopIds.containsSubsequence(truncatedPatternTrip.stopIds)
+        val truncatedPatternStopIds =
+            globalData.trips[representativeTripId]?.stopIds ?: return false
+        return truncatedPatternStopIds.contains(stopId) &&
+            fullPatternStopIds.containsSubsequence(truncatedPatternStopIds)
     }
 
     /**
@@ -131,6 +131,3 @@ private fun <T> List<T>.containsSubsequence(subsequence: List<T>): Boolean {
     if (this.size < startIndex + subsequence.size) return false
     return this.subList(startIndex, startIndex + subsequence.size) == subsequence
 }
-
-fun fetchedWithoutStopIds(routePattern: RoutePattern) =
-    "route pattern ${routePattern.id} representative trip ${routePattern.representativeTripId} fetched without stop IDs"

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
@@ -109,7 +109,7 @@ class TemporaryTerminalRewriter(
      * disruption on the same line). If there is no plausible truncated pattern, or if there are
      * several, does not truncate [fullPattern].
      */
-    fun truncatedPattern(
+    fun findTruncatedPattern(
         fullPattern: RoutePattern,
         fullPatternStopIds: List<String>,
         stopId: String
@@ -150,7 +150,7 @@ class TemporaryTerminalRewriter(
                 if (!fullPatternStopIds.contains(stopId)) continue
 
                 truncatedPatternByFullPatternAndStop[Pair(fullPattern.id, stopId)] =
-                    truncatedPattern(fullPattern, fullPatternStopIds, stopId)?.id
+                    findTruncatedPattern(fullPattern, fullPatternStopIds, stopId)?.id
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriter.kt
@@ -1,0 +1,71 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+
+class TemporaryTerminalRewriter(
+    val nearbyStaticData: NearbyStaticData,
+    val predictions: PredictionsStreamDataResponse,
+    val globalData: GlobalResponse,
+    val alerts: List<Alert>,
+    val schedules: ScheduleResponse
+) {
+    val schedulesByRoute = schedules.schedules.groupBy { it.routeId }
+    // predictions that reflect auto-cancelled schedules will throw everything off, so filter out
+    // cancellations
+    val predictionsByRoute =
+        predictions.predictions.values
+            .filterNot { it.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled }
+            .groupBy { it.routeId }
+    val routePatternsByRoute = globalData.routePatterns.values.groupBy { it.routeId }
+
+    fun Schedule.routePattern(): RoutePattern? =
+        schedules.trips[tripId]?.let { globalData.routePatterns[it.routePatternId] }
+
+    fun Prediction.routePattern(): RoutePattern? =
+        predictions.trips[tripId]?.let { globalData.routePatterns[it.routePatternId] }
+
+    /**
+     * Rewriting realtime data for temporary terminals causes what the app displays to diverge from
+     * what the API says is real, and so must be done with caution. Specifically, we only want to
+     * rewrite
+     * 1. subway routes
+     * 2. with alerts somewhere on the line
+     * 3. where the schedule has non-typical patterns and is missing a typical pattern (requiring
+     *    only non-typical patterns misses single-branch RL disruptions, but allowing just any
+     *    non-typical pattern hits GL early-morning cross-branch trips)
+     * 4. but the predictions all have typical patterns instead of non-typical patterns (meaning
+     *    this hasn't been fixed upstream yet)
+     */
+    fun appliesToRoute(route: Route): Boolean {
+        val routeId = route.id
+        val isSubway = route.type.isSubway()
+
+        val routeHasAlert =
+            alerts.any { alert ->
+                alert.effect in setOf(Alert.Effect.Suspension, Alert.Effect.Shuttle) &&
+                    alert.anyInformedEntity { it.appliesTo(routeId = routeId) }
+            }
+
+        val routeSchedules = schedulesByRoute[routeId].orEmpty()
+        val scheduledPatterns = routeSchedules.mapNotNullTo(mutableSetOf()) { it.routePattern() }
+        val routePatterns = routePatternsByRoute[routeId].orEmpty()
+        val scheduleMissingTypical =
+            routePatterns
+                .filter { it.typicality == RoutePattern.Typicality.Typical }
+                .any { it !in scheduledPatterns }
+        val scheduleHasNontypical =
+            scheduledPatterns.any { it.typicality != RoutePattern.Typicality.Typical }
+        val scheduleReplacedTypical = scheduleMissingTypical && scheduleHasNontypical
+
+        val routePredictions = predictionsByRoute[routeId].orEmpty()
+        val predictionsAlwaysTypical =
+            routePredictions.isNotEmpty() &&
+                routePredictions.all {
+                    it.routePattern()?.typicality == RoutePattern.Typicality.Typical
+                }
+
+        return isSubway && routeHasAlert && scheduleReplacedTypical && predictionsAlwaysTypical
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -1471,7 +1471,6 @@ class NearbyResponseTest {
                 stopSequence = 90
                 arrivalTime = time + 2.minutes
                 departureTime = null
-                pickUpType = Schedule.StopEdgeType.Unavailable
             }
 
         val staticData =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -617,6 +617,7 @@ class NearbyResponseTest {
                 ),
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
@@ -772,6 +773,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
@@ -884,6 +886,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = null,
@@ -1001,6 +1004,7 @@ class NearbyResponseTest {
 
         val realtimeRoutesSorted =
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = closeBusStop.position,
                 predictions = PredictionsStreamDataResponse(objects),
                 schedules = ScheduleResponse(objects),
@@ -1122,6 +1126,7 @@ class NearbyResponseTest {
 
         val realtimeRoutesSorted =
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = closeBusStop.position,
                 predictions = PredictionsStreamDataResponse(objects),
                 schedules = ScheduleResponse(objects),
@@ -1187,6 +1192,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = parentStop.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
@@ -1256,6 +1262,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
@@ -1355,6 +1362,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
@@ -1425,6 +1433,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
@@ -1497,6 +1506,7 @@ class NearbyResponseTest {
                 )
             ),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
@@ -1703,6 +1713,7 @@ class NearbyResponseTest {
         assertEquals(
             listOf(expected),
             staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
@@ -5,7 +5,6 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -300,7 +299,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf crashes on missing stop IDs`() = truncatedPatternTest {
+    fun `isTruncationOf does not crash on missing stop IDs`() = truncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val notEarly =
             objects.routePattern(route) {
@@ -309,7 +308,7 @@ class TemporaryTerminalRewriterTest {
                 representativeTrip()
             }
 
-        assertFails { notEarly.isTruncationOf(fullPattern, "a") }
+        assertFalse(notEarly.isTruncationOf(fullPattern, "a"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
@@ -208,7 +208,7 @@ class TemporaryTerminalRewriterTest {
         assertFalse(rewriter.appliesToRoute(route))
     }
 
-    private class TruncatedPatternTestHelper {
+    private class FindTruncatedPatternTestHelper {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()
 
@@ -246,19 +246,19 @@ class TemporaryTerminalRewriterTest {
                 isTruncationOf(fullPattern, fullPatternStopIds, stopId)
             }
 
-        fun truncatedPattern(fullPattern: RoutePattern, stopId: String) =
+        fun findTruncatedPattern(fullPattern: RoutePattern, stopId: String) =
             rewriter.run {
                 val fullPatternStopIds = objects.trips[fullPattern.representativeTripId]?.stopIds
                 checkNotNull(fullPatternStopIds)
-                truncatedPattern(fullPattern, fullPatternStopIds, stopId)
+                findTruncatedPattern(fullPattern, fullPatternStopIds, stopId)
             }
     }
 
-    private fun truncatedPatternTest(block: TruncatedPatternTestHelper.() -> Unit) =
-        TruncatedPatternTestHelper().block()
+    private fun findTruncatedPatternTest(block: FindTruncatedPatternTestHelper.() -> Unit) =
+        FindTruncatedPatternTestHelper().block()
 
     @Test
-    fun `isTruncationOf accepts truncations`() = truncatedPatternTest {
+    fun `isTruncationOf accepts truncations`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val early = diversion(0, "a", "b")
         val late = diversion(0, "d", "e")
@@ -270,7 +270,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf rejects typical`() = truncatedPatternTest {
+    fun `isTruncationOf rejects typical`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val almostEarly = typical(0, "a", "b")
 
@@ -278,7 +278,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf rejects wrong direction`() = truncatedPatternTest {
+    fun `isTruncationOf rejects wrong direction`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         // on subway it shouldn't be possible to not also have "b", "a" here anyway
         val notEarly = diversion(1, "a", "b")
@@ -287,7 +287,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf does not crash on missing trip`() = truncatedPatternTest {
+    fun `isTruncationOf does not crash on missing trip`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val notEarly =
             objects.routePattern(route) {
@@ -299,7 +299,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf does not crash on missing stop IDs`() = truncatedPatternTest {
+    fun `isTruncationOf does not crash on missing stop IDs`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val notEarly =
             objects.routePattern(route) {
@@ -312,7 +312,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf rejects missing current stop`() = truncatedPatternTest {
+    fun `isTruncationOf rejects missing current stop`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val early = diversion(0, "a", "b")
         val late = diversion(0, "d", "e")
@@ -322,7 +322,7 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `isTruncationOf rejects not subsequence`() = truncatedPatternTest {
+    fun `isTruncationOf rejects not subsequence`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val tooEarly = diversion(0, "z", "a", "b")
         val tooLate = diversion(0, "d", "e", "f")
@@ -340,41 +340,41 @@ class TemporaryTerminalRewriterTest {
     }
 
     @Test
-    fun `truncatedPattern uses single if available`() = truncatedPatternTest {
+    fun `findTruncatedPattern uses single if available`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val early = diversion(0, "a", "b")
         val late = diversion(0, "d", "e")
 
-        assertEquals(early, truncatedPattern(fullPattern, "a"))
-        assertEquals(late, truncatedPattern(fullPattern, "e"))
+        assertEquals(early, findTruncatedPattern(fullPattern, "a"))
+        assertEquals(late, findTruncatedPattern(fullPattern, "e"))
     }
 
     @Test
-    fun `truncatedPattern checks schedule if multiple available`() = truncatedPatternTest {
+    fun `findTruncatedPattern checks schedule if multiple available`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val earlyShort = diversion(0, "a", "b")
         diversion(0, "a", "b", "c")
         schedule(earlyShort)
 
-        assertEquals(earlyShort, truncatedPattern(fullPattern, "a"))
+        assertEquals(earlyShort, findTruncatedPattern(fullPattern, "a"))
     }
 
     @Test
-    fun `truncatedPattern gives up if multiple scheduled`() = truncatedPatternTest {
+    fun `findTruncatedPattern gives up if multiple scheduled`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
         val earlyShort = diversion(0, "a", "b")
         val earlyLong = diversion(0, "a", "b", "c")
         schedule(earlyShort)
         schedule(earlyLong)
 
-        assertNull(truncatedPattern(fullPattern, "a"))
+        assertNull(findTruncatedPattern(fullPattern, "a"))
     }
 
     @Test
-    fun `truncatedPattern gives up if none available`() = truncatedPatternTest {
+    fun `findTruncatedPattern gives up if none available`() = findTruncatedPatternTest {
         val fullPattern = typical(0, "a", "b", "c", "d", "e")
 
-        assertNull(truncatedPattern(fullPattern, "a"))
+        assertNull(findTruncatedPattern(fullPattern, "a"))
     }
 
     private class TruncatePatternsAtStopTestHelper {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
@@ -1,0 +1,288 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Unit tests for the individual helper functions defined in [TemporaryTerminalRewriter]. */
+class TemporaryTerminalRewriterTest {
+    private val boardExitRide =
+        listOf(
+            Alert.InformedEntity.Activity.Board,
+            Alert.InformedEntity.Activity.Exit,
+            Alert.InformedEntity.Activity.Ride
+        )
+
+    @Test
+    fun `appliesToRoute accepts non-branching suspension`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertTrue(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects bus`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.BUS }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects insufficient alert effect`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StationClosure
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects wrong route`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = "not-${route.id}")
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects without non-typical schedule`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(typical) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects without missing typical schedule`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.schedule { trip = objects.trip(typical) }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute accepts branching suspension`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typicalA = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val typicalB = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversionA =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversionA) }
+        objects.schedule { trip = objects.trip(typicalB) }
+        objects.prediction { trip = objects.trip(typicalA) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertTrue(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects no schedules`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.prediction { trip = objects.trip(typical) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects no predictions`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    @Test
+    fun `appliesToRoute rejects with diversion prediction`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(activities = boardExitRide, route = route.id)
+            }
+        val typical = objects.routePattern(route) { typicality = RoutePattern.Typicality.Typical }
+        val diversion =
+            objects.routePattern(route) { typicality = RoutePattern.Typicality.Diversion }
+        objects.schedule { trip = objects.trip(diversion) }
+        objects.prediction { trip = objects.trip(typical) }
+        objects.prediction { trip = objects.trip(diversion) }
+
+        val rewriter =
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                listOf(alert),
+                ScheduleResponse(objects)
+            )
+
+        assertFalse(rewriter.appliesToRoute(route))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalRewriterTest.kt
@@ -4,7 +4,10 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /** Unit tests for the individual helper functions defined in [TemporaryTerminalRewriter]. */
@@ -204,5 +207,174 @@ class TemporaryTerminalRewriterTest {
         val rewriter = rewriter()
 
         assertFalse(rewriter.appliesToRoute(route))
+    }
+
+    private class TruncatedPatternTestHelper {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+
+        fun typical(directionId: Int, vararg stopIds: String) =
+            objects.routePattern(route) {
+                this.directionId = directionId
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { this.stopIds = stopIds.asList() }
+            }
+
+        fun diversion(directionId: Int, vararg stopIds: String) =
+            objects.routePattern(route) {
+                this.directionId = directionId
+                typicality = RoutePattern.Typicality.Diversion
+                representativeTrip { this.stopIds = stopIds.asList() }
+            }
+
+        fun schedule(routePattern: RoutePattern) =
+            objects.schedule { trip = objects.trip(routePattern) }
+
+        val rewriter by lazy {
+            TemporaryTerminalRewriter(
+                NearbyStaticData(emptyList()),
+                PredictionsStreamDataResponse(objects),
+                GlobalResponse(objects, emptyMap()),
+                emptyList(),
+                ScheduleResponse(objects)
+            )
+        }
+
+        fun RoutePattern.isTruncationOf(fullPattern: RoutePattern, stopId: String) =
+            with(rewriter) {
+                val fullPatternStopIds = objects.trips[fullPattern.representativeTripId]?.stopIds
+                checkNotNull(fullPatternStopIds)
+                isTruncationOf(fullPattern, fullPatternStopIds, stopId)
+            }
+
+        fun truncatedPattern(fullPattern: RoutePattern, stopId: String) =
+            rewriter.run {
+                val fullPatternStopIds = objects.trips[fullPattern.representativeTripId]?.stopIds
+                checkNotNull(fullPatternStopIds)
+                truncatedPattern(fullPattern, fullPatternStopIds, stopId)
+            }
+    }
+
+    private fun truncatedPatternTest(block: TruncatedPatternTestHelper.() -> Unit) =
+        TruncatedPatternTestHelper().block()
+
+    @Test
+    fun `isTruncationOf accepts truncations`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val early = diversion(0, "a", "b")
+        val late = diversion(0, "d", "e")
+
+        assertTrue(early.isTruncationOf(fullPattern, "a"))
+        assertTrue(early.isTruncationOf(fullPattern, "b"))
+        assertTrue(late.isTruncationOf(fullPattern, "d"))
+        assertTrue(late.isTruncationOf(fullPattern, "e"))
+    }
+
+    @Test
+    fun `isTruncationOf rejects typical`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val almostEarly = typical(0, "a", "b")
+
+        assertFalse(almostEarly.isTruncationOf(fullPattern, "a"))
+    }
+
+    @Test
+    fun `isTruncationOf rejects wrong direction`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        // on subway it shouldn't be possible to not also have "b", "a" here anyway
+        val notEarly = diversion(1, "a", "b")
+
+        assertFalse(notEarly.isTruncationOf(fullPattern, "a"))
+    }
+
+    @Test
+    fun `isTruncationOf does not crash on missing trip`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val notEarly =
+            objects.routePattern(route) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Diversion
+            }
+
+        assertFalse(notEarly.isTruncationOf(fullPattern, "a"))
+    }
+
+    @Test
+    fun `isTruncationOf crashes on missing stop IDs`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val notEarly =
+            objects.routePattern(route) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Diversion
+                representativeTrip()
+            }
+
+        assertFails { notEarly.isTruncationOf(fullPattern, "a") }
+    }
+
+    @Test
+    fun `isTruncationOf rejects missing current stop`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val early = diversion(0, "a", "b")
+        val late = diversion(0, "d", "e")
+
+        assertFalse(early.isTruncationOf(fullPattern, "e"))
+        assertFalse(late.isTruncationOf(fullPattern, "a"))
+    }
+
+    @Test
+    fun `isTruncationOf rejects not subsequence`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val tooEarly = diversion(0, "z", "a", "b")
+        val tooLate = diversion(0, "d", "e", "f")
+        val earlyBranch = diversion(0, "a", "b", "g")
+        val lateBranch = diversion(0, "h", "d", "e")
+        val earlyReversed = diversion(0, "b", "a")
+        val lateReversed = diversion(0, "e", "d")
+
+        assertFalse(tooEarly.isTruncationOf(fullPattern, "a"))
+        assertFalse(tooLate.isTruncationOf(fullPattern, "e"))
+        assertFalse(earlyBranch.isTruncationOf(fullPattern, "a"))
+        assertFalse(lateBranch.isTruncationOf(fullPattern, "e"))
+        assertFalse(earlyReversed.isTruncationOf(fullPattern, "a"))
+        assertFalse(lateReversed.isTruncationOf(fullPattern, "e"))
+    }
+
+    @Test
+    fun `truncatedPattern uses single if available`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val early = diversion(0, "a", "b")
+        val late = diversion(0, "d", "e")
+
+        assertEquals(early, truncatedPattern(fullPattern, "a"))
+        assertEquals(late, truncatedPattern(fullPattern, "e"))
+    }
+
+    @Test
+    fun `truncatedPattern checks schedule if multiple available`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val earlyShort = diversion(0, "a", "b")
+        diversion(0, "a", "b", "c")
+        schedule(earlyShort)
+
+        assertEquals(earlyShort, truncatedPattern(fullPattern, "a"))
+    }
+
+    @Test
+    fun `truncatedPattern gives up if multiple scheduled`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+        val earlyShort = diversion(0, "a", "b")
+        val earlyLong = diversion(0, "a", "b", "c")
+        schedule(earlyShort)
+        schedule(earlyLong)
+
+        assertNull(truncatedPattern(fullPattern, "a"))
+    }
+
+    @Test
+    fun `truncatedPattern gives up if none available`() = truncatedPatternTest {
+        val fullPattern = typical(0, "a", "b", "c", "d", "e")
+
+        assertNull(truncatedPattern(fullPattern, "a"))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -12,6 +12,10 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
+/**
+ * An integration test for all of the logic in [NearbyStaticData.rewrittenForTemporaryTerminals] and
+ * [TemporaryTerminalRewriter].
+ */
 class TemporaryTerminalTest {
     val now = Instant.parse("2024-08-19T16:44:08-04:00")
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -12,10 +12,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 
-/**
- * An integration test for all of the logic in [NearbyStaticData.rewrittenForTemporaryTerminals] and
- * [TemporaryTerminalRewriter].
- */
+/** An integration test for all of the logic in [TemporaryTerminalRewriter]. */
 class TemporaryTerminalTest {
     val now = Instant.parse("2024-08-19T16:44:08-04:00")
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -1,0 +1,505 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import io.github.dellisd.spatialk.geojson.Position
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+class TemporaryTerminalTest {
+    val now = Instant.parse("2024-08-19T16:44:08-04:00")
+
+    val objects = ObjectCollectionBuilder()
+    val red =
+        objects.route {
+            id = "Red"
+            type = RouteType.HEAVY_RAIL
+        }
+
+    data class StopWithPlatforms(val northbound: Stop, val southbound: Stop, val station: Stop) {
+        val childIds: List<String> = listOf(northbound.id, southbound.id)
+    }
+
+    fun stop(): StopWithPlatforms {
+        var northbound: Stop? = null
+        var southbound: Stop? = null
+        val station =
+            objects.stop {
+                northbound = childStop()
+                southbound = childStop()
+            }
+        return StopWithPlatforms(checkNotNull(northbound), checkNotNull(southbound), station)
+    }
+
+    val alewife = stop()
+    val davis = stop()
+    val porter = stop()
+    val harvard = stop()
+    val central = stop()
+    val kendallMit = stop()
+    val charlesMgh = stop()
+    val parkStreet = stop()
+    val downtownCrossing = stop()
+    val southStation = stop()
+    val broadway = stop()
+    val andrew = stop()
+    val jfkUmass = stop()
+    val savinHill = stop()
+    val fieldsCorner = stop()
+    val shawmut = stop()
+    val ashmont = stop()
+    val northQuincy = stop()
+    val wollaston = stop()
+    val quincyCenter = stop()
+    val quincyAdams = stop()
+    val braintree = stop()
+
+    val stopsNorthOfShuttle = listOf(alewife, davis, porter, harvard, central, kendallMit)
+    val stopsInShuttle =
+        listOf(charlesMgh, parkStreet, downtownCrossing, southStation, broadway, andrew)
+    val stopsAshmontBranch = listOf(jfkUmass, savinHill, fieldsCorner, shawmut, ashmont)
+    val stopsBraintreeBranch =
+        listOf(jfkUmass, northQuincy, wollaston, quincyCenter, quincyAdams, braintree)
+
+    fun Iterable<StopWithPlatforms>.southbound() = map(StopWithPlatforms::southbound)
+
+    fun Iterable<StopWithPlatforms>.northbound() = map(StopWithPlatforms::northbound)
+
+    private fun pattern(
+        id: String,
+        typicality: RoutePattern.Typicality,
+        sortOrder: Int,
+        headsign: String,
+        stops: List<StopWithPlatforms>
+    ) =
+        objects.routePattern(red) {
+            this.id = id
+            val directionId = id.substringAfterLast('-')
+            this.directionId = directionId.toInt()
+            this.typicality = typicality
+            this.sortOrder = sortOrder
+            representativeTrip {
+                this.headsign = headsign
+                this.stopIds =
+                    if (directionId == "0") {
+                            stops.southbound()
+                        } else {
+                            stops.northbound()
+                        }
+                        .map { it.id }
+            }
+        }
+
+    val redAlewifeAshmont =
+        pattern(
+            "Red-1-0",
+            RoutePattern.Typicality.Typical,
+            100100001,
+            "Ashmont",
+            stopsNorthOfShuttle + stopsInShuttle + stopsAshmontBranch
+        )
+    val redAlewifeBraintree =
+        pattern(
+            "Red-3-0",
+            RoutePattern.Typicality.Typical,
+            100100000,
+            "Braintree",
+            stopsNorthOfShuttle + stopsInShuttle + stopsBraintreeBranch
+        )
+    val redJfkAshmont =
+        pattern(
+            "Red-A-0",
+            RoutePattern.Typicality.Atypical,
+            100100090,
+            "Ashmont",
+            stopsAshmontBranch
+        )
+    val redJfkBraintree =
+        pattern(
+            "Red-B-0",
+            RoutePattern.Typicality.Atypical,
+            100100140,
+            "Braintree",
+            stopsBraintreeBranch
+        )
+    val redAlewifeKendall =
+        pattern(
+            "Red-S-0",
+            RoutePattern.Typicality.Atypical,
+            100100150,
+            "Kendall/MIT",
+            stopsNorthOfShuttle
+        )
+    val redAshmontAlewife =
+        pattern(
+            "Red-1-1",
+            RoutePattern.Typicality.Typical,
+            100101001,
+            "Alewife",
+            (stopsNorthOfShuttle + stopsInShuttle + stopsAshmontBranch).reversed()
+        )
+    val redBraintreeAlewife =
+        pattern(
+            "Red-3-1",
+            RoutePattern.Typicality.Typical,
+            100101000,
+            "Alewife",
+            (stopsNorthOfShuttle + stopsInShuttle + stopsBraintreeBranch).reversed()
+        )
+    val redAshmontJfk =
+        pattern(
+            "Red-A-1",
+            RoutePattern.Typicality.Atypical,
+            100101100,
+            "JFK/UMass",
+            stopsAshmontBranch.reversed()
+        )
+    val redBraintreeJfk =
+        pattern(
+            "Red-B-1",
+            RoutePattern.Typicality.Atypical,
+            100101150,
+            "JFK/UMass",
+            stopsBraintreeBranch.reversed()
+        )
+    val redKendallAlewife =
+        pattern(
+            "Red-S-1",
+            RoutePattern.Typicality.Atypical,
+            100101160,
+            "Alewife",
+            stopsNorthOfShuttle.reversed()
+        )
+
+    val patternIdsByStop =
+        buildMap<String, List<String>> {
+            for (pattern in objects.routePatterns.values) {
+                val patternId = pattern.id
+                val trip = objects.trips.getValue(pattern.representativeTripId)
+                for (stopId in trip.stopIds!!) {
+                    put(stopId, getOrElse(stopId, ::emptyList) + listOf(patternId))
+                }
+            }
+        }
+
+    // 588541
+    val alert =
+        objects.alert {
+            effect = Alert.Effect.Shuttle
+            activePeriod(
+                Instant.parse("2024-08-19T04:30:00-04:00"),
+                Instant.parse("2024-08-26T02:30:00-04:00")
+            )
+            fun informedEntity(stop: Stop, board: Boolean = true, exit: Boolean = true) =
+                this.informedEntity(
+                    buildList {
+                        if (board) add(Alert.InformedEntity.Activity.Board)
+                        if (exit) add(Alert.InformedEntity.Activity.Exit)
+                        add(Alert.InformedEntity.Activity.Ride)
+                    },
+                    routeType = RouteType.HEAVY_RAIL,
+                    route = red.id,
+                    stop = stop.id
+                )
+            fun informedEntity(station: StopWithPlatforms) {
+                informedEntity(station.southbound)
+                informedEntity(station.northbound)
+            }
+            informedEntity(kendallMit.southbound, exit = false)
+            informedEntity(kendallMit.northbound, board = false)
+            informedEntity(charlesMgh)
+            informedEntity(parkStreet)
+            informedEntity(downtownCrossing)
+            informedEntity(southStation)
+            informedEntity(broadway)
+            informedEntity(andrew)
+            // technically, the JFK/UMass Braintree platforms had BOARD, EXIT, RIDE,
+            // but I don't think that was correct, and it shouldn't matter for this test
+            informedEntity(jfkUmass.southbound, board = false)
+            informedEntity(jfkUmass.northbound, exit = false)
+        }
+
+    fun trip(routePattern: RoutePattern, id: String) = objects.trip(routePattern) { this.id = id }
+
+    fun schedule(
+        trip: Trip,
+        stop: Stop,
+        time: String,
+        departs: Boolean = true,
+        arrives: Boolean = true
+    ) =
+        objects.schedule {
+            this.trip = trip
+            this.stopId = stop.id
+            val predictionTime = Instant.parse("2024-08-19T$time:00-04:00")
+            if (departs) this.departureTime = predictionTime
+            if (arrives) this.arrivalTime = predictionTime
+        }
+
+    fun prediction(trip: Trip, stop: Stop, arrivalTime: String?, departureTime: String?) =
+        objects.prediction {
+            this.trip = trip
+            this.stopId = stop.id
+            if (arrivalTime != null)
+                this.arrivalTime = Instant.parse("2024-08-19T$arrivalTime-04:00")
+            if (departureTime != null)
+                this.departureTime = Instant.parse("2024-08-19T$departureTime-04:00")
+        }
+
+    val tripBraintreeJfk = trip(redBraintreeJfk, "BraintreeJfk")
+    val scheduleBraintreeJfk =
+        schedule(tripBraintreeJfk, jfkUmass.northbound, "16:45", departs = false)
+    val tripKendallAlewife = trip(redKendallAlewife, "KendallAlewife")
+    val scheduleKendallAlewife = schedule(tripKendallAlewife, harvard.northbound, "16:45")
+    val tripJfkAshmont = trip(redJfkAshmont, "JfkAshmont")
+    val scheduleJfkAshmont = schedule(tripJfkAshmont, jfkUmass.southbound, "16:49", arrives = false)
+    val tripAlewifeKendall = trip(redAlewifeKendall, "AlewifeKendall")
+    val scheduleAlewifeKendall = schedule(tripAlewifeKendall, harvard.southbound, "16:50")
+    val tripAshmontJfk = trip(redAshmontJfk, "AshmontJfk")
+    val scheduleAshmontJfk = schedule(tripAshmontJfk, jfkUmass.northbound, "16:52", departs = false)
+    val tripJfkBraintree = trip(redJfkBraintree, "JfkBraintree")
+    val scheduleJfkBraintree =
+        schedule(tripJfkBraintree, jfkUmass.southbound, "16:56", arrives = false)
+
+    val tripBraintreeAlewife1 = trip(redBraintreeAlewife, "BraintreeAlewife1")
+    val predictionBraintreeAlewife1 =
+        prediction(tripBraintreeAlewife1, harvard.northbound, "16:43:22", "16:44:30")
+    val tripAshmontAlewife1 = trip(redAshmontAlewife, "AshmontAlewife1")
+    val predictionAshmontAlewife1 =
+        prediction(tripAshmontAlewife1, jfkUmass.northbound, "16:44:00", null)
+    val tripAlewifeBraintree1 = trip(redAlewifeBraintree, "AlewifeBraintree1")
+    val predictionAlewifeBraintree1 =
+        prediction(tripAlewifeBraintree1, harvard.southbound, "16:50:38", "16:51:55")
+    val tripAlewifeBraintree2 = trip(redAlewifeBraintree, "AlewifeBraintree2")
+    val predictionAlewifeBraintree2 =
+        prediction(tripAlewifeBraintree2, harvard.southbound, "16:52:58", "16:54:15")
+    val tripAshmontAlewife2 = trip(redAshmontAlewife, "AshmontAlewife2")
+    val predictionAshmontAlewife2 =
+        prediction(tripAshmontAlewife2, jfkUmass.northbound, "16:56:11", null)
+    val tripAlewifeBraintree3 = trip(redAlewifeBraintree, "AlewifeBraintree3")
+    val predictionAlewifeBraintree3 =
+        prediction(tripAlewifeBraintree3, harvard.southbound, "17:03:16", "17:04:33")
+    val tripAshmontAlewife3 = trip(redAshmontAlewife, "AshmontAlewife3")
+    val predictionAshmontAlewife3 =
+        prediction(tripAshmontAlewife3, jfkUmass.northbound, "17:08:20", null)
+
+    val globalData = GlobalResponse(objects, patternIdsByStop)
+    val position = Position(latitude = 42.351371, longitude = -71.066496)
+    val nearbyOutsideShuttle = NearbyResponse(harvard.childIds)
+    val nearbyInsideShuttle = NearbyResponse(parkStreet.childIds)
+    val nearbyAtShuttleEdge = NearbyResponse(jfkUmass.childIds)
+    val schedules = ScheduleResponse(objects)
+    val predictions = PredictionsStreamDataResponse(objects)
+    val alerts = AlertsStreamDataResponse(objects)
+
+    fun expected(stop: Stop, vararg realtimePatterns: RealtimePatterns) =
+        listOf(
+            StopsAssociated.WithRoute(
+                red,
+                listOf(PatternsByStop(red, stop, realtimePatterns.asList()))
+            )
+        )
+
+    @Test
+    fun `shows only temporary terminals when outside shuttle`() {
+        assertEquals(
+            expected(
+                    harvard.station,
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Kendall/MIT",
+                        null,
+                        listOf(redAlewifeBraintree, redAlewifeAshmont, redAlewifeKendall),
+                        listOf(
+                            UpcomingTrip(tripAlewifeKendall, scheduleAlewifeKendall),
+                            UpcomingTrip(tripAlewifeBraintree1, predictionAlewifeBraintree1),
+                            UpcomingTrip(tripAlewifeBraintree2, predictionAlewifeBraintree2),
+                            UpcomingTrip(tripAlewifeBraintree3, predictionAlewifeBraintree3)
+                        ),
+                        emptyList()
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Alewife",
+                        null,
+                        listOf(redBraintreeAlewife, redAshmontAlewife, redKendallAlewife),
+                        listOf(
+                            UpcomingTrip(tripBraintreeAlewife1, predictionBraintreeAlewife1),
+                            UpcomingTrip(tripKendallAlewife, scheduleKendallAlewife)
+                        ),
+                        emptyList()
+                    )
+                )
+                .condensed(),
+            NearbyStaticData(globalData, nearbyOutsideShuttle)
+                .withRealtimeInfo(
+                    globalData,
+                    position,
+                    schedules,
+                    predictions,
+                    alerts,
+                    now,
+                    emptySet()
+                )
+                .condensed()
+        )
+    }
+
+    @Test
+    fun `shows only regular terminals when inside shuttle`() {
+        assertEquals(
+            expected(
+                    parkStreet.station,
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Braintree",
+                        null,
+                        listOf(redAlewifeBraintree),
+                        emptyList(),
+                        listOf(alert)
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Ashmont",
+                        null,
+                        listOf(redAlewifeAshmont),
+                        emptyList(),
+                        listOf(alert)
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Alewife",
+                        null,
+                        listOf(redBraintreeAlewife, redAshmontAlewife),
+                        emptyList(),
+                        listOf(alert)
+                    )
+                )
+                .condensed(),
+            NearbyStaticData(globalData, nearbyInsideShuttle)
+                .withRealtimeInfo(
+                    globalData,
+                    position,
+                    schedules,
+                    predictions,
+                    alerts,
+                    now,
+                    emptySet()
+                )
+                .condensed()
+        )
+    }
+
+    @Test
+    fun `shows correct set of terminals when at boundary of shuttle`() {
+        assertEquals(
+            expected(
+                    jfkUmass.station,
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Braintree",
+                        null,
+                        listOf(redAlewifeBraintree, redJfkBraintree),
+                        listOf(UpcomingTrip(tripJfkBraintree, scheduleJfkBraintree)),
+                        // TODO remove alert once we fix alert boundaries
+                        listOf(alert)
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Ashmont",
+                        null,
+                        listOf(redAlewifeAshmont, redJfkAshmont),
+                        listOf(UpcomingTrip(tripJfkAshmont, scheduleJfkAshmont)),
+                        // TODO remove alert once we fix alert boundaries
+                        listOf(alert)
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "Alewife",
+                        null,
+                        listOf(redBraintreeAlewife, redAshmontAlewife),
+                        emptyList(),
+                        listOf(alert)
+                    ),
+                    RealtimePatterns.ByHeadsign(
+                        red,
+                        "JFK/UMass",
+                        null,
+                        listOf(redAshmontJfk, redBraintreeJfk),
+                        listOf(
+                            UpcomingTrip(tripAshmontAlewife1, predictionAshmontAlewife1),
+                            UpcomingTrip(tripBraintreeJfk, scheduleBraintreeJfk),
+                            UpcomingTrip(tripAshmontJfk, scheduleAshmontJfk),
+                            UpcomingTrip(tripAshmontAlewife2, predictionAshmontAlewife2),
+                            UpcomingTrip(tripAshmontAlewife3, predictionAshmontAlewife3),
+                        ),
+                        // TODO remove alert once we fix alert boundaries
+                        listOf(alert)
+                    )
+                )
+                .condensed(),
+            NearbyStaticData(globalData, nearbyAtShuttleEdge)
+                .withRealtimeInfo(
+                    globalData,
+                    position,
+                    schedules,
+                    predictions,
+                    alerts,
+                    now,
+                    emptySet()
+                )
+                .condensed()
+        )
+    }
+
+    // for more legible diffs
+    fun List<StopsAssociated>.condensed(): String {
+        fun Instant.condensed() = toLocalDateTime(TimeZone.of("America/New_York")).time.toString()
+        fun timeRangeCondensed(arrivalTime: Instant?, departureTime: Instant?) = buildString {
+            if (arrivalTime != null) append(arrivalTime.condensed())
+            if (arrivalTime != null && departureTime != null && arrivalTime != departureTime)
+                append("-")
+            if (departureTime != null && arrivalTime != departureTime)
+                append(departureTime.condensed())
+        }
+        fun UpcomingTrip.condensed() = buildString {
+            append("            trip=${trip.id}")
+            schedule?.let {
+                append(" schedule=")
+                append(timeRangeCondensed(it.arrivalTime, it.departureTime))
+            }
+            prediction?.let {
+                append(" prediction=")
+                append(timeRangeCondensed(it.arrivalTime, it.departureTime))
+            }
+            if (vehicle != null) append(" vehicle=$vehicle")
+        }
+
+        fun RealtimePatterns.condensed() =
+            when (this) {
+                is RealtimePatterns.ByHeadsign -> "        $headsign"
+                is RealtimePatterns.ByDirection ->
+                    "        ${direction.name} to ${direction.destination}"
+            } +
+                " (patterns=${patterns.joinToString { it.id }}) alerts=${alertsHere.orEmpty().joinToString(prefix = "[", postfix = "]") { it.id }}\n" +
+                upcomingTrips.orEmpty().joinToString(separator = "\n") { it.condensed() }
+
+        fun PatternsByStop.condensed() =
+            "    stop=${stop.id}\n${patterns.joinToString(separator = "\n") { it.condensed() }}"
+
+        fun StopsAssociated.condensed() =
+            when (this) {
+                is StopsAssociated.WithLine ->
+                    "line=${line.id} (routes=${routes.joinToString { it.id }})"
+                is StopsAssociated.WithRoute -> "route=${route.id}"
+            } + patternsByStop.joinToString(separator = "\n", prefix = "\n") { it.condensed() }
+
+        return joinToString(separator = "\n") { it.condensed() }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -431,21 +431,7 @@ class TemporaryTerminalTest {
                         emptyList(),
                         listOf(alert)
                     ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "JFK/UMass",
-                        null,
-                        listOf(redAshmontJfk, redBraintreeJfk),
-                        listOf(
-                            UpcomingTrip(tripAshmontAlewife1, predictionAshmontAlewife1),
-                            UpcomingTrip(tripBraintreeJfk, scheduleBraintreeJfk),
-                            UpcomingTrip(tripAshmontJfk, scheduleAshmontJfk),
-                            UpcomingTrip(tripAshmontAlewife2, predictionAshmontAlewife2),
-                            UpcomingTrip(tripAshmontAlewife3, predictionAshmontAlewife3),
-                        ),
-                        // TODO remove alert once we fix alert boundaries
-                        listOf(alert)
-                    )
+                    // JFK/UMass filtered out because arrival only
                 )
                 .condensed(),
             NearbyStaticData(globalData, nearbyAtShuttleEdge)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -490,20 +490,20 @@ class UpcomingTripTest {
         val trip = trip()
 
         val schedule1 = schedule {
+            arrivalTime = Clock.System.now()
             departureTime = null
-            pickUpType = Schedule.StopEdgeType.Unavailable
         }
         assertEquals(true, UpcomingTrip(trip, schedule1).isArrivalOnly())
 
         val schedule2 = schedule {
+            arrivalTime = Clock.System.now()
             departureTime = Clock.System.now()
-            pickUpType = Schedule.StopEdgeType.Regular
         }
         assertEquals(false, UpcomingTrip(trip, schedule2).isArrivalOnly())
 
         val schedule3 = schedule {
-            pickUpType = Schedule.StopEdgeType.Unavailable
-            dropOffType = Schedule.StopEdgeType.Unavailable
+            arrivalTime = null
+            departureTime = null
         }
         assertEquals(null, UpcomingTrip(trip, schedule3).isArrivalOnly())
     }
@@ -533,17 +533,12 @@ class UpcomingTripTest {
         val trip = trip()
         val scheduleArrivalOnly = schedule {
             arrivalTime = Clock.System.now()
-            dropOffType = Schedule.StopEdgeType.Regular
             departureTime = null
-            pickUpType = Schedule.StopEdgeType.Unavailable
         }
-        val scheduleNormal = schedule {
-            departureTime = Clock.System.now()
-            pickUpType = Schedule.StopEdgeType.Regular
-        }
+        val scheduleNormal = schedule { departureTime = Clock.System.now() }
         val scheduleNeither = schedule {
-            dropOffType = Schedule.StopEdgeType.Unavailable
-            pickUpType = Schedule.StopEdgeType.Unavailable
+            arrivalTime = null
+            departureTime = null
         }
         val predictionArrivalOnly = prediction {
             arrivalTime = Clock.System.now()


### PR DESCRIPTION
### Summary

_Ticket:_ [Show only temporary terminals as headsigns during subway shuttles/suspensions](https://app.asana.com/0/1205732265579288/1208057797841305/f)

I really wish we just had correct data upstream. This was initially some of the ugliest code I've written in my life, and it took longer to refactor than it did to write in the first place.

### Testing

Added tests with real data taken from the recent partial RL closure.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
