### PR TITLE
stop details auto-filtering on Android, move logic to shared code

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -145,6 +145,9 @@ fun NearbyTransitPage(
 
                             fun updateStopDepartures(departures: StopDetailsDepartures?) {
                                 stopDetailsDepartures = departures
+                                if (departures != null && stopDetailsFilter == null) {
+                                    stopDetailsFilter = departures.autoFilter()
+                                }
                             }
 
                             LaunchedEffect(navRoute) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -73,12 +73,14 @@ fun StopDetailsView(
     Column(modifier) {
         Column {
             SheetHeader(onClose = onClose, title = stop.name)
-            StopDetailsFilterPills(
-                servedRoutes = servedRoutes,
-                filter = filter,
-                onTapRoutePill = onTapRoutePill,
-                onClearFilter = { updateStopFilter(null) }
-            )
+            if (servedRoutes.size > 1) {
+                StopDetailsFilterPills(
+                    servedRoutes = servedRoutes,
+                    filter = filter,
+                    onTapRoutePill = onTapRoutePill,
+                    onClearFilter = { updateStopFilter(null) }
+                )
+            }
             HorizontalDivider(
                 Modifier.fillMaxWidth()
                     .padding(top = 8.dp)
@@ -91,7 +93,7 @@ fun StopDetailsView(
                 departures,
                 globalResponse,
                 now,
-                filter,
+                filter ?: departures.autoFilter(),
                 togglePinnedRoute,
                 pinnedRoutes,
                 updateStopFilter

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -158,17 +158,10 @@ struct StopDetailsPage: View {
             nil
         }
 
-        if filter == nil, let newFilter = Self.autoFilterFor(departures: newDepartures) {
+        if filter == nil, let newFilter = newDepartures?.autoFilter() {
             filter = newFilter
         }
 
         nearbyVM.setDepartures(newDepartures)
-    }
-
-    private static func autoFilterFor(departures: StopDetailsDepartures?) -> StopDetailsFilter? {
-        guard let routes = departures?.routes, routes.count == 1, let route = routes.first else { return nil }
-        let directionIds = Set(route.patterns.map { $0.directionId() }).sorted()
-        guard directionIds.count == 1, let directionId = directionIds.first else { return nil }
-        return .init(routeId: route.routeIdentifier, directionId: directionId)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -81,6 +81,19 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
         }
     )
 
+    fun autoFilter(): StopDetailsFilter? {
+        if (routes.size != 1) {
+            return null
+        }
+        val route = routes.first()
+        val directions = route.patterns.map { it.directionId() }.toSet()
+        if (directions.size != 1) {
+            return null
+        }
+        val direction = directions.first()
+        return StopDetailsFilter(route.routeIdentifier, direction)
+    }
+
     companion object {
 
         private fun tripMapByHeadsign(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobileBackendClient.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobileBackendClient.kt
@@ -24,7 +24,7 @@ class MobileBackendClient(engine: HttpClientEngine, val appVariant: AppVariant) 
             install(ContentNegotiation) { json(json) }
             install(WebSockets) { contentConverter = KotlinxWebsocketSerializationConverter(json) }
             install(ContentEncoding) { gzip(0.9F) }
-            install(HttpTimeout) { requestTimeoutMillis = 5000 }
+            install(HttpTimeout) { requestTimeoutMillis = 8000 }
             defaultRequest { url(appVariant.backendRoot) }
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -667,4 +667,68 @@ class StopDetailsDeparturesTest {
             departures
         )
     }
+
+    @Test
+    fun `StopDetailsDepartues provides a default StopDetailsFilter given a single route and direction`() {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route()
+        val routePattern =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+        val departures =
+            StopDetailsDepartures(
+                stop,
+                GlobalResponse(objects, mapOf(stop.id to listOf(routePattern.id))),
+                ScheduleResponse(objects),
+                PredictionsStreamDataResponse(objects),
+                AlertsStreamDataResponse(objects),
+                emptySet(),
+                time
+            )
+
+        assertEquals(
+            StopDetailsFilter(routeId = route.id, directionId = routePattern.directionId),
+            departures.autoFilter()
+        )
+    }
+
+    @Test
+    fun `StopDetailsDepartures provides a null filter value given multiple routes and directions`() {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route1 = objects.route()
+        val routePattern1 =
+            objects.routePattern(route1) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+        val route2 = objects.route()
+        val routePattern2 =
+            objects.routePattern(route2) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "B" }
+            }
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+        val departures =
+            StopDetailsDepartures(
+                stop,
+                GlobalResponse(
+                    objects,
+                    mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                ),
+                ScheduleResponse(objects),
+                PredictionsStreamDataResponse(objects),
+                AlertsStreamDataResponse(objects),
+                emptySet(),
+                time
+            )
+
+        assertEquals(null, departures.autoFilter())
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[Android] Auto-filter stop details serving one route](https://app.asana.com/0/1205732265579288/1208135554089993/f)

What is this PR for?

Brings the automatic filtering of the Stop Details view when only one available route and direction are available to Android.

### Testing

What testing have you done?

Unit tests for new shared code method.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
