### PR TITLE
fix: Tweak map pan deceleration

### DIFF
--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -38,7 +38,11 @@ struct AnnotatedMap: View {
 
     var body: some View {
         map
-            .gestureOptions(.init(rotateEnabled: false, pitchEnabled: false))
+            .gestureOptions(.init(
+                rotateEnabled: false,
+                pitchEnabled: false,
+                panDecelerationFactor: 0.99
+            ))
             .mapStyle(.init(uri: appVariant.styleUri(colorScheme: colorScheme)))
             .debugOptions(mapDebug ? .camera : [])
             .onCameraChanged { change in handleCameraChange(change) }


### PR DESCRIPTION
### Summary

_Ticket:_ [Make map movement less slippery](https://app.asana.com/0/1205732265579288/1208437030601033/f)

Change how quickly the map decelerates after you fling it with a pan or during a zoom. This prevents the map from feeling slippery and accidentally flinging your location far away from the place you want to be.

### Testing

Not testable with code, but tried a few values manually to find a comfortable value, and gave it to Paul to demo.