### PR TITLE
fix: show cancelled trips in departure lists

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -14,10 +14,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -114,6 +117,27 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                         text = stringResource(R.string.minutes_abbr, state.trip.minutes),
                         modifier = modifier
                     )
+                is TripInstantDisplay.Cancelled ->
+                    Row(modifier, verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            "Cancelled",
+                            color = colorResource(R.color.deemphasized),
+                            textAlign = TextAlign.End,
+                            style = MaterialTheme.typography.headlineMedium,
+                            fontSize = 13.sp
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            formatTime(state.trip.scheduledTime),
+                            color = colorResource(R.color.deemphasized),
+                            textAlign = TextAlign.End,
+                            style =
+                                TextStyle(textDecoration = TextDecoration.LineThrough)
+                                    .merge(MaterialTheme.typography.headlineMedium),
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 13.sp,
+                        )
+                    }
             }
         is UpcomingTripViewState.NoService ->
             NoServiceView(NoServiceViewEffect.from(state.effect), modifier)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -120,7 +120,7 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                 is TripInstantDisplay.Cancelled ->
                     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
                         Text(
-                            "Cancelled",
+                            stringResource(R.string.cancelled),
                             color = colorResource(R.color.deemphasized),
                             textAlign = TextAlign.End,
                             style = MaterialTheme.typography.headlineMedium,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
@@ -13,6 +13,7 @@ import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.PatternsByStop
+import com.mbta.tid.mbta_app.model.Prediction
 import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
@@ -93,6 +94,19 @@ private fun StopDetailsRoutesViewPreview() {
             trip = trip3
             departureTime = Clock.System.now() + 8.minutes
         }
+    val trip4 = objects.trip()
+    val schedule3 =
+        objects.schedule {
+            trip = trip4
+            departureTime = Clock.System.now() + 10.minutes
+        }
+    val prediction3 =
+        objects.prediction {
+            trip = trip4
+            departureTime = null
+            arrivalTime = null
+            scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+        }
 
     MyApplicationTheme {
         StopDetailsRoutesView(
@@ -129,6 +143,13 @@ private fun StopDetailsRoutesViewPreview() {
                                     null,
                                     emptyList(),
                                     listOf(UpcomingTrip(trip2, schedule2))
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route2,
+                                    "D",
+                                    null,
+                                    emptyList(),
+                                    listOf(UpcomingTrip(trip4, schedule3, prediction3))
                                 )
                             )
                         )

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="stop_closed">Stop Closed</string>
     <string name="suspension">Suspension</string>
     <string name="no_service">No Service</string>
+    <string name="cancelled">Cancelled</string>
     <string name="nearby_transit_link">Nearby</string>
     <string name="settings_link">Settings</string>
     <string name="filterShowAll">All</string>

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -120,6 +120,25 @@ struct UpcomingTripView: View {
                         ? accessibilityFormatters.predictionMinutesFirst(minutes: format.minutes,
                                                                          vehicleText: vehicleTypeText)
                         : accessibilityFormatters.predictionMinutesOther(minutes: format.minutes))
+            case let .cancelled(schedule):
+                HStack(spacing: Self.subjectSpacing) {
+                    Text("Cancelled")
+                        .font(Typography.footnote)
+                        .foregroundStyle(Color.deemphasized)
+                    Text(schedule.scheduledTime.toNSDate(), style: .time)
+                        .font(Typography.footnoteSemibold)
+                        .strikethrough()
+                        .foregroundStyle(Color.deemphasized)
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(
+                    isFirst
+                        ? accessibilityFormatters.scheduledFirst(
+                            date: schedule.scheduledTime.toNSDate(),
+                            vehicleText: vehicleTypeText
+                        )
+                        : accessibilityFormatters.scheduledOther(date: schedule.scheduledTime.toNSDate())
+                )
             }
         case let .noService(alertEffect):
             NoServiceView(effect: .from(alertEffect: alertEffect))
@@ -182,6 +201,14 @@ class UpcomingTripAccessibilityFormatters {
 
     public func predictionTimeOther(date: Date) -> Text {
         Text("and at \(timeFormatter.string(from: date))")
+    }
+
+    public func cancelledFirst(date: Date, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) cancelled")
+    }
+
+    public func cancelledOther(date: Date) -> Text {
+        Text("and at \(timeFormatter.string(from: date)) cancelled")
     }
 }
 
@@ -278,6 +305,7 @@ struct UpcomingTripView_Previews: PreviewProvider {
             UpcomingTripView(prediction: .noService(.suspension), routeType: .heavyRail)
             UpcomingTripView(prediction: .noService(.shuttle), routeType: .heavyRail)
             UpcomingTripView(prediction: .noService(.stopClosure), routeType: .heavyRail)
+            UpcomingTripView(prediction: .noService(.detour), routeType: .heavyRail)
             UpcomingTripView(prediction: .noService(.detour), routeType: .heavyRail)
         }
         .padding(8)

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -25,6 +25,16 @@
         }
       }
     },
+    "%@ arriving at %@ cancelled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ arriving at %2$@ cancelled"
+          }
+        }
+      }
+    },
     "%@ arriving at %@ scheduled" : {
       "localizations" : {
         "en" : {
@@ -121,6 +131,9 @@
     "and at %@" : {
 
     },
+    "and at %@ cancelled" : {
+
+    },
     "and at %@ scheduled" : {
 
     },
@@ -147,6 +160,9 @@
     },
     "buses" : {
       "comment" : "buses"
+    },
+    "Cancelled" : {
+
     },
     "Coast Guard Restriction" : {
       "comment" : "Possible alert cause"

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
@@ -80,6 +80,17 @@ struct StopDetailsRoutesView: View {
         prediction.trip = trip3
         prediction.departureTime = (Date.now + 8 * 60).toKotlinInstant()
     }
+    let trip4 = objects.trip { _ in }
+    let schedule3 = objects.schedule { schedule in
+        schedule.trip = trip4
+        schedule.departureTime = (Date.now + 10 * 60).toKotlinInstant()
+    }
+    let prediction3 = objects.prediction { prediction in
+        prediction.trip = trip4
+        prediction.departureTime = nil
+        prediction.arrivalTime = nil
+        prediction.scheduleRelationship = .cancelled
+    }
 
     return StopDetailsRoutesView(departures: .init(routes: [
         .init(route: route1, stop: stop, patterns: [
@@ -111,6 +122,16 @@ struct StopDetailsRoutesView: View {
                 upcomingTrips: [.init(trip: trip2, schedule: schedule2)],
                 alertsHere: nil,
                 hasSchedulesToday: true
+            ),
+            .ByHeadsign(
+                route: route2,
+                headsign: "D",
+                line: nil,
+                patterns: [],
+                upcomingTrips: [
+                    .init(trip: trip4, schedule: schedule3, prediction: prediction3),
+                ],
+                alertsHere: nil
             ),
         ]),
     ]), global: nil, now: Date.now.toKotlinInstant(), filter: .constant(nil), pushNavEntry: { _ in },

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
@@ -131,7 +131,8 @@ struct StopDetailsRoutesView: View {
                 upcomingTrips: [
                     .init(trip: trip4, schedule: schedule3, prediction: prediction3),
                 ],
-                alertsHere: nil
+                alertsHere: nil,
+                hasSchedulesToday: true
             ),
         ]),
     ]), global: nil, now: Date.now.toKotlinInstant(), filter: .constant(nil), pushNavEntry: { _ in },

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
@@ -29,7 +29,7 @@ final class AlertDetailsPageTests: XCTestCase {
         }
     }
 
-    func testAlertDetailsPageParentStopResolution() throws {
+    @MainActor func testAlertDetailsPageParentStopResolution() throws {
         let objects = ObjectCollectionBuilder()
 
         let stop1 = objects.stop { stop in

--- a/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
+++ b/iosApp/iosAppTests/Pages/Map/HomeMapViewTest.swift
@@ -19,7 +19,7 @@ final class HomeMapViewTest: XCTestCase {
         executionTimeAllowance = 60
     }
 
-    func testAppears() throws {
+    @MainActor func testAppears() throws {
         let viewportProvider: ViewportProvider = .init(viewport: .followPuck(zoom: 1))
         let sheetHeight: Binding<CGFloat> = .constant(100)
 

--- a/iosApp/iosAppTests/Pages/Settings/SettingsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/Settings/SettingsPageTests.swift
@@ -43,7 +43,7 @@ final class SettingsPageTests: XCTestCase {
         }
     }
 
-    func testLoadsState() throws {
+    @MainActor func testLoadsState() throws {
         let loadedPublisher = PassthroughSubject<Void, Never>()
 
         let settingsRepository = FakeSettingsRepository(
@@ -65,7 +65,7 @@ final class SettingsPageTests: XCTestCase {
         wait(for: [exp], timeout: 2)
     }
 
-    func testSavesState() throws {
+    @MainActor func testSavesState() throws {
         let loadedPublisher = PassthroughSubject<Void, Never>()
         let savedExp = expectation(description: "saved state")
 

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -127,7 +127,7 @@ final class StopDetailsPageTests: XCTestCase {
         XCTAssertNil(filter.wrappedValue)
     }
 
-    func testDisplaysSchedules() {
+    @MainActor func testDisplaysSchedules() {
         let objects = ObjectCollectionBuilder()
         let route = objects.route()
         let stop = objects.stop { _ in }
@@ -275,7 +275,7 @@ final class StopDetailsPageTests: XCTestCase {
         wait(for: [joinExpectation], timeout: 1)
     }
 
-    func testAppliesFilterAutomatically() throws {
+    @MainActor func testAppliesFilterAutomatically() throws {
         let objects = ObjectCollectionBuilder()
         let route = objects.route()
         let stop = objects.stop { _ in }

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -13,7 +13,7 @@ import ViewInspector
 import XCTest
 
 final class TripDetailsPageTests: XCTestCase {
-    func testLoadsStopList() throws {
+    @MainActor func testLoadsStopList() throws {
         let objects = ObjectCollectionBuilder()
 
         let trip = objects.trip { _ in }
@@ -66,7 +66,7 @@ final class TripDetailsPageTests: XCTestCase {
         wait(for: [showsStopsExp], timeout: 5)
     }
 
-    func testIncludesVehicleCard() throws {
+    @MainActor func testIncludesVehicleCard() throws {
         let objects = ObjectCollectionBuilder()
 
         let stop1 = objects.stop { stop in
@@ -129,7 +129,7 @@ final class TripDetailsPageTests: XCTestCase {
         wait(for: [showVehicleCardExp], timeout: 5)
     }
 
-    func testSplitsWithTarget() throws {
+    @MainActor func testSplitsWithTarget() throws {
         let objects = ObjectCollectionBuilder()
 
         let stop1 = objects.stop { stop in
@@ -173,7 +173,7 @@ final class TripDetailsPageTests: XCTestCase {
         wait(for: [splitViewExp], timeout: 5)
     }
 
-    func testDisplaysTransferRoutes() throws {
+    @MainActor func testDisplaysTransferRoutes() throws {
         let objects = ObjectCollectionBuilder()
 
         let stop1 = objects.stop { stop in
@@ -290,7 +290,7 @@ final class TripDetailsPageTests: XCTestCase {
         wait(for: [routeExp], timeout: 5)
     }
 
-    func testTripRequestError() throws {
+    @MainActor func testTripRequestError() throws {
         let objects = ObjectCollectionBuilder()
 
         let trip = objects.trip { trip in
@@ -422,7 +422,7 @@ final class TripDetailsPageTests: XCTestCase {
         subscription.cancel()
     }
 
-    func testResolvesParentStop() {
+    @MainActor func testResolvesParentStop() {
         let objects = ObjectCollectionBuilder()
         let route = objects.route { _ in }
         let trip = objects.trip { $0.routeId = route.id }

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -125,7 +125,7 @@ final class ContentViewTests: XCTestCase {
         wait(for: [tokenConfigExpectation], timeout: 5)
     }
 
-    func testFetchesConfigOnMapboxError() throws {
+    @MainActor func testFetchesConfigOnMapboxError() throws {
         let loadConfigCallback = XCTestExpectation(description: "load config called")
         loadConfigCallback.expectedFulfillmentCount = 2
 

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -207,7 +207,7 @@ final class HomeMapViewTests: XCTestCase {
         }
     }
 
-    func testUpdatesRouteAndChildStopsWhenStopSelected() throws {
+    @MainActor func testUpdatesRouteAndChildStopsWhenStopSelected() throws {
         let globalLoadSubject = PassthroughSubject<Void, Never>()
 
         let stopMapDetailsLoadedPublisher = PassthroughSubject<Void, Never>()
@@ -261,7 +261,7 @@ final class HomeMapViewTests: XCTestCase {
         }
     }
 
-    func testSetsRouteSourceWhenStopSelectedWithRouteFilter() throws {
+    @MainActor func testSetsRouteSourceWhenStopSelectedWithRouteFilter() throws {
         let globalLoadSubject = PassthroughSubject<Void, Never>()
         let stopMapDetailsLoadedPublisher = PassthroughSubject<Void, Never>()
         HelpersKt
@@ -318,7 +318,7 @@ final class HomeMapViewTests: XCTestCase {
         }
     }
 
-    func testUpdatesRouteSourceWhenStopSelectedWithRouteFilterAndUpcomingDepartures() throws {
+    @MainActor func testUpdatesRouteSourceWhenStopSelectedWithRouteFilterAndUpcomingDepartures() throws {
         let globalLoadSubject = PassthroughSubject<Void, Never>()
         let stopMapDetailsLoadedPublisher = PassthroughSubject<Void, Never>()
         HelpersKt
@@ -397,7 +397,7 @@ final class HomeMapViewTests: XCTestCase {
         }
     }
 
-    func testUpdatesSourcesWhenTripSelected() throws {
+    @MainActor func testUpdatesSourcesWhenTripSelected() throws {
         let globalLoadSubject = PassthroughSubject<Void, Never>()
         let tripShapeLoadSubject = PassthroughSubject<Void, Never>()
 
@@ -568,7 +568,7 @@ final class HomeMapViewTests: XCTestCase {
         }
     }
 
-    func testVehicleChanging() throws {
+    @MainActor func testVehicleChanging() throws {
         class FakeStopRepository: IStopRepository {
             func __getStopMapData(stopId _: String) async throws -> StopMapResponse {
                 StopMapResponse(

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -783,7 +783,7 @@ final class NearbyTransitViewTests: XCTestCase {
             .find(text: "Failed to load nearby transit, test error"))
     }
 
-    func testPredictionErrorMessage() throws {
+    @MainActor func testPredictionErrorMessage() throws {
         let predictionsErroredPublisher = PassthroughSubject<Bool, Never>()
         let state = NearbyViewModel.NearbyTransitState(
             loadedLocation: CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -4,6 +4,28 @@ import kotlinx.datetime.Instant
 
 typealias UpcomingTripsMap = Map<RealtimePatterns.UpcomingTripKey, List<UpcomingTrip>>
 
+internal fun List<UpcomingTrip>.filterCancellations(isSubway: Boolean): List<UpcomingTrip> {
+    /**
+     * Do not display cancelled/skipped trips in contexts where there are only two departures shown
+     * since it's more important that riders know about trips they can still take. Never show
+     * cancelled trips for subways.
+     */
+    return if (this.size <= 2) {
+        this.filter { trip -> !trip.isCancelled }
+    } else {
+        this.filter { trip ->
+            if (isSubway) {
+                !trip.isCancelled
+            } else {
+                true
+            }
+        }
+    }
+}
+
+internal fun UpcomingTripsMap.filterCancellations(isSubway: Boolean): UpcomingTripsMap =
+    this.entries.associate { it.key to it.value.filterCancellations(isSubway) }
+
 sealed class RealtimePatterns : Comparable<RealtimePatterns> {
     sealed class UpcomingTripKey {
         data class ByRoutePattern(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -203,20 +203,21 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                 NearbyStaticData.filterStopsByPatterns(patterns, global, allStopIds)
                             val upcomingTrips =
                                 if (tripMap != null) {
-                                    patterns
-                                        .mapNotNull { pattern ->
-                                            tripMap[
-                                                RealtimePatterns.UpcomingTripKey.ByRoutePattern(
-                                                    route.id,
-                                                    pattern.id,
-                                                    stop.id
-                                                )]
-                                        }
-                                        .flatten()
-                                        .sorted()
-                                } else {
-                                    null
-                                }
+                                        patterns
+                                            .mapNotNull { pattern ->
+                                                tripMap[
+                                                    RealtimePatterns.UpcomingTripKey.ByRoutePattern(
+                                                        route.id,
+                                                        pattern.id,
+                                                        stop.id
+                                                    )]
+                                            }
+                                            .flatten()
+                                            .sorted()
+                                    } else {
+                                        null
+                                    }
+                                    ?.filterCancellations(route.type.isSubway())
                             RealtimePatterns.ByHeadsign(
                                 route,
                                 headsign,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -28,6 +28,8 @@ sealed class TripInstantDisplay {
 
     data class Skipped(val scheduledTime: Instant?) : TripInstantDisplay()
 
+    data class Cancelled(val scheduledTime: Instant) : TripInstantDisplay()
+
     data class Minutes(val minutes: Int) : TripInstantDisplay()
 
     enum class Context {
@@ -56,6 +58,13 @@ sealed class TripInstantDisplay {
                     return Skipped(it)
                 }
                 return Hidden
+            }
+            if (
+                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
+                    schedule?.scheduleTime != null &&
+                    routeType?.isSubway() == false
+            ) {
+                return Cancelled(schedule.scheduleTime)
             }
             val departureTime =
                 if (prediction != null) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -38,7 +38,10 @@ data class UpcomingTrip(
     ) : this(trip, null, prediction, vehicle)
 
     val time =
-        if (prediction != null) {
+        if (
+            prediction != null &&
+                prediction.scheduleRelationship != Prediction.ScheduleRelationship.Cancelled
+        ) {
             prediction.predictionTime
         } else {
             schedule?.scheduleTime
@@ -50,6 +53,11 @@ data class UpcomingTrip(
         }
         prediction?.stopSequence ?: schedule?.stopSequence
     }
+
+    val isCancelled: Boolean
+        get() =
+            schedule?.scheduleTime != null &&
+                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled
 
     override fun compareTo(other: UpcomingTrip) = nullsLast<Instant>().compare(time, other.time)
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -756,4 +756,171 @@ class RealtimePatternsTest {
             actual
         )
     }
+
+    @Test
+    fun `includes cancelled trips`() = parametricTest {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+
+        val schedule1 =
+            objects.schedule {
+                trip = trip1
+                departureTime = now + 2.minutes
+            }
+        val prediction1 =
+            objects.prediction {
+                trip = trip1
+                departureTime = null
+                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            }
+        val prediction2 =
+            objects.prediction {
+                trip = trip2
+                departureTime = now + 5.minutes
+            }
+
+        val upcomingTrip1 = objects.upcomingTrip(schedule1, prediction1)
+        val upcomingTrip2 = objects.upcomingTrip(prediction2)
+        val routeType = RouteType.BUS
+        assertEquals(
+            RealtimePatterns.Format.Some(
+                listOf(
+                    RealtimePatterns.Format.Some.FormatWithId(
+                        trip1.id,
+                        routeType,
+                        TripInstantDisplay.Cancelled(schedule1.departureTime!!)
+                    ),
+                    RealtimePatterns.Format.Some.FormatWithId(
+                        trip2.id,
+                        routeType,
+                        TripInstantDisplay.Minutes(5)
+                    )
+                ),
+                null
+            ),
+            RealtimePatterns.ByHeadsign(
+                    route,
+                    "",
+                    null,
+                    emptyList(),
+                    listOf(upcomingTrip1, upcomingTrip2)
+                )
+                .format(now, routeType, anyContext())
+        )
+    }
+
+    @Test
+    fun `filterCancellations filters if 2 or less`() {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+
+        val schedule1 =
+            objects.schedule {
+                trip = trip1
+                departureTime = now + 2.minutes
+            }
+        val prediction1 =
+            objects.prediction {
+                trip = trip1
+                departureTime = null
+                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            }
+        val prediction2 =
+            objects.prediction {
+                trip = trip2
+                departureTime = now + 5.minutes
+            }
+
+        val upcomingTrip1 = objects.upcomingTrip(schedule1, prediction1)
+        val upcomingTrip2 = objects.upcomingTrip(prediction2)
+        val sut = listOf(upcomingTrip1, upcomingTrip2).filterCancellations(false)
+        assertEquals(sut, listOf(upcomingTrip2))
+    }
+
+    @Test
+    fun `filterCancellations filters subway cancellations`() {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+        val trip3 = objects.trip()
+
+        val schedule1 =
+            objects.schedule {
+                trip = trip1
+                departureTime = now + 2.minutes
+            }
+        val prediction1 =
+            objects.prediction {
+                trip = trip1
+                departureTime = null
+                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            }
+        val prediction2 =
+            objects.prediction {
+                trip = trip2
+                departureTime = now + 5.minutes
+            }
+        val prediction3 =
+            objects.prediction {
+                trip = trip3
+                departureTime = now + 7.minutes
+            }
+
+        val upcomingTrip1 = objects.upcomingTrip(schedule1, prediction1)
+        val upcomingTrip2 = objects.upcomingTrip(prediction2)
+        val upcomingTrip3 = objects.upcomingTrip(prediction3)
+        val sut = listOf(upcomingTrip1, upcomingTrip2, upcomingTrip3).filterCancellations(true)
+        assertEquals(sut, listOf(upcomingTrip2, upcomingTrip3))
+    }
+
+    @Test
+    fun `include cancellations if not subway`() {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+        val trip3 = objects.trip()
+
+        val schedule1 =
+            objects.schedule {
+                trip = trip1
+                departureTime = now + 2.minutes
+            }
+        val prediction1 =
+            objects.prediction {
+                trip = trip1
+                departureTime = null
+                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            }
+        val prediction2 =
+            objects.prediction {
+                trip = trip2
+                departureTime = now + 5.minutes
+            }
+        val prediction3 =
+            objects.prediction {
+                trip = trip3
+                departureTime = now + 7.minutes
+            }
+
+        val upcomingTrip1 = objects.upcomingTrip(schedule1, prediction1)
+        val upcomingTrip2 = objects.upcomingTrip(prediction2)
+        val upcomingTrip3 = objects.upcomingTrip(prediction3)
+        val sut = listOf(upcomingTrip1, upcomingTrip2, upcomingTrip3).filterCancellations(false)
+        assertEquals(sut, listOf(upcomingTrip1, upcomingTrip2, upcomingTrip3))
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -657,4 +657,48 @@ class TripInstantDisplayTest {
             )
         )
     }
+
+    @Test
+    fun `scheduled trip cancelled`() = parametricTest {
+        val now = Clock.System.now()
+        assertEquals(
+            TripInstantDisplay.Cancelled(now + 15.minutes),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+                        arrivalTime = null
+                        departureTime = null
+                    },
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule { departureTime = now + 15.minutes },
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = anyEnumValue()
+            )
+        )
+    }
+
+    @Test
+    fun `cancelled subway trip is hidden`() = parametricTest {
+        val now = Clock.System.now()
+        assertEquals(
+            TripInstantDisplay.Hidden,
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+                        arrivalTime = null
+                        departureTime = null
+                    },
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule { departureTime = now + 15.minutes },
+                vehicle = null,
+                routeType = RouteType.LIGHT_RAIL,
+                now = now,
+                context = anyEnumValue()
+            )
+        )
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -512,7 +512,7 @@ class UpcomingTripTest {
         val predictionDropped = prediction {
             arrivalTime = null
             departureTime = null
-            scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            scheduleRelationship = Prediction.ScheduleRelationship.Skipped
         }
 
         assertEquals(null, UpcomingTrip(trip, schedule, predictionDropped).time)


### PR DESCRIPTION
### Summary

_Ticket:_ [Show explicitly cancelled bus, CR, ferry trips in departure lists](https://app.asana.com/0/1205425564113216/1207678190799459/f)

Show cancelled trips for non-subway stops when there are more than 2 departures. You'll see I added a lot of `@MainActor` annotations to tests, this was because SwiftUI previews would not work until I did so.

### Testing

Added some unit tests around new filtering and trip display formatting. Also added new previews to Android and iOS.
