### PR TITLE
feat(iOS): forget predictions if backgrounded for over ten minutes

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -195,6 +195,8 @@ class NearbyTransitPageTest : KoinTest {
 
                         override var lastUpdated: Instant? = null
 
+                        override fun shouldForgetPredictions(predictionCount: Int) = false
+
                         override fun disconnect() {
                             /* no-op */
                         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -189,6 +189,8 @@ class NearbyTransitViewTest : KoinTest {
 
                         override var lastUpdated: Instant? = null
 
+                        override fun shouldForgetPredictions(predictionCount: Int) = false
+
                         override fun disconnect() {
                             /* no-op */
                         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -135,6 +135,8 @@ class StopDetailsViewTest {
 
                         override var lastUpdated: Instant? = null
 
+                        override fun shouldForgetPredictions(predictionCount: Int) = false
+
                         override fun disconnect() {
                             /* no-op */
                         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
@@ -59,6 +59,8 @@ class SubscribeToPredictionsTest {
 
                 override var lastUpdated: Instant? = null
 
+                override fun shouldForgetPredictions(predictionCount: Int) = false
+
                 override fun disconnect() {
                     check(isConnected) { "called disconnect when not connected" }
                     isConnected = false

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -88,7 +88,14 @@ struct NearbyTransitView: View {
             }
         }
         .withScenePhaseHandlers(
-            onActive: { joinPredictions(state.nearbyByRouteAndStop?.stopIds()) },
+            onActive: {
+                if let predictionsByStop,
+                   predictionsRepository
+                   .shouldForgetPredictions(predictionCount: predictionsByStop.predictionQuantity()) {
+                    self.predictionsByStop = nil
+                }
+                joinPredictions(state.nearbyByRouteAndStop?.stopIds())
+            },
             onInactive: leavePredictions,
             onBackground: {
                 leavePredictions()

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -106,11 +106,20 @@ struct StopDetailsPage: View {
             .onDisappear {
                 leavePredictions()
             }
-            .withScenePhaseHandlers(onActive: { joinPredictions(stop) },
-                                    onInactive: leavePredictions,
-                                    onBackground: { leavePredictions()
-                                        isReturningFromBackground = true
-                                    })
+            .withScenePhaseHandlers(
+                onActive: {
+                    if let predictionsByStop,
+                       predictionsRepository
+                       .shouldForgetPredictions(predictionCount: predictionsByStop.predictionQuantity()) {
+                        self.predictionsByStop = nil
+                    }
+                    joinPredictions(stop)
+                },
+                onInactive: leavePredictions,
+                onBackground: { leavePredictions()
+                    isReturningFromBackground = true
+                }
+            )
         }
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -130,12 +130,21 @@ struct TripDetailsPage: View {
             joinVehicle(vehicleId: vehicleId)
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
-        .withScenePhaseHandlers(onActive: joinRealtime,
-                                onInactive: leaveRealtime,
-                                onBackground: {
-                                    leaveRealtime()
-                                    isReturningFromBackground = true
-                                })
+        .withScenePhaseHandlers(
+            onActive: {
+                if let tripPredictions,
+                   tripPredictionsRepository
+                   .shouldForgetPredictions(predictionCount: tripPredictions.predictionQuantity()) {
+                    self.tripPredictions = nil
+                }
+                joinRealtime()
+            },
+            onInactive: leaveRealtime,
+            onBackground: {
+                leaveRealtime()
+                isReturningFromBackground = true
+            }
+        )
     }
 
     private func loadEverything() {

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -655,6 +655,10 @@ final class TripDetailsPageTests: XCTestCase {
 
         var lastUpdated: Instant?
 
+        func shouldForgetPredictions(predictionCount _: Int32) -> Bool {
+            false
+        }
+
         func disconnect() {
             onDisconnect?()
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -133,6 +133,8 @@ fun endToEndModule(): Module {
 
                 override var lastUpdated: Instant? = null
 
+                override fun shouldForgetPredictions(predictionCount: Int) = false
+
                 override fun connectV2(
                     stopIds: List<String>,
                     onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
@@ -198,6 +200,8 @@ fun endToEndModule(): Module {
                 }
 
                 override var lastUpdated: Instant? = null
+
+                override fun shouldForgetPredictions(predictionCount: Int) = false
 
                 override fun disconnect() {
                     TODO("Not yet implemented")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -10,6 +10,7 @@ import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixPushStatus
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.PredictionsForStopsChannel
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
@@ -28,6 +29,8 @@ interface IPredictionsRepository {
 
     var lastUpdated: Instant?
 
+    fun shouldForgetPredictions(predictionCount: Int): Boolean
+
     fun disconnect()
 }
 
@@ -37,6 +40,10 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
     var channel: PhoenixChannel? = null
 
     override var lastUpdated: Instant? = null
+
+    override fun shouldForgetPredictions(predictionCount: Int) =
+        (Clock.System.now() - (lastUpdated ?: Instant.DISTANT_FUTURE)) > 10.minutes &&
+            predictionCount > 0
 
     override fun connect(
         stopIds: List<String>,
@@ -220,6 +227,8 @@ class MockPredictionsRepository(
     }
 
     override var lastUpdated: Instant? = null
+
+    override fun shouldForgetPredictions(predictionCount: Int) = false
 
     override fun disconnect() {
         onDisconnect()


### PR DESCRIPTION
### Summary

_Ticket:_ [[Loading states] Clear predictions when older than 10 minutes](https://app.asana.com/0/1205732265579288/1208468599574698/f)

My first draft had all the logic in the `onActive` callbacks, but there's enough of it that it makes sense to move it into the shared code.

### Testing

Manually verified that predictions are forgotten after ten minutes but not after nine minutes. Added unit tests for the logic in shared code; I'm not sure how straightforward it'd be to test the scene phase handlers, but if it's worth a look I can try.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
