### PR TITLE
fix: Show correct headsigns and groupings on all GL branches

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
@@ -11,11 +11,12 @@ data class Direction(
         directionId: Int,
         route: Route,
         stop: Stop? = null,
-        routeStopIds: List<String>? = null
+        routeStopIds: List<String>? = null,
+        patternDestination: String? = null
     ) : this(
         name = route.directionNames[directionId] ?: "",
         destination = getSpecialCaseDestination(directionId, route.id, stop?.id, routeStopIds)
-                ?: route.directionDestinations[directionId] ?: "",
+                ?: patternDestination ?: route.directionDestinations[directionId] ?: "",
         directionId
     )
 
@@ -126,8 +127,9 @@ data class Direction(
                 return Direction(pattern.directionId, route)
             }
 
+            val patternDestination = global.trips[pattern.representativeTripId]?.headsign
             val stopList = getStopListForPattern(pattern, global)
-            return Direction(pattern.directionId, route, stop, stopList)
+            return Direction(pattern.directionId, route, stop, stopList, patternDestination)
         }
 
         fun getDirectionsForLine(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
@@ -7,6 +7,18 @@ data class Direction(
     var destination: String?,
     var id: Int,
 ) {
+    /**
+     * This constructor is used to provide additional context to a Direction to allow for overriding
+     * the destination label in cases where a route or line has branching. We want to display a
+     * different label when you're on the trunk or a branch to match station signage. First, this
+     * checks if any special case overrides should be applied for the provided route, stop, and
+     * direction (ex "Copley & West" at any GL stop upstream of the E and B/C/D fork at Copley). If
+     * no special case is found, fall back to an optional pattern destination, used when a pattern
+     * goes to an atypical destination that doesn't match the route's destination. If one of those
+     * isn't provided, then use the value from route.directionDestinations, which should be accurate
+     * in the majority of typical cases. If this doesn't exist for some reason, fall back to null so
+     * that the direction label will just display the direction name.
+     */
     constructor(
         directionId: Int,
         route: Route,
@@ -16,7 +28,7 @@ data class Direction(
     ) : this(
         name = route.directionNames[directionId] ?: "",
         destination = getSpecialCaseDestination(directionId, route.id, stop?.id, routeStopIds)
-                ?: patternDestination ?: route.directionDestinations[directionId] ?: "",
+                ?: patternDestination ?: route.directionDestinations[directionId],
         directionId
     )
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -133,6 +133,10 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                     } else {
                         when (val it = typicalHere.first()) {
                             is StaticPatterns.ByDirection -> it.direction
+                            // When buildStopPatternsForLine creates a StaticPatterns.ByHeadsign,
+                            // it should always set it.direction to a non-null value, this fallback
+                            // is only here to make the compiler happy and do something sensible if
+                            // there are possible edge cases where one is set to null.
                             is StaticPatterns.ByHeadsign -> it.direction
                                     ?: Direction(
                                         it.route.directionNames[directionId] ?: "",
@@ -326,7 +330,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             )
         }
 
-        fun buildStopPatternsForLine(
+        private fun buildStopPatternsForLine(
             stop: Stop,
             patterns: Map<Route, List<RoutePattern>>,
             line: Line,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -683,10 +683,18 @@ class NearbyStaticDataBuilder {
             route: Route,
             headsign: String,
             patterns: List<RoutePattern>,
-            stopIds: Set<String> = allStopIds
+            stopIds: Set<String> = allStopIds,
+            direction: Direction? = null
         ) {
             data.add(
-                NearbyStaticData.StaticPatterns.ByHeadsign(route, headsign, line, patterns, stopIds)
+                NearbyStaticData.StaticPatterns.ByHeadsign(
+                    route,
+                    headsign,
+                    line,
+                    patterns,
+                    stopIds,
+                    direction
+                )
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.NearbyStaticData.StopPatterns.ForLine.Companion.groupedDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
@@ -33,7 +34,8 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             val headsign: String,
             val line: Line?,
             override val patterns: List<RoutePattern>,
-            override val stopIds: Set<String>
+            override val stopIds: Set<String>,
+            val direction: Direction? = null,
         ) : StaticPatterns() {
             override fun copy(patterns: List<RoutePattern>, stopIds: Set<String>) =
                 copy(route = route, patterns = patterns, stopIds = stopIds)
@@ -113,20 +115,32 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                     routes: List<Route>,
                     directionId: Int
                 ): Direction {
-                    return patterns
-                        .firstOrNull {
-                            when (it) {
-                                is StaticPatterns.ByDirection -> it.direction.id == directionId
-                                else -> false
+                    val typicalHere =
+                        patterns.filter {
+                            it.patterns.any { pattern ->
+                                pattern.typicality == RoutePattern.Typicality.Typical &&
+                                    pattern.directionId == directionId
                             }
                         }
-                        ?.let {
-                            when (it) {
-                                is StaticPatterns.ByDirection -> it.direction
-                                else -> null
-                            }
+                    return if (typicalHere.isEmpty()) {
+                        Direction(directionId, routes.first())
+                    } else if (typicalHere.size > 1) {
+                        Direction(
+                            routes.first().directionNames[directionId] ?: "",
+                            null,
+                            directionId
+                        )
+                    } else {
+                        when (val it = typicalHere.first()) {
+                            is StaticPatterns.ByDirection -> it.direction
+                            is StaticPatterns.ByHeadsign -> it.direction
+                                    ?: Direction(
+                                        it.route.directionNames[directionId] ?: "",
+                                        it.headsign,
+                                        directionId
+                                    )
                         }
-                        ?: Direction(directionId, routes.first())
+                    }
                 }
             }
         }
@@ -354,7 +368,8 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                                 headsign,
                                 line,
                                 patterns.sorted(),
-                                filterStopsByPatterns(patterns, global, allStopIds)
+                                filterStopsByPatterns(patterns, global, allStopIds),
+                                direction
                             )
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -380,19 +380,24 @@ class ObjectCollectionBuilder {
 
     fun vehicle(block: VehicleBuilder.() -> Unit = {}) = build(vehicles, VehicleBuilder(), block)
 
-    fun upcomingTrip(schedule: Schedule) =
-        UpcomingTrip(trips.getValue(schedule.tripId), schedule, null, null)
+    fun upcomingTrip(schedule: Schedule, prediction: Prediction, vehicle: Vehicle): UpcomingTrip {
+        check(schedule.tripId == prediction.tripId)
+        return UpcomingTrip(trips.getValue(prediction.tripId), schedule, prediction, vehicle)
+    }
 
     fun upcomingTrip(schedule: Schedule, prediction: Prediction): UpcomingTrip {
         check(schedule.tripId == prediction.tripId)
         return UpcomingTrip(trips.getValue(prediction.tripId), schedule, prediction, null)
     }
 
-    fun upcomingTrip(prediction: Prediction) =
-        UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, null)
-
     fun upcomingTrip(prediction: Prediction, vehicle: Vehicle) =
         UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, vehicle)
+
+    fun upcomingTrip(schedule: Schedule) =
+        UpcomingTrip(trips.getValue(schedule.tripId), schedule, null, null)
+
+    fun upcomingTrip(prediction: Prediction) =
+        UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, null)
 
     private fun <Built : BackendObject, Builder : ObjectBuilder<Built>> build(
         source: MutableMap<String, Built>,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -38,19 +38,21 @@ data class PatternsByStop(
         },
         staticData.stop,
         staticData.patterns
-            .map {
+            .flatMap {
                 when (it) {
                     is NearbyStaticData.StaticPatterns.ByHeadsign ->
-                        RealtimePatterns.ByHeadsign(
-                            it,
-                            upcomingTripsMap,
-                            staticData.stop.id,
-                            alerts,
-                            hasSchedulesTodayByPattern,
-                            allDataLoaded
+                        listOf(
+                            RealtimePatterns.ByHeadsign(
+                                it,
+                                upcomingTripsMap,
+                                staticData.stop.id,
+                                alerts,
+                                hasSchedulesTodayByPattern,
+                                allDataLoaded
+                            )
                         )
                     is NearbyStaticData.StaticPatterns.ByDirection ->
-                        RealtimePatterns.ByDirection(
+                        resolveRealtimePatternForDirection(
                             it,
                             upcomingTripsMap,
                             staticData.stop.id,
@@ -98,5 +100,144 @@ data class PatternsByStop(
                     .toSet()
             }
             .distinct()
+    }
+
+    companion object {
+        // Even if a direction can serve multiple routes according to the static data, it's possible
+        // that only one of those routes is typical, in which case we don't want to display it as a
+        // grouped direction in the UI. If there are only predicted trips on a single route, this
+        // will split the grouped direction up into as many headsign rows as there are headsigns.
+        fun resolveRealtimePatternForDirection(
+            staticData: NearbyStaticData.StaticPatterns.ByDirection,
+            upcomingTripsMap: UpcomingTripsMap?,
+            parentStopId: String,
+            alerts: Collection<Alert>?,
+            hasSchedulesTodayByPattern: Map<String, Boolean>?,
+            allDataLoaded: Boolean,
+        ): List<RealtimePatterns> {
+            val typicalPatternsByRoute =
+                staticData.patterns
+                    .filter { it.typicality == RoutePattern.Typicality.Typical }
+                    .groupBy({ it.routeId }, { it.id })
+
+            // If data hasn't loaded, or there are more than one typical routes in this direction,
+            // we never want to split into individual headsign rows.
+            if (!allDataLoaded || typicalPatternsByRoute.size > 1) {
+                return listOf(
+                    RealtimePatterns.ByDirection(
+                        staticData,
+                        upcomingTripsMap,
+                        parentStopId,
+                        alerts,
+                        hasSchedulesTodayByPattern,
+                        allDataLoaded
+                    )
+                )
+            }
+
+            val patternsById = staticData.patterns.associateBy { it.id }
+            val tripsByPattern =
+                upcomingTripsMap
+                    .orEmpty()
+                    .mapNotNull {
+                        when (val key = it.key) {
+                            is RealtimePatterns.UpcomingTripKey.ByRoutePattern ->
+                                if (
+                                    key.routePatternId != null &&
+                                        patternsById.containsKey(key.routePatternId) &&
+                                        key.parentStopId == parentStopId
+                                ) {
+                                    key.routePatternId to it.value
+                                } else {
+                                    null
+                                }
+                            else -> null
+                        }
+                    }
+                    .toMap()
+            val upcomingPatternsByRouteAndHeadsign =
+                tripsByPattern.values
+                    .flatten()
+                    .groupBy({ it.trip.routeId }, { it.trip.headsign to it.trip.routePatternId })
+                    .mapValues { routeEntry ->
+                        routeEntry.value.groupBy({ it.first }, { it.second })
+                    }
+
+            val predictedPatternsByRoute =
+                staticData.patterns
+                    .filter {
+                        tripsByPattern[it.id]?.any { trip ->
+                            trip.prediction != null && trip.vehicle?.tripId == trip.trip.id
+                        } == true
+                    }
+                    .groupBy({ it.routeId }, { it.id })
+
+            // We don't have access to global data or representative trips here, so the only way
+            // that we can determine headsigns is by looking at the actual upcoming trips.
+            val headsignsAndPatternsToDisplayByRoute =
+                upcomingPatternsByRouteAndHeadsign
+                    .mapNotNull {
+                        val headsignsToDisplay =
+                            it.value
+                                .mapNotNull { headsignsToPatterns ->
+                                    val patternsToDisplay =
+                                        (typicalPatternsByRoute[it.key].orEmpty() +
+                                                predictedPatternsByRoute[it.key].orEmpty())
+                                            .toSet()
+                                            .intersect(headsignsToPatterns.value.toSet())
+                                    if (patternsToDisplay.isEmpty()) {
+                                        null
+                                    } else {
+                                        headsignsToPatterns.key to patternsToDisplay
+                                    }
+                                }
+                                .toMap()
+                        if (headsignsToDisplay.isEmpty()) {
+                            null
+                        } else {
+                            it.key to headsignsToDisplay
+                        }
+                    }
+                    .toMap()
+
+            // If there is only a single route with predicted or typical trips, we want to break up
+            // the grouped direction instead into individual headsign rows.
+            val firstDisplayedRoute =
+                staticData.routes.firstOrNull {
+                    it.id == headsignsAndPatternsToDisplayByRoute.keys.firstOrNull()
+                }
+            if (headsignsAndPatternsToDisplayByRoute.size == 1 && firstDisplayedRoute != null) {
+                val headsignsToDisplay =
+                    (headsignsAndPatternsToDisplayByRoute[firstDisplayedRoute.id] ?: emptyMap())
+                return headsignsToDisplay.map { (headsign, patternIds) ->
+                    val patternsForHeadsign = patternIds.mapNotNull { patternsById[it] }
+                    RealtimePatterns.ByHeadsign(
+                        NearbyStaticData.StaticPatterns.ByHeadsign(
+                            firstDisplayedRoute,
+                            headsign,
+                            staticData.line,
+                            patternsForHeadsign,
+                            staticData.stopIds
+                        ),
+                        upcomingTripsMap,
+                        parentStopId,
+                        alerts,
+                        hasSchedulesTodayByPattern,
+                        allDataLoaded
+                    )
+                }
+            }
+
+            return listOf(
+                RealtimePatterns.ByDirection(
+                    staticData,
+                    upcomingTripsMap,
+                    parentStopId,
+                    alerts,
+                    hasSchedulesTodayByPattern,
+                    allDataLoaded
+                )
+            )
+        }
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -674,6 +674,131 @@ class NearbyResponseTest {
     }
 
     @Test
+    fun `StopPatterns ForLine groupedDirection helper returns expected Direction objects`() {
+        val objects = ObjectCollectionBuilder()
+        val route1 =
+            objects.route {
+                directionNames = listOf("North", "South")
+                directionDestinations = listOf("Unique Place", "Shared Place")
+            }
+        val route2 =
+            objects.route {
+                directionNames = listOf("North", "South")
+                directionDestinations = listOf("Other Unique Place", "Shared Place")
+            }
+        val line = objects.line()
+        val headsignPattern1Route1 =
+            objects.routePattern(route1) {
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+            }
+        val headsignPattern2Route1 =
+            objects.routePattern(route1) {
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+            }
+        val headsignPattern3Route1 =
+            objects.routePattern(route1) {
+                typicality = RoutePattern.Typicality.Atypical
+                directionId = 0
+            }
+        val headsignPattern1Route2 =
+            objects.routePattern(route2) {
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+            }
+        val headsignPattern2Route2 =
+            objects.routePattern(route2) {
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+            }
+        val staticByHeadsign1 =
+            NearbyStaticData.StaticPatterns.ByHeadsign(
+                route1,
+                "Unique Place",
+                line,
+                listOf(headsignPattern1Route1),
+                emptySet(),
+            )
+        val staticByHeadsign1Atypical =
+            NearbyStaticData.StaticPatterns.ByHeadsign(
+                route1,
+                "Third Unique Place",
+                line,
+                listOf(headsignPattern3Route1),
+                emptySet(),
+            )
+        val staticByHeadsign2 =
+            NearbyStaticData.StaticPatterns.ByHeadsign(
+                route2,
+                "Other Unique Place",
+                line,
+                listOf(headsignPattern1Route2),
+                emptySet(),
+            )
+        val overriddenDirection = Direction("South", "Overridden Value", 0)
+        val staticByHeadsign2WithDirection =
+            NearbyStaticData.StaticPatterns.ByHeadsign(
+                route2,
+                "Other Unique Place",
+                line,
+                listOf(headsignPattern1Route2),
+                emptySet(),
+                overriddenDirection
+            )
+        val sharedDirection = Direction("South", "Shared Place", 1)
+        val staticByDirection =
+            NearbyStaticData.StaticPatterns.ByDirection(
+                line,
+                listOf(route1, route2),
+                sharedDirection,
+                listOf(headsignPattern2Route1, headsignPattern2Route2),
+                emptySet()
+            )
+
+        assertEquals(
+            Direction("North", null, 0),
+            NearbyStaticData.StopPatterns.ForLine.groupedDirection(
+                listOf(staticByHeadsign1, staticByHeadsign2, staticByDirection),
+                listOf(route1, route2),
+                0
+            )
+        )
+        assertEquals(
+            Direction("North", "Other Unique Place", 0),
+            NearbyStaticData.StopPatterns.ForLine.groupedDirection(
+                listOf(staticByHeadsign1Atypical, staticByHeadsign2, staticByDirection),
+                listOf(route1, route2),
+                0
+            )
+        )
+        assertEquals(
+            Direction("North", "Unique Place", 0),
+            NearbyStaticData.StopPatterns.ForLine.groupedDirection(
+                listOf(staticByHeadsign1Atypical, staticByDirection),
+                listOf(route1, route2),
+                0
+            )
+        )
+        assertEquals(
+            overriddenDirection,
+            NearbyStaticData.StopPatterns.ForLine.groupedDirection(
+                listOf(staticByHeadsign2WithDirection, staticByDirection),
+                listOf(route1, route2),
+                0
+            )
+        )
+        assertEquals(
+            sharedDirection,
+            NearbyStaticData.StopPatterns.ForLine.groupedDirection(
+                listOf(staticByHeadsign1, staticByHeadsign2, staticByDirection),
+                listOf(route1, route2),
+                1
+            )
+        )
+    }
+
+    @Test
     fun `withRealtimeInfo includes predictions filtered to the correct stop and pattern`() {
         val objects = ObjectCollectionBuilder()
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -491,7 +491,7 @@ class NearbyResponseTest {
             NearbyStaticData.build {
                 line(line, listOf(route1, route2)) {
                     stop(stop1, routes = listOf(route1), directions = listOf(bDir, parkDir)) {
-                        headsign(route1, "Boston College", listOf(route1rp1))
+                        headsign(route1, "Boston College", listOf(route1rp1), direction = bDir)
                     }
                     stop(
                         stop3,
@@ -501,7 +501,7 @@ class NearbyResponseTest {
                         direction(parkDir, listOf(route1, route2), listOf(route1rp2, route2rp2))
                     }
                     stop(stop2, listOf(route2), directions = listOf(cDir, parkDir)) {
-                        headsign(route2, "Cleveland Circle", listOf(route2rp1))
+                        headsign(route2, "Cleveland Circle", listOf(route2rp1), direction = cDir)
                     }
                 }
             },

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
@@ -301,8 +301,7 @@ class PatternsByStopTest {
         assertEquals(listOf(alert), patternsByStop.alertsHereFor(1, global))
     }
 
-    @Test
-    fun `resolveRealtimePatternForDirection splits direction groups into headsigns when needed`() {
+    object GroupedGLTestPatterns {
         val objects = ObjectCollectionBuilder()
 
         val line = objects.line()
@@ -473,136 +472,132 @@ class PatternsByStopTest {
                 routePatternEMedford.id to true,
             )
 
-        assertEquals(
-            listOf(
-                RealtimePatterns.ByHeadsign(
-                    routeE,
-                    "Heath Street",
-                    line,
-                    listOf(routePatternEHeath),
-                    upcomingTrips = listOf(upcomingTripEHeath1),
-                    null,
-                    true
-                )
-            ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsWest,
-                typicalUpcomingTrips,
+        fun resolveWith(
+            staticData: NearbyStaticData.StaticPatterns.ByDirection,
+            upcomingTripsMap: UpcomingTripsMap?
+        ): List<RealtimePatterns> {
+            return PatternsByStop.resolveRealtimePatternForDirection(
+                staticData,
+                upcomingTripsMap,
                 stop.id,
                 null,
                 hasSchedules,
                 true
             )
-        )
+        }
+    }
 
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByHeadsign when only typical trips are predicted with distinct atypical static headsigns in a direction`() {
+        val data = GroupedGLTestPatterns
         assertEquals(
             listOf(
                 RealtimePatterns.ByHeadsign(
-                    routeE,
+                    data.routeE,
                     "Heath Street",
-                    line,
-                    listOf(routePatternEHeath),
-                    upcomingTrips = listOf(upcomingTripEHeath1),
+                    data.line,
+                    listOf(data.routePatternEHeath),
+                    upcomingTrips = listOf(data.upcomingTripEHeath1),
                     null,
                     true
                 )
             ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsWest,
-                atypicalScheduledTripsMap,
-                stop.id,
-                null,
-                hasSchedules,
-                true
-            )
+            data.resolveWith(data.staticPatternsWest, data.typicalUpcomingTrips)
         )
+    }
 
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByHeadsign when atypical trips are scheduled but not predicted with distinct atypical static headsigns in a direction`() {
+        val data = GroupedGLTestPatterns
+        assertEquals(
+            listOf(
+                RealtimePatterns.ByHeadsign(
+                    data.routeE,
+                    "Heath Street",
+                    data.line,
+                    listOf(data.routePatternEHeath),
+                    upcomingTrips = listOf(data.upcomingTripEHeath1),
+                    null,
+                    true
+                )
+            ),
+            data.resolveWith(data.staticPatternsWest, data.atypicalScheduledTripsMap)
+        )
+    }
+
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByDirection when atypical trips are predicted with distinct headsigns in a direction`() {
+        val data = GroupedGLTestPatterns
         assertEquals(
             listOf(
                 RealtimePatterns.ByDirection(
-                    line,
-                    listOf(routeC, routeE),
+                    data.line,
+                    listOf(data.routeC, data.routeE),
                     Direction("West", "Copley & West", 0),
-                    listOf(routePatternCCleveland, routePatternEHeath),
-                    upcomingTrips = listOf(upcomingTripEHeath1, upcomingTripCCleveland1),
+                    listOf(data.routePatternCCleveland, data.routePatternEHeath),
+                    upcomingTrips = listOf(data.upcomingTripEHeath1, data.upcomingTripCCleveland1),
                     null,
                     true
                 )
             ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsWest,
-                atypicalUpcomingTripsMap,
-                stop.id,
-                null,
-                hasSchedules,
-                true
-            )
+            data.resolveWith(data.staticPatternsWest, data.atypicalUpcomingTripsMap)
         )
+    }
 
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByHeadsign when only typical trips are predicted with the same static headsign in a direction`() {
+        val data = GroupedGLTestPatterns
         assertEquals(
             listOf(
                 RealtimePatterns.ByHeadsign(
-                    routeE,
+                    data.routeE,
                     "Medford/Tufts",
-                    line,
-                    listOf(routePatternEMedford),
-                    upcomingTrips = listOf(upcomingTripEMedford1),
+                    data.line,
+                    listOf(data.routePatternEMedford),
+                    upcomingTrips = listOf(data.upcomingTripEMedford1),
                     null,
                     true
                 )
             ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsEast,
-                typicalUpcomingTrips,
-                stop.id,
-                null,
-                hasSchedules,
-                true
-            )
+            data.resolveWith(data.staticPatternsEast, data.typicalUpcomingTrips)
         )
+    }
 
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByHeadsign when atypical trips are scheduled but not predicted with the same static headsign in a direction`() {
+        val data = GroupedGLTestPatterns
         assertEquals(
             listOf(
                 RealtimePatterns.ByHeadsign(
-                    routeE,
+                    data.routeE,
                     "Medford/Tufts",
-                    line,
-                    listOf(routePatternEMedford),
-                    upcomingTrips = listOf(upcomingTripEMedford1),
+                    data.line,
+                    listOf(data.routePatternEMedford),
+                    upcomingTrips = listOf(data.upcomingTripEMedford1),
                     null,
                     true
                 )
             ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsEast,
-                atypicalScheduledTripsMap,
-                stop.id,
-                null,
-                hasSchedules,
-                true
-            )
+            data.resolveWith(data.staticPatternsEast, data.atypicalScheduledTripsMap)
         )
+    }
 
+    @Test
+    fun `resolveRealtimePatternForDirection returns a realtime ByDirection when atypical trips are predicted with the same headsign in a direction`() {
+        val data = GroupedGLTestPatterns
         assertEquals(
             listOf(
                 RealtimePatterns.ByDirection(
-                    line,
-                    listOf(routeC, routeE),
+                    data.line,
+                    listOf(data.routeC, data.routeE),
                     Direction("East", "Medford/Tufts", 1),
-                    listOf(routePatternCMedford, routePatternEMedford),
-                    upcomingTrips = listOf(upcomingTripEMedford1, upcomingTripCMedford1),
+                    listOf(data.routePatternCMedford, data.routePatternEMedford),
+                    upcomingTrips = listOf(data.upcomingTripEMedford1, data.upcomingTripCMedford1),
                     null,
                     true
                 )
             ),
-            PatternsByStop.resolveRealtimePatternForDirection(
-                staticPatternsEast,
-                atypicalUpcomingTripsMap,
-                stop.id,
-                null,
-                hasSchedules,
-                true
-            )
+            data.resolveWith(data.staticPatternsEast, data.atypicalUpcomingTripsMap)
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -290,7 +290,7 @@ class StopDetailsDeparturesTest {
                                 )
                             ),
                         ),
-                        listOf(directionWest, directionEast)
+                        listOf(Direction("West", null, 0), directionEast)
                     )
                 )
             ),


### PR DESCRIPTION
### Summary

_Ticket:_ [GL showing duplicate Eastbound @ Gov Center with no data](https://app.asana.com/0/1205732265579288/1208378317839446/f)

Most of the added lines here are in the tests, sorry for the large PR! 😅 

After #454, there were issues introduced where we would only ever display grouped nearby headsigns on the Medford/Tufts branch. This changes the headsign grouping to split grouped routes into separate headsigns if only a single route pattern is predicted in one direction. This means that it's technically possible (but very unlikely) for a grouping to be displayed when an atypical trip is predicted but has multiple other predictions before it and so wouldn't be displayed in nearby, but since this only applies to a stretch of 5 stops that rarely have more than 2 trains headed inbound at any time, this shouldn't happen often.

This also includes changes to use the pattern headsign to generate directions, since the destination names in the route only apply to the route's typical pattern, and includes a default null `Direction` object in the `StaticPatterns.ByHeadsign`, because we still want the special cased `Direction` object (like "Park St & North") used in `groupedDirection` to set the overall directions in `StopPatterns.ForLine` for displaying in the filtered stop details direction toggle.

Screenshots of correct behavior after these changes:

![Simulator Screenshot - iPhone 15 Pro - 2024-10-15 at 11 42 17](https://github.com/user-attachments/assets/c47fd892-e428-4452-b88a-7491785495df)![Simulator Screenshot - iPhone 15 Pro - 2024-10-15 at 11 42 22](https://github.com/user-attachments/assets/0af336cc-cca6-44a5-a67e-f14c55804ce9)![Simulator Screenshot - iPhone 15 Pro - 2024-10-15 at 11 46 04](https://github.com/user-attachments/assets/faa6b4bd-1ed7-420f-8716-59edf4174d8e)![Simulator Screenshot - iPhone 15 Pro - 2024-10-15 at 11 46 09](https://github.com/user-attachments/assets/bc334d8e-bfd6-4feb-a1ed-29ff3e4c4470)


### Testing

Added tests for newly added functionality and updated Direction behavior.