### PR TITLE
test: remove all NotUnderTestError declarations

### DIFF
--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
@@ -18,8 +18,6 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 final class NearbyTransitPageViewTests: XCTestCase {
-    struct NotUnderTestError: Error {}
-
     private let pinnedRoutesRepository = MockPinnedRoutesRepository()
 
     override func setUp() {

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -16,8 +16,6 @@ import XCTest
 @_spi(Experimental) import MapboxMaps
 
 final class ContentViewTests: XCTestCase {
-    struct NotUnderTestError: Error {}
-
     override func setUp() {
         executionTimeAllowance = 60
         HelpersKt

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -18,8 +18,6 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 final class NearbyTransitViewTests: XCTestCase {
-    struct NotUnderTestError: Error {}
-
     private let pinnedRoutesRepository = MockPinnedRoutesRepository()
     private var cancellables = Set<AnyCancellable>()
 

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -13,8 +13,6 @@ import ViewInspector
 import XCTest
 
 final class SearchResultViewTests: XCTestCase {
-    struct NotUnderTestError: Error {}
-
     override func setUp() {
         executionTimeAllowance = 60
     }
@@ -35,7 +33,7 @@ final class SearchResultViewTests: XCTestCase {
 
             func __getSearchResults(query _: String) async throws -> SearchResults? {
                 getSearchResultsExpectation.fulfill()
-                throw NotUnderTestError()
+                return nil
             }
         }
 


### PR DESCRIPTION
### Summary

_Ticket:_ none

Most of these are dead code, and the one that wasn't appears to have been intermittently causing crashes elsewhere in the tests, mostly in CI.

### Testing

Ran the tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
