### PR TITLE
fix(StopDetails): use updated now throughout child views

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -79,6 +79,7 @@ struct StopDetailsPage: View {
                 setFilter: { filter in nearbyVM.pushNavEntry(.stopDetails(stop, filter)) },
                 departures: internalDepartures,
                 nearbyVM: nearbyVM,
+                now: now,
                 pinnedRoutes: pinnedRoutes,
                 togglePinnedRoute: togglePinnedRoute
             )

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -21,7 +21,7 @@ struct StopDetailsView: View {
     var filter: StopDetailsFilter?
     var setFilter: (StopDetailsFilter?) -> Void
     var departures: StopDetailsDepartures?
-    @State var now = Date.now
+    var now = Date.now
     var servedRoutes: [StopDetailsFilterPills.FilterBy] = []
     @ObservedObject var nearbyVM: NearbyViewModel
     let pinnedRoutes: Set<String>
@@ -39,6 +39,7 @@ struct StopDetailsView: View {
         setFilter: @escaping (StopDetailsFilter?) -> Void,
         departures: StopDetailsDepartures?,
         nearbyVM: NearbyViewModel,
+        now: Date,
         pinnedRoutes: Set<String>,
         togglePinnedRoute: @escaping (String) -> Void
     ) {
@@ -48,6 +49,7 @@ struct StopDetailsView: View {
         self.setFilter = setFilter
         self.departures = departures
         self.nearbyVM = nearbyVM
+        self.now = now
         self.pinnedRoutes = pinnedRoutes
         self.togglePinnedRoute = togglePinnedRoute
 
@@ -102,9 +104,6 @@ struct StopDetailsView: View {
                     LoadingCard()
                 }
             }
-        }
-        .onReceive(timer) { input in
-            now = input
         }
         .task {
             do {

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -40,6 +40,7 @@ final class StopDetailsViewTests: XCTestCase {
                                       .init(route: routeDefaultSort0, stop: stop, patterns: []),
                                   ]),
                                   nearbyVM: .init(),
+                                  now: Date.now,
                                   pinnedRoutes: [], togglePinnedRoute: { _ in })
 
         ViewHosting.host(view: sut)
@@ -63,6 +64,7 @@ final class StopDetailsViewTests: XCTestCase {
                                       .init(route: route, stop: stop, patterns: []),
                                   ]),
                                   nearbyVM: .init(),
+                                  now: Date.now,
                                   pinnedRoutes: [], togglePinnedRoute: { _ in })
 
         ViewHosting.host(view: sut)
@@ -81,6 +83,7 @@ final class StopDetailsViewTests: XCTestCase {
             setFilter: { _ in },
             departures: nil,
             nearbyVM: nearbyVM,
+            now: Date.now,
             pinnedRoutes: [], togglePinnedRoute: { _ in }
         )
 
@@ -105,6 +108,7 @@ final class StopDetailsViewTests: XCTestCase {
             setFilter: { _ in },
             departures: nil,
             nearbyVM: nearbyVM,
+            now: Date.now,
             pinnedRoutes: [], togglePinnedRoute: { _ in }
         )
 
@@ -124,6 +128,7 @@ final class StopDetailsViewTests: XCTestCase {
             setFilter: { _ in },
             departures: nil,
             nearbyVM: nearbyVM,
+            now: Date.now,
             pinnedRoutes: [], togglePinnedRoute: { _ in }
         )
 


### PR DESCRIPTION
### Summary

No ticket, issue caught while preparing to switch to new predictions channel.

What is this PR for?

The predictions displayed in the stop details page were not updating as time passed. `now` in `StopDetailsPageView` was updating, but the separate `now` in `StopDetailsView` was not because the `onReceive(of: timer)` was never hit. This change makes `StopDetailsView` use the same `now` as `StopDetailsPageView`. We may want to again consider making an environment object for `now` to use in all places for consistency, but that can be addressed as a larger change. 

### Testing

What testing have you done?
* Updated unit tests
* Ran locally and confirmed predictions count down as expected

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
