### PR TITLE
chore: increase test waits to address flakiness

### DIFF
--- a/iosApp/iosAppTests/Views/ErrorBannerTests.swift
+++ b/iosApp/iosAppTests/Views/ErrorBannerTests.swift
@@ -30,7 +30,7 @@ final class ErrorBannerTests: XCTestCase {
 
         let stateSetPublisher = PassthroughSubject<Void, Never>()
 
-        let showedState = sut.inspection.inspect(onReceive: stateSetPublisher, after: 0.2) { view in
+        let showedState = sut.inspection.inspect(onReceive: stateSetPublisher, after: 0.5) { view in
             XCTAssertEqual(try view.find(ViewType.Text.self).string(), "Updated \(minutesAgo) minutes ago")
 
             try view.find(ViewType.Button.self).tap()

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -463,7 +463,7 @@ final class NearbyTransitViewTests: XCTestCase {
             nearbyVM: .init()
         )
 
-        let exp = sut.inspection.inspect(onReceive: globalLoadedPublisher, after: 0.2) { view in
+        let exp = sut.inspection.inspect(onReceive: globalLoadedPublisher, after: 0.5) { view in
             let stops = view.findAll(NearbyStopView.self)
             XCTAssertEqual(stops[0].findAll(DestinationRowView.self).count, 3)
 
@@ -710,7 +710,7 @@ final class NearbyTransitViewTests: XCTestCase {
             nearbyVM: .init()
         )
 
-        sut.inspection.inspect(after: 0.2) { view in
+        sut.inspection.inspect(after: 0.5) { view in
             XCTAssertNotNil(try view.view(NearbyTransitView.self)
                 .find(text: "Error loading data"))
         }


### PR DESCRIPTION
### Summary

No ticket, addresses some test failures creeping in
What is this PR for?

This addresses some test flakiness that is creeping in, such as in https://github.com/mbta/mobile_app/pull/464. In https://github.com/mbta/mobile_app/pull/293 we found that increasing the wait to 1 second fixed the flakiness we were seeing. Trying a bump to 0.5.

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
