### PR TITLE
fix(iOS): display Service Change in alert header

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -351,6 +351,9 @@
     "select location" : {
 
     },
+    "Service Change" : {
+      "comment" : "Possible alert effect"
+    },
     "Service ended" : {
 
     },

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -32,6 +32,7 @@ struct AlertDetails: View {
         switch alert.effect {
         case .detour: NSLocalizedString("Detour", comment: "Possible alert effect")
         case .dockClosure: NSLocalizedString("Dock Closure", comment: "Possible alert effect")
+        case .serviceChange: NSLocalizedString("Service Change", comment: "Possible alert effect")
         case .shuttle: NSLocalizedString("Shuttle", comment: "Possible alert effect")
         case .stationClosure: NSLocalizedString("Station Closure", comment: "Possible alert effect")
         case .stopClosure: NSLocalizedString("Stop Closure", comment: "Possible alert effect")


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1728570239748239)

I think I may have just forgotten that this was its own list when I first added service change alert support.

### Testing

Manually verified that service change alerts have a proper header in alert details.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
