### PR TITLE
fix: show loading instead of service ended when partially loaded

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
@@ -111,7 +111,8 @@ class StopDetailsRouteViewTest {
                                     ),
                                 parentStopId = stop.id,
                                 alerts = null,
-                                hasSchedulesTodayByPattern = null
+                                hasSchedulesTodayByPattern = null,
+                                allDataLoaded = false
                             )
                         )
                     ),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -213,7 +213,8 @@ class StopDetailsViewTest {
                                                     ),
                                                 parentStopId = stop.id,
                                                 alerts = null,
-                                                hasSchedulesTodayByPattern = null
+                                                hasSchedulesTodayByPattern = null,
+                                                allDataLoaded = false
                                             )
                                         )
                                 )

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -471,7 +471,8 @@ struct NearbyTransitView_Previews: PreviewProvider {
                                         UpcomingTrip(trip: busTrip, prediction: busPrediction2),
                                     ],
                                     alertsHere: nil,
-                                    hasSchedulesToday: true
+                                    hasSchedulesToday: true,
+                                    allDataLoaded: true
                                 ),
                             ]
                         ),
@@ -500,7 +501,8 @@ struct NearbyTransitView_Previews: PreviewProvider {
                                         UpcomingTrip(trip: crTrip, prediction: crPrediction2),
                                     ],
                                     alertsHere: nil,
-                                    hasSchedulesToday: true
+                                    hasSchedulesToday: true,
+                                    allDataLoaded: true
                                 ),
                             ]
                         ),

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -88,7 +88,8 @@ struct DirectionPicker: View {
                     patterns: [patternOutbound],
                     upcomingTrips: nil,
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 ),
                 .ByHeadsign(
                     route: route,
@@ -97,7 +98,8 @@ struct DirectionPicker: View {
                     patterns: [patternInbound],
                     upcomingTrips: nil,
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 ),
             ],
             directions: [

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
@@ -103,7 +103,8 @@ struct StopDetailsRoutesView: View {
                 patterns: [],
                 upcomingTrips: [.init(trip: trip1, prediction: prediction1)],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
         ]),
         .init(route: route2, stop: stop, patterns: [
@@ -114,7 +115,8 @@ struct StopDetailsRoutesView: View {
                 patterns: [],
                 upcomingTrips: [.init(trip: trip3, prediction: prediction2)],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
             .ByHeadsign(
                 route: route2,
@@ -123,7 +125,8 @@ struct StopDetailsRoutesView: View {
                 patterns: [],
                 upcomingTrips: [.init(trip: trip2, schedule: schedule2)],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
             .ByHeadsign(
                 route: route2,
@@ -134,7 +137,8 @@ struct StopDetailsRoutesView: View {
                     .init(trip: trip4, schedule: schedule3, prediction: prediction3),
                 ],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
         ]),
     ]), global: nil, now: Date.now.toKotlinInstant(), filter: nil, setFilter: { _ in }, pushNavEntry: { _ in },

--- a/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
@@ -39,12 +39,12 @@ final class DirectionPickerTests: XCTestCase {
                 .ByHeadsign(
                     route: route, headsign: "North", line: nil,
                     patterns: [patternNorth], upcomingTrips: [],
-                    alertsHere: nil, hasSchedulesToday: true
+                    alertsHere: nil, hasSchedulesToday: true, allDataLoaded: true
                 ),
                 .ByHeadsign(
                     route: route, headsign: "South", line: nil,
                     patterns: [patternSouth], upcomingTrips: [],
-                    alertsHere: nil, hasSchedulesToday: true
+                    alertsHere: nil, hasSchedulesToday: true, allDataLoaded: true
                 ),
             ],
             directions: [

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
@@ -110,7 +110,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                 patterns: [patternNorth],
                 upcomingTrips: [objects.upcomingTrip(prediction: predictionNorth)],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
             RealtimePatterns.ByHeadsign(
                 route: route,
@@ -119,7 +120,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                 patterns: [patternSouth],
                 upcomingTrips: [objects.upcomingTrip(prediction: predictionSouth)],
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             ),
         ])
 
@@ -138,7 +140,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                         objects.upcomingTrip(prediction: linePredictionTrunk2),
                     ],
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 ),
                 RealtimePatterns.ByHeadsign(
                     route: lineRoute3,
@@ -147,7 +150,8 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                     patterns: [linePatternBranch],
                     upcomingTrips: [objects.upcomingTrip(prediction: linePredictionBranch)],
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 ),
             ],
             directions: [

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -97,7 +97,8 @@ final class StopDetailsPageTests: XCTestCase {
                 patterns: [routePattern1],
                 upcomingTrips: nil,
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             )]
         )
         let route2Departures = PatternsByStop(
@@ -110,7 +111,8 @@ final class StopDetailsPageTests: XCTestCase {
                 patterns: [routePattern2],
                 upcomingTrips: nil,
                 alertsHere: nil,
-                hasSchedulesToday: true
+                hasSchedulesToday: true,
+                allDataLoaded: true
             )]
         )
 

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsRouteViewTests.swift
@@ -31,7 +31,8 @@ final class StopDetailsRouteViewTests: XCTestCase {
             patterns: [northPattern],
             upcomingTrips: nil,
             alertsHere: nil,
-            hasSchedulesToday: true
+            hasSchedulesToday: true,
+            allDataLoaded: true
         )
         let patternsByHeadsignSouth = RealtimePatterns.ByHeadsign(
             route: route,
@@ -40,7 +41,8 @@ final class StopDetailsRouteViewTests: XCTestCase {
             patterns: [southPattern],
             upcomingTrips: nil,
             alertsHere: nil,
-            hasSchedulesToday: true
+            hasSchedulesToday: true,
+            allDataLoaded: true
         )
         let patternsByStop = PatternsByStop(
             route: route,
@@ -95,7 +97,8 @@ final class StopDetailsRouteViewTests: XCTestCase {
             patterns: [northPattern],
             upcomingTrips: nil,
             alertsHere: nil,
-            hasSchedulesToday: true
+            hasSchedulesToday: true,
+            allDataLoaded: true
         )
         let patternsByHeadsignSouth = RealtimePatterns.ByHeadsign(
             route: route,
@@ -104,7 +107,8 @@ final class StopDetailsRouteViewTests: XCTestCase {
             patterns: [southPattern],
             upcomingTrips: nil,
             alertsHere: nil,
-            hasSchedulesToday: true
+            hasSchedulesToday: true,
+            allDataLoaded: true
         )
         let patternsByStop = PatternsByStop(
             route: route,

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -366,7 +366,8 @@ final class HomeMapViewTests: XCTestCase {
                     patterns: [MapTestDataHelper.shared.patternOrange30],
                     upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 )]
             )]
         ))
@@ -533,7 +534,8 @@ final class HomeMapViewTests: XCTestCase {
                     patterns: [MapTestDataHelper.shared.patternOrange30],
                     upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 )]
             )]
         ))
@@ -639,7 +641,8 @@ final class HomeMapViewTests: XCTestCase {
                     patterns: [MapTestDataHelper.shared.patternOrange30],
                     upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 )]
             )]
         ))

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -349,7 +349,7 @@ final class NearbyTransitViewTests: XCTestCase {
             try view.vStack().callOnChange(newValue: predictionsByStop)
             let stops = view.findAll(NearbyStopView.self)
             XCTAssertNotNil(try stops[0].find(text: "Charles River Loop")
-                .parent().parent().find(text: "Service ended"))
+                .parent().parent().find(ViewType.ProgressView.self))
 
             XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
                 .parent().parent().find(text: "10 min"))
@@ -765,7 +765,8 @@ final class NearbyTransitViewTests: XCTestCase {
                     patterns: [pattern],
                     upcomingTrips: nil,
                     alertsHere: nil,
-                    hasSchedulesToday: true
+                    hasSchedulesToday: true,
+                    allDataLoaded: true
                 )]
 
             ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -424,6 +424,8 @@ fun NearbyStaticData.withRealtimeInfo(
             it.isActive(filterAtTime) && it.significance >= AlertSignificance.Secondary
         }
 
+    val allDataLoaded = schedules != null && predictions != null
+
     // this needs to change how the trip keys are constructed
     val (rewrittenThis, rewrittenPredictions) =
         if (
@@ -524,7 +526,8 @@ fun NearbyStaticData.withRealtimeInfo(
                                     filterAtTime,
                                     cutoffTime,
                                     activeRelevantAlerts,
-                                    hasSchedulesTodayByPattern
+                                    hasSchedulesTodayByPattern,
+                                    allDataLoaded
                                 )
                             }
                             .filterEmptyAndSort()
@@ -543,7 +546,8 @@ fun NearbyStaticData.withRealtimeInfo(
                                     filterAtTime,
                                     cutoffTime,
                                     activeRelevantAlerts,
-                                    hasSchedulesTodayByPattern
+                                    hasSchedulesTodayByPattern,
+                                    allDataLoaded
                                 )
                             }
                             .filterEmptyAndSort()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -28,6 +28,7 @@ data class PatternsByStop(
         cutoffTime: Instant,
         alerts: Collection<Alert>?,
         hasSchedulesTodayByPattern: Map<String, Boolean>?,
+        allDataLoaded: Boolean,
     ) : this(
         when (staticData) {
             is NearbyStaticData.StopPatterns.ForRoute -> listOf(staticData.route)
@@ -47,7 +48,8 @@ data class PatternsByStop(
                             upcomingTripsMap,
                             staticData.stop.id,
                             alerts,
-                            hasSchedulesTodayByPattern
+                            hasSchedulesTodayByPattern,
+                            allDataLoaded
                         )
                     is NearbyStaticData.StaticPatterns.ByDirection ->
                         RealtimePatterns.ByDirection(
@@ -55,7 +57,8 @@ data class PatternsByStop(
                             upcomingTripsMap,
                             staticData.stop.id,
                             alerts,
-                            hasSchedulesTodayByPattern
+                            hasSchedulesTodayByPattern,
+                            allDataLoaded
                         )
                 }
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -44,6 +44,7 @@ sealed class RealtimePatterns {
     abstract val upcomingTrips: List<UpcomingTrip>?
     abstract val alertsHere: List<Alert>?
     abstract val hasSchedulesToday: Boolean
+    abstract val allDataLoaded: Boolean
 
     val hasMajorAlerts
         get() = run {
@@ -63,6 +64,7 @@ sealed class RealtimePatterns {
         override val upcomingTrips: List<UpcomingTrip>? = null,
         override val alertsHere: List<Alert>? = null,
         override val hasSchedulesToday: Boolean = true,
+        override val allDataLoaded: Boolean = true,
     ) : RealtimePatterns() {
         override val id = headsign
 
@@ -72,6 +74,7 @@ sealed class RealtimePatterns {
             parentStopId: String,
             alerts: Collection<Alert>?,
             hasSchedulesTodayByPattern: Map<String, Boolean>?,
+            allDataLoaded: Boolean,
         ) : this(
             staticData.route,
             staticData.headsign,
@@ -100,6 +103,7 @@ sealed class RealtimePatterns {
                 )
             },
             hasSchedulesToday(hasSchedulesTodayByPattern, staticData.patterns),
+            allDataLoaded,
         )
     }
 
@@ -116,6 +120,7 @@ sealed class RealtimePatterns {
         override val upcomingTrips: List<UpcomingTrip>? = null,
         override val alertsHere: List<Alert>? = null,
         override val hasSchedulesToday: Boolean = true,
+        override val allDataLoaded: Boolean = true,
     ) : RealtimePatterns() {
         override val id = "${line.id}:${direction.id}"
         val representativeRoute = routes.min()
@@ -136,6 +141,7 @@ sealed class RealtimePatterns {
             parentStopId: String,
             alerts: Collection<Alert>?,
             hasSchedulesTodayByPattern: Map<String, Boolean>?,
+            allDataLoaded: Boolean,
         ) : this(
             staticData.line,
             staticData.routes,
@@ -164,6 +170,7 @@ sealed class RealtimePatterns {
                 )
             },
             hasSchedulesToday(hasSchedulesTodayByPattern, staticData.patterns),
+            allDataLoaded,
         )
     }
 
@@ -239,6 +246,7 @@ sealed class RealtimePatterns {
                 .take(count)
         return when {
             tripsToShow.isNotEmpty() -> Format.Some(tripsToShow, secondaryAlert)
+            !allDataLoaded -> Format.Loading
             !hasSchedulesToday -> Format.NoSchedulesToday(secondaryAlert)
             allTrips.any { it.time != null && it.time > now && !it.isCancelled } ->
                 // there are trips in the future but we're not showing them (maybe because we're on

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -184,6 +184,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             hasSchedulesTodayByPattern: Map<String, Boolean>?,
         ): PatternsByStop {
             global.run {
+                val allDataLoaded = !loading
                 val patternsByHeadsign =
                     routePatterns.groupBy {
                         routePatterns.groupBy { trips.getValue(it.representativeTripId) }
@@ -231,7 +232,8 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                 RealtimePatterns.hasSchedulesToday(
                                     hasSchedulesTodayByPattern,
                                     patterns
-                                )
+                                ),
+                                allDataLoaded
                             )
                         }
                         .filter {
@@ -255,6 +257,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             hasSchedulesTodayByPattern: Map<String, Boolean>?,
         ): PatternsByStop {
             global.run {
+                val allDataLoaded = !loading
                 val groupedPatternsByRoute = patternsByRoute.filter { it.key.lineId == line.id }
 
                 val staticPatterns =
@@ -276,7 +279,8 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                         tripMap,
                                         stop.id,
                                         alerts,
-                                        hasSchedulesTodayByPattern
+                                        hasSchedulesTodayByPattern,
+                                        allDataLoaded
                                     )
                                 is NearbyStaticData.StaticPatterns.ByDirection ->
                                     RealtimePatterns.ByDirection(
@@ -284,7 +288,8 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                                         tripMap,
                                         stop.id,
                                         alerts,
-                                        hasSchedulesTodayByPattern
+                                        hasSchedulesTodayByPattern,
+                                        allDataLoaded
                                     )
                             }
                         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -600,7 +600,8 @@ class NearbyResponseTest {
                                     listOf(
                                         objects.upcomingTrip(stop1Pattern2Prediction),
                                         objects.upcomingTrip(stop1Pattern1Prediction)
-                                    )
+                                    ),
+                                    allDataLoaded = false
                                 )
                             )
                         ),
@@ -613,7 +614,8 @@ class NearbyResponseTest {
                                     "Nubian",
                                     null,
                                     listOf(pattern3),
-                                    listOf(objects.upcomingTrip(stop2Pattern3Prediction))
+                                    listOf(objects.upcomingTrip(stop2Pattern3Prediction)),
+                                    allDataLoaded = false
                                 )
                             )
                         )
@@ -748,14 +750,16 @@ class NearbyResponseTest {
                                     "Typical Out",
                                     null,
                                     listOf(typicalOutbound),
-                                    listOf(objects.upcomingTrip(typicalOutboundPrediction))
+                                    listOf(objects.upcomingTrip(typicalOutboundPrediction)),
+                                    allDataLoaded = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
                                     route1,
                                     "Deviation Out",
                                     null,
                                     listOf(deviationOutbound),
-                                    listOf(objects.upcomingTrip(deviationOutboundPrediction))
+                                    listOf(objects.upcomingTrip(deviationOutboundPrediction)),
+                                    allDataLoaded = false
                                 ),
                                 // since this has trips it's sorted earlier than typical in
                                 RealtimePatterns.ByHeadsign(
@@ -763,14 +767,16 @@ class NearbyResponseTest {
                                     "Atypical In",
                                     null,
                                     listOf(atypicalInbound),
-                                    listOf(objects.upcomingTrip(atypicalInboundPrediction))
+                                    listOf(objects.upcomingTrip(atypicalInboundPrediction)),
+                                    allDataLoaded = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
                                     route1,
                                     "Typical In",
                                     null,
                                     listOf(typicalInbound),
-                                    emptyList()
+                                    emptyList(),
+                                    allDataLoaded = false
                                 ),
                             )
                         )
@@ -1051,14 +1057,16 @@ class NearbyResponseTest {
                                     "Typical Out",
                                     null,
                                     listOf(typicalOutbound),
-                                    emptyList()
+                                    emptyList(),
+                                    allDataLoaded = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
                                     route1,
                                     "Typical In",
                                     null,
                                     listOf(typicalInbound),
-                                    emptyList()
+                                    emptyList(),
+                                    allDataLoaded = false
                                 ),
                             )
                         )
@@ -1678,7 +1686,8 @@ class NearbyResponseTest {
                                     "Harvard",
                                     null,
                                     listOf(pattern1),
-                                    listOf(objects.upcomingTrip(prediction1))
+                                    listOf(objects.upcomingTrip(prediction1)),
+                                    allDataLoaded = false
                                 )
                             )
                         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -221,6 +221,27 @@ class RealtimePatternsTest {
     }
 
     @Test
+    fun `formats as loading if empty trips but still loading`() = parametricTest {
+        val now = Clock.System.now()
+
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = anyEnumValue() }
+        val pattern = objects.routePattern(route)
+        assertEquals(
+            RealtimePatterns.Format.Loading,
+            RealtimePatterns.ByHeadsign(
+                    route,
+                    "",
+                    null,
+                    listOf(pattern),
+                    upcomingTrips = emptyList(),
+                    allDataLoaded = false
+                )
+                .format(now, route.type, anyContext())
+        )
+    }
+
+    @Test
     fun `skips trips that should be hidden`() = parametricTest {
         val now = Clock.System.now()
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -308,7 +308,11 @@ class StopDetailsDeparturesTest {
             val scheduledTrip: UpcomingTrip?,
             val predictedTrip: UpcomingTrip?,
         ) {
-            fun patternsByHeadsign(trips: List<UpcomingTrip>?, hasSchedulesToday: Boolean = true) =
+            fun patternsByHeadsign(
+                trips: List<UpcomingTrip>?,
+                hasSchedulesToday: Boolean = true,
+                allDataLoaded: Boolean = true
+            ) =
                 RealtimePatterns.ByHeadsign(
                     route,
                     headsign,
@@ -316,7 +320,8 @@ class StopDetailsDeparturesTest {
                     listOf(routePattern),
                     trips,
                     null,
-                    hasSchedulesToday
+                    hasSchedulesToday,
+                    allDataLoaded
                 )
         }
 
@@ -390,34 +395,50 @@ class StopDetailsDeparturesTest {
 
         assertEquals(
             expected(
-                scheduledPredicted.patternsByHeadsign(null),
-                scheduledUnpredicted.patternsByHeadsign(null),
-                unscheduledPredicted.patternsByHeadsign(null),
-                unscheduledUnpredicted.patternsByHeadsign(null)
+                scheduledPredicted.patternsByHeadsign(null, allDataLoaded = false),
+                scheduledUnpredicted.patternsByHeadsign(null, allDataLoaded = false),
+                unscheduledPredicted.patternsByHeadsign(null, allDataLoaded = false),
+                unscheduledUnpredicted.patternsByHeadsign(null, allDataLoaded = false)
             ),
             actual(includeSchedules = false, includePredictions = false)
         )
 
         assertEquals(
             expected(
-                scheduledPredicted.patternsByHeadsign(listOf(scheduledPredicted.predictedTrip!!)),
-                unscheduledPredicted.patternsByHeadsign(
-                    listOf(unscheduledPredicted.predictedTrip!!)
+                scheduledPredicted.patternsByHeadsign(
+                    listOf(scheduledPredicted.predictedTrip!!),
+                    allDataLoaded = false
                 ),
-                scheduledUnpredicted.patternsByHeadsign(emptyList()),
-                unscheduledUnpredicted.patternsByHeadsign(emptyList())
+                unscheduledPredicted.patternsByHeadsign(
+                    listOf(unscheduledPredicted.predictedTrip!!),
+                    allDataLoaded = false
+                ),
+                scheduledUnpredicted.patternsByHeadsign(emptyList(), allDataLoaded = false),
+                unscheduledUnpredicted.patternsByHeadsign(emptyList(), allDataLoaded = false)
             ),
             actual(includeSchedules = false, includePredictions = true)
         )
 
         assertEquals(
             expected(
-                scheduledPredicted.patternsByHeadsign(listOf(scheduledPredicted.scheduledTrip!!)),
-                scheduledUnpredicted.patternsByHeadsign(
-                    listOf(scheduledUnpredicted.scheduledTrip!!)
+                scheduledPredicted.patternsByHeadsign(
+                    listOf(scheduledPredicted.scheduledTrip!!),
+                    allDataLoaded = false
                 ),
-                unscheduledPredicted.patternsByHeadsign(emptyList(), hasSchedulesToday = false),
-                unscheduledUnpredicted.patternsByHeadsign(emptyList(), hasSchedulesToday = false)
+                scheduledUnpredicted.patternsByHeadsign(
+                    listOf(scheduledUnpredicted.scheduledTrip!!),
+                    allDataLoaded = false
+                ),
+                unscheduledPredicted.patternsByHeadsign(
+                    emptyList(),
+                    hasSchedulesToday = false,
+                    allDataLoaded = false
+                ),
+                unscheduledUnpredicted.patternsByHeadsign(
+                    emptyList(),
+                    hasSchedulesToday = false,
+                    allDataLoaded = false
+                )
             ),
             actual(includeSchedules = true, includePredictions = false)
         )
@@ -485,6 +506,7 @@ class StopDetailsDeparturesTest {
                 null,
                 listOf(earlyPattern),
                 emptyList(),
+                allDataLoaded = false
             )
         val expectedLateBeforeLoad =
             RealtimePatterns.ByHeadsign(
@@ -493,6 +515,7 @@ class StopDetailsDeparturesTest {
                 null,
                 listOf(latePattern),
                 listOf(UpcomingTrip(lateTrip, latePrediction)),
+                allDataLoaded = false
             )
         val expectedLateAfterLoad =
             RealtimePatterns.ByHeadsign(


### PR DESCRIPTION
### Summary

_Ticket:_ [Handle service ended for the day](https://app.asana.com/0/1205732265579288/1208217009015140/f), kinda
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1728334936690569)

If predictions load before schedules, hasSchedulesToday defaults to true while schedules are loading, so we'll say "Service ended" in places where there are no predictions. Making that default to null won't help if schedules load before predictions; we'll still flash "predictions unavailable" on subway. The most direct way to ensure that we don't make claims about absent service until all the data has loaded is to keep track directly of whether or not all the data has loaded.

### Testing

Manually verified that everything looks like it's working correctly, updated unit tests, added a new unit test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
