### PR TITLE
fix: never display alerts twice in filtered stop details

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -93,10 +93,12 @@ data class PatternsByStop(
                     }
                 }
                 .toSet()
-        return stopsInDirection.flatMap { stopId ->
-            patternsInDirection
-                .flatMap { it.alertsHereFor(setOf(stopId), directionId) ?: emptyList() }
-                .toSet()
-        }
+        return stopsInDirection
+            .flatMap { stopId ->
+                patternsInDirection
+                    .flatMap { it.alertsHereFor(setOf(stopId), directionId) ?: emptyList() }
+                    .toSet()
+            }
+            .distinct()
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1728320094267839)

If there are multiple alerts worth showing, we do want to show each of them, but if it's the same alert twice we do not in fact want to show it.

### Testing

Checked that this fixes the bug as reported. Added a unit test to ensure it stays fixed.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
