### PR TITLE
refactor: unify stop details with nearby transit

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -72,13 +72,17 @@ object PatternSorting {
 
     fun compareStopsAssociated(
         pinnedRoutes: Set<String>,
-        sortByDistanceFrom: Position
+        sortByDistanceFrom: Position?
     ): Comparator<StopsAssociated> =
         compareBy(
             { pinnedRouteBucket(it.sortRoute(), pinnedRoutes) },
             { patternServiceBucket(it.patternsByStop.first().patterns.first()) },
             { subwayBucket(it.sortRoute()) },
-            { it.distanceFrom(sortByDistanceFrom) },
+            if (sortByDistanceFrom != null) {
+                { it.distanceFrom(sortByDistanceFrom) }
+            } else {
+                { 0 }
+            },
             { it.sortRoute() },
         )
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -4,7 +4,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import io.github.dellisd.spatialk.geojson.Position
 import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
 import io.github.dellisd.spatialk.turf.distance
-import kotlinx.datetime.Instant
 
 /**
  * @property patterns [RealtimePatterns]s serving the stop grouped by headsign or direction. The
@@ -24,8 +23,7 @@ data class PatternsByStop(
     constructor(
         staticData: NearbyStaticData.StopPatterns,
         upcomingTripsMap: UpcomingTripsMap?,
-        filterTime: Instant,
-        cutoffTime: Instant,
+        patternsPredicate: (RealtimePatterns) -> Boolean,
         alerts: Collection<Alert>?,
         hasSchedulesTodayByPattern: Map<String, Boolean>?,
         allDataLoaded: Boolean,
@@ -62,10 +60,7 @@ data class PatternsByStop(
                         )
                 }
             }
-            .filter {
-                (it.isTypical() || it.isUpcomingWithin(filterTime, cutoffTime)) &&
-                    !it.isArrivalOnly()
-            }
+            .filter(patternsPredicate)
             .sortedWith(PatternSorting.compareRealtimePatterns()),
         staticData.directions
     )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -2,9 +2,9 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
-import com.mbta.tid.mbta_app.utils.resolveParentId
 import kotlinx.datetime.Instant
 
 data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
@@ -18,73 +18,29 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
         filterAtTime: Instant
     ) : this(
         global.run {
-            val loading = schedules == null || predictions == null
-            val tripMapByHeadsign = tripMapByHeadsign(stops, schedules, predictions, filterAtTime)
-
             val allStopIds =
                 if (patternIdsByStop.containsKey(stop.id)) {
-                    setOf(stop.id)
+                    listOf(stop.id)
                 } else {
-                    stop.childStopIds.toSet()
+                    stop.childStopIds.filter { global.stops.containsKey(it) }
                 }
 
-            val patternsByRoute =
-                allStopIds
-                    .flatMap { patternIdsByStop[it] ?: emptyList() }
-                    .map { patternId -> routePatterns.getValue(patternId) }
-                    .groupBy { routes.getValue(it.routeId) }
+            val staticData = NearbyStaticData(global, NearbyResponse(allStopIds))
 
-            val touchedLines: MutableSet<String> = mutableSetOf()
-
-            val activeRelevantAlerts =
-                alerts?.alerts?.values?.filter {
-                    it.isActive(filterAtTime) && it.significance >= AlertSignificance.Minor
-                }
-            val hasSchedulesTodayByPattern = NearbyStaticData.getSchedulesTodayByPattern(schedules)
-
-            patternsByRoute
-                .mapNotNull { (route, routePatterns) ->
-                    if (touchedLines.contains(route.lineId)) {
-                        return@mapNotNull null
-                    } else if (NearbyStaticData.groupedLines.contains(route.lineId)) {
-                        val line = global.lines[route.lineId] ?: return@mapNotNull null
-                        touchedLines.add(line.id)
-
-                        return@mapNotNull patternsByStopForLine(
-                            stop,
-                            line,
-                            patternsByRoute,
-                            tripMapByHeadsignOrDirection(
-                                stops,
-                                tripMapByHeadsign,
-                                schedules,
-                                predictions,
-                                filterAtTime
-                            ),
-                            allStopIds,
-                            loading,
-                            global,
-                            activeRelevantAlerts,
-                            hasSchedulesTodayByPattern
-                        )
-                    }
-
-                    return@mapNotNull patternsByStopForRoute(
-                        stop,
-                        route,
-                        routePatterns,
-                        tripMapByHeadsign,
-                        allStopIds,
-                        loading,
-                        global,
-                        activeRelevantAlerts,
-                        hasSchedulesTodayByPattern
-                    )
-                }
-                .filterNot { it.patterns.isEmpty() }
-                .sortedWith(
-                    PatternSorting.comparePatternsByStop(pinnedRoutes, sortByDistanceFrom = null)
+            staticData
+                .withRealtimeInfo(
+                    global,
+                    null,
+                    schedules,
+                    predictions,
+                    alerts,
+                    filterAtTime,
+                    showAllPatternsWhileLoading = true,
+                    hideNonTypicalPatternsBeyondNext = null,
+                    filterCancellations = false,
+                    pinnedRoutes
                 )
+                .flatMap { it.patternsByStop }
         }
     )
 
@@ -99,213 +55,5 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
         }
         val direction = directions.first()
         return StopDetailsFilter(route.routeIdentifier, direction)
-    }
-
-    companion object {
-
-        private fun tripMapByHeadsign(
-            stops: Map<String, Stop>,
-            schedules: ScheduleResponse?,
-            predictions: PredictionsStreamDataResponse?,
-            filterAtTime: Instant
-        ): Map<RealtimePatterns.UpcomingTripKey.ByRoutePattern, List<UpcomingTrip>>? {
-            return UpcomingTrip.tripsMappedBy(
-                stops,
-                schedules,
-                predictions,
-                scheduleKey = { schedule, scheduleData ->
-                    val trip = scheduleData.trips.getValue(schedule.tripId)
-                    RealtimePatterns.UpcomingTripKey.ByRoutePattern(
-                        schedule.routeId,
-                        trip.routePatternId,
-                        stops.resolveParentId(schedule.stopId)
-                    )
-                },
-                predictionKey = { prediction, streamData ->
-                    val trip = streamData.trips.getValue(prediction.tripId)
-                    RealtimePatterns.UpcomingTripKey.ByRoutePattern(
-                        prediction.routeId,
-                        trip.routePatternId,
-                        stops.resolveParentId(prediction.stopId)
-                    )
-                },
-                filterAtTime
-            )
-        }
-
-        private fun tripMapByHeadsignOrDirection(
-            stops: Map<String, Stop>,
-            tripMapByRoutePattern:
-                Map<RealtimePatterns.UpcomingTripKey.ByRoutePattern, List<UpcomingTrip>>?,
-            schedules: ScheduleResponse?,
-            predictions: PredictionsStreamDataResponse?,
-            filterAtTime: Instant
-        ): Map<RealtimePatterns.UpcomingTripKey, List<UpcomingTrip>>? {
-            val tripMapByDirection =
-                UpcomingTrip.tripsMappedBy(
-                    stops,
-                    schedules,
-                    predictions,
-                    scheduleKey = { schedule, scheduleData ->
-                        val trip = scheduleData.trips.getValue(schedule.tripId)
-                        RealtimePatterns.UpcomingTripKey.ByDirection(
-                            schedule.routeId,
-                            trip.directionId,
-                            stops.resolveParentId(schedule.stopId)
-                        )
-                    },
-                    predictionKey = { prediction, streamData ->
-                        val trip = streamData.trips.getValue(prediction.tripId)
-                        RealtimePatterns.UpcomingTripKey.ByDirection(
-                            prediction.routeId,
-                            trip.directionId,
-                            stops.resolveParentId(prediction.stopId)
-                        )
-                    },
-                    filterAtTime
-                )
-
-            return if (tripMapByRoutePattern != null || tripMapByDirection != null) {
-                (tripMapByRoutePattern ?: emptyMap()) + (tripMapByDirection ?: emptyMap())
-            } else {
-                null
-            }
-        }
-
-        private fun patternsByStopForRoute(
-            stop: Stop,
-            route: Route,
-            routePatterns: List<RoutePattern>,
-            tripMap: Map<RealtimePatterns.UpcomingTripKey.ByRoutePattern, List<UpcomingTrip>>?,
-            allStopIds: Set<String>,
-            loading: Boolean,
-            global: GlobalResponse,
-            alerts: Collection<Alert>?,
-            hasSchedulesTodayByPattern: Map<String, Boolean>?,
-        ): PatternsByStop {
-            global.run {
-                val allDataLoaded = !loading
-                val patternsByHeadsign =
-                    routePatterns.groupBy { trips.getValue(it.representativeTripId).headsign }
-                return PatternsByStop(
-                    listOf(route),
-                    null,
-                    stop,
-                    patternsByHeadsign
-                        .map { (headsign, patterns) ->
-                            val stopIdsOnPatterns =
-                                NearbyStaticData.filterStopsByPatterns(patterns, global, allStopIds)
-                            val upcomingTrips =
-                                if (tripMap != null) {
-                                        patterns
-                                            .mapNotNull { pattern ->
-                                                tripMap[
-                                                    RealtimePatterns.UpcomingTripKey.ByRoutePattern(
-                                                        route.id,
-                                                        pattern.id,
-                                                        stop.id
-                                                    )]
-                                            }
-                                            .flatten()
-                                            .sorted()
-                                    } else {
-                                        null
-                                    }
-                                    ?.filterCancellations(route.type.isSubway())
-                            RealtimePatterns.ByHeadsign(
-                                route,
-                                headsign,
-                                null,
-                                patterns,
-                                upcomingTrips,
-                                alerts?.let {
-                                    RealtimePatterns.applicableAlerts(
-                                        routes = listOf(route),
-                                        stopIds = stopIdsOnPatterns,
-                                        alerts = alerts
-                                    )
-                                },
-                                RealtimePatterns.hasSchedulesToday(
-                                    hasSchedulesTodayByPattern,
-                                    patterns
-                                ),
-                                allDataLoaded
-                            )
-                        }
-                        .filter {
-                            loading || ((it.isTypical() || it.isUpcoming()) && !it.isArrivalOnly())
-                        }
-                        .sortedWith(PatternSorting.compareRealtimePatterns()),
-                    Direction.getDirections(global, stop, route, routePatterns)
-                )
-            }
-        }
-
-        private fun patternsByStopForLine(
-            stop: Stop,
-            line: Line,
-            patternsByRoute: Map<Route, List<RoutePattern>>,
-            tripMap: Map<RealtimePatterns.UpcomingTripKey, List<UpcomingTrip>>?,
-            allStopIds: Set<String>,
-            loading: Boolean,
-            global: GlobalResponse,
-            alerts: Collection<Alert>?,
-            hasSchedulesTodayByPattern: Map<String, Boolean>?,
-        ): PatternsByStop {
-            global.run {
-                val allDataLoaded = !loading
-                val groupedPatternsByRoute = patternsByRoute.filter { it.key.lineId == line.id }
-
-                val staticPatterns =
-                    NearbyStaticData.buildStopPatternsForLine(
-                        stop,
-                        groupedPatternsByRoute,
-                        line,
-                        allStopIds,
-                        global
-                    )
-
-                val realtimePatterns =
-                    staticPatterns.patterns
-                        .map {
-                            when (it) {
-                                is NearbyStaticData.StaticPatterns.ByHeadsign ->
-                                    RealtimePatterns.ByHeadsign(
-                                        it,
-                                        tripMap,
-                                        stop.id,
-                                        alerts,
-                                        hasSchedulesTodayByPattern,
-                                        allDataLoaded
-                                    )
-                                is NearbyStaticData.StaticPatterns.ByDirection ->
-                                    RealtimePatterns.ByDirection(
-                                        it,
-                                        tripMap,
-                                        stop.id,
-                                        alerts,
-                                        hasSchedulesTodayByPattern,
-                                        allDataLoaded
-                                    )
-                            }
-                        }
-                        .filter {
-                            loading || ((it.isTypical() || it.isUpcoming()) && !it.isArrivalOnly())
-                        }
-                        .sortedWith(PatternSorting.compareRealtimePatterns())
-
-                return PatternsByStop(
-                    groupedPatternsByRoute.map { it.key },
-                    line,
-                    stop,
-                    realtimePatterns,
-                    Direction.getDirectionsForLine(
-                        global,
-                        stop,
-                        realtimePatterns.flatMap { it.patterns }
-                    )
-                )
-            }
-        }
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -1221,7 +1221,7 @@ class NearbyResponseTest {
                                     "Typical Out",
                                     null,
                                     listOf(typicalOutbound),
-                                    emptyList(),
+                                    null,
                                     allDataLoaded = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
@@ -1229,7 +1229,7 @@ class NearbyResponseTest {
                                     "Typical In",
                                     null,
                                     listOf(typicalInbound),
-                                    emptyList(),
+                                    null,
                                     allDataLoaded = false
                                 ),
                             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -265,7 +265,7 @@ class StopDetailsDeparturesTest {
                                 )
                             ),
                         ),
-                        listOf(Direction("West", null, 0), directionEast)
+                        listOf(directionWest, directionEast)
                     )
                 )
             ),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -309,35 +309,36 @@ class TemporaryTerminalTest {
 
     @Test
     fun `shows only temporary terminals when outside shuttle`() {
-        assertEquals(
+        val expected =
             expected(
-                    harvard.station,
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Kendall/MIT",
-                        null,
-                        listOf(redAlewifeBraintree, redAlewifeAshmont, redAlewifeKendall),
-                        listOf(
-                            UpcomingTrip(tripAlewifeKendall, scheduleAlewifeKendall),
-                            UpcomingTrip(tripAlewifeBraintree1, predictionAlewifeBraintree1),
-                            UpcomingTrip(tripAlewifeBraintree2, predictionAlewifeBraintree2),
-                            UpcomingTrip(tripAlewifeBraintree3, predictionAlewifeBraintree3)
-                        ),
-                        emptyList()
+                harvard.station,
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Kendall/MIT",
+                    null,
+                    listOf(redAlewifeBraintree, redAlewifeAshmont, redAlewifeKendall),
+                    listOf(
+                        UpcomingTrip(tripAlewifeKendall, scheduleAlewifeKendall),
+                        UpcomingTrip(tripAlewifeBraintree1, predictionAlewifeBraintree1),
+                        UpcomingTrip(tripAlewifeBraintree2, predictionAlewifeBraintree2),
+                        UpcomingTrip(tripAlewifeBraintree3, predictionAlewifeBraintree3)
                     ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Alewife",
-                        null,
-                        listOf(redBraintreeAlewife, redAshmontAlewife, redKendallAlewife),
-                        listOf(
-                            UpcomingTrip(tripBraintreeAlewife1, predictionBraintreeAlewife1),
-                            UpcomingTrip(tripKendallAlewife, scheduleKendallAlewife)
-                        ),
-                        emptyList()
-                    )
+                    emptyList()
+                ),
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Alewife",
+                    null,
+                    listOf(redBraintreeAlewife, redAshmontAlewife, redKendallAlewife),
+                    listOf(
+                        UpcomingTrip(tripBraintreeAlewife1, predictionBraintreeAlewife1),
+                        UpcomingTrip(tripKendallAlewife, scheduleKendallAlewife)
+                    ),
+                    emptyList()
                 )
-                .condensed(),
+            )
+        assertEquals(
+            expected.condensed(),
             NearbyStaticData(globalData, nearbyOutsideShuttle)
                 .withRealtimeInfo(
                     globalData,
@@ -350,39 +351,54 @@ class TemporaryTerminalTest {
                 )
                 .condensed()
         )
+        assertEquals(
+            expected.condensed(),
+            StopDetailsDepartures(
+                    harvard.station,
+                    globalData,
+                    schedules,
+                    predictions,
+                    alerts,
+                    emptySet(),
+                    now
+                )
+                .asNearby()
+                .condensed()
+        )
     }
 
     @Test
     fun `shows only regular terminals when inside shuttle`() {
-        assertEquals(
+        val expected =
             expected(
-                    parkStreet.station,
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Braintree",
-                        null,
-                        listOf(redAlewifeBraintree),
-                        emptyList(),
-                        listOf(alert)
-                    ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Ashmont",
-                        null,
-                        listOf(redAlewifeAshmont),
-                        emptyList(),
-                        listOf(alert)
-                    ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Alewife",
-                        null,
-                        listOf(redBraintreeAlewife, redAshmontAlewife),
-                        emptyList(),
-                        listOf(alert)
-                    )
+                parkStreet.station,
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Braintree",
+                    null,
+                    listOf(redAlewifeBraintree),
+                    emptyList(),
+                    listOf(alert)
+                ),
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Ashmont",
+                    null,
+                    listOf(redAlewifeAshmont),
+                    emptyList(),
+                    listOf(alert)
+                ),
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Alewife",
+                    null,
+                    listOf(redBraintreeAlewife, redAshmontAlewife),
+                    emptyList(),
+                    listOf(alert)
                 )
-                .condensed(),
+            )
+        assertEquals(
+            expected.condensed(),
             NearbyStaticData(globalData, nearbyInsideShuttle)
                 .withRealtimeInfo(
                     globalData,
@@ -395,40 +411,55 @@ class TemporaryTerminalTest {
                 )
                 .condensed()
         )
+        assertEquals(
+            expected.condensed(),
+            StopDetailsDepartures(
+                    parkStreet.station,
+                    globalData,
+                    schedules,
+                    predictions,
+                    alerts,
+                    emptySet(),
+                    now
+                )
+                .asNearby()
+                .condensed()
+        )
     }
 
     @Test
     fun `shows correct set of terminals when at boundary of shuttle`() {
-        assertEquals(
+        val expected =
             expected(
-                    jfkUmass.station,
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Braintree",
-                        null,
-                        listOf(redAlewifeBraintree, redJfkBraintree),
-                        listOf(UpcomingTrip(tripJfkBraintree, scheduleJfkBraintree)),
-                        emptyList()
-                    ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Ashmont",
-                        null,
-                        listOf(redAlewifeAshmont, redJfkAshmont),
-                        listOf(UpcomingTrip(tripJfkAshmont, scheduleJfkAshmont)),
-                        emptyList()
-                    ),
-                    RealtimePatterns.ByHeadsign(
-                        red,
-                        "Alewife",
-                        null,
-                        listOf(redBraintreeAlewife, redAshmontAlewife),
-                        emptyList(),
-                        listOf(alert)
-                    ),
-                    // JFK/UMass filtered out because arrival only
-                )
-                .condensed(),
+                jfkUmass.station,
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Braintree",
+                    null,
+                    listOf(redAlewifeBraintree, redJfkBraintree),
+                    listOf(UpcomingTrip(tripJfkBraintree, scheduleJfkBraintree)),
+                    emptyList()
+                ),
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Ashmont",
+                    null,
+                    listOf(redAlewifeAshmont, redJfkAshmont),
+                    listOf(UpcomingTrip(tripJfkAshmont, scheduleJfkAshmont)),
+                    emptyList()
+                ),
+                RealtimePatterns.ByHeadsign(
+                    red,
+                    "Alewife",
+                    null,
+                    listOf(redBraintreeAlewife, redAshmontAlewife),
+                    emptyList(),
+                    listOf(alert)
+                ),
+                // JFK/UMass filtered out because arrival only
+            )
+        assertEquals(
+            expected.condensed(),
             NearbyStaticData(globalData, nearbyAtShuttleEdge)
                 .withRealtimeInfo(
                     globalData,
@@ -441,7 +472,25 @@ class TemporaryTerminalTest {
                 )
                 .condensed()
         )
+        assertEquals(
+            expected.condensed(),
+            StopDetailsDepartures(
+                    jfkUmass.station,
+                    globalData,
+                    schedules,
+                    predictions,
+                    alerts,
+                    emptySet(),
+                    now
+                )
+                .asNearby()
+                .condensed()
+        )
     }
+
+    // for easier assertions about stop details
+    fun StopDetailsDepartures.asNearby(): List<StopsAssociated> =
+        listOf(StopsAssociated.WithRoute(red, this.routes))
 
     // for more legible diffs
     fun List<StopsAssociated>.condensed(): String {


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1728582832329829)

This applies temporary terminal rewriting in stop details.

### Testing

Checked that all unit tests still pass. Manually verified that temporary terminals are rewritten in Nearby Transit and in Stop Details. Added Stop Details to the temporary terminal integration tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
