### PR TITLE
feat: Prevent map zooming when navigating between stop details and nearby transit

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -54,7 +54,6 @@ import com.mbta.tid.mbta_app.android.util.rememberPrevious
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.android.util.toPoint
 import com.mbta.tid.mbta_app.map.ColorPalette
-import com.mbta.tid.mbta_app.map.MapDefaults
 import com.mbta.tid.mbta_app.map.RouteFeaturesBuilder
 import com.mbta.tid.mbta_app.map.RouteLineData
 import com.mbta.tid.mbta_app.map.StopFeaturesBuilder
@@ -143,8 +142,7 @@ fun HomeMapView(
         val stopPoint =
             stopFeature?.geometry() as? Point ?: Point.fromLngLat(stop.longitude, stop.latitude)
         mapViewportState.easeTo(
-            cameraOptions =
-                CameraOptions.Builder().center(stopPoint).zoom(MapDefaults.stopPageZoom).build(),
+            cameraOptions = CameraOptions.Builder().center(stopPoint).build(),
             animationOptions = MapAnimationDefaults.options
         )
     }

--- a/iosApp/iosApp/Fetchers/ViewportProvider.swift
+++ b/iosApp/iosApp/Fetchers/ViewportProvider.swift
@@ -124,9 +124,16 @@ class ViewportProvider: ObservableObject {
     }
 
     func restoreNearbyTransitViewport() {
-        if let savedNearbyTransitViewport {
+        if let saved = savedNearbyTransitViewport {
             withViewportAnimation(Defaults.animation) {
-                self.viewport = savedNearbyTransitViewport
+                let currentZoom = cameraStateSubject.value.zoom
+                self.viewport = if let camera = saved.camera {
+                    .camera(center: camera.center, zoom: currentZoom)
+                } else if let _ = saved.followPuck {
+                    .followPuck(zoom: currentZoom)
+                } else {
+                    saved
+                }
             }
         }
         savedNearbyTransitViewport = nil

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -146,7 +146,7 @@ extension HomeMapView {
 
     func handleStopDetailsChange(_ stop: Stop, _ filter: StopDetailsFilter?) {
         mapVM.stopSourceData = .init(selectedStopId: stop.id)
-        viewportProvider.animateTo(coordinates: stop.coordinate, zoom: MapDefaults.shared.stopPageZoom)
+        viewportProvider.animateTo(coordinates: stop.coordinate)
 
         Task {
             stopMapData = try await stopRepository.getStopMapData(stopId: stop.id)

--- a/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
+++ b/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
@@ -57,11 +57,33 @@ final class ViewportProviderTest: XCTestCase {
     func testSaveFollowing() throws {
         let provider = ViewportProvider(viewport: .followPuck(zoom: 16.0))
 
+        let newCenter: CLLocationCoordinate2D = .init(latitude: 1, longitude: 1)
+        let newZoom: CGFloat = 17.0
         provider.saveNearbyTransitViewport()
-        provider.animateTo(coordinates: .init(latitude: 1, longitude: 1), zoom: 17.0)
+        provider.animateTo(coordinates: newCenter, zoom: newZoom)
+        provider.updateCameraState(
+            .init(center: newCenter, padding: .zero, zoom: newZoom, bearing: 0, pitch: 0)
+        )
         provider.restoreNearbyTransitViewport()
 
-        XCTAssertEqual(provider.viewport.followPuck?.zoom, 16.0)
+        XCTAssertEqual(provider.viewport.followPuck?.zoom, newZoom)
+    }
+
+    func testSaveCameraLocation() throws {
+        let startCenter: CLLocationCoordinate2D = .init(latitude: 0, longitude: 0)
+        let provider = ViewportProvider(viewport: .camera(center: startCenter, zoom: 16.0))
+
+        let newCenter: CLLocationCoordinate2D = .init(latitude: 1, longitude: 1)
+        let newZoom: CGFloat = 14.0
+        provider.saveNearbyTransitViewport()
+        provider.animateTo(coordinates: newCenter, zoom: newZoom)
+        provider.updateCameraState(
+            .init(center: newCenter, padding: .zero, zoom: newZoom, bearing: 0, pitch: 0)
+        )
+        provider.restoreNearbyTransitViewport()
+
+        XCTAssertEqual(provider.viewport.camera?.center, startCenter)
+        XCTAssertEqual(provider.viewport.camera?.zoom, newZoom)
     }
 
     func testSavePanned() throws {

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -158,11 +158,18 @@ final class HomeMapViewTests: XCTestCase {
         ViewHosting.host(view: sut)
         wait(for: [hasAppeared], timeout: 1)
         XCTAssertEqual(ViewportProvider.Defaults.center, sut.viewportProvider.viewport.camera!.center)
+        XCTAssertEqual(ViewportProvider.Defaults.zoom, sut.viewportProvider.viewport.camera!.zoom)
+
+        let newZoom = 10.0
+        sut.viewportProvider.updateCameraState(
+            .init(center: .init(latitude: 0, longitude: 0), padding: .zero, zoom: newZoom, bearing: 0, pitch: 0)
+        )
 
         let newEntry: SheetNavigationStackEntry = .stopDetails(stop, nil)
 
         try sut.inspect().find(ProxyModifiedMap.self).callOnChange(newValue: newEntry)
         XCTAssertEqual(stop.coordinate, sut.viewportProvider.viewport.camera!.center)
+        XCTAssertEqual(newZoom, sut.viewportProvider.viewport.camera!.zoom)
     }
 
     func testUpdatesStopSourceWhenStopSelected() throws {
@@ -880,7 +887,7 @@ final class HomeMapViewTests: XCTestCase {
     }
 
     func testJoinsVehiclesChannelOnActiveWhenTripDetails() {
-        var joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
+        let joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
 
         var sut = HomeMapView(
             mapVM: .init(),
@@ -905,7 +912,7 @@ final class HomeMapViewTests: XCTestCase {
     }
 
     func testJoinsVehiclesChannelOnActiveWhenFilteredStopDetails() {
-        var joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
+        let joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
 
         let stop = ObjectCollectionBuilder().stop { _ in }
 
@@ -928,7 +935,7 @@ final class HomeMapViewTests: XCTestCase {
     }
 
     func testDoesntJoinsVehiclesChannelOnActiveWhenUnfilteredtopDetails() {
-        var joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
+        let joinsVehiclesExp = XCTestExpectation(description: "Joins vehicles channel")
 
         joinsVehiclesExp.isInverted = true
 
@@ -952,7 +959,7 @@ final class HomeMapViewTests: XCTestCase {
     }
 
     func testLeavesVehiclesChannelOnbackground() {
-        var leavesVehiclesExp = XCTestExpectation(description: "Leaves vehicles channel")
+        let leavesVehiclesExp = XCTestExpectation(description: "Leaves vehicles channel")
 
         let stop = ObjectCollectionBuilder().stop { _ in }
 
@@ -975,7 +982,7 @@ final class HomeMapViewTests: XCTestCase {
     }
 
     func testClearsVehiclesOnNavClear() {
-        var leavesVehiclesExp = XCTestExpectation(description: "Leaves vehicles channel")
+        let leavesVehiclesExp = XCTestExpectation(description: "Leaves vehicles channel")
 
         let stop = ObjectCollectionBuilder().stop { _ in }
         let vehicle = ObjectCollectionBuilder().vehicle { vehicle in

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapDefaults.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapDefaults.kt
@@ -4,5 +4,4 @@ object MapDefaults {
     val midZoomThreshold = 11.0
     val closeZoomThreshold = 15.0
     val defaultZoomThreshold = 16.0
-    val stopPageZoom = 17.0
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Don't zoom map when navigating to Nearby Transit or Stop Details](https://app.asana.com/0/1205732265579288/1208389938532288/f)

There was too much map movement when transitioning between nearby transit, stop details, and trip details. We don't want to zoom in and out so much on every page transition. This change makes it so that the camera simply pans at the current zoom level to the selected stop on the stop page, or the previous location in nearby transit.

### Testing

Updated existing tests of this behavior to also assert zoom level, and added a new test for returning to a saved camera state.