### PR TITLE
fix: Don't sort disrupted routes without schedules to the bottom of nearby transit

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -572,13 +572,7 @@ fun NearbyStaticData.withRealtimeInfo(
             compareBy<StopsAssociated, Route>(Route.pinnedRoutesComparator(pinnedRoutes)) {
                     it.sortRoute()
                 }
-                .thenBy {
-                    it.patternsByStop.all { byStop ->
-                        byStop.patterns.all { patterns ->
-                            patterns.upcomingTrips.isNullOrEmpty() && !patterns.hasSchedulesToday
-                        }
-                    }
-                }
+                .thenBy { !it.hasSchedulesToday }
                 .thenBy(Route.subwayFirstComparator) { it.sortRoute() }
                 .thenBy { it.distanceFrom(sortByDistanceFrom) }
                 .thenBy { it.sortRoute() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -572,7 +572,7 @@ fun NearbyStaticData.withRealtimeInfo(
             compareBy<StopsAssociated, Route>(Route.pinnedRoutesComparator(pinnedRoutes)) {
                     it.sortRoute()
                 }
-                .thenBy { !it.hasSchedulesToday }
+                .thenBy { !it.hasServiceOrDisruptionToday }
                 .thenBy(Route.subwayFirstComparator) { it.sortRoute() }
                 .thenBy { it.distanceFrom(sortByDistanceFrom) }
                 .thenBy { it.sortRoute() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -23,6 +23,11 @@ sealed class RealtimePatterns : Comparable<RealtimePatterns> {
     abstract val alertsHere: List<Alert>?
     abstract val hasSchedulesToday: Boolean
 
+    val hasMajorAlerts
+        get() = run {
+            this.alertsHere?.any { alert -> alert.significance == AlertSignificance.Major } == true
+        }
+
     /**
      * @property patterns [RoutePattern] listed in ascending order based on [RoutePattern.sortOrder]
      * @property upcomingTrips Every [UpcomingTrip] for the [Stop] in the containing

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopsAssociated.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopsAssociated.kt
@@ -7,7 +7,13 @@ sealed class StopsAssociated() {
     abstract val id: String
     abstract val patternsByStop: List<PatternsByStop>
 
-    val hasSchedulesToday
+    /**
+     * @property hasServiceOrDisruptionToday This is used to determine whether or not the route
+     *   should be sorted to the bottom of the nearby transit list. If this is false, it means that
+     *   service is not running or expected to run today, and that's not because of a disruption
+     *   which we would want to leave in place.
+     */
+    val hasServiceOrDisruptionToday
         get() = run {
             this.patternsByStop.any { byStop ->
                 byStop.patterns.any { patterns ->

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopsAssociated.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopsAssociated.kt
@@ -7,6 +7,17 @@ sealed class StopsAssociated() {
     abstract val id: String
     abstract val patternsByStop: List<PatternsByStop>
 
+    val hasSchedulesToday
+        get() = run {
+            this.patternsByStop.any { byStop ->
+                byStop.patterns.any { patterns ->
+                    patterns.hasSchedulesToday ||
+                        patterns.hasMajorAlerts ||
+                        patterns.upcomingTrips?.isNotEmpty() == true
+                }
+            }
+        }
+
     fun distanceFrom(position: Position): Double = this.distance(position)
 
     fun isEmpty(): Boolean = this.patternsByStop.isEmpty()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
@@ -2338,5 +2339,113 @@ class NearbyResponseTest {
 
         assertTrue(hasSchedulesToday?.get(routePatternA.id)!!)
         assertNull(hasSchedulesToday[routePatternB.id])
+    }
+
+    @Test
+    fun `StopsAssociated hasServiceOrDisruptionToday is true when expected`() {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route { sortOrder = 1 }
+        val routePattern = objects.routePattern(route)
+        val trip = objects.trip(routePattern)
+
+        val time = Instant.parse("2024-03-18T10:41:13-04:00")
+
+        assertTrue(
+            StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePattern),
+                                    emptyList(),
+                                    emptyList(),
+                                    true
+                                )
+                            )
+                        )
+                    )
+                )
+                .hasServiceOrDisruptionToday
+        )
+        assertTrue(
+            StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "B",
+                                    null,
+                                    listOf(routePattern),
+                                    listOf(
+                                        objects.upcomingTrip(
+                                            objects.prediction {
+                                                tripId = trip.id
+                                                departureTime = time + 1.5.minutes
+                                            }
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+                .hasServiceOrDisruptionToday
+        )
+        assertTrue(
+            StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "B",
+                                    null,
+                                    listOf(routePattern),
+                                    listOf(),
+                                    listOf(objects.alert { effect = Alert.Effect.Suspension })
+                                )
+                            )
+                        )
+                    )
+                )
+                .hasServiceOrDisruptionToday
+        )
+        assertFalse(
+            StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "B",
+                                    null,
+                                    listOf(routePattern),
+                                    listOf(),
+                                    listOf(),
+                                    false
+                                )
+                            )
+                        )
+                    )
+                )
+                .hasServiceOrDisruptionToday
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -1428,7 +1429,7 @@ class NearbyResponseTest {
                 typicality = RoutePattern.Typicality.Typical
             }
         val midSubwayPattern =
-            objects.routePattern(farSubwayRoute) {
+            objects.routePattern(midSubwayRoute) {
                 sortOrder = 1
                 representativeTrip { headsign = "Medford/Tufts" }
                 typicality = RoutePattern.Typicality.Typical
@@ -1510,6 +1511,123 @@ class NearbyResponseTest {
                 closeSubwayRoute,
                 closeBusRoute,
                 farBusRoute
+            ),
+            realtimeRoutesSorted.flatMap {
+                when (it) {
+                    is StopsAssociated.WithRoute -> listOf(it.route)
+                    is StopsAssociated.WithLine -> it.routes
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `withRealtimeInfo doesn't sort unscheduled routes to the bottom if they are disrupted`() {
+        val objects = ObjectCollectionBuilder()
+
+        val closeSubwayStop = objects.stop()
+        val midSubwayStop =
+            objects.stop {
+                latitude = closeSubwayStop.latitude + 0.3
+                longitude = closeSubwayStop.longitude + 0.3
+            }
+        val farSubwayStop =
+            objects.stop {
+                latitude = closeSubwayStop.latitude + 0.5
+                longitude = closeSubwayStop.longitude + 0.5
+            }
+
+        // No alerts, no schedules
+        val closeSubwayRoute =
+            objects.route {
+                id = "close-subway"
+                type = RouteType.HEAVY_RAIL
+            }
+        // Some alerts, no schedules
+        val midSubwayRoute =
+            objects.route {
+                id = "mid-subway"
+                type = RouteType.LIGHT_RAIL
+            }
+        // No alerts, some schedules
+        val farSubwayRoute =
+            objects.route {
+                id = "far-subway"
+                type = RouteType.HEAVY_RAIL
+            }
+
+        val closeSubwayPattern =
+            objects.routePattern(closeSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Alewife" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val midSubwayPattern =
+            objects.routePattern(midSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Medford/Tufts" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val farSubwayPattern =
+            objects.routePattern(farSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Oak Grove" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(farSubwayRoute) {
+                    stop(farSubwayStop) { headsign("Oak Grove", listOf(farSubwayPattern)) }
+                }
+                route(midSubwayRoute) {
+                    stop(midSubwayStop) { headsign("Medford/Tufts", listOf(midSubwayPattern)) }
+                }
+                route(closeSubwayRoute) {
+                    stop(closeSubwayStop) { headsign("Alewife", listOf(closeSubwayPattern)) }
+                }
+            }
+
+        val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+        objects.schedule {
+            routeId = farSubwayRoute.id
+            tripId = farSubwayPattern.representativeTripId
+        }
+
+        objects.alert {
+            activePeriod(time.minus(2.days), time.plus(2.days))
+            effect = Alert.Effect.Suspension
+            informedEntity(
+                listOf(
+                    Alert.InformedEntity.Activity.Board,
+                    Alert.InformedEntity.Activity.Exit,
+                    Alert.InformedEntity.Activity.Ride
+                ),
+                route = midSubwayRoute.id,
+                routeType = midSubwayRoute.type,
+                stop = midSubwayStop.id
+            )
+        }
+
+        val realtimeRoutesSorted =
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects, emptyMap()),
+                sortByDistanceFrom = closeSubwayStop.position,
+                predictions = PredictionsStreamDataResponse(objects),
+                schedules = ScheduleResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),
+            )
+
+        // If a route has major disruptions and doesn't have any scheduled trips, it should still
+        // be sorted as it normally would be.
+        assertEquals(
+            listOf(
+                midSubwayRoute,
+                farSubwayRoute,
+                closeSubwayRoute,
             ),
             realtimeRoutesSorted.flatMap {
                 when (it) {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -317,6 +317,38 @@ class RealtimePatternsTest {
     }
 
     @Test
+    fun `hasMajorAlerts is true when a major alert is active`() = parametricTest {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+
+        val majorAlert = objects.alert { effect = Alert.Effect.Suspension }
+        val minorAlert = objects.alert { effect = Alert.Effect.FacilityIssue }
+
+        assertTrue(
+            RealtimePatterns.ByHeadsign(
+                    route,
+                    "",
+                    null,
+                    emptyList(),
+                    emptyList(),
+                    listOf(majorAlert)
+                )
+                .hasMajorAlerts
+        )
+        assertFalse(
+            RealtimePatterns.ByHeadsign(
+                    route,
+                    "",
+                    null,
+                    emptyList(),
+                    emptyList(),
+                    listOf(minorAlert)
+                )
+                .hasMajorAlerts
+        )
+    }
+
+    @Test
     fun `hasSchedulesToday returns true when schedules exist or have not loaded`() {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()


### PR DESCRIPTION
### Summary

_Ticket:_ Follow up fix for [Handle no service for the entire service day](https://app.asana.com/0/1205732265579288/1208217009015138/f)

In response to [this slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1727187298728979), routes that have major disruptions should still show up in their usual place in nearby transit.

### Testing

Added a test for sorting behavior with alerts