### PR TITLE
build(deps): Bump Sentry without upgrading kotlin

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Sentry (8.26.0):
-    - Sentry/Core (= 8.26.0)
-  - Sentry/Core (8.26.0)
+  - Sentry (8.36.0):
+    - Sentry/Core (= 8.36.0)
+  - Sentry/Core (8.36.0)
   - shared (1.0):
-    - Sentry (~> 8.26.0)
+    - Sentry (~> 8.36.0)
 
 DEPENDENCIES:
   - shared (from `../shared/`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../shared/"
 
 SPEC CHECKSUMS:
-  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
-  shared: 3feb3c866b91cde11fd8e459d237a2cc925cd032
+  Sentry: f8374b5415bc38dfb5645941b3ae31230fbeae57
+  shared: 19e2aa6dcc6627fddba6b8c32232f932ea8b8cc2
 
 PODFILE CHECKSUM: 32413a7fdb16d40c9f57cf8da0c74d4507ff5f90
 

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target    = '15.0'
-    spec.dependency 'Sentry', '~> 8.26.0'
+    spec.dependency 'Sentry', '~> 8.36.0'
 
     if !Dir.exist?('build/cocoapods/framework/shared.framework') || Dir.empty?('build/cocoapods/framework/shared.framework')
         raise "


### PR DESCRIPTION
### Summary

_Ticket:_ None

Some of the devs were hitting local issues with Sentry versions and pod installs. This was included in #457, but there were issues with the XCode version bump, so instead this just upgrades Sentry. 
