### PR TITLE
refactor: flatten ErrorDetails into ApiResult.Error

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/repositories/AppCheckRepository.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/repositories/AppCheckRepository.kt
@@ -1,12 +1,11 @@
 package com.mbta.tid.mbta_app.android.repositories
 
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.repositories.IAppCheckRepository
 import com.mbta.tid.mbta_app.repositories.Token
 
 class AppCheckRepository : IAppCheckRepository {
     override suspend fun getToken(): ApiResult<Token> {
-        return ApiResult.Error(ErrorDetails(message = "TODO: Implement"))
+        return ApiResult.Error(message = "TODO: Implement")
     }
 }

--- a/iosApp/iosApp/Analytics/AppCheckRepository.swift
+++ b/iosApp/iosApp/Analytics/AppCheckRepository.swift
@@ -17,7 +17,7 @@ class AppCheckRepository: IAppCheckRepository {
             let token = try await AppCheck.appCheck().token(forcingRefresh: false)
             return ApiResultOk(data: Token(token: token.token))
         } catch {
-            return ApiResultError(error: ErrorDetails(code: nil, message: "\(error)"))
+            return ApiResultError(code: nil, message: "\(error)")
         }
     }
 }

--- a/iosApp/iosApp/ContentViewModel.swift
+++ b/iosApp/iosApp/ContentViewModel.swift
@@ -43,7 +43,7 @@ class ContentViewModel: ObservableObject {
         do {
             configResponse = try await configUseCase.getConfig()
         } catch {
-            configResponse = ApiResultError(error: .init(code: nil, message: "\(error.localizedDescription)"))
+            configResponse = ApiResultError(code: nil, message: "\(error.localizedDescription)")
         }
     }
 }

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -307,7 +307,7 @@ final class TripDetailsPageTests: XCTestCase {
         let tripSchedulesLoaded = PassthroughSubject<Void, Never>()
 
         let tripRepository = FakeTripRepository(
-            tripError: .init(code: 404, message: "Bad response"),
+            tripError: ApiResultError(code: 404, message: "Bad response"),
             scheduleResponse: TripSchedulesResponse.StopIds(stopIds: []),
             onGetTripSchedules: { tripSchedulesLoaded.send() }
         )
@@ -521,12 +521,12 @@ final class TripDetailsPageTests: XCTestCase {
         }
 
         init(
-            tripError: ErrorDetails,
+            tripError: ApiResultError<TripResponse>,
             scheduleResponse: TripSchedulesResponse,
             onGetTrip: (() -> Void)? = nil,
             onGetTripSchedules: (() -> Void)? = nil
         ) {
-            tripResponse = ApiResultError(error: tripError)
+            tripResponse = tripError
             self.scheduleResponse = scheduleResponse
             self.onGetTrip = onGetTrip
             self.onGetTripSchedules = onGetTripSchedules

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
@@ -1,11 +1,7 @@
 package com.mbta.tid.mbta_app.model.response
 
-import kotlinx.serialization.Serializable
-
-@Serializable data class ErrorDetails(val code: Int? = null, val message: String)
-
 sealed class ApiResult<T : Any> {
     data class Ok<T : Any>(val data: T) : ApiResult<T>()
 
-    data class Error<T : Any>(val error: ErrorDetails) : ApiResult<T>()
+    data class Error<T : Any>(val code: Int? = null, val message: String) : ApiResult<T>()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepository.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.call.body
 import io.ktor.client.request.header
@@ -18,7 +17,7 @@ interface IConfigRepository {
     suspend fun getConfig(token: String): ApiResult<ConfigResponse>
 }
 
-class ConfigRepository() : IConfigRepository, KoinComponent {
+class ConfigRepository : IConfigRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     override suspend fun getConfig(token: String): ApiResult<ConfigResponse> {
@@ -34,10 +33,10 @@ class ConfigRepository() : IConfigRepository, KoinComponent {
             if (response.status === HttpStatusCode.OK) {
                 return ApiResult.Ok(data = json.decodeFromString(response.body()))
             } else {
-                return ApiResult.Error(ErrorDetails(response.status.value, response.bodyAsText()))
+                return ApiResult.Error(response.status.value, response.bodyAsText())
             }
         } catch (e: Exception) {
-            return ApiResult.Error(ErrorDetails(message = e.message ?: e.toString()))
+            return ApiResult.Error(message = e.message ?: e.toString())
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripRepository.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.TripShape
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.model.response.TripResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
@@ -11,6 +10,7 @@ import io.ktor.client.call.body
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.path
 import io.ktor.serialization.JsonConvertException
@@ -60,10 +60,13 @@ class TripRepository : ITripRepository, KoinComponent {
             if (response.status === HttpStatusCode.OK) {
                 return ApiResult.Ok(data = json.decodeFromString(response.body()))
             } else {
-                return ApiResult.Error(json.decodeFromString<ErrorDetails>(response.body()))
+                return ApiResult.Error(
+                    code = response.status.value,
+                    message = response.bodyAsText()
+                )
             }
         } catch (e: Exception) {
-            return ApiResult.Error(ErrorDetails(message = e.message ?: e.toString()))
+            return ApiResult.Error(message = e.message ?: e.toString())
         }
     }
 
@@ -80,10 +83,13 @@ class TripRepository : ITripRepository, KoinComponent {
             if (response.status === HttpStatusCode.OK) {
                 return ApiResult.Ok(data = json.decodeFromString(response.body()))
             } else {
-                return ApiResult.Error(json.decodeFromString<ErrorDetails>(response.body()))
+                return ApiResult.Error(
+                    code = response.status.value,
+                    message = response.bodyAsText()
+                )
             }
         } catch (e: Exception) {
-            return ApiResult.Error(ErrorDetails(message = e.message ?: e.toString()))
+            return ApiResult.Error(message = e.message ?: e.toString())
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUseCase.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.usecases
 
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.repositories.IAppCheckRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import org.koin.core.component.KoinComponent
@@ -12,21 +11,16 @@ class ConfigUseCase(
     private val configRepo: IConfigRepository
 ) : KoinComponent {
 
-    suspend fun getConfig(): ApiResult<ConfigResponse> {
+    suspend fun getConfig(): ApiResult<ConfigResponse> =
         try {
             when (val tokenResult = appCheckRepo.getToken()) {
                 is ApiResult.Error ->
-                    return ApiResult.Error(
-                        ErrorDetails(
-                            message = "app check token failure ${tokenResult.error.message}"
-                        )
-                    )
+                    ApiResult.Error(message = "app check token failure ${tokenResult.message}")
                 is ApiResult.Ok -> {
-                    return configRepo.getConfig(tokenResult.data.token)
+                    configRepo.getConfig(tokenResult.data.token)
                 }
             }
         } catch (e: Exception) {
-            return ApiResult.Error(ErrorDetails(message = e.message ?: e.toString()))
+            ApiResult.Error(message = e.message ?: e.toString())
         }
-    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepositoryTests.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -14,6 +13,8 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -75,10 +76,9 @@ class ConfigRepositoryTests {
         runBlocking {
             val response = ConfigRepository().getConfig("token")
 
-            assertEquals(
-                response,
-                ApiResult.Error(ErrorDetails(code = 401, message = "{\"message\": \"oh no\"}"))
-            )
+            assertIs<ApiResult.Error<*>>(response)
+            assertEquals(401, response.code)
+            assertTrue(response.message.contains("{\"message\": \"oh no\"}"))
         }
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.model.Shape
 import com.mbta.tid.mbta_app.model.TripShape
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.model.response.ShapeWithStops
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
@@ -16,6 +15,7 @@ import io.ktor.http.headersOf
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 import kotlinx.coroutines.runBlocking
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -113,12 +113,11 @@ class TripRepositoryTest : KoinTest {
         }
 
         runBlocking {
-            val apiResult: ApiResult<TripShape> = TripRepository().getTripShape(tripId = "12345")
+            val apiResult = TripRepository().getTripShape(tripId = "12345")
 
-            assertEquals(
-                ApiResult.Error(error = ErrorDetails(code = 404, message = "not_found")),
-                apiResult
-            )
+            assertIs<ApiResult.Error<*>>(apiResult)
+            assertEquals(404, apiResult.code)
+            assertContains(apiResult.message, "not_found")
         }
 
         stopKoin()
@@ -140,10 +139,10 @@ class TripRepositoryTest : KoinTest {
         }
 
         runBlocking {
-            val apiResult: ApiResult.Error<TripShape> =
-                TripRepository().getTripShape(tripId = "12345") as ApiResult.Error<TripShape>
+            val apiResult = TripRepository().getTripShape(tripId = "12345")
+            assertIs<ApiResult.Error<*>>(apiResult)
 
-            assertContains(apiResult.error.message, "Field 'shape_with_stops' is required for type")
+            assertContains(apiResult.message, "Field 'shape_with_stops' is required for type")
         }
 
         stopKoin()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUsecaseTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUsecaseTests.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.usecases
 
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
-import com.mbta.tid.mbta_app.model.response.ErrorDetails
 import com.mbta.tid.mbta_app.repositories.MockAppCheckRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
 import kotlin.test.Test
@@ -27,7 +26,7 @@ class ConfigUsecaseTests {
 
     @Test
     fun testGetConfigAppCheckError() {
-        val appCheckRepo = MockAppCheckRepository(ApiResult.Error(ErrorDetails(message = "oops")))
+        val appCheckRepo = MockAppCheckRepository(ApiResult.Error(message = "oops"))
         val configRepo =
             MockConfigRepository(ApiResult.Ok(ConfigResponse(mapboxPublicToken = "fake_token")))
 
@@ -35,10 +34,7 @@ class ConfigUsecaseTests {
             val response =
                 ConfigUseCase(appCheckRepo = appCheckRepo, configRepo = configRepo).getConfig()
 
-            assertEquals(
-                ApiResult.Error(ErrorDetails(message = "app check token failure oops")),
-                response
-            )
+            assertEquals(ApiResult.Error(message = "app check token failure oops"), response)
         }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [General data error banner](https://app.asana.com/0/1205732265579288/1208304466486199/f)

If we create `ApiResult.Error`s for every failure and not just non-success HTTP responses from the backend, we will benefit from it being more straightforward to create `ApiResult.Error`s from things that are not HTTP responses.

### Testing

Ran unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
