### PR TITLE
Optimize Stop Details screen reader text

### DIFF
--- a/iosApp/iosApp/ComponentViews/LineHeader.swift
+++ b/iosApp/iosApp/ComponentViews/LineHeader.swift
@@ -32,6 +32,9 @@ struct LineHeader<Content: View>: View {
                 modeIcon: routeIcon(route),
                 rightContent: rightContent
             )
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityHeading(.h2)
         } else {
             EmptyView()
         }

--- a/iosApp/iosApp/ComponentViews/PinButton.swift
+++ b/iosApp/iosApp/ComponentViews/PinButton.swift
@@ -21,7 +21,9 @@ struct PinButton: View {
                 Image(pinned ? .pinnedRouteActive : .pinnedRouteInactive)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .accessibilityLabel("pin route")
+                    .accessibilityLabel("Star route")
+                    .accessibilityHint(pinned ? "Removes route from the top of the list" :
+                        "Pins route to the top of the list")
             }
         )
         .accessibilityIdentifier("pinButton")

--- a/iosApp/iosApp/ComponentViews/RouteHeader.swift
+++ b/iosApp/iosApp/ComponentViews/RouteHeader.swift
@@ -28,6 +28,7 @@ struct RouteHeader<Content: View>: View {
             modeIcon: routeIcon(route),
             rightContent: rightContent
         )
+        .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)
         .accessibilityHeading(.h2)
     }

--- a/iosApp/iosApp/ComponentViews/RouteHeader.swift
+++ b/iosApp/iosApp/ComponentViews/RouteHeader.swift
@@ -28,5 +28,7 @@ struct RouteHeader<Content: View>: View {
             modeIcon: routeIcon(route),
             rightContent: rightContent
         )
+        .accessibilityAddTraits(.isHeader)
+        .accessibilityHeading(.h2)
     }
 }

--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -125,7 +125,9 @@ struct RoutePill: View {
                 .modifier(ClipShapeModifier(spec: spec))
                 .accessibilityElement()
                 .accessibilityAddTraits(isActive ? [.isSelected] : [])
-                .accessibilityLabel("\(route?.label ?? line!.longName) \(route?.type.typeText(isOnly: true) ?? "")")
+                .accessibilityLabel(
+                    "\(route?.label ?? line?.longName ?? "") \(route?.type.typeText(isOnly: true) ?? "")"
+                )
         }
     }
 }

--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -123,6 +123,8 @@ struct RoutePill: View {
                 .lineLimit(1)
                 .modifier(ColorModifier(pill: self))
                 .modifier(ClipShapeModifier(spec: spec))
+                .accessibilityElement()
+                .accessibilityLabel("\(route?.label ?? "") \(route?.type.typeText(isOnly: true) ?? "")")
         }
     }
 }

--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -124,7 +124,8 @@ struct RoutePill: View {
                 .modifier(ColorModifier(pill: self))
                 .modifier(ClipShapeModifier(spec: spec))
                 .accessibilityElement()
-                .accessibilityLabel("\(route?.label ?? "") \(route?.type.typeText(isOnly: true) ?? "")")
+                .accessibilityAddTraits(isActive ? [.isSelected] : [])
+                .accessibilityLabel("\(route?.label ?? line!.longName) \(route?.type.typeText(isOnly: true) ?? "")")
         }
     }
 }

--- a/iosApp/iosApp/ComponentViews/TransitHeader.swift
+++ b/iosApp/iosApp/ComponentViews/TransitHeader.swift
@@ -23,8 +23,6 @@ struct TransitHeader<Content: View>: View {
         Label {
             Text(name)
                 .font(Typography.bodySemibold)
-                .accessibilityAddTraits(.isHeader)
-                .accessibilityHeading(.h2)
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(textColor)
                 .textCase(.none)

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -17,6 +17,8 @@ struct DirectionPicker: View {
     let route: Route
     let line: Line?
 
+    @State private var directionId = ""
+
     init(patternsByStop: PatternsByStop, filter: StopDetailsFilter?,
          setFilter: @escaping (StopDetailsFilter?) -> Void) {
         self.filter = filter
@@ -27,6 +29,11 @@ struct DirectionPicker: View {
         directions = patternsByStop.directions
         route = patternsByStop.representativeRoute
         line = patternsByStop.line
+        directionId = if filter != nil {
+            String(filter!.directionId)
+        } else {
+            ""
+        }
     }
 
     var body: some View {
@@ -37,7 +44,7 @@ struct DirectionPicker: View {
                     let isSelected = filter?.directionId == direction
                     let action = { setFilter(.init(routeId: line?.id ?? route.id, directionId: direction)) }
 
-                    Button(action: action) {
+                    let button = Button(action: action) {
                         DirectionLabel(direction: directions[Int(direction)])
                             .padding(8)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -45,12 +52,31 @@ struct DirectionPicker: View {
                     .background(isSelected ? Color(hex: route.color) : deselectedBackroundColor)
                     .foregroundStyle(isSelected ? Color(hex: route.textColor) : .deselectedToggleText)
                     .clipShape(.rect(cornerRadius: 6))
+
+                    if isSelected {
+                        button
+                            .accessibilityAddTraits(.isSelected)
+                    } else {
+                        button
+                    }
                 }
             }
             .padding(2)
             .background(deselectedBackroundColor)
             .clipShape(.rect(cornerRadius: 8))
         }
+
+        HStack(alignment: .center, content: {
+            Picker("Select Direction", selection: $directionId) {
+                let availableDirectionIds = availableDirections.map { String($0) }
+
+                ForEach(availableDirectionIds, id: \.self) { direction in
+                    let direction = directions[Int(direction)!]
+                    Text(direction.name)
+                }
+            }
+            .pickerStyle(.segmented)
+        })
     }
 
     private func deselectedBackgroundColor(_ route: Route) -> Color {

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -37,21 +37,15 @@ struct DirectionPicker: View {
                     let isSelected = filter?.directionId == direction
                     let action = { setFilter(.init(routeId: line?.id ?? route.id, directionId: direction)) }
 
-                    let button = Button(action: action) {
+                    Button(action: action) {
                         DirectionLabel(direction: directions[Int(direction)])
                             .padding(8)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     }
+                    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
                     .background(isSelected ? Color(hex: route.color) : deselectedBackroundColor)
                     .foregroundStyle(isSelected ? Color(hex: route.textColor) : .deselectedToggleText)
                     .clipShape(.rect(cornerRadius: 6))
-
-                    if isSelected {
-                        button
-                            .accessibilityAddTraits(.isSelected)
-                    } else {
-                        button
-                    }
                 }
             }
             .padding(2)

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -17,8 +17,6 @@ struct DirectionPicker: View {
     let route: Route
     let line: Line?
 
-    @State private var directionId = ""
-
     init(patternsByStop: PatternsByStop, filter: StopDetailsFilter?,
          setFilter: @escaping (StopDetailsFilter?) -> Void) {
         self.filter = filter
@@ -29,11 +27,6 @@ struct DirectionPicker: View {
         directions = patternsByStop.directions
         route = patternsByStop.representativeRoute
         line = patternsByStop.line
-        directionId = if filter != nil {
-            String(filter!.directionId)
-        } else {
-            ""
-        }
     }
 
     var body: some View {
@@ -65,18 +58,6 @@ struct DirectionPicker: View {
             .background(deselectedBackroundColor)
             .clipShape(.rect(cornerRadius: 8))
         }
-
-        HStack(alignment: .center, content: {
-            Picker("Select Direction", selection: $directionId) {
-                let availableDirectionIds = availableDirections.map { String($0) }
-
-                ForEach(availableDirectionIds, id: \.self) { direction in
-                    let direction = directions[Int(direction)!]
-                    Text(direction.name)
-                }
-            }
-            .pickerStyle(.segmented)
-        })
     }
 
     private func deselectedBackgroundColor(_ route: Route) -> Color {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilterPills.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilterPills.swift
@@ -28,6 +28,7 @@ struct StopDetailsFilterPills: View {
     var setFilter: (StopDetailsFilter?) -> Void
 
     var body: some View {
+        let routePillHint = "Applies a filter so that only arrivals from this route are displayed"
         HStack(spacing: 0) {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -41,6 +42,7 @@ struct StopDetailsFilterPills: View {
                                     type: .flex,
                                     isActive: filter == nil || filter?.routeId == route.id
                                 )
+                                .accessibilityHint(routePillHint)
                                 .frame(minWidth: 44, minHeight: 44, alignment: .center)
                                 .onTapGesture { tapRoutePill(filterBy) }
                             case let .line(line):
@@ -50,6 +52,7 @@ struct StopDetailsFilterPills: View {
                                     type: .flex,
                                     isActive: filter == nil || filter?.routeId == line.id
                                 )
+                                .accessibilityHint(routePillHint)
                                 .frame(minWidth: 44, minHeight: 44, alignment: .center)
                                 .onTapGesture { tapRoutePill(filterBy) }
                             }
@@ -78,6 +81,8 @@ struct StopDetailsFilterPills: View {
                         .padding(.vertical, 7)
                         .background(Color.contrast)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .accessibilityLabel("All routes")
+                        .accessibilityHint("Removes selected filter so that arrivals from all routes are displayed")
                 }
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
                 .padding(.trailing, 16)


### PR DESCRIPTION
### Summary

_Ticket:_ [Optimize Stop Details screen reader text](https://app.asana.com/0/1205732265579288/1208295417175122/f)

What is this PR for?

Improves Stop Details accessibility for VoiceOver users.

NB: One area where I deviated from the Figma spec is in the DirectionPicker. Figma has the number of options repeated as part of the input, e.g. "option 1 of 2"; however, when I added a native Picker as a test, that content was not presented. I therefore opted to leave it out of the DirectionPicker accessibility text. See screenshots:

Native Picker:
<img width="1202" alt="Screenshot 2024-10-17 at 12 29 40 PM" src="https://github.com/user-attachments/assets/65e4711e-fdfd-4be2-902b-5e2251298c8c">

Custom DirectionPicker:
<img width="1172" alt="Screenshot 2024-10-17 at 12 29 09 PM" src="https://github.com/user-attachments/assets/a5846f88-20f1-4f2a-b418-c041ec0cb643">


### Testing

What testing have you done?

Manual testing with Accessibility Inspector
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
