### PR TITLE
feat: cutover to use new predictions channel

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -466,9 +466,6 @@
     "Updated: %@" : {
       "comment" : "Interpolated value is a timestamp for when displayed alert details were last changed"
     },
-    "Using Predictions Channel V2" : {
-
-    },
     "Weather" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -20,7 +20,6 @@ struct NearbyTransitView: View {
     var pinnedRouteRepository = RepositoryDI().pinnedRoutes
     @State var predictionsRepository = RepositoryDI().predictions
     var schedulesRepository = RepositoryDI().schedules
-    var settingsRepository = RepositoryDI().settings
     var getNearby: (GlobalResponse, CLLocationCoordinate2D) -> Void
     @Binding var state: NearbyViewModel.NearbyTransitState
     @Binding var location: CLLocationCoordinate2D?
@@ -32,9 +31,7 @@ struct NearbyTransitView: View {
     @State var now = Date.now
     @State var pinnedRoutes: Set<String> = []
     @State var predictionsByStop: PredictionsByStopJoinResponse?
-    @State var predictions: PredictionsStreamDataResponse?
     @State var predictionsError: String?
-    @State var predictionsV2Enabled = false
     var errorBannerRepository = RepositoryDI().errorBanner
 
     let inspection = Inspection<Self>()
@@ -51,10 +48,7 @@ struct NearbyTransitView: View {
         .onAppear {
             getGlobal()
             getNearby(location: location, globalData: globalData)
-            Task {
-                await getPredictionsFeatureFlag()
-                joinPredictions(state.nearbyByRouteAndStop?.stopIds())
-            }
+            joinPredictions(state.nearbyByRouteAndStop?.stopIds())
             updateNearbyRoutes()
             updatePinnedRoutes()
             getSchedule()
@@ -82,9 +76,6 @@ struct NearbyTransitView: View {
             } else {
                 updateNearbyRoutes(predictions: nil)
             }
-        }
-        .onChange(of: predictions) { predictions in
-            updateNearbyRoutes(predictions: predictions)
         }
         .onChange(of: nearbyVM.alerts) { alerts in
             updateNearbyRoutes(alerts: alerts)
@@ -123,9 +114,6 @@ struct NearbyTransitView: View {
         } else {
             ScrollViewReader { proxy in
                 ScrollView {
-                    if predictionsV2Enabled {
-                        Text("Using Predictions Channel V2")
-                    }
                     LazyVStack {
                         ForEach(transit, id: \.id) { nearbyTransit in
                             switch onEnum(of: nearbyTransit) {
@@ -194,33 +182,8 @@ struct NearbyTransitView: View {
         }
     }
 
-    func getPredictionsFeatureFlag() async {
-        do {
-            let settings = try await settingsRepository.getSettings()
-            predictionsV2Enabled = settings.first(where: { $0.key == .predictionsV2Channel })?.isOn ?? false
-        } catch {}
-    }
-
     func joinPredictions(_ stopIds: Set<String>?) {
         guard let stopIds else { return }
-        if predictionsV2Enabled {
-            joinPredictionsV2(stopIds: stopIds)
-        } else {
-            predictionsRepository.connect(stopIds: Array(stopIds)) { outcome in
-                DispatchQueue.main.async {
-                    switch onEnum(of: outcome) {
-                    case let .ok(result):
-                        predictions = result.data
-                        predictionsError = nil
-                    case let .error(error):
-                        predictionsError = error.message
-                    }
-                }
-            }
-        }
-    }
-
-    func joinPredictionsV2(stopIds: Set<String>) {
         predictionsRepository.connectV2(stopIds: Array(stopIds), onJoin: { outcome in
             DispatchQueue.main.async {
                 switch onEnum(of: outcome) {
@@ -287,7 +250,6 @@ struct NearbyTransitView: View {
                 predictionsLastUpdated: lastPredictions,
                 predictionQuantity: Int32(
                     predictionsByStop?.predictionQuantity() ??
-                        predictions?.predictionQuantity() ??
                         0
                 ),
                 action: {
@@ -309,9 +271,7 @@ struct NearbyTransitView: View {
         alerts: AlertsStreamDataResponse? = nil,
         pinnedRoutes: Set<String>? = nil
     ) {
-        let fallbackPredictions = if let predictionsByStop {
-            predictionsByStop.toPredictionsStreamDataResponse()
-        } else { self.predictions }
+        let fallbackPredictions = predictionsByStop?.toPredictionsStreamDataResponse()
 
         nearbyWithRealtimeInfo = withRealtimeInfo(
             schedules: scheduleResponse ?? self.scheduleResponse,

--- a/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
+++ b/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
@@ -22,8 +22,6 @@ extension Setting: Identifiable {
             "Search - Route Results"
         case .map:
             "Map Debug"
-        case .predictionsV2Channel:
-            "Predictions V2 Channel"
         }
     }
 
@@ -35,8 +33,6 @@ extension Setting: Identifiable {
             "point.topleft.down.to.point.bottomright.curvepath.fill"
         case .map:
             "location.magnifyingglass"
-        case .predictionsV2Channel:
-            "magnifyingglass"
         }
     }
 
@@ -45,8 +41,6 @@ extension Setting: Identifiable {
         case .search:
             .featureFlags
         case .searchRouteResults:
-            .featureFlags
-        case .predictionsV2Channel:
             .featureFlags
         case .map:
             .debug

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -234,7 +234,7 @@ final class NearbyTransitViewTests: XCTestCase {
         )
 
         let exp = sut.on(\.didAppear) { view in
-            try view.vStack().callOnChange(newValue: PredictionsStreamDataResponse(objects: objects))
+            try view.vStack().callOnChange(newValue: PredictionsByStopJoinResponse(objects: objects))
             let patterns = view.findAll(HeadsignRowView.self)
 
             XCTAssertEqual(try patterns[0].actualView().headsign, "Dedham Mall")
@@ -332,94 +332,7 @@ final class NearbyTransitViewTests: XCTestCase {
             prediction.stopId = "84791"
             prediction.tripId = objects.trip(routePattern: rp2).id
         }
-        let predictions: PredictionsStreamDataResponse = .init(objects: objects)
 
-        var sut = NearbyTransitView(
-            togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
-            pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository(),
-            getNearby: { _, _ in },
-            state: .constant(route52State),
-            location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
-            nearbyVM: .init(),
-            now: now
-        )
-
-        let exp = sut.on(\.didAppear) { view in
-            try view.vStack().callOnChange(newValue: predictions)
-            let stops = view.findAll(NearbyStopView.self)
-            XCTAssertNotNil(try stops[0].find(text: "Charles River Loop")
-                .parent().parent().find(text: "Service ended"))
-
-            XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
-                .parent().parent().find(text: "10 min"))
-            XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
-                .parent().parent().find(text: "Overridden"))
-
-            XCTAssertNotNil(try stops[1].find(text: "Watertown Yard")
-                .parent().parent().find(text: "1 min"))
-            let expectedMinutes = distantMinutes
-            let expectedState = UpcomingTripView.State.some(.Minutes(minutes: Int32(expectedMinutes)))
-            XCTAssert(try !stops[1].find(text: "Watertown Yard").parent().parent()
-                .findAll(UpcomingTripView.self, where: { sut in
-                    try sut.actualView().prediction == expectedState
-                }).isEmpty)
-        }
-        ViewHosting.host(view: sut)
-        wait(for: [exp], timeout: 1)
-    }
-
-    @MainActor func testWithPredictionsV2() throws {
-        NSTimeZone.default = TimeZone(identifier: "America/New_York")!
-        let now = Date.now
-        let distantMinutes: Double = 10
-        let distantInstant = now.addingTimeInterval(distantMinutes * 60).toKotlinInstant()
-        let objects = ObjectCollectionBuilder()
-        let route = objects.route()
-
-        let rp1 = objects.routePattern(route: route) { routePattern in
-            routePattern.id = "52-5-0"
-            routePattern.representativeTrip { representativeTrip in
-                representativeTrip.headsign = "Dedham Mall"
-                representativeTrip.routePatternId = routePattern.id
-            }
-        }
-        let rp2 = objects.routePattern(route: route) { routePattern in
-            routePattern.id = "52-4-1"
-            routePattern.representativeTrip { representativeTrip in
-                representativeTrip.headsign = "Watertown Yard"
-                representativeTrip.routePatternId = routePattern.id
-            }
-        }
-        objects.prediction { prediction in
-            prediction.arrivalTime = now.addingTimeInterval(distantMinutes * 60).toKotlinInstant()
-            prediction.departureTime = now.addingTimeInterval((distantMinutes + 2) * 60).toKotlinInstant()
-            prediction.routeId = "52"
-            prediction.stopId = "8552"
-            prediction.tripId = objects.trip(routePattern: rp1).id
-        }
-        objects.prediction { prediction in
-            prediction.arrivalTime = now.addingTimeInterval((distantMinutes + 1) * 60).toKotlinInstant()
-            prediction.departureTime = now.addingTimeInterval((distantMinutes + 5) * 60).toKotlinInstant()
-            prediction.status = "Overridden"
-            prediction.routeId = "52"
-            prediction.stopId = "8552"
-            prediction.tripId = objects.trip(routePattern: rp1).id
-        }
-        objects.prediction { prediction in
-            prediction.arrivalTime = now.addingTimeInterval(1 * 60 + 1).toKotlinInstant()
-            prediction.departureTime = now.addingTimeInterval(2 * 60).toKotlinInstant()
-            prediction.routeId = "52"
-            prediction.stopId = "84791"
-            prediction.tripId = objects.trip(routePattern: rp2).id
-        }
-        objects.prediction { prediction in
-            prediction.departureTime = distantInstant
-            prediction.routeId = "52"
-            prediction.stopId = "84791"
-            prediction.tripId = objects.trip(routePattern: rp2).id
-        }
         let predictionsByStop: PredictionsByStopJoinResponse = .init(objects: objects)
 
         var sut = NearbyTransitView(
@@ -427,7 +340,6 @@ final class NearbyTransitViewTests: XCTestCase {
             pinnedRouteRepository: pinnedRoutesRepository,
             predictionsRepository: MockPredictionsRepository(),
             schedulesRepository: MockScheduleRepository(),
-            settingsRepository: MockSettingsRepository(settings: [.init(key: .predictionsV2Channel, isOn: true)]),
             getNearby: { _, _ in },
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
@@ -528,14 +440,14 @@ final class NearbyTransitViewTests: XCTestCase {
             prediction.stopId = Green.shared.stopEastbound.id
             prediction.tripId = objects.trip(routePattern: Green.shared.rpE1).id
         }
-        let predictions: PredictionsStreamDataResponse = .init(objects: Green.shared.objects)
+        let predictions: PredictionsByStopJoinResponse = .init(objects: Green.shared.objects)
 
         let globalLoadedPublisher = PassthroughSubject<Void, Never>()
 
         let sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(response: predictions),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: predictions),
             schedulesRepository: MockScheduleRepository(),
             getNearby: { _, _ in },
             state: .constant(greenLineState),
@@ -573,44 +485,16 @@ final class NearbyTransitViewTests: XCTestCase {
         let sawmillAtWalshExpectation = expectation(description: "joins predictions for Sawmill @ Walsh")
         let lechmereExpectation = expectation(description: "joins predictions for Lechmere")
 
-        class FakePredictionsRepository: IPredictionsRepository {
-            let sawmillAtWalshExpectation: XCTestExpectation
-            let lechmereExpectation: XCTestExpectation
-
-            init(sawmillAtWalshExpectation: XCTestExpectation, lechmereExpectation: XCTestExpectation) {
-                self.sawmillAtWalshExpectation = sawmillAtWalshExpectation
-                self.lechmereExpectation = lechmereExpectation
+        let predictionsRepo = MockPredictionsRepository(onConnect: {}, onConnectV2: { stopIds in
+            if stopIds.sorted() == ["84791", "8552"] {
+                sawmillAtWalshExpectation.fulfill()
+            } else if stopIds == ["place-lech"] {
+                lechmereExpectation.fulfill()
+            } else {
+                XCTFail("unexpected stop IDs \(stopIds)")
             }
+        }, onDisconnect: {})
 
-            func connect(
-                stopIds: [String],
-                onReceive _: @escaping (ApiResult<PredictionsStreamDataResponse>)
-                    -> Void
-            ) {
-                if stopIds.sorted() == ["84791", "8552"] {
-                    sawmillAtWalshExpectation.fulfill()
-                } else if stopIds == ["place-lech"] {
-                    lechmereExpectation.fulfill()
-                } else {
-                    XCTFail("unexpected stop IDs \(stopIds)")
-                }
-            }
-
-            func connectV2(stopIds _: [String],
-                           onJoin _: @escaping (ApiResult<PredictionsByStopJoinResponse>) -> Void,
-                           onMessage _: @escaping (ApiResult<PredictionsByStopMessageResponse>) -> Void) {
-                /* no-op */
-            }
-
-            var lastUpdated: Instant?
-
-            func disconnect() { /* no-op */ }
-        }
-
-        let predictionsRepo = FakePredictionsRepository(
-            sawmillAtWalshExpectation: sawmillAtWalshExpectation,
-            lechmereExpectation: lechmereExpectation
-        )
         let sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
@@ -663,45 +547,6 @@ final class NearbyTransitViewTests: XCTestCase {
             nearbyVM: .init()
         )
 
-        func prediction(minutesAway: Double) -> PredictionsStreamDataResponse {
-            let objects = ObjectCollectionBuilder()
-            let trip = objects.trip { trip in
-                trip.headsign = "Dedham Mall"
-                trip.routePatternId = "52-5-0"
-            }
-            objects.prediction { prediction in
-                prediction.departureTime = Date.now.addingTimeInterval(minutesAway * 60).toKotlinInstant()
-                prediction.routeId = "52"
-                prediction.stopId = "8552"
-                prediction.tripId = trip.id
-            }
-            return PredictionsStreamDataResponse(objects: objects)
-        }
-
-        let exp = sut.on(\.didAppear) { view in
-            try view.vStack().callOnChange(newValue: prediction(minutesAway: 2))
-            XCTAssertNotNil(try view.vStack().find(text: "2 min"))
-            try view.vStack().callOnChange(newValue: prediction(minutesAway: 3))
-            XCTAssertNotNil(try view.vStack().find(text: "3 min"))
-        }
-        ViewHosting.host(view: sut)
-        wait(for: [exp], timeout: 1)
-    }
-
-    func testRendersUpdatedPredictionsV2() throws {
-        NSTimeZone.default = TimeZone(identifier: "America/New_York")!
-        var sut = NearbyTransitView(
-            togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
-            pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository(),
-            settingsRepository: MockSettingsRepository(settings: [.init(key: .predictionsV2Channel, isOn: true)]),
-            getNearby: { _, _ in },
-            state: .constant(route52State),
-            location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
-            nearbyVM: .init()
-        )
-
         func prediction(minutesAway: Double) -> PredictionsByStopJoinResponse {
             let objects = ObjectCollectionBuilder()
             let trip = objects.trip { trip in
@@ -732,8 +577,8 @@ final class NearbyTransitViewTests: XCTestCase {
         let leaveExpectation = expectation(description: "leaves predictions")
 
         let predictionsRepo = MockPredictionsRepository(
-            onConnect: { joinExpectation.fulfill() },
-            onConnectV2: {},
+            onConnect: {},
+            onConnectV2: { _ in joinExpectation.fulfill() },
             onDisconnect: { leaveExpectation.fulfill() }
         )
         let sut = NearbyTransitView(
@@ -759,8 +604,9 @@ final class NearbyTransitViewTests: XCTestCase {
         let joinExpectation = expectation(description: "joins predictions")
         let leaveExpectation = expectation(description: "leaves predictions")
 
-        let predictionsRepo = MockPredictionsRepository(onConnect: { joinExpectation.fulfill() },
-                                                        onConnectV2: {}, onDisconnect: { leaveExpectation.fulfill() })
+        let predictionsRepo = MockPredictionsRepository(onConnect: {},
+                                                        onConnectV2: { _ in joinExpectation.fulfill() },
+                                                        onDisconnect: { leaveExpectation.fulfill() })
 
         let sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
@@ -789,8 +635,8 @@ final class NearbyTransitViewTests: XCTestCase {
         let leaveExpectation = expectation(description: "leaves predictions")
 
         let predictionsRepo = MockPredictionsRepository(
-            onConnect: { joinExpectation.fulfill() },
-            onConnectV2: {},
+            onConnect: {},
+            onConnectV2: { _ in joinExpectation.fulfill() },
             onDisconnect: { leaveExpectation.fulfill() }
         )
         let sut = NearbyTransitView(
@@ -861,15 +707,14 @@ final class NearbyTransitViewTests: XCTestCase {
             nearbyByRouteAndStop: NearbyStaticData(data: [])
         )
 
-        let predictionsRepo = MockPredictionsRepository(onConnect: { predictionsErroredPublisher.send(true) },
-                                                        onConnectV2: {},
+        let predictionsRepo = MockPredictionsRepository(onConnect: {},
+                                                        onConnectV2: { _ in predictionsErroredPublisher.send(true) },
                                                         onDisconnect: {},
-                                                        connectOutcome:
-                                                        ApiResultError(
+                                                        connectOutcome: nil,
+                                                        connectV2Outcome: ApiResultError(
                                                             code: nil,
                                                             message: SocketError.shared.FAILURE
-                                                        ),
-                                                        connectV2Outcome: nil)
+                                                        ))
         let sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -46,6 +46,7 @@ data class PredictionsByStopJoinResponse(
         }
 
         val updatedTrips = trips.plus(updatedPredictions.trips).filterKeys { it in usedTrips }
+
         val updatedVehicles =
             vehicles.plus(updatedPredictions.vehicles).filterKeys { it in usedVehicles }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -169,7 +169,7 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
 
 class MockPredictionsRepository(
     val onConnect: () -> Unit = {},
-    val onConnectV2: () -> Unit = {},
+    val onConnectV2: (List<String>) -> Unit = {},
     val onDisconnect: () -> Unit = {},
     private val connectOutcome: ApiResult<PredictionsStreamDataResponse>? = null,
     private val connectV2Outcome: ApiResult<PredictionsByStopJoinResponse>? = null
@@ -183,8 +183,12 @@ class MockPredictionsRepository(
     ) : this(connectOutcome = ApiResult.Ok(response))
 
     constructor(
+        connectV2Outcome: PredictionsByStopJoinResponse
+    ) : this(connectV2Outcome = ApiResult.Ok(connectV2Outcome))
+
+    constructor(
         onConnect: () -> Unit = {},
-        onConnectV2: () -> Unit = {},
+        onConnectV2: (List<String>) -> Unit = {},
         onDisconnect: () -> Unit = {},
     ) : this(
         onConnect = onConnect,
@@ -209,7 +213,7 @@ class MockPredictionsRepository(
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit
     ) {
-        onConnectV2()
+        onConnectV2(stopIds)
         if (connectV2Outcome != null) {
             onJoin(connectV2Outcome)
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -38,7 +38,6 @@ enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     Map(booleanPreferencesKey("map_debug")),
     Search(booleanPreferencesKey("search_featureFlag")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
-    PredictionsV2Channel(booleanPreferencesKey("predictions_v2Channel"))
 }
 
 data class Setting(val key: Settings, var isOn: Boolean)


### PR DESCRIPTION
### Summary

Ticket: [https://app.asana.com/0/1205732265579288/1207791938443981/f](Predictions Scalability: use new predictions channel)

What is this PR for?
This removes the predictions V2 channel from behind a feature flag so that all app users will use the new channel. Also removes references to the old channel.

Note: This does not include updating the android client to use the V2 predictions channel - I'll split out a separate ticket for that.

### Testing

What testing have you done?
* Repaired unit tests to ensure all use the new channel
* Ran locally to confirm predictions load & update as expected

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
