### PR TITLE
feat: Use new predictions V2 channel behind feature flag

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -23,6 +23,8 @@ import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -183,6 +185,15 @@ class NearbyTransitPageTest : KoinTest {
                                 (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
                         ) {
                             onReceive(Outcome(PredictionsStreamDataResponse(builder), null))
+                        }
+
+                        override fun connectV2(
+                            stopIds: List<String>,
+                            onJoin: (Outcome<PredictionsByStopJoinResponse?, SocketError>) -> Unit,
+                            onMessage:
+                                (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
+                        ) {
+                            /* no-op */
                         }
 
                         override fun disconnect() {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -12,6 +12,8 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -177,6 +179,15 @@ class NearbyTransitViewTest : KoinTest {
                                 (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
                         ) {
                             onReceive(Outcome(PredictionsStreamDataResponse(builder), null))
+                        }
+
+                        override fun connectV2(
+                            stopIds: List<String>,
+                            onJoin: (Outcome<PredictionsByStopJoinResponse?, SocketError>) -> Unit,
+                            onMessage:
+                                (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
+                        ) {
+                            /* no-op */
                         }
 
                         override fun disconnect() {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -18,6 +18,8 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
@@ -123,6 +125,15 @@ class StopDetailsViewTest {
                                 (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
                         ) {
                             onReceive(Outcome(PredictionsStreamDataResponse(builder), null))
+                        }
+
+                        override fun connectV2(
+                            stopIds: List<String>,
+                            onJoin: (Outcome<PredictionsByStopJoinResponse?, SocketError>) -> Unit,
+                            onMessage:
+                                (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
+                        ) {
+                            /* no-op */
                         }
 
                         override fun disconnect() {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Outcome
 import com.mbta.tid.mbta_app.model.SocketError
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import kotlinx.coroutines.channels.Channel
@@ -46,6 +48,14 @@ class SubscribeToPredictionsTest {
                     isConnected = true
                     launch { stopIdsChannel.send(stopIds) }
                     this.onReceive = onReceive
+                }
+
+                override fun connectV2(
+                    stopIds: List<String>,
+                    onJoin: (Outcome<PredictionsByStopJoinResponse?, SocketError>) -> Unit,
+                    onMessage: (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
+                ) {
+                    /* no-op */
                 }
 
                 override fun disconnect() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/subscribeToPredictions.kt
@@ -10,7 +10,6 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -413,6 +413,9 @@
     "Updated: %@" : {
       "comment" : "Interpolated value is a timestamp for when displayed alert details were last changed"
     },
+    "Using Predictions Channel V2" : {
+
+    },
     "Weather" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -291,8 +291,7 @@ struct NearbyTransitView: View {
         let fallbackPredictions = if let predictionsByStop {
             PredictionsByStopJoinResponse.companion
                 .toPredictionsStreamDataResponse(predictionsByStop: predictionsByStop)
-        } else { self.predictions
-        }
+        } else { self.predictions }
 
         nearbyWithRealtimeInfo = withRealtimeInfo(
             schedules: scheduleResponse ?? self.scheduleResponse,

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -77,8 +77,7 @@ struct NearbyTransitView: View {
         }
         .onChange(of: predictionsByStop) { newPredictionsByStop in
             if let newPredictionsByStop {
-                let condensedPredictions = PredictionsByStopJoinResponse.companion
-                    .toPredictionsStreamDataResponse(predictionsByStop: newPredictionsByStop)
+                let condensedPredictions = newPredictionsByStop.toPredictionsStreamDataResponse()
                 updateNearbyRoutes(predictions: condensedPredictions)
             } else {
                 updateNearbyRoutes(predictions: nil)
@@ -230,8 +229,7 @@ struct NearbyTransitView: View {
             DispatchQueue.main.async {
                 if let data = outcome.data {
                     if let existingPredictionsByStop = predictionsByStop {
-                        predictionsByStop = PredictionsByStopJoinResponse.companion
-                            .mergePredictions(allByStop: existingPredictionsByStop, updatedPredictions: data)
+                        predictionsByStop = existingPredictionsByStop.mergePredictions(updatedPredictions: data)
                         predictionsError = nil
                     } else {
                         predictionsByStop = PredictionsByStopJoinResponse(
@@ -289,8 +287,7 @@ struct NearbyTransitView: View {
         pinnedRoutes: Set<String>? = nil
     ) {
         let fallbackPredictions = if let predictionsByStop {
-            PredictionsByStopJoinResponse.companion
-                .toPredictionsStreamDataResponse(predictionsByStop: predictionsByStop)
+            predictionsByStop.toPredictionsStreamDataResponse()
         } else { self.predictions }
 
         nearbyWithRealtimeInfo = withRealtimeInfo(

--- a/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
+++ b/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
@@ -22,6 +22,8 @@ extension Setting: Identifiable {
             "Search - Route Results"
         case .map:
             "Map Debug"
+        case .predictionsV2Channel:
+            "Predictions V2 Channel"
         }
     }
 
@@ -33,6 +35,8 @@ extension Setting: Identifiable {
             "point.topleft.down.to.point.bottomright.curvepath.fill"
         case .map:
             "location.magnifyingglass"
+        case .predictionsV2Channel:
+            "magnifyingglass"
         }
     }
 
@@ -41,6 +45,8 @@ extension Setting: Identifiable {
         case .search:
             .featureFlags
         case .searchRouteResults:
+            .featureFlags
+        case .predictionsV2Channel:
             .featureFlags
         case .map:
             .debug

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -175,8 +175,7 @@ struct StopDetailsPage: View {
             DispatchQueue.main.async {
                 if let data = outcome.data {
                     if let existingPredictionsByStop = predictionsByStop {
-                        predictionsByStop = PredictionsByStopJoinResponse.companion
-                            .mergePredictions(allByStop: existingPredictionsByStop, updatedPredictions: data)
+                        predictionsByStop = existingPredictionsByStop.mergePredictions(updatedPredictions: data)
                     } else {
                         predictionsByStop = PredictionsByStopJoinResponse(
                             predictionsByStop: [data.stopId: data.predictions],
@@ -203,15 +202,10 @@ struct StopDetailsPage: View {
         let predictionsByStop = predictionsByStop ?? self.predictionsByStop
 
         let targetPredictions = if let predictionsByStop {
-            PredictionsByStopJoinResponse.companion
-                .toPredictionsStreamDataResponse(predictionsByStop: predictionsByStop)
+            predictionsByStop.toPredictionsStreamDataResponse()
         } else {
             predictions ?? self.predictions
         }
-
-        print("TARGET \(targetPredictions)")
-
-        print("GLOBAL \(globalResponse)")
 
         let newDepartures: StopDetailsDepartures? = if let globalResponse {
             StopDetailsDepartures(

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -16,6 +16,7 @@ struct StopDetailsPage: View {
     @State var globalResponse: GlobalResponse?
     @ObservedObject var viewportProvider: ViewportProvider
     let schedulesRepository: ISchedulesRepository
+    var settingsRepository = RepositoryDI().settings
     @State var schedulesResponse: ScheduleResponse?
     var pinnedRouteRepository = RepositoryDI().pinnedRoutes
     var togglePinnedUsecase = UsecaseDI().toggledPinnedRouteUsecase
@@ -27,6 +28,8 @@ struct StopDetailsPage: View {
     @ObservedObject var nearbyVM: NearbyViewModel
     @State var pinnedRoutes: Set<String> = []
     @State var predictions: PredictionsStreamDataResponse?
+    @State var predictionsByStop: PredictionsByStopJoinResponse?
+    @State var predictionsV2Enabled = false
 
     let inspection = Inspection<Self>()
     let timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
@@ -34,48 +37,60 @@ struct StopDetailsPage: View {
     init(
         globalRepository: IGlobalRepository = RepositoryDI().global,
         schedulesRepository: ISchedulesRepository = RepositoryDI().schedules,
+        settingsRepository: ISettingsRepository = RepositoryDI().settings,
         predictionsRepository: IPredictionsRepository = RepositoryDI().predictions,
         viewportProvider: ViewportProvider,
         stop: Stop,
         filter: Binding<StopDetailsFilter?>,
-        nearbyVM: NearbyViewModel
+        nearbyVM: NearbyViewModel,
+        predictionsV2Enabled: Bool = false
     ) {
         self.globalRepository = globalRepository
         self.schedulesRepository = schedulesRepository
+        self.settingsRepository = settingsRepository
         self.predictionsRepository = predictionsRepository
         self.viewportProvider = viewportProvider
         self.stop = stop
         _filter = filter
         self.nearbyVM = nearbyVM
+        self.predictionsV2Enabled = predictionsV2Enabled
     }
 
     var body: some View {
-        StopDetailsView(
-            stop: stop,
-            filter: $filter,
-            nearbyVM: nearbyVM,
-            pinnedRoutes: pinnedRoutes,
-            togglePinnedRoute: togglePinnedRoute
-        )
-        .onAppear {
-            loadGlobalData()
-            changeStop(stop)
-            loadPinnedRoutes()
+        VStack {
+            if predictionsV2Enabled {
+                Text("Using Predictions Channel V2")
+            }
+            StopDetailsView(
+                stop: stop,
+                filter: $filter,
+                nearbyVM: nearbyVM,
+                pinnedRoutes: pinnedRoutes,
+                togglePinnedRoute: togglePinnedRoute
+            )
+            .onAppear {
+                loadGlobalData()
+                changeStop(stop)
+                loadPinnedRoutes()
+            }
+            .onChange(of: stop) { nextStop in changeStop(nextStop) }
+            .onChange(of: globalResponse) { _ in updateDepartures() }
+            .onChange(of: pinnedRoutes) { _ in updateDepartures() }
+            .onChange(of: predictionsByStop) { _ in
+                updateDepartures()
+            }
+            .onChange(of: predictions) { _ in updateDepartures() }
+            .onChange(of: schedulesResponse) { _ in updateDepartures() }
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+            .onReceive(timer) { input in
+                now = input
+                updateDepartures()
+            }
+            .onDisappear { leavePredictions() }
+            .withScenePhaseHandlers(onActive: { joinPredictions(stop) },
+                                    onInactive: leavePredictions,
+                                    onBackground: leavePredictions)
         }
-        .onChange(of: stop) { nextStop in changeStop(nextStop) }
-        .onChange(of: globalResponse) { _ in updateDepartures() }
-        .onChange(of: pinnedRoutes) { _ in updateDepartures() }
-        .onChange(of: predictions) { _ in updateDepartures() }
-        .onChange(of: schedulesResponse) { _ in updateDepartures() }
-        .onReceive(inspection.notice) { inspection.visit(self, $0) }
-        .onReceive(timer) { input in
-            now = input
-            updateDepartures()
-        }
-        .onDisappear { leavePredictions() }
-        .withScenePhaseHandlers(onActive: { joinPredictions(stop) },
-                                onInactive: leavePredictions,
-                                onBackground: leavePredictions)
     }
 
     func loadGlobalData() {
@@ -126,15 +141,50 @@ struct StopDetailsPage: View {
     }
 
     func joinPredictions(_ stop: Stop) {
-        predictionsRepository.connect(stopIds: [stop.id]) { outcome in
-            DispatchQueue.main.async {
-                predictions = if let data = outcome.data {
-                    data
-                } else {
-                    nil
+        Task {
+            let settings = try await settingsRepository.getSettings()
+            var isEnabled = settings.first(where: { $0.key == .predictionsV2Channel })?.isOn ?? false
+            predictionsV2Enabled = isEnabled
+            if isEnabled {
+                joinPredictionsV2(stopIds: [stop.id])
+            } else {
+                predictionsRepository.connect(stopIds: [stop.id]) { outcome in
+                    DispatchQueue.main.async {
+                        predictions = if let data = outcome.data {
+                            data
+                        } else {
+                            nil
+                        }
+                    }
                 }
             }
         }
+    }
+
+    func joinPredictionsV2(stopIds: Set<String>) {
+        predictionsRepository.connectV2(stopIds: Array(stopIds), onJoin: { outcome in
+            DispatchQueue.main.async {
+                if let data = outcome.data {
+                    predictionsByStop = data
+                }
+            }
+        }, onMessage: { outcome in
+            DispatchQueue.main.async {
+                if let data = outcome.data {
+                    if let existingPredictionsByStop = predictionsByStop {
+                        predictionsByStop = PredictionsByStopJoinResponse.companion
+                            .mergePredictions(allByStop: existingPredictionsByStop, updatedPredictions: data)
+                    } else {
+                        predictionsByStop = PredictionsByStopJoinResponse(
+                            predictionsByStop: [data.stopId: data.predictions],
+                            trips: data.trips,
+                            vehicles: data.vehicles
+                        )
+                    }
+                }
+            }
+
+        })
     }
 
     func leavePredictions() {
@@ -144,12 +194,19 @@ struct StopDetailsPage: View {
     func updateDepartures(_ stop: Stop? = nil) {
         let stop = stop ?? self.stop
 
+        let targetPredictions = if let predictionsByStop {
+            PredictionsByStopJoinResponse.companion
+                .toPredictionsStreamDataResponse(predictionsByStop: predictionsByStop)
+        } else {
+            predictions
+        }
+
         let newDepartures: StopDetailsDepartures? = if let globalResponse {
             StopDetailsDepartures(
                 stop: stop,
                 global: globalResponse,
                 schedules: schedulesResponse,
-                predictions: predictions,
+                predictions: targetPredictions,
                 alerts: nearbyVM.alerts,
                 pinnedRoutes: pinnedRoutes,
                 filterAtTime: now.toKotlinInstant()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -6,7 +6,7 @@ enum class AppVariant(
     val darkMapStyle: String
 ) {
     Staging(
-        "mobile-app-backend-staging.mbtace.com",
+        "mobile-app-backend-dev-orange.mbtace.com",
         "mapbox://styles/mbtamobileapp/cm02vf0cf00cu01pnfgnu5onh",
         "mapbox://styles/mbtamobileapp/cm02vgvsp003c01ombyewgu70"
     ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -6,7 +6,7 @@ enum class AppVariant(
     val darkMapStyle: String
 ) {
     Staging(
-        "mobile-app-backend-dev-orange.mbtace.com",
+        "mobile-app-backend-staging.mbtace.com",
         "mapbox://styles/mbtamobileapp/cm02vf0cf00cu01pnfgnu5onh",
         "mapbox://styles/mbtamobileapp/cm02vgvsp003c01ombyewgu70"
     ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -11,6 +11,8 @@ import com.mbta.tid.mbta_app.model.TripShape
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
@@ -116,6 +118,14 @@ fun endToEndModule(): Module {
                     onReceive: (Outcome<PredictionsStreamDataResponse?, SocketError>) -> Unit
                 ) {
                     onReceive(Outcome(PredictionsStreamDataResponse(objects), null))
+                }
+
+                override fun connectV2(
+                    stopIds: List<String>,
+                    onJoin: (Outcome<PredictionsByStopJoinResponse?, SocketError>) -> Unit,
+                    onMessage: (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
+                ) {
+                    onJoin(Outcome(PredictionsByStopJoinResponse(objects), null))
                 }
 
                 override fun disconnect() {}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -25,9 +25,9 @@ data class PredictionsByStopJoinResponse(
     )
 
     companion object {
-        /*
-        Merge the latest predictions for a single stop into the predictions for all stops.
-        Removes vehicles & trips that are no longer referenced in any predictions
+        /**
+         * Merge the latest predictions for a single stop into the predictions for all stops.
+         * Removes vehicles & trips that are no longer referenced in any predictions
          */
         fun mergePredictions(
             allByStop: PredictionsByStopJoinResponse,
@@ -63,6 +63,7 @@ data class PredictionsByStopJoinResponse(
             )
         }
 
+        /** Flattens the `predictionsByStop` field into a single map of predictions by id */
         fun toPredictionsStreamDataResponse(
             predictionsByStop: PredictionsByStopJoinResponse
         ): PredictionsStreamDataResponse {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -1,0 +1,80 @@
+package com.mbta.tid.mbta_app.model.response
+
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Prediction
+import com.mbta.tid.mbta_app.model.Trip
+import com.mbta.tid.mbta_app.model.Vehicle
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PredictionsByStopJoinResponse(
+    @SerialName("predictions_by_stop") val predictionsByStop: Map<String, Map<String, Prediction>>,
+    val trips: Map<String, Trip>,
+    val vehicles: Map<String, Vehicle>
+) {
+
+    constructor(
+        objects: ObjectCollectionBuilder
+    ) : this(
+        objects.predictions.values
+            .groupBy { it.stopId }
+            .mapValues { predictions -> predictions.value.associateBy { it.id } },
+        objects.trips,
+        objects.vehicles
+    )
+
+    companion object {
+        /*
+        Merge the latest predictions for a single stop into the predictions for all stops.
+        Removes vehicles & trips that are no longer referenced in any predictions
+         */
+        fun mergePredictions(
+            allByStop: PredictionsByStopJoinResponse,
+            updatedPredictions: PredictionsByStopMessageResponse
+        ): PredictionsByStopJoinResponse {
+
+            val updatedPredictionsByStop: Map<String, Map<String, Prediction>> =
+                allByStop.predictionsByStop.plus(
+                    Pair(updatedPredictions.stopId, updatedPredictions.predictions)
+                )
+
+            val usedTrips = mutableSetOf<String>()
+            val usedVehicles = mutableSetOf<String>()
+            val predictions = updatedPredictionsByStop.flatMap { it.value.values }
+            predictions.forEach {
+                usedTrips.add(it.tripId)
+                if (it.vehicleId != null) {
+                    usedVehicles.add(it.vehicleId)
+                }
+            }
+
+            val updatedTrips =
+                allByStop.trips.plus(updatedPredictions.trips).filterKeys { it in usedTrips }
+            val updatedVehicles =
+                allByStop.vehicles.plus(updatedPredictions.vehicles).filterKeys {
+                    it in usedVehicles
+                }
+
+            return PredictionsByStopJoinResponse(
+                predictionsByStop = updatedPredictionsByStop,
+                trips = updatedTrips,
+                vehicles = updatedVehicles
+            )
+        }
+
+        fun toPredictionsStreamDataResponse(
+            predictionsByStop: PredictionsByStopJoinResponse
+        ): PredictionsStreamDataResponse {
+            val predictionsById =
+                predictionsByStop.predictionsByStop
+                    .flatMap { it.value.values }
+                    .associateBy { it.id }
+            return PredictionsStreamDataResponse(
+                predictions = predictionsById,
+                trips = predictionsByStop.trips,
+                vehicles = predictionsByStop.vehicles
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
@@ -1,0 +1,15 @@
+package com.mbta.tid.mbta_app.model.response
+
+import com.mbta.tid.mbta_app.model.Prediction
+import com.mbta.tid.mbta_app.model.Trip
+import com.mbta.tid.mbta_app.model.Vehicle
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PredictionsByStopMessageResponse(
+    @SerialName("stop_id") val stopId: String,
+    val predictions: Map<String, Prediction>,
+    val trips: Map<String, Trip>,
+    val vehicles: Map<String, Vehicle>
+) {}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/PredictionsForStopsChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/PredictionsForStopsChannel.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.phoenix
 
 import com.mbta.tid.mbta_app.json
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 
 class PredictionsForStopsChannel {
@@ -9,12 +11,24 @@ class PredictionsForStopsChannel {
 
         val newDataEvent = "stream_data"
 
+        fun topicV2(stopIds: List<String>) = "predictions:stops:v2:${stopIds.joinToString(",")}"
+
         fun joinPayload(stopIds: List<String>): Map<String, Any> {
             return mapOf("stop_ids" to stopIds)
         }
 
         @Throws(IllegalArgumentException::class)
         fun parseMessage(payload: String): PredictionsStreamDataResponse {
+            return json.decodeFromString(payload)
+        }
+
+        @Throws(IllegalArgumentException::class)
+        fun parseV2JoinMessage(payload: String): PredictionsByStopJoinResponse {
+            return json.decodeFromString(payload)
+        }
+
+        @Throws(IllegalArgumentException::class)
+        fun parseV2Message(payload: String): PredictionsByStopMessageResponse {
             return json.decodeFromString(payload)
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -113,6 +113,7 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
                 try {
                     PredictionsForStopsChannel.parseV2JoinMessage(rawPayload)
                 } catch (e: IllegalArgumentException) {
+                    print("ERROR $e")
                     onJoin(Outcome(null, SocketError.Unknown))
                     return
                 }
@@ -125,7 +126,13 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
         }
     }
 
-    private fun handleV2Message(
+    /**
+     * Parse the phoenix message & pass to the onMessage callback
+     *
+     * @param message: the message to parse, expected as a PredictionsByStopMessageResponse
+     * @param onMessage: the callback ot invoke on the parsed message
+     */
+    internal fun handleV2Message(
         message: PhoenixMessage,
         onMessage: (Outcome<PredictionsByStopMessageResponse?, SocketError>) -> Unit
     ) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -169,6 +169,10 @@ class MockPredictionsRepository(
         this(onConnect = {}, onConnectV2 = {}, connectOutcome = null, connectV2Outcome = null)
 
     constructor(
+        response: PredictionsStreamDataResponse?
+    ) : this(connectOutcome = Outcome(response, null))
+
+    constructor(
         onConnect: () -> Unit = {},
         onConnectV2: () -> Unit = {},
         onDisconnect: () -> Unit = {},

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -38,6 +38,7 @@ enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     Map(booleanPreferencesKey("map_debug")),
     Search(booleanPreferencesKey("search_featureFlag")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
+    PredictionsV2Channel(booleanPreferencesKey("predictions_v2Channel"))
 }
 
 data class Setting(val key: Settings, var isOn: Boolean)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponseTest.kt
@@ -1,0 +1,160 @@
+package com.mbta.tid.mbta_app.model.response
+
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.prediction
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.trip
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.vehicle
+import com.mbta.tid.mbta_app.model.Prediction
+import com.mbta.tid.mbta_app.model.Vehicle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PredictionsByStopJoinResponseTest {
+    @Test
+    fun `mergePredictions replaces predictions for existing stop`() {
+        val trip = trip()
+        val vehicle = vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+
+        val p1stop1 = prediction {
+            stopId = "1"
+            tripId = trip.id
+            vehicleId = vehicle.id
+        }
+
+        val p1stop1updated = prediction {
+            id = p1stop1.id
+            stopId = "1"
+            tripId = trip.id
+            vehicleId = vehicle.id
+            scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+        }
+        val p2stop1 = prediction {
+            stopId = "1"
+            tripId = trip.id
+            vehicleId = vehicle.id
+        }
+
+        val p1stop2 = prediction {
+            stopId = "2"
+            tripId = trip.id
+            vehicleId = vehicle.id
+        }
+        val p2stop2 = prediction {
+            stopId = "2"
+            tripId = trip.id
+            vehicleId = vehicle.id
+        }
+
+        val existingPredictions =
+            PredictionsByStopJoinResponse(
+                predictionsByStop =
+                    mapOf(
+                        "1" to mapOf(p1stop1.id to p1stop1),
+                        "2" to mapOf(p1stop2.id to p1stop2, p2stop2.id to p2stop2)
+                    ),
+                trips = mapOf(trip.id to trip),
+                vehicles = mapOf(vehicle.id to vehicle)
+            )
+
+        val stop1NewPredictions =
+            PredictionsByStopMessageResponse(
+                stopId = "1",
+                predictions = mapOf(p1stop1updated.id to p1stop1updated, p2stop1.id to p2stop1),
+                trips = mapOf(),
+                vehicles = mapOf()
+            )
+
+        val result =
+            PredictionsByStopJoinResponse.mergePredictions(existingPredictions, stop1NewPredictions)
+
+        assertEquals(
+            mapOf(p1stop1updated.id to p1stop1updated, p2stop1.id to p2stop1),
+            result.predictionsByStop["1"]
+        )
+        assertEquals(
+            mapOf(p1stop2.id to p1stop2, p2stop2.id to p2stop2),
+            result.predictionsByStop["2"]
+        )
+        assertEquals(mapOf(trip.id to trip), result.trips)
+        assertEquals(mapOf(vehicle.id to vehicle), result.vehicles)
+    }
+
+    @Test
+    fun `mergePredictions removes trips and vehicles that are no longer referenced`() {
+        val trip1 = trip()
+        val vehicle1 = vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+
+        val trip2 = trip()
+        val vehicle2 = vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+
+        val p1stop1 = prediction {
+            stopId = "1"
+            tripId = trip1.id
+            vehicleId = vehicle1.id
+        }
+
+        val p1stop2 = prediction {
+            stopId = "2"
+            tripId = trip2.id
+            vehicleId = vehicle2.id
+        }
+
+        val existingPredictions =
+            PredictionsByStopJoinResponse(
+                predictionsByStop =
+                    mapOf("1" to mapOf(p1stop1.id to p1stop1), "2" to mapOf(p1stop2.id to p1stop2)),
+                trips = mapOf(trip1.id to trip1, trip2.id to trip2),
+                vehicles = mapOf(vehicle1.id to vehicle1, vehicle2.id to vehicle2)
+            )
+
+        val stop1NewPredictions =
+            PredictionsByStopMessageResponse(
+                stopId = "1",
+                predictions = mapOf(),
+                trips = mapOf(),
+                vehicles = mapOf()
+            )
+
+        val result =
+            PredictionsByStopJoinResponse.mergePredictions(existingPredictions, stop1NewPredictions)
+
+        assertEquals(mapOf(), result.predictionsByStop["1"])
+        assertEquals(mapOf(p1stop2.id to p1stop2), result.predictionsByStop["2"])
+        assertEquals(mapOf(trip2.id to trip2), result.trips)
+        assertEquals(mapOf(vehicle2.id to vehicle2), result.vehicles)
+    }
+
+    @Test
+    fun `toPredictionsStreamDataResponse flattens predictionsByStop  preserves trips + vehicles`() {
+        val trip1 = trip()
+        val vehicle1 = vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+
+        val trip2 = trip()
+        val vehicle2 = vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+
+        val p1stop1 = prediction {
+            stopId = "1"
+            tripId = trip1.id
+            vehicleId = vehicle1.id
+        }
+
+        val p1stop2 = prediction {
+            stopId = "2"
+            tripId = trip2.id
+            vehicleId = vehicle2.id
+        }
+
+        val data =
+            PredictionsByStopJoinResponse(
+                predictionsByStop =
+                    mapOf("1" to mapOf(p1stop1.id to p1stop1), "2" to mapOf(p1stop2.id to p1stop2)),
+                trips = mapOf(trip1.id to trip1, trip2.id to trip2),
+                vehicles = mapOf(vehicle1.id to vehicle1, vehicle2.id to vehicle2)
+            )
+
+        val response = PredictionsByStopJoinResponse.toPredictionsStreamDataResponse(data)
+
+        assertEquals(mapOf(p1stop1.id to p1stop1, p1stop2.id to p1stop2), response.predictions)
+        assertEquals(mapOf(trip1.id to trip1, trip2.id to trip2), response.trips)
+        assertEquals(mapOf(vehicle1.id to vehicle1, vehicle2.id to vehicle2), response.vehicles)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponseTest.kt
@@ -63,8 +63,7 @@ class PredictionsByStopJoinResponseTest {
                 vehicles = mapOf()
             )
 
-        val result =
-            PredictionsByStopJoinResponse.mergePredictions(existingPredictions, stop1NewPredictions)
+        val result = existingPredictions.mergePredictions(stop1NewPredictions)
 
         assertEquals(
             mapOf(p1stop1updated.id to p1stop1updated, p2stop1.id to p2stop1),
@@ -114,8 +113,7 @@ class PredictionsByStopJoinResponseTest {
                 vehicles = mapOf()
             )
 
-        val result =
-            PredictionsByStopJoinResponse.mergePredictions(existingPredictions, stop1NewPredictions)
+        val result = existingPredictions.mergePredictions(stop1NewPredictions)
 
         assertEquals(mapOf(), result.predictionsByStop["1"])
         assertEquals(mapOf(p1stop2.id to p1stop2), result.predictionsByStop["2"])
@@ -151,7 +149,7 @@ class PredictionsByStopJoinResponseTest {
                 vehicles = mapOf(vehicle1.id to vehicle1, vehicle2.id to vehicle2)
             )
 
-        val response = PredictionsByStopJoinResponse.toPredictionsStreamDataResponse(data)
+        val response = data.toPredictionsStreamDataResponse()
 
         assertEquals(mapOf(p1stop1.id to p1stop1, p1stop2.id to p1stop2), response.predictions)
         assertEquals(mapOf(trip1.id to trip1, trip2.id to trip2), response.trips)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -155,7 +155,7 @@ class PredictionsRepositoryTests : KoinTest {
         every { channel.attach() } returns push
 
         every { push.receive(any(), any()) } returns push
-        every { socket.getChannel("predictions:stops:v2:1,2", any()) } returns channel
+        every { socket.getChannel(any(), any()) } returns channel
         assertNull(predictionsRepo.channel)
         predictionsRepo.connectV2(
             stopIds = listOf("1", "2"),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -177,17 +177,25 @@ class PredictionsRepositoryTests : KoinTest {
     @Test
     fun testV2ChannelClearedOnLeave() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val channel = mock<PhoenixChannel>(MockMode.autofill)
+        val push = mock<PhoenixPush>(MockMode.autofill)
         val predictionsRepo = PredictionsRepository(socket)
-        every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
+        every { channel.attach() } returns push
+
+        every { push.receive(any(), any()) } returns push
+        every { socket.getChannel(any(), any()) } returns channel
+        assertNull(predictionsRepo.channel)
         predictionsRepo.connectV2(
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */},
             onMessage = { /* no-op */}
         )
+
         assertNotNull(predictionsRepo.channel)
 
         predictionsRepo.disconnect()
-        assertNull(predictionsRepo.channel)
+
+        verify { channel.detach() }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -124,4 +124,263 @@ class PredictionsRepositoryTests : KoinTest {
             }
         )
     }
+
+    @Test
+    fun testV2ChannelSetOnRun() {
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val channel = mock<PhoenixChannel>(MockMode.autofill)
+        val push = mock<PhoenixPush>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        every { channel.attach() } returns push
+        every { push.receive(any(), any()) } returns push
+        every { socket.getChannel("predictions:stops:v2:1,2", any()) } returns channel
+        assertNull(predictionsRepo.channel)
+        predictionsRepo.connectV2(
+            stopIds = listOf("1", "2"),
+            onJoin = { /* no-op */},
+            onMessage = { /* no-op */}
+        )
+
+        assertNotNull(predictionsRepo.channel)
+    }
+
+    @Test
+    fun testV2ChannelClearedOnLeave() {
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
+        predictionsRepo.connectV2(
+            stopIds = listOf("1", "2"),
+            onJoin = { /* no-op */},
+            onMessage = { /* no-op */}
+        )
+        assertNotNull(predictionsRepo.channel)
+
+        predictionsRepo.disconnect()
+        assertNull(predictionsRepo.channel)
+    }
+
+    @Test
+    fun testV2SetsPredictionsOnJoinResponse() {
+        class MockPush : PhoenixPush {
+            override fun receive(
+                status: PhoenixPushStatus,
+                callback: (PhoenixMessage) -> Unit
+            ): PhoenixPush {
+                if (status == PhoenixPushStatus.Ok) {
+                    callback(
+                        MockMessage(
+                            jsonBody =
+                                """
+                                {"predictions_by_stop":
+                                    {"12345":
+                                        {
+                                            "p_1": {
+                                                "id": "p_1",
+                                                "arrival_time": null,
+                                                "departure_time": null,
+                                                "direction_id": 0,
+                                                "revenue": false,
+                                                "schedule_relationship": "scheduled",
+                                                "status": null,
+                                                "route_id": "66",
+                                                "stop_id": "12345",
+                                                "trip_id": "t_1",
+                                                "vehicle_id": "v_1",
+                                                "stop_sequence": 38
+                                            }
+                                        }
+                                    },
+                                    "trips": {
+                                        "t_1": {
+                                            "id": "t_1",
+                                            "direction_id": 0,
+                                            "headsign": "Nubian",
+                                            "route_id": "66",
+                                            "route_pattern_id": "66-0-0",
+                                            "shape_id": "shape_id",
+                                            "stop_ids": []
+                                        }
+                                    },
+                                    "vehicles": {
+                                        "v_1": {
+                                            "id": "v_1",
+                                            "bearing": 351,
+                                            "current_status": "in_transit_to",
+                                            "current_stop_sequence": 17,
+                                            "direction_id": 0,
+                                            "route_id": "66",
+                                            "trip_id": "t_1",
+                                            "stop_id": "12345",
+                                            "latitude": 42.34114183,
+                                            "longitude": -71.121119039,
+                                            "updated_at": "2024-09-23T11:30:26-04:00"
+
+                                        }
+                                    }
+                                }
+                            """
+                                    .trimIndent()
+                        )
+                    )
+                }
+                return this
+            }
+        }
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        val channel = mock<PhoenixChannel>(MockMode.autofill)
+        val push = MockPush()
+        every { socket.getChannel(any(), any()) } returns channel
+        every { channel.attach() } returns push
+
+        predictionsRepo.connectV2(
+            stopIds = listOf("1"),
+            onJoin = { outcome ->
+                outcome.data?.let {
+                    assertEquals(1, it.predictionsByStop.size)
+                    assertEquals("p_1", it.predictionsByStop["12345"]?.get("p_1")?.id)
+
+                    assertEquals(1, it.trips.size)
+                    assertEquals("t_1", it.trips["t_1"]?.id)
+
+                    assertEquals(1, it.vehicles.size)
+                    assertEquals("v_1", it.vehicles["v_1"]?.id)
+                }
+                outcome.error?.let { fail() }
+            },
+            onMessage = { /* no-op */}
+        )
+    }
+
+    @Test
+    fun testV2HandleV2Message() {
+
+        val message =
+            MockMessage(
+                jsonBody =
+                    """
+                                {
+                                    "stop_id": "12345",
+                                    "predictions":
+                                        {
+                                            "p_1": {
+                                                "id": "p_1",
+                                                "arrival_time": null,
+                                                "departure_time": null,
+                                                "direction_id": 0,
+                                                "revenue": false,
+                                                "schedule_relationship": "scheduled",
+                                                "status": null,
+                                                "route_id": "66",
+                                                "stop_id": "12345",
+                                                "trip_id": "t_1",
+                                                "vehicle_id": "v_1",
+                                                "stop_sequence": 38
+                                            }
+                                        },
+                                        "trips": {
+                                            "t_1": {
+                                                "id": "t_1",
+                                                "direction_id": 0,
+                                                "headsign": "Nubian",
+                                                "route_id": "66",
+                                                "route_pattern_id": "66-0-0",
+                                                "shape_id": "shape_id",
+                                                "stop_ids": []
+                                            }
+                                        },
+                                        "vehicles": {
+                                            "v_1": {
+                                                "id": "v_1",
+                                                "bearing": 351,
+                                                "current_status": "in_transit_to",
+                                                "current_stop_sequence": 17,
+                                                "direction_id": 0,
+                                                "route_id": "66",
+                                                "trip_id": "t_1",
+                                                "stop_id": "12345",
+                                                "latitude": 42.34114183,
+                                                "longitude": -71.121119039,
+                                                "updated_at": "2024-09-23T11:30:26-04:00"
+
+                                            }
+                                        }
+                                }
+                            """
+                        .trimIndent()
+            )
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        predictionsRepo.handleV2Message(
+            message,
+            onMessage = { outcome ->
+                outcome.data?.let {
+                    assertEquals("12345", it.stopId)
+                    assertEquals("p_1", it.predictions["p_1"]?.id)
+
+                    assertEquals(1, it.trips.size)
+                    assertEquals("t_1", it.trips["t_1"]?.id)
+
+                    assertEquals(1, it.vehicles.size)
+                    assertEquals("v_1", it.vehicles["v_1"]?.id)
+                }
+                outcome.error?.let { fail() }
+            }
+        )
+    }
+
+    @Test
+    fun testV2SetsErrorWhenReceivedOnJoin() {
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        val push = mock<PhoenixPush>(MockMode.autofill)
+        every { push.receive(any(), any()) } returns push
+        class MockChannel : PhoenixChannel {
+            override fun onEvent(event: String, callback: (PhoenixMessage) -> Unit) {
+                /* no-op */
+            }
+
+            override fun onFailure(callback: (message: PhoenixMessage) -> Unit) {
+                callback(MockMessage())
+            }
+
+            override fun onDetach(callback: (PhoenixMessage) -> Unit) {
+                /* no-op */
+            }
+
+            override fun attach(): PhoenixPush {
+                return push
+            }
+
+            override fun detach(): PhoenixPush {
+                return push
+            }
+        }
+        every { socket.getChannel(any(), any()) } returns MockChannel()
+        predictionsRepo.connectV2(
+            stopIds = listOf("1"),
+            onJoin = { outcome ->
+                assertNotNull(outcome.error)
+                assertEquals(outcome.error, SocketError.Unknown)
+            },
+            onMessage = { /* no-op */}
+        )
+    }
+
+    @Test
+    fun testV2SetsErrorWhenReceivedOnMessage() {
+
+        val message = MockMessage(jsonBody = "BAD_DATA")
+        val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val predictionsRepo = PredictionsRepository(socket)
+        predictionsRepo.handleV2Message(
+            message,
+            onMessage = { outcome ->
+                outcome.data?.let { fail() }
+
+                outcome.error?.let { error -> assertEquals(SocketError.Unknown, error) }
+            }
+        )
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Predictions Scalability: use new predictions channel](https://app.asana.com/0/1205732265579288/1207791938443981/f)

What is this PR for?

This switches nearby transit & stop details to use the new predictions channel, currently behind a cutover. Temporarily pointing to dev-orange to pick up https://github.com/mbta/mobile_app_backend/pull/203, will remove that before merging.

### Testing

What testing have you done?

Added a few unit tests & ran locally to confirm predictions continued to update as expected.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
