### PR TITLE
Jvc trip details screen reader text

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		9A3B09362B967CEC00691427 /* NonNilModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3B09352B967CEC00691427 /* NonNilModifier.swift */; };
 		9A3BAB722BEAB8E200DAFDE2 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A3BAB712BEAB8E200DAFDE2 /* Colors.xcassets */; };
 		9A3BAB742BEABADF00DAFDE2 /* ColorAssetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3BAB732BEABADF00DAFDE2 /* ColorAssetExtension.swift */; };
+		9A4850572CB56A1600F50EE7 /* RouteTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4850562CB56A1500F50EE7 /* RouteTypeExtension.swift */; };
 		9A4DB7782C937EE300E8755B /* SearchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB7772C937EE300E8755B /* SearchViewModel.swift */; };
 		9A4DB77A2CA47E6D00E8755B /* SearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB7792CA47E6D00E8755B /* SearchField.swift */; };
 		9A4DB77F2CA4A32800E8755B /* SearchOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB77E2CA4A32800E8755B /* SearchOverlay.swift */; };
@@ -353,6 +354,7 @@
 		9A3B09352B967CEC00691427 /* NonNilModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonNilModifier.swift; sourceTree = "<group>"; };
 		9A3BAB712BEAB8E200DAFDE2 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		9A3BAB732BEABADF00DAFDE2 /* ColorAssetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorAssetExtension.swift; sourceTree = "<group>"; };
+		9A4850562CB56A1500F50EE7 /* RouteTypeExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTypeExtension.swift; sourceTree = "<group>"; };
 		9A4DB7772C937EE300E8755B /* SearchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModel.swift; sourceTree = "<group>"; };
 		9A4DB7792CA47E6D00E8755B /* SearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchField.swift; sourceTree = "<group>"; };
 		9A4DB77E2CA4A32800E8755B /* SearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchOverlay.swift; sourceTree = "<group>"; };
@@ -918,6 +920,7 @@
 				8C0923A62C210C8C00813454 /* Typography.swift */,
 				8CA485B72BDC679A00E84E1F /* VehicleExtension.swift */,
 				9A5830552BA3A2CE0039876E /* ViewportExtension.swift */,
+				9A4850562CB56A1500F50EE7 /* RouteTypeExtension.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -1362,6 +1365,7 @@
 				8C815AF32BF5257B009BB51C /* TripDetailsStopListView.swift in Sources */,
 				8C3D64102BE19DBA0026DD53 /* SettingsPage.swift in Sources */,
 				EDE92FA62C3DD675007AD2F6 /* ScreenTracker.swift in Sources */,
+				9A4850572CB56A1600F50EE7 /* RouteTypeExtension.swift in Sources */,
 				EDE92FA82C408A32007AD2F6 /* SettingsViewModel.swift in Sources */,
 				8CA1FB752BF7EB3500384658 /* TripDetailsStopListSplitView.swift in Sources */,
 				8CE014122BBDB96900918FAE /* StopDetailsRouteView.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/RouteIcon.swift
+++ b/iosApp/iosApp/ComponentViews/RouteIcon.swift
@@ -15,7 +15,7 @@ func routeIcon(_ route: Route) -> Image {
 }
 
 func routeIcon(_ routeType: RouteType) -> Image {
-    switch routeType {
+    let image = switch routeType {
     case .bus:
         Image(.modeBus)
     case .commuterRail:
@@ -25,4 +25,6 @@ func routeIcon(_ routeType: RouteType) -> Image {
     default:
         Image(.modeSubway)
     }
+
+    return image
 }

--- a/iosApp/iosApp/ComponentViews/SheetHeader.swift
+++ b/iosApp/iosApp/ComponentViews/SheetHeader.swift
@@ -23,6 +23,7 @@ struct SheetHeader: View {
                 Text(title)
                     .font(Typography.title3Semibold)
                     .padding([.top], 1)
+                    .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h1)
             }
             if let onClose {

--- a/iosApp/iosApp/ComponentViews/TransitHeader.swift
+++ b/iosApp/iosApp/ComponentViews/TransitHeader.swift
@@ -23,6 +23,7 @@ struct TransitHeader<Content: View>: View {
         Label {
             Text(name)
                 .font(Typography.bodySemibold)
+                .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h2)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(textColor)

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -44,23 +44,6 @@ struct UpcomingTripView: View {
             .padding(.trailing, 4)
     }
 
-    var vehicleTypeText: String {
-        // hardcoding plurals because pluralized strings that don't include the number are not supported
-        // https://developer.apple.com/forums/thread/737329#737329021
-        switch routeType {
-        case .bus:
-            isOnly ? NSLocalizedString("bus", comment: "bus") : NSLocalizedString("buses", comment: "buses")
-
-        case .commuterRail, .heavyRail, .lightRail:
-            isOnly ? NSLocalizedString("train", comment: "train") : NSLocalizedString("trains", comment: "trains")
-
-        case .ferry: isOnly ? NSLocalizedString("ferry", comment: "ferry")
-            : NSLocalizedString("ferries", comment: "ferries")
-
-        case nil: ""
-        }
-    }
-
     @ViewBuilder
     var predictionView: some View {
         switch prediction {
@@ -74,17 +57,20 @@ struct UpcomingTripView: View {
             case .now:
                 Text("Now").font(Typography.headlineBold)
                     .accessibilityLabel(isFirst
-                        ? accessibilityFormatters.arrivingFirst(vehicleText: vehicleTypeText)
+                        ? accessibilityFormatters
+                        .arrivingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.arrivingOther())
             case .boarding:
                 Text("BRD").font(Typography.headlineBold)
                     .accessibilityLabel(isFirst
-                        ? accessibilityFormatters.boardingFirst(vehicleText: vehicleTypeText)
+                        ? accessibilityFormatters
+                        .boardingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.boardingOther())
             case .arriving:
                 Text("ARR").font(Typography.headlineBold)
                     .accessibilityLabel(isFirst
-                        ? accessibilityFormatters.arrivingFirst(vehicleText: vehicleTypeText)
+                        ? accessibilityFormatters
+                        .arrivingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.arrivingOther())
             case .approaching:
                 PredictionText(minutes: 1)
@@ -93,7 +79,7 @@ struct UpcomingTripView: View {
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters.distantFutureFirst(
                             date: format.predictionTime.toNSDate(),
-                            vehicleText: vehicleTypeText
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
                         )
                         : accessibilityFormatters
                         .distantFutureOther(date: format.predictionTime.toNSDate()))
@@ -104,7 +90,7 @@ struct UpcomingTripView: View {
                         .accessibilityLabel(isFirst
                             ? accessibilityFormatters.scheduledFirst(
                                 date: schedule.scheduleTime.toNSDate(),
-                                vehicleText: vehicleTypeText
+                                vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
                             )
                             : accessibilityFormatters
                             .scheduledOther(date: schedule.scheduleTime.toNSDate()))
@@ -120,7 +106,8 @@ struct UpcomingTripView: View {
                 PredictionText(minutes: format.minutes)
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters.predictionMinutesFirst(minutes: format.minutes,
-                                                                         vehicleText: vehicleTypeText)
+                                                                         vehicleText: routeType?
+                                                                             .typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.predictionMinutesOther(minutes: format.minutes))
             case let .cancelled(schedule):
                 HStack(spacing: Self.subjectSpacing) {
@@ -137,7 +124,7 @@ struct UpcomingTripView: View {
                     isFirst
                         ? accessibilityFormatters.scheduledFirst(
                             date: schedule.scheduledTime.toNSDate(),
-                            vehicleText: vehicleTypeText
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
                         )
                         : accessibilityFormatters.scheduledOther(date: schedule.scheduledTime.toNSDate())
                 )

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -143,9 +143,6 @@
     "and in %@ min" : {
 
     },
-    "Approaching" : {
-
-    },
     "ARR" : {
 
     },
@@ -300,9 +297,6 @@
     "Medical Emergency" : {
       "comment" : "Possible alert cause"
     },
-    "Next stop" : {
-
-    },
     "No nearby MBTA stops" : {
 
     },
@@ -313,9 +307,6 @@
 
     },
     "Now" : {
-
-    },
-    "Now at" : {
 
     },
     "Open for more arrivals" : {

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
@@ -28,7 +28,7 @@ struct TripDetailsHeader: View {
                 .accessibilityElement()
                 .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h1)
-                .accessibilityLabel("\(line?.shortName ?? "") \(route.type.typeText(isOnly: true)) to \(trip.headsign)")
+                .accessibilityLabel("\(route.label) \(route.type.typeText(isOnly: true)) to \(trip.headsign)")
             }
             Spacer()
             ActionButton(kind: .close, action: onClose)

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
@@ -47,7 +47,6 @@ struct TripDetailsHeader: View {
         }
         .accessibilityElement()
         .accessibilityAddTraits(.isHeader)
-        .accessibilityHeading(.h1)
         .accessibilityLabel("Real-time arrivals updating live")
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
@@ -25,6 +25,10 @@ struct TripDetailsHeader: View {
                     RoutePill(route: route, line: line, type: .fixed)
                     toHeadsign(trip.headsign)
                 }
+                .accessibilityElement()
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityHeading(.h1)
+                .accessibilityLabel("\(line?.shortName ?? "") \(route.type.typeText(isOnly: true)) to \(trip.headsign)")
             }
             Spacer()
             ActionButton(kind: .close, action: onClose)
@@ -41,12 +45,15 @@ struct TripDetailsHeader: View {
             Text("Live")
                 .font(Typography.footnote)
         }
+        .accessibilityElement()
+        .accessibilityAddTraits(.isHeader)
+        .accessibilityHeading(.h1)
+        .accessibilityLabel("Real-time arrivals updating live")
     }
 
     func toHeadsign(_ headsign: String) -> some View {
         Text("to \(headsign)")
             .font(Typography.headlineBold)
-            .accessibilityHeading(.h1)
     }
 }
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
@@ -24,16 +24,14 @@ struct TripDetailsStopListSplitView: View {
                     }
                 }
                 .accessibilityElement()
-                .accessibilityAddTraits(/*@START_MENU_TOKEN@*/ .isHeader/*@END_MENU_TOKEN@*/)
+                .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h2)
                 .accessibilityLabel(
                     LocalizedStringKey(
                         "\(routeType?.typeText(isOnly: true) ?? "") is \(splitStops.collapsedStops.count, specifier: "%ld") stops away from \(splitStops.targetStop.stop.name)"
                     )
                 )
-                .accessibilityHint(
-                    splitStops.collapsedStops.map(\.stop.name).joined(separator: ", ")
-                )
+                .accessibilityHint("List remaining stops")
             }
             TripDetailsStopView(stop: splitStops.targetStop, now: now, onTapLink: onTapLink, routeType: routeType)
                 .listRowBackground(Color.keyInverse.opacity(0.15))

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
@@ -23,6 +23,17 @@ struct TripDetailsStopListSplitView: View {
                         TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink, routeType: routeType)
                     }
                 }
+                .accessibilityElement()
+                .accessibilityAddTraits(/*@START_MENU_TOKEN@*/ .isHeader/*@END_MENU_TOKEN@*/)
+                .accessibilityHeading(.h2)
+                .accessibilityLabel(
+                    LocalizedStringKey(
+                        "\(routeType?.typeText(isOnly: true) ?? "") is \(splitStops.collapsedStops.count, specifier: "%ld") stops away from \(splitStops.targetStop.stop.name)"
+                    )
+                )
+                .accessibilityHint(
+                    splitStops.collapsedStops.map(\.stop.name).joined(separator: ", ")
+                )
             }
             TripDetailsStopView(stop: splitStops.targetStop, now: now, onTapLink: onTapLink, routeType: routeType)
                 .listRowBackground(Color.keyInverse.opacity(0.15))

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -44,11 +44,11 @@ struct TripDetailsStopView: View {
             return "Connection to \(stop.routes.first!.label) \(stop.routes.first!.type.typeText(isOnly: true))"
         } else {
             let lastConnection = stop.routes.last
-            return stop.routes.prefix(stop.routes.count - 1).map {
+            return "Connections to" + stop.routes.prefix(stop.routes.count - 1).map {
                 "\($0.label) \($0.type.typeText(isOnly: true))"
             }
             .joined(separator: ", ") +
-            "and \(lastConnection!.label) \(lastConnection!.type.typeText(isOnly: true))"
+            " and \(lastConnection!.label) \(lastConnection!.type.typeText(isOnly: true))"
         }
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -26,9 +26,33 @@ struct TripDetailsStopView: View {
                         Spacer()
                         UpcomingTripView(prediction: upcomingTripViewState, routeType: routeType)
                     }
+                    .accessibilityElement()
+                    .accessibilityAddTraits(.isHeader)
+                    .accessibilityHeading(.h2)
+                    // TODO: When the accessibility status of the station
+                    // is propogated from the backend, add the accessibility
+                    // status of the station to the label
+                    .accessibilityLabel(accessibilityLabel)
                 }
             )
             scrollRoutes
+        }
+    }
+
+    var accessibilityLabel: String {
+        let base = "\(stop.stop.name), arriving at \(stop.format(now: now, routeType: routeType))."
+        if stop.routes.isEmpty {
+            return base
+        } else if stop.routes.count == 1 {
+            return base +
+                "Connection to \(stop.routes.first!.shortName) \(stop.routes.first!.type.typeText(isOnly: true))"
+        } else {
+            let lastConnection = stop.routes.last
+            return base + stop.routes.prefix(stop.routes.count - 1).map {
+                "\($0.shortName) \($0.type.typeText(isOnly: true))"
+            }
+            .joined(separator: ", ") +
+            "and \(lastConnection!.shortName) \(lastConnection!.type.typeText(isOnly: true))"
         }
     }
 
@@ -45,9 +69,6 @@ struct TripDetailsStopView: View {
             HStack {
                 ForEach(stop.routes, id: \.id) { route in
                     RoutePill(route: route, line: nil, type: .flex)
-                        .onTapGesture {
-                            onTapLink(.stopDetails(stop.stop, nil), stop, route.id)
-                        }
                 }
             }.padding(.horizontal, 20)
         }.padding(.horizontal, -20).onTapGesture {

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -32,6 +32,7 @@ struct TripDetailsStopView: View {
                 }
             )
             scrollRoutes
+                .accessibilityElement()
                 .accessibilityLabel(scrollRoutesAccessibilityLabel)
         }
     }
@@ -40,14 +41,14 @@ struct TripDetailsStopView: View {
         if stop.routes.isEmpty {
             return ""
         } else if stop.routes.count == 1 {
-            return "Connection to \(stop.routes.first!.shortName) \(stop.routes.first!.type.typeText(isOnly: true))"
+            return "Connection to \(stop.routes.first!.label) \(stop.routes.first!.type.typeText(isOnly: true))"
         } else {
             let lastConnection = stop.routes.last
             return stop.routes.prefix(stop.routes.count - 1).map {
-                "\($0.shortName) \($0.type.typeText(isOnly: true))"
+                "\($0.label) \($0.type.typeText(isOnly: true))"
             }
             .joined(separator: ", ") +
-            "and \(lastConnection!.shortName) \(lastConnection!.type.typeText(isOnly: true))"
+            "and \(lastConnection!.label) \(lastConnection!.type.typeText(isOnly: true))"
         }
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -26,29 +26,24 @@ struct TripDetailsStopView: View {
                         Spacer()
                         UpcomingTripView(prediction: upcomingTripViewState, routeType: routeType)
                     }
-                    .accessibilityElement()
+                    .accessibilityElement(children: .combine)
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h2)
-                    // TODO: When the accessibility status of the station
-                    // is propogated from the backend, add the accessibility
-                    // status of the station to the label
-                    .accessibilityLabel(accessibilityLabel)
                 }
             )
             scrollRoutes
+                .accessibilityLabel(scrollRoutesAccessibilityLabel)
         }
     }
 
-    var accessibilityLabel: String {
-        let base = "\(stop.stop.name), arriving at \(stop.format(now: now, routeType: routeType))."
+    var scrollRoutesAccessibilityLabel: String {
         if stop.routes.isEmpty {
-            return base
+            return ""
         } else if stop.routes.count == 1 {
-            return base +
-                "Connection to \(stop.routes.first!.shortName) \(stop.routes.first!.type.typeText(isOnly: true))"
+            return "Connection to \(stop.routes.first!.shortName) \(stop.routes.first!.type.typeText(isOnly: true))"
         } else {
             let lastConnection = stop.routes.last
-            return base + stop.routes.prefix(stop.routes.count - 1).map {
+            return stop.routes.prefix(stop.routes.count - 1).map {
                 "\($0.shortName) \($0.type.typeText(isOnly: true))"
             }
             .joined(separator: ", ") +

--- a/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
@@ -78,10 +78,18 @@ struct VehicleOnTripView: View {
                     .font(Typography.headlineBold)
                     .foregroundColor(textColor)
             }
+            .accessibilityElement()
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityHeading(.h2)
+            .accessibilityLabel(
+                "\(route.type.typeText(isOnly: true)) \(vehicleStatusDescription(vehicle.currentStatus)) \(stop.name)"
+            )
         } else {
             Text("This vehicle is completing another trip.")
                 .font(Typography.headlineBold)
                 .foregroundColor(textColor)
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityHeading(.h2)
         }
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
@@ -123,6 +123,7 @@ struct VehicleOnTripView: View {
                 .frame(width: 24, height: 24)
                 .foregroundColor(textColor)
         }
+        .accessibilityHidden(true)
         .padding([.bottom], 4)
         .frame(width: 56, height: 56)
     }

--- a/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
@@ -82,7 +82,7 @@ struct VehicleOnTripView: View {
             .accessibilityAddTraits(.isHeader)
             .accessibilityHeading(.h2)
             .accessibilityLabel(
-                "\(route.type.typeText(isOnly: true)) \(vehicleStatusDescription(vehicle.currentStatus)) \(stop.name)"
+                "\(route.type.typeText(isOnly: true)) \(vehicleStatusText(vehicle.currentStatus)) \(stop.name)"
             )
         } else {
             Text("This vehicle is completing another trip.")
@@ -97,10 +97,16 @@ struct VehicleOnTripView: View {
     private func vehicleStatusDescription(
         _ vehicleStatus: __Bridge__Vehicle_CurrentStatus
     ) -> some View {
+        Text(vehicleStatusText(vehicleStatus))
+    }
+
+    private func vehicleStatusText(
+        _ vehicleStatus: __Bridge__Vehicle_CurrentStatus
+    ) -> String {
         switch vehicleStatus {
-        case .incomingAt: Text("Approaching")
-        case .inTransitTo: Text("Next stop")
-        case .stoppedAt: Text("Now at")
+        case .incomingAt: "Approaching"
+        case .inTransitTo: "Next stop"
+        case .stoppedAt: "Now at"
         }
     }
 

--- a/iosApp/iosApp/Utils/RouteTypeExtension.swift
+++ b/iosApp/iosApp/Utils/RouteTypeExtension.swift
@@ -1,0 +1,27 @@
+//
+//  RouteTypeExtension.swift
+//  iosApp
+//
+//  Created by Jack Curtis on 10/8/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import shared
+
+extension RouteType {
+    func typeText(isOnly: Bool) -> String {
+        // hardcoding plurals because pluralized strings that don't include the number are not supported
+        // https://developer.apple.com/forums/thread/737329#737329021
+        switch self {
+        case .bus:
+            isOnly ? NSLocalizedString("bus", comment: "bus") : NSLocalizedString("buses", comment: "buses")
+
+        case .commuterRail, .heavyRail, .lightRail:
+            isOnly ? NSLocalizedString("train", comment: "train") : NSLocalizedString("trains", comment: "trains")
+
+        case .ferry: isOnly ? NSLocalizedString("ferry", comment: "ferry")
+            : NSLocalizedString("ferries", comment: "ferries")
+        }
+    }
+}

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
@@ -78,45 +78,6 @@ final class TripDetailsStopViewTests: XCTestCase {
         wait(for: [exp], timeout: 5)
     }
 
-    func testHandlesTapOnConnectingRoute() throws {
-        let objects = ObjectCollectionBuilder()
-        let stop = objects.stop { stop in
-            stop.name = "Boylston"
-        }
-        let now = Date.now
-        let prediction = objects.prediction { prediction in
-            prediction.departureTime = now.addingTimeInterval(60).toKotlinInstant()
-        }
-        let connectingRoute = objects.route { route in
-            route.shortName = "28"
-            route.type = .bus
-        }
-        let stopListEntry = TripDetailsStopList.Entry(
-            stop: stop,
-            stopSequence: 1,
-            alert: nil,
-            schedule: nil,
-            prediction: prediction,
-            vehicle: nil,
-            routes: [connectingRoute]
-        )
-        let exp = expectation(description: "calls onTapLink")
-        let sut = TripDetailsStopView(
-            stop: stopListEntry,
-            now: now.toKotlinInstant(),
-            onTapLink: { navStackEntry, actualStopListEntry, connectingRouteId in
-                XCTAssertEqual(navStackEntry, .stopDetails(stop, nil))
-                XCTAssertEqual(stopListEntry, actualStopListEntry)
-                XCTAssertEqual(connectingRouteId, connectingRoute.id)
-                exp.fulfill()
-            },
-            routeType: nil
-        )
-
-        try sut.inspect().find(text: "28").find(RoutePill.self, relation: .parent).callOnTapGesture()
-        wait(for: [exp], timeout: 5)
-    }
-
     func testShowsNowForBus() throws {
         let now = Date.now
         let objects = ObjectCollectionBuilder()


### PR DESCRIPTION
### Summary

_Ticket:_ [Optimize Trip Details screen reader text](https://app.asana.com/0/1205732265579288/1208295417175124/f)

What is this PR for?

Updates the Trip Details page to use accessible elements and headings for improved VoiceOver access.

### Testing

What testing have you done?

Manual testing in the Accessibility inspector. Unfortunately I can't find a way to test accessibility labels and elements through the unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
