### PR TITLE
fix: trips that already happened don't count as upcoming

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -506,6 +506,7 @@ fun NearbyStaticData.withRealtimeInfo(
                                     it,
                                     upcomingTripsByRoutePatternAndStop +
                                         upcomingTripsByDirectionAndStop,
+                                    filterAtTime,
                                     cutoffTime,
                                     activeRelevantAlerts
                                 )
@@ -528,6 +529,7 @@ fun NearbyStaticData.withRealtimeInfo(
                                     it,
                                     upcomingTripsByRoutePatternAndStop +
                                         upcomingTripsByDirectionAndStop,
+                                    filterAtTime,
                                     cutoffTime,
                                     activeRelevantAlerts
                                 )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -391,6 +391,9 @@ class ObjectCollectionBuilder {
     fun upcomingTrip(prediction: Prediction) =
         UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, null)
 
+    fun upcomingTrip(prediction: Prediction, vehicle: Vehicle) =
+        UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, vehicle)
+
     private fun <Built : BackendObject, Builder : ObjectBuilder<Built>> build(
         source: MutableMap<String, Built>,
         builder: Builder,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -24,6 +24,7 @@ data class PatternsByStop(
     constructor(
         staticData: NearbyStaticData.StopPatterns,
         upcomingTripsMap: UpcomingTripsMap?,
+        filterTime: Instant,
         cutoffTime: Instant,
         alerts: Collection<Alert>?,
     ) : this(
@@ -45,7 +46,10 @@ data class PatternsByStop(
                         RealtimePatterns.ByDirection(it, upcomingTripsMap, alerts)
                 }
             }
-            .filter { (it.isTypical() || it.isUpcomingBefore(cutoffTime)) && !it.isArrivalOnly() }
+            .filter {
+                (it.isTypical() || it.isUpcomingWithin(filterTime, cutoffTime)) &&
+                    !it.isArrivalOnly()
+            }
             .sorted(),
         staticData.directions
     )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -233,15 +233,19 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
         patterns.any { it.typicality == null || it.typicality == RoutePattern.Typicality.Typical }
 
     /**
-     * Checks if a trip exists before the given cutoff time.
+     * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet
+     * left this stop.
      *
      * If [upcomingTrips] are unavailable (i.e. null), returns false, since non-typical patterns
      * should be hidden until data is available.
      */
-    fun isUpcomingBefore(cutoffTime: Instant) =
+    fun isUpcomingWithin(currentTime: Instant, cutoffTime: Instant) =
         upcomingTrips?.any {
             val tripTime = it.time
-            tripTime != null && tripTime < cutoffTime
+            tripTime != null &&
+                tripTime < cutoffTime &&
+                (tripTime >= currentTime ||
+                    (it.prediction != null && it.prediction.stopId == it.vehicle?.stopId))
         }
             ?: false
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -785,6 +785,177 @@ class NearbyResponseTest {
     }
 
     @Test
+    fun `withRealtimeInfo handles schedule and predictions edge cases`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // exclude, schedule in past
+        val schedulePast =
+            objects.routePattern(route1) {
+                sortOrder = 1
+                representativeTrip { headsign = "Schedule Past" }
+            }
+        // include, schedule upcoming
+        val scheduleSoon =
+            objects.routePattern(route1) {
+                sortOrder = 2
+                representativeTrip { headsign = "Schedule Soon" }
+            }
+        // exclude, schedule too late
+        val scheduleLater =
+            objects.routePattern(route1) {
+                sortOrder = 3
+                representativeTrip { headsign = "Schedule Later" }
+            }
+        // exclude, prediction in past
+        val predictionPast =
+            objects.routePattern(route1) {
+                sortOrder = 4
+                representativeTrip { headsign = "Prediction Past" }
+            }
+        // include, prediction in past but BRD
+        val predictionBrd =
+            objects.routePattern(route1) {
+                sortOrder = 5
+                representativeTrip { headsign = "Prediction BRD" }
+            }
+        // include, prediction upcoming
+        val predictionSoon =
+            objects.routePattern(route1) {
+                sortOrder = 6
+                representativeTrip { headsign = "Prediction Soon" }
+            }
+        // exclude, prediction later
+        val predictionLater =
+            objects.routePattern(route1) {
+                sortOrder = 7
+                representativeTrip { headsign = "Prediction Later" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(stop1) {
+                        headsign("Schedule Past", listOf(schedulePast))
+                        headsign("Schedule Soon", listOf(scheduleSoon))
+                        headsign("Schedule Later", listOf(scheduleLater))
+                        headsign("Prediction Past", listOf(predictionPast))
+                        headsign("Prediction BRD", listOf(predictionBrd))
+                        headsign("Prediction Soon", listOf(predictionSoon))
+                        headsign("Prediction Later", listOf(predictionLater))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-09-19T13:43:19-04:00")
+
+        val schedulePastSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(schedulePast)
+                departureTime = time - 1.minutes
+            }
+        val scheduleSoonSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(scheduleSoon)
+                departureTime = time + 5.minutes
+            }
+        val scheduleLaterSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(scheduleLater)
+                departureTime = time + 91.minutes
+            }
+        val predictionPastPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionPast)
+                departureTime = time - 1.minutes
+            }
+        val predictionBrdTrip = objects.trip(predictionBrd)
+        val predictionBrdVehicle =
+            objects.vehicle {
+                stopId = stop1.id
+                tripId = predictionBrdTrip.id
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+            }
+        val predictionBrdPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = predictionBrdTrip
+                departureTime = time - 1.minutes
+                vehicleId = predictionBrdVehicle.id
+            }
+        val predictionSoonPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionSoon)
+                departureTime = time + 5.minutes
+            }
+        val predictionLaterPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionLater)
+                departureTime = time + 91.minutes
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Schedule Soon",
+                                    null,
+                                    listOf(scheduleSoon),
+                                    listOf(objects.upcomingTrip(scheduleSoonSchedule))
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Prediction BRD",
+                                    null,
+                                    listOf(predictionBrd),
+                                    listOf(
+                                        objects.upcomingTrip(
+                                            predictionBrdPrediction,
+                                            predictionBrdVehicle
+                                        )
+                                    )
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Prediction Soon",
+                                    null,
+                                    listOf(predictionSoon),
+                                    listOf(objects.upcomingTrip(predictionSoonPrediction))
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
+                sortByDistanceFrom = stop1.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = null,
+                filterAtTime = time,
+                pinnedRoutes = setOf(),
+            )
+        )
+    }
+
+    @Test
     fun `withRealtimeInfo hides rare patterns while loading`() {
         val objects = ObjectCollectionBuilder()
 


### PR DESCRIPTION
### Summary

_Ticket:_ none
_Slack thread_: https://mbta.slack.com/archives/C05QMG9GS9M/p1726766304114719

Oops!

### Testing

Checked that this fixes the current issue. Added unit tests ensuring that schedules and predictions in the past are correctly filtered out but predictions in the past with vehicles that haven't yet left the stop are correctly retained.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
