### PR TITLE
fix: Add missing alert cause enum values

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -202,6 +202,12 @@
     "Fire" : {
       "comment" : "Possible alert cause"
     },
+    "Fire Department Activity" : {
+      "comment" : "Possible alert cause"
+    },
+    "Flooding" : {
+      "comment" : "Possible alert cause"
+    },
     "Fog" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -61,6 +61,8 @@ struct AlertDetails: View {
         case .drawbridgeBeingRaised: NSLocalizedString("Drawbridge Being Raised", comment: "Possible alert cause")
         case .electricalWork: NSLocalizedString("Electrical Work", comment: "Possible alert cause")
         case .fire: NSLocalizedString("Fire", comment: "Possible alert cause")
+        case .fireDepartmentActivity: NSLocalizedString("Fire Department Activity", comment: "Possible alert cause")
+        case .flooding: NSLocalizedString("Flooding", comment: "Possible alert cause")
         case .fog: NSLocalizedString("Fog", comment: "Possible alert cause")
         case .freightTrainInterference: NSLocalizedString("Freight Train Interference", comment: "Possible alert cause")
         case .hazmatCondition: NSLocalizedString("Hazmat Condition", comment: "Possible alert cause")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -74,6 +74,8 @@ data class Alert(
         @SerialName("drawbridge_being_raised") DrawbridgeBeingRaised,
         @SerialName("electrical_work") ElectricalWork,
         @SerialName("fire") Fire,
+        @SerialName("fire_department_activity") FireDepartmentActivity,
+        @SerialName("flooding") Flooding,
         @SerialName("fog") Fog,
         @SerialName("freight_train_interference") FreightTrainInterference,
         @SerialName("hazmat_condition") HazmatCondition,


### PR DESCRIPTION
### Summary

_Ticket:_ Tangentially related to [Allow for fallback enum values in the backend API parsing code](https://app.asana.com/0/1205732265579288/1207992284641906/f)

Add alert enum cause values which we've gotten sentry errors for.