### PR TITLE
fix: alert boundaries in stop details

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -382,7 +382,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             )
         }
 
-        private fun filterStopsByPatterns(
+        fun filterStopsByPatterns(
             routePatterns: List<RoutePattern>,
             global: GlobalResponse,
             localStops: Set<String>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -180,9 +180,11 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                     stop,
                     patternsByHeadsign
                         .map { (headsign, patterns) ->
+                            val stopIdsOnPatterns =
+                                NearbyStaticData.filterStopsByPatterns(patterns, global, allStopIds)
                             val upcomingTrips =
                                 if (tripMap != null) {
-                                    allStopIds
+                                    stopIdsOnPatterns
                                         .map { stopId ->
                                             patterns
                                                 .mapNotNull { pattern ->
@@ -210,7 +212,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                 alerts?.let {
                                     RealtimePatterns.applicableAlerts(
                                         routes = listOf(route),
-                                        stopIds = allStopIds,
+                                        stopIds = stopIdsOnPatterns,
                                         alerts = alerts
                                     )
                                 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -603,14 +603,33 @@ class StopDetailsDeparturesTest {
     }
 
     @Test
-    fun `StopDetailsDepartures picks out alerts`() {
+    fun `StopDetailsDepartures picks out alerts by platform`() {
         val objects = ObjectCollectionBuilder()
-        val stop = objects.stop()
+        lateinit var platform1: Stop
+        lateinit var platform2: Stop
+        val stop =
+            objects.stop {
+                platform1 = childStop()
+                platform2 = childStop()
+            }
         val route = objects.route { sortOrder = 1 }
-        val routePattern =
+        val routePattern1 =
             objects.routePattern(route) {
+                directionId = 0
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "A" }
+                representativeTrip {
+                    headsign = "A"
+                    stopIds = listOf(platform1.id)
+                }
+            }
+        val routePattern2 =
+            objects.routePattern(route) {
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip {
+                    headsign = "B"
+                    stopIds = listOf(platform2.id)
+                }
             }
 
         val time = Instant.parse("2024-03-19T14:16:17-04:00")
@@ -630,14 +649,20 @@ class StopDetailsDeparturesTest {
                     ),
                     route = route.id,
                     routeType = route.type,
-                    stop = stop.id
+                    stop = platform1.id
                 )
             }
 
         val departures =
             StopDetailsDepartures(
                 stop,
-                GlobalResponse(objects, mapOf(stop.id to listOf(routePattern.id))),
+                GlobalResponse(
+                    objects,
+                    mapOf(
+                        platform1.id to listOf(routePattern1.id),
+                        platform2.id to listOf(routePattern2.id)
+                    )
+                ),
                 ScheduleResponse(objects),
                 PredictionsStreamDataResponse(objects),
                 AlertsStreamDataResponse(objects),
@@ -656,9 +681,17 @@ class StopDetailsDeparturesTest {
                                 route,
                                 "A",
                                 null,
-                                listOf(routePattern),
+                                listOf(routePattern1),
                                 emptyList(),
                                 alertsHere = listOf(alert)
+                            ),
+                            RealtimePatterns.ByHeadsign(
+                                route,
+                                "B",
+                                null,
+                                listOf(routePattern2),
+                                emptyList(),
+                                alertsHere = emptyList()
                             )
                         )
                     )


### PR DESCRIPTION
### Summary

_Ticket:_ [Correctly handle shuttle/suspension boundaries](https://app.asana.com/0/1205732265579288/1207247862893776/f)

I wish I had remembered to check this.

### Testing

Checked that this fixes the issue, and updated the existing stop details alerts test to also check this.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
