### PR TITLE
fix: match schedules to predictions by parent

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
@@ -109,6 +109,7 @@ class StopDetailsRouteViewTest {
                                             stop.id,
                                         ) to listOf(UpcomingTrip(trip, prediction))
                                     ),
+                                parentStopId = stop.id,
                                 alerts = null
                             )
                         )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -201,6 +201,7 @@ class StopDetailsViewTest {
                                                             ) to
                                                             listOf(UpcomingTrip(trip, prediction))
                                                     ),
+                                                parentStopId = stop.id,
                                                 alerts = null
                                             )
                                         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
@@ -19,6 +19,7 @@ import com.mbta.tid.mbta_app.model.greenRoutes
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.model.response.ShapeWithStops
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
+import com.mbta.tid.mbta_app.utils.resolveParentId
 import io.github.dellisd.spatialk.geojson.LineString
 import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
 import io.github.dellisd.spatialk.turf.lineSlice
@@ -98,9 +99,7 @@ object RouteFeaturesBuilder {
     ): MapFriendlyRouteResponse.RouteWithSegmentedShapes? {
         val shape = shapeWithStops.shape ?: return null
         val parentResolvedStops =
-            shapeWithStops.stopIds.map {
-                stopsById?.get(it)?.resolveParent(stops = stopsById)?.id ?: it
-            }
+            shapeWithStops.stopIds.map { stopsById?.resolveParentId(it) ?: it }
         return MapFriendlyRouteResponse.RouteWithSegmentedShapes(
             routeId = shapeWithStops.routeId,
             segmentedShapes =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.utils.resolveParentId
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
@@ -444,9 +445,12 @@ fun NearbyStaticData.withRealtimeInfo(
                 )
                 .rewritten()
 
+    val globalStops = globalData?.stops.orEmpty()
+
     // add predictions and apply filtering
     val upcomingTripsByRoutePatternAndStop =
         UpcomingTrip.tripsMappedBy(
+                globalData?.stops.orEmpty(),
                 schedules,
                 rewrittenPredictions,
                 scheduleKey = { schedule, scheduleData ->
@@ -454,7 +458,7 @@ fun NearbyStaticData.withRealtimeInfo(
                     RealtimePatterns.UpcomingTripKey.ByRoutePattern(
                         schedule.routeId,
                         trip.routePatternId,
-                        schedule.stopId
+                        globalStops.resolveParentId(schedule.stopId)
                     )
                 },
                 predictionKey = { prediction, streamData ->
@@ -462,7 +466,7 @@ fun NearbyStaticData.withRealtimeInfo(
                     RealtimePatterns.UpcomingTripKey.ByRoutePattern(
                         prediction.routeId,
                         trip.routePatternId,
-                        prediction.stopId
+                        globalStops.resolveParentId(prediction.stopId)
                     )
                 }
             )
@@ -470,6 +474,7 @@ fun NearbyStaticData.withRealtimeInfo(
 
     val upcomingTripsByDirectionAndStop =
         UpcomingTrip.tripsMappedBy(
+                globalData?.stops.orEmpty(),
                 schedules,
                 rewrittenPredictions,
                 scheduleKey = { schedule, scheduleData ->
@@ -477,7 +482,7 @@ fun NearbyStaticData.withRealtimeInfo(
                     RealtimePatterns.UpcomingTripKey.ByDirection(
                         schedule.routeId,
                         trip.directionId,
-                        schedule.stopId
+                        globalStops.resolveParentId(schedule.stopId)
                     )
                 },
                 predictionKey = { prediction, streamData ->
@@ -485,7 +490,7 @@ fun NearbyStaticData.withRealtimeInfo(
                     RealtimePatterns.UpcomingTripKey.ByDirection(
                         prediction.routeId,
                         trip.directionId,
-                        prediction.stopId
+                        globalStops.resolveParentId(prediction.stopId)
                     )
                 }
             )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -41,9 +41,19 @@ data class PatternsByStop(
             .map {
                 when (it) {
                     is NearbyStaticData.StaticPatterns.ByHeadsign ->
-                        RealtimePatterns.ByHeadsign(it, upcomingTripsMap, alerts)
+                        RealtimePatterns.ByHeadsign(
+                            it,
+                            upcomingTripsMap,
+                            staticData.stop.id,
+                            alerts
+                        )
                     is NearbyStaticData.StaticPatterns.ByDirection ->
-                        RealtimePatterns.ByDirection(it, upcomingTripsMap, alerts)
+                        RealtimePatterns.ByDirection(
+                            it,
+                            upcomingTripsMap,
+                            staticData.stop.id,
+                            alerts
+                        )
                 }
             }
             .filter {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -9,10 +9,10 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
         data class ByRoutePattern(
             val routeId: String,
             val routePatternId: String?,
-            val stopId: String
+            val parentStopId: String
         ) : UpcomingTripKey()
 
-        data class ByDirection(val routeId: String, val direction: Int, val stopId: String) :
+        data class ByDirection(val routeId: String, val direction: Int, val parentStopId: String) :
             UpcomingTripKey()
     }
 
@@ -39,6 +39,7 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
         constructor(
             staticData: NearbyStaticData.StaticPatterns.ByHeadsign,
             upcomingTripsMap: UpcomingTripsMap?,
+            parentStopId: String,
             alerts: Collection<Alert>?,
         ) : this(
             staticData.route,
@@ -46,18 +47,14 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
             staticData.line,
             staticData.patterns,
             if (upcomingTripsMap != null) {
-                staticData.stopIds
-                    .map { stopId ->
-                        staticData.patterns
-                            .mapNotNull { pattern ->
-                                upcomingTripsMap[
-                                    UpcomingTripKey.ByRoutePattern(
-                                        staticData.route.id,
-                                        pattern.id,
-                                        stopId
-                                    )]
-                            }
-                            .flatten()
+                staticData.patterns
+                    .mapNotNull { pattern ->
+                        upcomingTripsMap[
+                            UpcomingTripKey.ByRoutePattern(
+                                staticData.route.id,
+                                pattern.id,
+                                parentStopId
+                            )]
                     }
                     .flatten()
                     .sorted()
@@ -103,6 +100,7 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
         constructor(
             staticData: NearbyStaticData.StaticPatterns.ByDirection,
             upcomingTripsMap: UpcomingTripsMap?,
+            parentStopId: String,
             alerts: Collection<Alert>?,
         ) : this(
             staticData.line,
@@ -110,16 +108,14 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
             staticData.direction,
             staticData.patterns,
             if (upcomingTripsMap != null) {
-                staticData.stopIds
-                    .flatMap { stopId ->
-                        staticData.routes.mapNotNull { route ->
-                            upcomingTripsMap[
-                                UpcomingTripKey.ByDirection(
-                                    route.id,
-                                    staticData.direction.id,
-                                    stopId
-                                )]
-                        }
+                staticData.routes
+                    .mapNotNull { route ->
+                        upcomingTripsMap[
+                            UpcomingTripKey.ByDirection(
+                                route.id,
+                                staticData.direction.id,
+                                parentStopId
+                            )]
                     }
                     .flatten()
                     .sorted()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -73,13 +73,22 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
     }
 }
 
-class MockPredictionsRepository : IPredictionsRepository {
+class MockPredictionsRepository(
+    private val instantReceive: Outcome<PredictionsStreamDataResponse?, SocketError>?
+) : IPredictionsRepository {
+    constructor() : this(instantReceive = null)
+
+    constructor(
+        response: PredictionsStreamDataResponse?
+    ) : this(instantReceive = Outcome(response, null))
 
     override fun connect(
         stopIds: List<String>,
         onReceive: (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
     ) {
-        /* no-op */
+        if (instantReceive != null) {
+            onReceive(instantReceive)
+        }
     }
 
     override fun disconnect() {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/resolveParentId.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/resolveParentId.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.utils
+
+import com.mbta.tid.mbta_app.model.Stop
+
+fun Map<String, Stop>.resolveParentId(stopId: String): String {
+    val stop = this[stopId] ?: return stopId
+    val parentStopId = stop.parentStationId ?: return stopId
+    return resolveParentId(parentStopId)
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -640,4 +640,88 @@ class RealtimePatternsTest {
             actual
         )
     }
+
+    @Test
+    fun `handles logical vs physical platforms`() {
+        // at Union Sq, North/South Station, and some others, the platforms don't map one-to-one to
+        // the directions, and the schedules are by direction but the predictions are by physical
+        // platform
+        val objects = ObjectCollectionBuilder()
+        lateinit var logicalPlatform: Stop
+        lateinit var physicalPlatform: Stop
+        val station =
+            objects.stop {
+                logicalPlatform = childStop()
+                physicalPlatform = childStop()
+            }
+
+        val route = objects.route()
+        val pattern =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                sortOrder = 1
+                representativeTrip {
+                    headsign = "A"
+                    stopIds = listOf(logicalPlatform.id)
+                }
+            }
+
+        val static =
+            NearbyStaticData.build {
+                route(route) {
+                    stop(station) { headsign("A", listOf(pattern), setOf(logicalPlatform.id)) }
+                }
+            }
+
+        val now = Clock.System.now()
+
+        val schedule =
+            objects.schedule {
+                trip = objects.trip(pattern)
+                stopId = logicalPlatform.id
+                departureTime = now + 5.minutes
+            }
+
+        val prediction =
+            objects.prediction(schedule) {
+                stopId = physicalPlatform.id
+                departureTime = now + 5.minutes
+            }
+
+        val actual =
+            static.withRealtimeInfo(
+                GlobalResponse(objects, emptyMap()),
+                Position(0.0, 0.0),
+                ScheduleResponse(objects),
+                PredictionsStreamDataResponse(objects),
+                AlertsStreamDataResponse(objects),
+                now,
+                emptySet()
+            )
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            station,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(pattern),
+                                    listOf(objects.upcomingTrip(schedule, prediction)),
+                                    emptyList()
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            actual
+        )
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -410,6 +410,7 @@ class UpcomingTripTest {
 
         val result =
             UpcomingTrip.tripsFromData(
+                objects.stops,
                 objects.schedules.values.toList(),
                 objects.predictions.values.toList(),
                 objects.trips,


### PR DESCRIPTION
### Summary

_Ticket:_ [Duplicate departure rows for Commuter Rail trips](https://app.asana.com/0/1205425564113216/1207114848419521/f)
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1727112428287779) from different symptoms of the same bug

Matching trips by parent station ID is so clearly the right thing to do that I have no idea why we ever put up with the `flatMap()` in the `RealtimePatterns` constructors.

### Testing

Added a unit test that would've caught both the new symptom and the old symptom.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
