### PR TITLE
feat: handle service ended today

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -84,6 +84,8 @@ fun PredictionRowView(
                     is RealtimePatterns.Format.NoService ->
                         UpcomingTripView(UpcomingTripViewState.NoService(predictions.alert.effect))
                     is RealtimePatterns.Format.None -> UpcomingTripView(UpcomingTripViewState.None)
+                    is RealtimePatterns.Format.ServiceEndedToday ->
+                        UpcomingTripView(UpcomingTripViewState.ServiceEndedToday)
                     is RealtimePatterns.Format.NoSchedulesToday ->
                         UpcomingTripView(UpcomingTripViewState.NoSchedulesToday)
                     is RealtimePatterns.Format.Loading ->

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -43,6 +43,8 @@ sealed interface UpcomingTripViewState {
 
     data object NoSchedulesToday : UpcomingTripViewState
 
+    data object ServiceEndedToday : UpcomingTripViewState
+
     data class NoService(val effect: Alert.Effect) : UpcomingTripViewState
 
     data class Some(val trip: TripInstantDisplay) : UpcomingTripViewState
@@ -142,6 +144,8 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
         is UpcomingTripViewState.NoService ->
             NoServiceView(NoServiceViewEffect.from(state.effect), modifier)
         is UpcomingTripViewState.None -> Text("No Predictions", modifier, fontSize = 13.sp)
+        is UpcomingTripViewState.ServiceEndedToday ->
+            Text("Service ended", modifier, fontSize = 13.sp)
         is UpcomingTripViewState.NoSchedulesToday ->
             Text("No service today", modifier, fontSize = 13.sp)
         is UpcomingTripViewState.Loading -> CircularProgressIndicator(modifier)

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -68,6 +68,8 @@ struct PredictionRowView: View {
                 UpcomingTripView(prediction: .none, isFirst: true, isOnly: true)
             case .noSchedulesToday:
                 UpcomingTripView(prediction: .noSchedulesToday, isFirst: true, isOnly: true)
+            case .serviceEndedToday:
+                UpcomingTripView(prediction: .serviceEndedToday, isFirst: true, isOnly: true)
             case .loading:
                 UpcomingTripView(prediction: .loading, isFirst: true, isOnly: true)
             }

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -32,6 +32,7 @@ struct UpcomingTripView: View {
         case loading
         case none
         case noSchedulesToday
+        case serviceEndedToday
         case noService(shared.Alert.Effect)
         case some(TripInstantDisplay)
     }
@@ -145,6 +146,8 @@ struct UpcomingTripView: View {
             NoServiceView(effect: .from(alertEffect: alertEffect))
         case .none:
             Text("Predictions unavailable").font(Typography.footnote)
+        case .serviceEndedToday:
+            Text("Service ended").font(Typography.footnote)
         case .noSchedulesToday:
             Text("No service today").font(Typography.footnote)
         case .loading:

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -306,9 +306,6 @@
     "No nearby MBTA stops" : {
 
     },
-    "Predictions unavailable" : {
-
-    },
     "No results found" : {
 
     },
@@ -342,10 +339,16 @@
     "Power Problem" : {
       "comment" : "Possible alert cause"
     },
+    "Predictions unavailable" : {
+
+    },
     "Routes" : {
 
     },
     "select location" : {
+
+    },
+    "Service ended" : {
 
     },
     "Service suspended" : {

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -252,7 +252,7 @@ final class NearbyTransitViewTests: XCTestCase {
             )
 
             XCTAssertEqual(try patterns[2].actualView().headsign, "Watertown Yard")
-            XCTAssertEqual(try patterns[2].find(UpcomingTripView.self).actualView().prediction, .none)
+            XCTAssertEqual(try patterns[2].find(UpcomingTripView.self).actualView().prediction, .serviceEndedToday)
         }
         ViewHosting.host(view: sut)
         wait(for: [exp], timeout: 1)
@@ -350,7 +350,7 @@ final class NearbyTransitViewTests: XCTestCase {
             try view.vStack().callOnChange(newValue: predictions)
             let stops = view.findAll(NearbyStopView.self)
             XCTAssertNotNil(try stops[0].find(text: "Charles River Loop")
-                .parent().parent().find(text: "Predictions unavailable"))
+                .parent().parent().find(text: "Service ended"))
 
             XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
                 .parent().parent().find(text: "10 min"))
@@ -439,7 +439,7 @@ final class NearbyTransitViewTests: XCTestCase {
             try view.vStack().callOnChange(newValue: predictionsByStop)
             let stops = view.findAll(NearbyStopView.self)
             XCTAssertNotNil(try stops[0].find(text: "Charles River Loop")
-                .parent().parent().find(text: "Predictions unavailable"))
+                .parent().parent().find(text: "Service ended"))
 
             XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
                 .parent().parent().find(text: "10 min"))

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -5,12 +5,13 @@ import io.github.dellisd.spatialk.geojson.Position
 object PatternSorting {
     private fun patternServiceBucket(realtimePatterns: RealtimePatterns) =
         when {
-            // service or alert today
-            realtimePatterns.hasSchedulesToday ||
-                realtimePatterns.hasMajorAlerts ||
+            // showing either a trip or an alert
+            realtimePatterns.hasMajorAlerts ||
                 realtimePatterns.upcomingTrips.orEmpty().isNotEmpty() -> 1
+            // service ended
+            realtimePatterns.hasSchedulesToday -> 2
             // no service today
-            else -> 2
+            else -> 3
         }
 
     private fun pinnedRouteBucket(route: Route, pinnedRoutes: Set<String>) =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -757,6 +757,14 @@ class NearbyResponseTest {
                                     listOf(deviationOutbound),
                                     listOf(objects.upcomingTrip(deviationOutboundPrediction))
                                 ),
+                                // since this has trips it's sorted earlier than typical in
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Atypical In",
+                                    null,
+                                    listOf(atypicalInbound),
+                                    listOf(objects.upcomingTrip(atypicalInboundPrediction))
+                                ),
                                 RealtimePatterns.ByHeadsign(
                                     route1,
                                     "Typical In",
@@ -764,13 +772,6 @@ class NearbyResponseTest {
                                     listOf(typicalInbound),
                                     emptyList()
                                 ),
-                                RealtimePatterns.ByHeadsign(
-                                    route1,
-                                    "Atypical In",
-                                    null,
-                                    listOf(atypicalInbound),
-                                    listOf(objects.upcomingTrip(atypicalInboundPrediction))
-                                )
                             )
                         )
                     )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -152,13 +152,13 @@ class PatternSortingTest {
         objects.stop()
         val southbound = Direction("Southbound", "Ashmont/Braintree", 0)
         val northbound = Direction("Northbound", "Alewife", 1)
-        // also checking if alerts, trips, and schedules are treated as equal
+        // also checking if alerts and trips are treated as equal
         val patterns1 = realtimePatternsByDirection(southbound, 1, trips = 1)
         val patterns2 = realtimePatternsByDirection(southbound, 2, alerts = 1)
-        val patterns3 = realtimePatternsByDirection(southbound, 3, hasSchedulesToday = true)
-        val patterns4 = realtimePatternsByDirection(southbound, 4, trips = 1)
-        val patterns5 = realtimePatternsByHeadsign("Ashmont", 0, 1, trips = 1)
-        val patterns6 = realtimePatternsByDirection(northbound, 1, trips = 1)
+        val patterns3 = realtimePatternsByDirection(southbound, 3, trips = 1)
+        val patterns4 = realtimePatternsByHeadsign("Ashmont", 0, 1, trips = 1)
+        val patterns5 = realtimePatternsByDirection(northbound, 1, trips = 1)
+        val patterns6 = realtimePatternsByDirection(southbound, 1, hasSchedulesToday = true)
         val patterns7 = realtimePatternsByDirection(southbound, 1)
 
         val expected =
@@ -211,15 +211,24 @@ class PatternSortingTest {
                 stop1,
                 listOf(realtimePatternsByHeadsign(route2, "", 0, 1, trips = 1))
             )
-        // pinned, no service, subway, near, direction 0
+        // pinned, service ended, subway, near, direction 0
         val patternsByStop5 =
+            PatternsByStop(
+                route1,
+                stop1,
+                listOf(
+                    realtimePatternsByHeadsign(route1, "Ashmont", 0, 1, hasSchedulesToday = true)
+                )
+            )
+        // pinned, no service, subway, near, direction 0
+        val patternsByStop6 =
             PatternsByStop(
                 route1,
                 stop1,
                 listOf(realtimePatternsByHeadsign(route1, "Ashmont", 0, 1))
             )
         // unpinned, has service, subway, near, direction 0
-        val patternsByStop6 =
+        val patternsByStop7 =
             PatternsByStop(
                 route3,
                 stop1,
@@ -233,7 +242,8 @@ class PatternSortingTest {
                 patternsByStop3,
                 patternsByStop4,
                 patternsByStop5,
-                patternsByStop6
+                patternsByStop6,
+                patternsByStop7
             )
         val actual =
             expected
@@ -355,8 +365,22 @@ class PatternSortingTest {
                     )
                 )
             )
-        // pinned, no service, subway, near, route sort order 1
+        // pinned, service ended, subway, near, route sort order 1
         val stopsAssociated5 =
+            StopsAssociated.WithRoute(
+                route1,
+                listOf(
+                    PatternsByStop(
+                        route1,
+                        stop1,
+                        listOf(
+                            realtimePatternsByHeadsign(route1, "", 0, 1, hasSchedulesToday = true)
+                        )
+                    )
+                )
+            )
+        // pinned, no service, subway, near, route sort order 1
+        val stopsAssociated6 =
             StopsAssociated.WithRoute(
                 route1,
                 listOf(
@@ -368,7 +392,7 @@ class PatternSortingTest {
                 )
             )
         // not pinned, has service, subway, near, route sort order 1
-        val stopsAssociated6 =
+        val stopsAssociated7 =
             StopsAssociated.WithRoute(
                 route4,
                 listOf(
@@ -387,7 +411,8 @@ class PatternSortingTest {
                 stopsAssociated3,
                 stopsAssociated4,
                 stopsAssociated5,
-                stopsAssociated6
+                stopsAssociated6,
+                stopsAssociated7
             )
         val actual =
             expected

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -401,10 +401,10 @@ class StopDetailsDeparturesTest {
         assertEquals(
             expected(
                 scheduledPredicted.patternsByHeadsign(listOf(scheduledPredicted.predictedTrip!!)),
-                scheduledUnpredicted.patternsByHeadsign(emptyList()),
                 unscheduledPredicted.patternsByHeadsign(
                     listOf(unscheduledPredicted.predictedTrip!!)
                 ),
+                scheduledUnpredicted.patternsByHeadsign(emptyList()),
                 unscheduledUnpredicted.patternsByHeadsign(emptyList())
             ),
             actual(includeSchedules = false, includePredictions = true)
@@ -510,7 +510,7 @@ class StopDetailsDeparturesTest {
                         listOf(route),
                         null,
                         stop,
-                        listOf(expectedEarly, expectedLateBeforeLoad),
+                        listOf(expectedLateBeforeLoad, expectedEarly),
                         listOf(Direction("", "", 0), Direction("", "", 1)),
                     )
                 )


### PR DESCRIPTION
### Summary

_Ticket:_ [Handle service ended for the day](https://app.asana.com/0/1205425564113216/1208217009015140/f)

Stacked on #445. Implements the display and sorting logic as called for in the task, except for in filtered Stop Details [per Slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1728320849085079?thread_ts=1728320481.516039&cid=C05QMG9GS9M).

### Testing

Checked manually that this works and added new / updated existing unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
