### PR TITLE
feat: shuffle around partially loaded data

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
@@ -39,8 +39,8 @@ class DirectionPickerTest {
             }
         val patterns =
             listOf(
-                RealtimePatterns.ByHeadsign(route, "A", null, listOf(aPattern)),
-                RealtimePatterns.ByHeadsign(route, "B", null, listOf(bPattern)),
+                RealtimePatterns.ByHeadsign(route, "A", null, listOf(aPattern), emptyList()),
+                RealtimePatterns.ByHeadsign(route, "B", null, listOf(bPattern), emptyList()),
             )
         val patternsByStop =
             PatternsByStop(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -8,6 +8,7 @@ import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
@@ -233,7 +234,7 @@ class NearbyTransitViewTest : KoinTest {
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 NearbyTransitView(
-                    alertData = null,
+                    alertData = AlertsStreamDataResponse(emptyMap()),
                     globalResponse = globalResponse,
                     targetLocation = Position(0.0, 0.0),
                     setLastLocation = {},

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import kotlin.time.Duration.Companion.minutes
@@ -104,14 +105,16 @@ class StopDetailsFilteredRouteViewTest {
 
             StopDetailsFilteredRouteView(
                 departures =
-                    StopDetailsDepartures(
-                        stop,
-                        globalResponse,
-                        null,
-                        PredictionsStreamDataResponse(builder),
-                        null,
-                        emptySet(),
-                        now
+                    checkNotNull(
+                        StopDetailsDepartures.fromData(
+                            stop,
+                            globalResponse,
+                            null,
+                            PredictionsStreamDataResponse(builder),
+                            AlertsStreamDataResponse(emptyMap()),
+                            emptySet(),
+                            now
+                        )
                     ),
                 global = globalResponse,
                 now = now,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRouteViewTest.kt
@@ -110,7 +110,7 @@ class StopDetailsRouteViewTest {
                                         ) to listOf(UpcomingTrip(trip, prediction))
                                     ),
                                 parentStopId = stop.id,
-                                alerts = null,
+                                alerts = emptyList(),
                                 hasSchedulesTodayByPattern = null,
                                 allDataLoaded = false
                             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import kotlin.time.Duration.Companion.minutes
@@ -100,14 +101,16 @@ class StopDetailsRoutesViewTest {
 
             StopDetailsRoutesView(
                 departures =
-                    StopDetailsDepartures(
-                        stop,
-                        globalResponse,
-                        null,
-                        PredictionsStreamDataResponse(builder),
-                        null,
-                        emptySet(),
-                        now
+                    checkNotNull(
+                        StopDetailsDepartures.fromData(
+                            stop,
+                            globalResponse,
+                            null,
+                            PredictionsStreamDataResponse(builder),
+                            AlertsStreamDataResponse(emptyMap()),
+                            emptySet(),
+                            now
+                        )
                     ),
                 global = globalResponse,
                 now = now,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -214,7 +214,7 @@ class StopDetailsViewTest {
                                                             listOf(UpcomingTrip(trip, prediction))
                                                     ),
                                                 parentStopId = stop.id,
-                                                alerts = null,
+                                                alerts = emptyList(),
                                                 hasSchedulesTodayByPattern = null,
                                                 allDataLoaded = false
                                             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -51,7 +51,7 @@ fun StopDetailsPage(
             now
         ) {
             if (globalResponse != null) {
-                StopDetailsDepartures(
+                StopDetailsDepartures.fromData(
                     stop,
                     globalResponse,
                     schedulesResponse,

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -189,9 +189,6 @@
     "Crossing Malfunction" : {
       "comment" : "Possible alert cause"
     },
-    "Custom message" : {
-
-    },
     "Demonstration" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -173,9 +173,6 @@
     "Construction" : {
       "comment" : "Possible alert cause"
     },
-    "Couldn't load stop list" : {
-
-    },
     "Crossing Malfunction" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -41,6 +41,7 @@ struct NearbyTransitView: View {
         VStack(spacing: 0) {
             if let nearbyWithRealtimeInfo {
                 nearbyList(nearbyWithRealtimeInfo)
+                    .onAppear { didLoadData?(self) }
             } else {
                 LoadingCard().padding(.horizontal, 16).padding(.bottom, 16)
             }
@@ -149,6 +150,7 @@ struct NearbyTransitView: View {
     }
 
     var didAppear: ((Self) -> Void)?
+    var didLoadData: ((Self) -> Void)?
 
     private func loadEverything() {
         getGlobal()
@@ -485,10 +487,7 @@ struct NearbyTransitView_Previews: PreviewProvider {
                                     upcomingTrips: [
                                         UpcomingTrip(trip: busTrip, prediction: busPrediction1),
                                         UpcomingTrip(trip: busTrip, prediction: busPrediction2),
-                                    ],
-                                    alertsHere: nil,
-                                    hasSchedulesToday: true,
-                                    allDataLoaded: true
+                                    ]
                                 ),
                             ]
                         ),
@@ -515,10 +514,7 @@ struct NearbyTransitView_Previews: PreviewProvider {
                                     upcomingTrips: [
                                         UpcomingTrip(trip: crTrip, prediction: crPrediction1),
                                         UpcomingTrip(trip: crTrip, prediction: crPrediction2),
-                                    ],
-                                    alertsHere: nil,
-                                    hasSchedulesToday: true,
-                                    allDataLoaded: true
+                                    ]
                                 ),
                             ]
                         ),

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -87,20 +87,14 @@ struct DirectionPicker: View {
                     headsign: "Out",
                     line: nil,
                     patterns: [patternOutbound],
-                    upcomingTrips: nil,
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: []
                 ),
                 .ByHeadsign(
                     route: route,
                     headsign: "In",
                     line: nil,
                     patterns: [patternInbound],
-                    upcomingTrips: nil,
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: []
                 ),
             ],
             directions: [

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -252,7 +252,7 @@ struct StopDetailsPage: View {
         let targetPredictions = predictionsByStop?.toPredictionsStreamDataResponse()
 
         let newDepartures: StopDetailsDepartures? = if let globalResponse {
-            StopDetailsDepartures(
+            StopDetailsDepartures.companion.fromData(
                 stop: stop,
                 global: globalResponse,
                 schedules: schedulesResponse,

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsRoutesView.swift
@@ -101,10 +101,7 @@ struct StopDetailsRoutesView: View {
                 headsign: "A",
                 line: nil,
                 patterns: [],
-                upcomingTrips: [.init(trip: trip1, prediction: prediction1)],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                upcomingTrips: [.init(trip: trip1, prediction: prediction1)]
             ),
         ]),
         .init(route: route2, stop: stop, patterns: [
@@ -113,20 +110,14 @@ struct StopDetailsRoutesView: View {
                 headsign: "B",
                 line: nil,
                 patterns: [],
-                upcomingTrips: [.init(trip: trip3, prediction: prediction2)],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                upcomingTrips: [.init(trip: trip3, prediction: prediction2)]
             ),
             .ByHeadsign(
                 route: route2,
                 headsign: "C",
                 line: nil,
                 patterns: [],
-                upcomingTrips: [.init(trip: trip2, schedule: schedule2)],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                upcomingTrips: [.init(trip: trip2, schedule: schedule2)]
             ),
             .ByHeadsign(
                 route: route2,
@@ -135,10 +126,7 @@ struct StopDetailsRoutesView: View {
                 patterns: [],
                 upcomingTrips: [
                     .init(trip: trip4, schedule: schedule3, prediction: prediction3),
-                ],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                ]
             ),
         ]),
     ]), global: nil, now: Date.now.toKotlinInstant(), filter: nil, setFilter: { _ in }, pushNavEntry: { _ in },

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -71,32 +71,31 @@ struct TripDetailsPage: View {
     var body: some View {
         VStack(spacing: 16) {
             header
-            if let trip, let globalResponse {
-                let vehicle = vehicleResponse?.vehicle
-                if let stops = TripDetailsStopList.companion.fromPieces(
-                    trip: trip,
-                    tripSchedules: tripSchedulesResponse,
-                    tripPredictions: tripPredictions,
-                    vehicle: vehicle, alertsData: nearbyVM.alerts, globalData: globalResponse
+            if let trip, let globalResponse, let vehicle = vehicleResponse?.vehicle,
+               let stops = TripDetailsStopList.companion.fromPieces(
+                   trip: trip,
+                   tripSchedules: tripSchedulesResponse,
+                   tripPredictions: tripPredictions,
+                   vehicle: vehicle,
+                   alertsData: nearbyVM.alerts,
+                   globalData: globalResponse
+               ) {
+                vehicleCardView
+                    .onAppear { didLoadData?(self) }
+                ErrorBanner(errorBannerVM).padding(.horizontal, 16)
+                if let target, let stopSequence = target.stopSequence, let splitStops = stops.splitForTarget(
+                    targetStopId: target.stopId,
+                    targetStopSequence: Int32(stopSequence),
+                    globalData: globalResponse
                 ) {
-                    vehicleCardView
-                    ErrorBanner(errorBannerVM).padding(.horizontal, 16)
-                    if let target, let stopSequence = target.stopSequence, let splitStops = stops.splitForTarget(
-                        targetStopId: target.stopId,
-                        targetStopSequence: Int32(stopSequence),
-                        globalData: globalResponse
-                    ) {
-                        TripDetailsStopListSplitView(
-                            splitStops: splitStops,
-                            now: now,
-                            onTapLink: onTapStop,
-                            routeType: routeType
-                        )
-                    } else {
-                        TripDetailsStopListView(stops: stops, now: now, onTapLink: onTapStop, routeType: routeType)
-                    }
+                    TripDetailsStopListSplitView(
+                        splitStops: splitStops,
+                        now: now,
+                        onTapLink: onTapStop,
+                        routeType: routeType
+                    )
                 } else {
-                    Text("Couldn't load stop list")
+                    TripDetailsStopListView(stops: stops, now: now, onTapLink: onTapStop, routeType: routeType)
                 }
             } else {
                 ProgressView()
@@ -144,6 +143,8 @@ struct TripDetailsPage: View {
             }
         )
     }
+
+    var didLoadData: ((Self) -> Void)?
 
     private func loadEverything() {
         loadGlobalData()

--- a/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
@@ -38,13 +38,11 @@ final class DirectionPickerTests: XCTestCase {
             patterns: [
                 .ByHeadsign(
                     route: route, headsign: "North", line: nil,
-                    patterns: [patternNorth], upcomingTrips: [],
-                    alertsHere: nil, hasSchedulesToday: true, allDataLoaded: true
+                    patterns: [patternNorth], upcomingTrips: []
                 ),
                 .ByHeadsign(
                     route: route, headsign: "South", line: nil,
-                    patterns: [patternSouth], upcomingTrips: [],
-                    alertsHere: nil, hasSchedulesToday: true, allDataLoaded: true
+                    patterns: [patternSouth], upcomingTrips: []
                 ),
             ],
             directions: [

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredRouteViewTests.swift
@@ -108,20 +108,14 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                 headsign: "North",
                 line: nil,
                 patterns: [patternNorth],
-                upcomingTrips: [objects.upcomingTrip(prediction: predictionNorth)],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                upcomingTrips: [objects.upcomingTrip(prediction: predictionNorth)]
             ),
             RealtimePatterns.ByHeadsign(
                 route: route,
                 headsign: "South",
                 line: nil,
                 patterns: [patternSouth],
-                upcomingTrips: [objects.upcomingTrip(prediction: predictionSouth)],
-                alertsHere: nil,
-                hasSchedulesToday: true,
-                allDataLoaded: true
+                upcomingTrips: [objects.upcomingTrip(prediction: predictionSouth)]
             ),
         ])
 
@@ -138,20 +132,14 @@ final class StopDetailsFilteredRouteViewTests: XCTestCase {
                     upcomingTrips: [
                         objects.upcomingTrip(prediction: linePredictionTrunk1),
                         objects.upcomingTrip(prediction: linePredictionTrunk2),
-                    ],
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    ]
                 ),
                 RealtimePatterns.ByHeadsign(
                     route: lineRoute3,
                     headsign: "Branch",
                     line: line,
                     patterns: [linePatternBranch],
-                    upcomingTrips: [objects.upcomingTrip(prediction: linePredictionBranch)],
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: [objects.upcomingTrip(prediction: linePredictionBranch)]
                 ),
             ],
             directions: [

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsRouteViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsRouteViewTests.swift
@@ -29,20 +29,14 @@ final class StopDetailsRouteViewTests: XCTestCase {
             headsign: "North",
             line: nil,
             patterns: [northPattern],
-            upcomingTrips: nil,
-            alertsHere: nil,
-            hasSchedulesToday: true,
-            allDataLoaded: true
+            upcomingTrips: []
         )
         let patternsByHeadsignSouth = RealtimePatterns.ByHeadsign(
             route: route,
             headsign: "South",
             line: nil,
             patterns: [southPattern],
-            upcomingTrips: nil,
-            alertsHere: nil,
-            hasSchedulesToday: true,
-            allDataLoaded: true
+            upcomingTrips: []
         )
         let patternsByStop = PatternsByStop(
             route: route,
@@ -95,20 +89,14 @@ final class StopDetailsRouteViewTests: XCTestCase {
             headsign: "North",
             line: nil,
             patterns: [northPattern],
-            upcomingTrips: nil,
-            alertsHere: nil,
-            hasSchedulesToday: true,
-            allDataLoaded: true
+            upcomingTrips: []
         )
         let patternsByHeadsignSouth = RealtimePatterns.ByHeadsign(
             route: route,
             headsign: "South",
             line: nil,
             patterns: [southPattern],
-            upcomingTrips: nil,
-            alertsHere: nil,
-            hasSchedulesToday: true,
-            allDataLoaded: true
+            upcomingTrips: []
         )
         let patternsByStop = PatternsByStop(
             route: route,

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -31,6 +31,10 @@ final class TripDetailsPageTests: XCTestCase {
             prediction.departureTime = Date.now.addingTimeInterval(30).toKotlinInstant()
         }
 
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.currentStatus = .inTransitTo
+        }
+
         let tripSchedulesLoaded = PassthroughSubject<Void, Never>()
 
         let tripRepository = FakeTripRepository(
@@ -41,22 +45,25 @@ final class TripDetailsPageTests: XCTestCase {
 
         let tripPredictionsRepository = FakeTripPredictionsRepository(response: .init(objects: objects))
 
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         let tripId = trip.id
         let vehicleId = "999"
-        let sut = TripDetailsPage(
+        var sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
             routeId: trip.routeId,
             target: nil,
             errorBannerVM: .init(),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             mapVM: .init(),
             globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: tripPredictionsRepository,
-            tripRepository: tripRepository
+            tripRepository: tripRepository,
+            vehicleRepository: MockVehicleRepository(outcome: ApiResultOk(data: .init(vehicle: vehicle)))
         )
 
-        let showsStopsExp = sut.inspection.inspect(onReceive: tripSchedulesLoaded, after: 1) { view in
+        let showsStopsExp = sut.on(\.didLoadData) { view in
             XCTAssertNotNil(try view.find(text: "Somewhere"))
             XCTAssertNotNil(try view.find(text: "Elsewhere"))
             XCTAssertNotNil(try view.find(text: "Elsewhere").parent().find(text: "ARR"))
@@ -108,13 +115,15 @@ final class TripDetailsPageTests: XCTestCase {
 
         let tripId = trip.id
         let vehicleId = vehicle.id
-        let sut = TripDetailsPage(
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
+        var sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
             routeId: route.id,
             target: nil,
             errorBannerVM: .init(),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             mapVM: .init(),
             globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: tripPredictionsRepository,
@@ -122,7 +131,7 @@ final class TripDetailsPageTests: XCTestCase {
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
         )
 
-        let showVehicleCardExp = sut.inspection.inspect(onReceive: tripSchedulesLoaded, after: 1) { view in
+        let showVehicleCardExp = sut.on(\.didLoadData) { view in
             XCTAssertNotNil(try view.find(VehicleOnTripView.self))
         }
 
@@ -151,23 +160,28 @@ final class TripDetailsPageTests: XCTestCase {
             onGetTripSchedules: { tripSchedulesLoaded.send() }
         )
 
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.currentStatus = .inTransitTo
+        }
         let tripId = trip.id
         let vehicleId = "999"
-        let sut = TripDetailsPage(
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
+        var sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
             routeId: trip.routeId,
             target: .init(stopId: stop1.id, stopSequence: 998),
             errorBannerVM: .init(),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             mapVM: .init(),
             globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: FakeTripPredictionsRepository(response: .init(objects: objects)),
             tripRepository: tripRepository,
-            vehicleRepository: FakeVehicleRepository(response: nil)
+            vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
         )
 
-        let splitViewExp = sut.inspection.inspect(onReceive: tripSchedulesLoaded, after: 1) { view in
+        let splitViewExp = sut.on(\.didLoadData) { view in
             XCTAssertNotNil(try view.find(TripDetailsStopListSplitView.self))
         }
 
@@ -247,30 +261,26 @@ final class TripDetailsPageTests: XCTestCase {
             stop2.id: [pattern1.id, pattern3.id],
         ])
 
-        let tripSchedulesLoaded = PassthroughSubject<Void, Never>()
-
         let tripRepository = FakeTripRepository(
             tripResponse: .init(trip: trip),
-            scheduleResponse: TripSchedulesResponse.StopIds(stopIds: [stop1.id, stop2.id]),
-            onGetTripSchedules: { tripSchedulesLoaded.send() }
+            scheduleResponse: TripSchedulesResponse.StopIds(stopIds: [stop1.id, stop2.id])
         )
-
-        let tripPredictionsLoaded = PassthroughSubject<Void, Never>()
 
         let tripPredictionsRepository = FakeTripPredictionsRepository(
-            response: .init(objects: objects),
-            onConnect: { _ in tripPredictionsLoaded.send() }
+            response: .init(objects: objects)
         )
 
+        let nearbyVM = NearbyViewModel(alertsRepository: MockAlertsRepository())
+        nearbyVM.alerts = .init(alerts: [:])
         let tripId = trip.id
         let vehicleId = vehicle.id
-        let sut = TripDetailsPage(
+        var sut = TripDetailsPage(
             tripId: tripId,
             vehicleId: vehicleId,
             routeId: trip.routeId,
             target: nil,
             errorBannerVM: .init(),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             mapVM: .init(),
             globalRepository: FakeGlobalRepository(response: globalData),
             tripPredictionsRepository: tripPredictionsRepository,
@@ -278,9 +288,7 @@ final class TripDetailsPageTests: XCTestCase {
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
         )
 
-        let everythingLoaded = tripSchedulesLoaded.zip(tripPredictionsLoaded)
-
-        let routeExp = sut.inspection.inspect(onReceive: everythingLoaded, after: 1) { view in
+        let routeExp = sut.on(\.didLoadData) { view in
             let stop1Row = try view.find(TripDetailsStopView.self, containing: stop1.name)
             let stop2Row = try view.find(TripDetailsStopView.self, containing: stop2.name)
             XCTAssertNotNil(try stop1Row.find(RoutePill.self, containing: "Green Line"))

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -369,10 +369,7 @@ final class HomeMapViewTests: XCTestCase {
                     headsign: MapTestDataHelper.shared.tripOrangeC1.headsign,
                     line: nil,
                     patterns: [MapTestDataHelper.shared.patternOrange30],
-                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)]
                 )]
             )]
         ))
@@ -380,7 +377,7 @@ final class HomeMapViewTests: XCTestCase {
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
         let sut = HomeMapView(
             mapVM: mapVM,
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             viewportProvider: ViewportProvider(),
             railRouteShapeRepository: railRouteShapeRepository,
             locationDataManager: locationDataManager,
@@ -537,10 +534,7 @@ final class HomeMapViewTests: XCTestCase {
                     headsign: MapTestDataHelper.shared.tripOrangeC1.headsign,
                     line: nil,
                     patterns: [MapTestDataHelper.shared.patternOrange30],
-                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)]
                 )]
             )]
         ))
@@ -644,10 +638,7 @@ final class HomeMapViewTests: XCTestCase {
                     headsign: MapTestDataHelper.shared.tripOrangeC1.headsign,
                     line: nil,
                     patterns: [MapTestDataHelper.shared.patternOrange30],
-                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)],
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: [UpcomingTrip(trip: trip, prediction: prediction)]
                 )]
             )]
         ))

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -139,18 +139,20 @@ final class NearbyTransitViewTests: XCTestCase {
     }
 
     func testRoutePatternsGroupedByRouteAndStop() throws {
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
             schedulesRepository: MockScheduleRepository(),
             getNearby: { _, _ in },
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
-        let exp = sut.on(\.didAppear) { view in
+        let exp = sut.on(\.didLoadData) { view in
             let routes = view.findAll(NearbyRouteView.self)
             XCTAssert(!routes.isEmpty)
             guard let route = routes.first else { return }
@@ -222,6 +224,8 @@ final class NearbyTransitViewTests: XCTestCase {
             prediction.scheduleRelationship = .cancelled
         }
 
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
@@ -231,7 +235,7 @@ final class NearbyTransitViewTests: XCTestCase {
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             scheduleResponse: .init(objects: objects)
         )
 
@@ -338,6 +342,8 @@ final class NearbyTransitViewTests: XCTestCase {
 
         let predictionsByStop: PredictionsByStopJoinResponse = .init(objects: objects)
 
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
@@ -347,7 +353,7 @@ final class NearbyTransitViewTests: XCTestCase {
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init(),
+            nearbyVM: nearbyVM,
             now: now
         )
 
@@ -462,7 +468,8 @@ final class NearbyTransitViewTests: XCTestCase {
 
         let globalLoadedPublisher = PassthroughSubject<Void, Never>()
         let globalResponse = GlobalResponse(objects: objects)
-
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         let sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
@@ -476,7 +483,7 @@ final class NearbyTransitViewTests: XCTestCase {
                 globalLoadedPublisher.send()
             },
             globalData: globalResponse,
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
 
         let exp = sut.inspection.inspect(onReceive: globalLoadedPublisher, after: 1) { view in
@@ -560,6 +567,8 @@ final class NearbyTransitViewTests: XCTestCase {
 
     func testRendersUpdatedPredictions() throws {
         NSTimeZone.default = TimeZone(identifier: "America/New_York")!
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
@@ -569,7 +578,7 @@ final class NearbyTransitViewTests: XCTestCase {
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
 
         func prediction(minutesAway: Double) -> PredictionsByStopJoinResponse {
@@ -691,16 +700,18 @@ final class NearbyTransitViewTests: XCTestCase {
 
     func testScrollToTopWhenNearbyChanges() throws {
         let scrollPositionSetExpectation = XCTestExpectation()
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
             schedulesRepository: MockScheduleRepository(),
             getNearby: { _, _ in },
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
         let exp = sut.on(\.didAppear) { view in
             let actualView = try view.actualView()
@@ -751,20 +762,21 @@ final class NearbyTransitViewTests: XCTestCase {
                 trip: nil
             )
         }
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(objects: objects)
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
             schedulesRepository: MockScheduleRepository(),
             getNearby: { _, _ in },
             state: .constant(route52State),
             location: .constant(CLLocationCoordinate2D(latitude: 12.34, longitude: -56.78)),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
 
-        let exp = sut.on(\.didAppear) { view in
-            try view.implicitAnyView().vStack().callOnChange(newValue: AlertsStreamDataResponse(objects: objects))
+        let exp = sut.on(\.didLoadData) { view in
             XCTAssertNotNil(try view.find(text: "Suspension"))
         }
         ViewHosting.host(view: sut)
@@ -798,10 +810,8 @@ final class NearbyTransitViewTests: XCTestCase {
                     headsign: "Place",
                     line: nil,
                     patterns: [pattern],
-                    upcomingTrips: nil,
-                    alertsHere: nil,
-                    hasSchedulesToday: true,
-                    allDataLoaded: true
+                    upcomingTrips: []
+
                 )]
 
             ),
@@ -816,19 +826,22 @@ final class NearbyTransitViewTests: XCTestCase {
     }
 
     func testEmptyFallback() throws {
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
+
         var sut = NearbyTransitView(
             togglePinnedUsecase: TogglePinnedRouteUsecase(repository: pinnedRoutesRepository),
             pinnedRouteRepository: pinnedRoutesRepository,
-            predictionsRepository: MockPredictionsRepository(),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
             schedulesRepository: MockScheduleRepository(),
             getNearby: { _, _ in },
             state: .constant(.init(loadedLocation: .init(), nearbyByRouteAndStop: .init(data: []))),
             location: .constant(ViewportProvider.Defaults.center),
             isReturningFromBackground: .constant(false),
-            nearbyVM: .init()
+            nearbyVM: nearbyVM
         )
 
-        let hasAppeared = sut.on(\.didAppear) { view in
+        let hasAppeared = sut.on(\.didLoadData) { view in
             XCTAssertNil(try? view.find(LoadingCard<Text>.self))
             XCTAssertNotNil(try view.find(text: "No nearby MBTA stops"))
             XCTAssertNotNil(try view.find(text: "Your current location is outside of our search area."))

--- a/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
+++ b/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
@@ -29,6 +29,8 @@ final class EndToEndOpenStopDetailsTest: XCTestCase {
     func testOpenStopDetails() throws {
         // UI tests must launch the application that they test.
         app.launch()
+        let alewifeHeadsign = app.staticTexts["Nearby Transit"]
+        XCTAssert(alewifeHeadsign.waitForExistence(timeout: 30))
 
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         app.staticTexts["Alewife"].tap()

--- a/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
+++ b/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
@@ -29,7 +29,7 @@ final class EndToEndOpenStopDetailsTest: XCTestCase {
     func testOpenStopDetails() throws {
         // UI tests must launch the application that they test.
         app.launch()
-        let alewifeHeadsign = app.staticTexts["Nearby Transit"]
+        let alewifeHeadsign = app.staticTexts["Alewife"]
         XCTAssert(alewifeHeadsign.waitForExistence(timeout: 30))
 
         // Use XCTAssert and related functions to verify your tests produce the correct results.

--- a/iosAppRetries.xctestplan
+++ b/iosAppRetries.xctestplan
@@ -30,6 +30,7 @@
     },
     {
       "skippedTests" : [
+        "EndToEndOpenStopDetailsTest\/testOpenStopDetails()",
         "HomeMapViewUITests\/testRecentersToUserLocation()",
         "IosAppUITests\/testMapShown()"
       ],

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripShape
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
@@ -89,7 +90,7 @@ fun endToEndModule(): Module {
             departureTime = now + 10.minutes
         }
     return module {
-        single<IAlertsRepository> { MockAlertsRepository() }
+        single<IAlertsRepository> { MockAlertsRepository(AlertsStreamDataResponse(objects)) }
         single<IAppCheckRepository> { MockAppCheckRepository() }
         single<IConfigRepository> { MockConfigRepository() }
         single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -109,9 +109,9 @@ data class PatternsByStop(
         // will split the grouped direction up into as many headsign rows as there are headsigns.
         fun resolveRealtimePatternForDirection(
             staticData: NearbyStaticData.StaticPatterns.ByDirection,
-            upcomingTripsMap: UpcomingTripsMap?,
+            upcomingTripsMap: UpcomingTripsMap,
             parentStopId: String,
-            alerts: Collection<Alert>?,
+            alerts: Collection<Alert>,
             hasSchedulesTodayByPattern: Map<String, Boolean>?,
             allDataLoaded: Boolean,
         ): List<RealtimePatterns> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -22,9 +22,9 @@ data class PatternsByStop(
 
     constructor(
         staticData: NearbyStaticData.StopPatterns,
-        upcomingTripsMap: UpcomingTripsMap?,
+        upcomingTripsMap: UpcomingTripsMap,
         patternsPredicate: (RealtimePatterns) -> Boolean,
-        alerts: Collection<Alert>?,
+        alerts: Collection<Alert>,
         hasSchedulesTodayByPattern: Map<String, Boolean>?,
         allDataLoaded: Boolean,
     ) : this(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -133,11 +133,12 @@ data class TripDetailsStopList(val stops: List<Entry>) {
             alertsData: AlertsStreamDataResponse?,
             globalData: GlobalResponse,
         ): TripDetailsStopList? {
+            if (tripPredictions == null || alertsData == null) return null
             val entries = mutableMapOf<Int, WorkingEntry>()
 
             val predictions =
                 deduplicatePredictionsByStopSequence(
-                    tripPredictions?.predictions?.values.orEmpty(),
+                    tripPredictions.predictions.values,
                     tripSchedules,
                     globalData
                 )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -68,4 +68,8 @@ data class PredictionsByStopJoinResponse(
     }
 
     fun predictionQuantity() = predictionsByStop.map { it.value.size }.sum()
+
+    companion object {
+        val empty = PredictionsByStopJoinResponse(emptyMap(), emptyMap(), emptyMap())
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -79,10 +80,13 @@ class AlertsRepository(private val socket: PhoenixSocket) : IAlertsRepository, K
     }
 }
 
-class MockAlertsRepository : IAlertsRepository {
+class MockAlertsRepository
+@DefaultArgumentInterop.Enabled
+constructor(private val response: AlertsStreamDataResponse = AlertsStreamDataResponse(emptyMap())) :
+    IAlertsRepository {
 
     override fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
-        /* no-op */
+        onReceive(ApiResult.Ok(response))
     }
 
     override fun disconnect() {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
@@ -69,12 +69,13 @@ class VehicleRepository(private val socket: PhoenixSocket) : IVehicleRepository,
     }
 }
 
-class MockVehicleRepository : IVehicleRepository {
+class MockVehicleRepository(private val outcome: ApiResult<VehicleStreamDataResponse>? = null) :
+    IVehicleRepository {
     override fun connect(
         vehicleId: String,
         onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit
     ) {
-        /* no-op */
+        outcome?.let { onReceive(it) }
     }
 
     override fun disconnect() {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -916,7 +916,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -1077,7 +1077,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -1230,8 +1230,7 @@ class NearbyResponseTest {
                                             predictionBrdVehicle
                                         )
                                     ),
-                                    null,
-                                    false
+                                    hasSchedulesToday = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
                                     route1,
@@ -1239,8 +1238,7 @@ class NearbyResponseTest {
                                     null,
                                     listOf(predictionSoon),
                                     listOf(objects.upcomingTrip(predictionSoonPrediction)),
-                                    null,
-                                    false
+                                    hasSchedulesToday = false
                                 )
                             )
                         )
@@ -1252,7 +1250,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop1.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -1346,7 +1344,7 @@ class NearbyResponseTest {
                                     "Typical Out",
                                     null,
                                     listOf(typicalOutbound),
-                                    null,
+                                    upcomingTrips = emptyList(),
                                     allDataLoaded = false
                                 ),
                                 RealtimePatterns.ByHeadsign(
@@ -1354,7 +1352,7 @@ class NearbyResponseTest {
                                     "Typical In",
                                     null,
                                     listOf(typicalInbound),
-                                    null,
+                                    upcomingTrips = emptyList(),
                                     allDataLoaded = false
                                 ),
                             )
@@ -1366,8 +1364,8 @@ class NearbyResponseTest {
                 globalData = GlobalResponse(objects),
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
-                predictions = null,
-                alerts = null,
+                predictions = PredictionsStreamDataResponse(emptyMap(), emptyMap(), emptyMap()),
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -1463,7 +1461,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop1.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 showAllPatternsWhileLoading = false,
                 hideNonTypicalPatternsBeyondNext = null,
@@ -1545,7 +1543,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop1.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 showAllPatternsWhileLoading = false,
                 hideNonTypicalPatternsBeyondNext = null,
@@ -1666,13 +1664,13 @@ class NearbyResponseTest {
                 sortByDistanceFrom = closeBusStop.position,
                 predictions = PredictionsStreamDataResponse(objects),
                 schedules = ScheduleResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
         assertEquals(
             listOf(closeSubwayRoute, farSubwayRoute, closeBusRoute, farBusRoute),
-            realtimeRoutesSorted.flatMap {
+            checkNotNull(realtimeRoutesSorted).flatMap {
                 when (it) {
                     is StopsAssociated.WithRoute -> listOf(it.route)
                     is StopsAssociated.WithLine -> it.routes
@@ -1788,13 +1786,13 @@ class NearbyResponseTest {
                 sortByDistanceFrom = closeBusStop.position,
                 predictions = PredictionsStreamDataResponse(objects),
                 schedules = ScheduleResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),
             )
         assertEquals(
             listOf(farSubwayRoute, farBusRoute, closeSubwayRoute, closeBusRoute),
-            realtimeRoutesSorted.flatMap {
+            checkNotNull(realtimeRoutesSorted).flatMap {
                 when (it) {
                     is StopsAssociated.WithRoute -> listOf(it.route)
                     is StopsAssociated.WithLine -> it.routes
@@ -1970,7 +1968,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = closeBusStop.position,
                 predictions = PredictionsStreamDataResponse(objects),
                 schedules = ScheduleResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),
             )
@@ -1991,7 +1989,7 @@ class NearbyResponseTest {
                 closeBusRoute,
                 farBusRoute
             ),
-            realtimeRoutesSorted.flatMap {
+            checkNotNull(realtimeRoutesSorted).flatMap {
                 when (it) {
                     is StopsAssociated.WithRoute -> listOf(it.route)
                     is StopsAssociated.WithLine -> it.routes
@@ -2108,7 +2106,7 @@ class NearbyResponseTest {
                 farSubwayRoute,
                 closeSubwayRoute,
             ),
-            realtimeRoutesSorted.flatMap {
+            checkNotNull(realtimeRoutesSorted).flatMap {
                 when (it) {
                     is StopsAssociated.WithRoute -> listOf(it.route)
                     is StopsAssociated.WithLine -> it.routes
@@ -2169,7 +2167,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = parentStop.position,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -2239,7 +2237,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -2310,8 +2308,7 @@ class NearbyResponseTest {
                                     null,
                                     listOf(routePatternB),
                                     emptyList(),
-                                    null,
-                                    false
+                                    hasSchedulesToday = false
                                 )
                             )
                         )
@@ -2323,7 +2320,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -2423,7 +2420,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -2571,7 +2568,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )
@@ -2778,7 +2775,7 @@ class NearbyResponseTest {
                 sortByDistanceFrom = stop.position,
                 schedules = ScheduleResponse(objects),
                 predictions = PredictionsStreamDataResponse(objects),
-                alerts = null,
+                alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
@@ -476,13 +476,13 @@ class PatternsByStopTest {
 
         fun resolveWith(
             staticData: NearbyStaticData.StaticPatterns.ByDirection,
-            upcomingTripsMap: UpcomingTripsMap?
+            upcomingTripsMap: UpcomingTripsMap
         ): List<RealtimePatterns> {
             return PatternsByStop.resolveRealtimePatternForDirection(
                 staticData,
                 upcomingTripsMap,
                 stop.id,
-                null,
+                emptyList(),
                 hasSchedules,
                 true
             )
@@ -500,8 +500,6 @@ class PatternsByStopTest {
                     data.line,
                     listOf(data.routePatternEHeath),
                     upcomingTrips = listOf(data.upcomingTripEHeath1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsWest, data.typicalUpcomingTrips)
@@ -519,8 +517,6 @@ class PatternsByStopTest {
                     data.line,
                     listOf(data.routePatternEHeath),
                     upcomingTrips = listOf(data.upcomingTripEHeath1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsWest, data.atypicalScheduledTripsMap)
@@ -538,8 +534,6 @@ class PatternsByStopTest {
                     Direction("West", "Copley & West", 0),
                     listOf(data.routePatternCCleveland, data.routePatternEHeath),
                     upcomingTrips = listOf(data.upcomingTripEHeath1, data.upcomingTripCCleveland1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsWest, data.atypicalUpcomingTripsMap)
@@ -557,8 +551,6 @@ class PatternsByStopTest {
                     data.line,
                     listOf(data.routePatternEMedford),
                     upcomingTrips = listOf(data.upcomingTripEMedford1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsEast, data.typicalUpcomingTrips)
@@ -576,8 +568,6 @@ class PatternsByStopTest {
                     data.line,
                     listOf(data.routePatternEMedford),
                     upcomingTrips = listOf(data.upcomingTripEMedford1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsEast, data.atypicalScheduledTripsMap)
@@ -595,8 +585,6 @@ class PatternsByStopTest {
                     Direction("East", "Medford/Tufts", 1),
                     listOf(data.routePatternCMedford, data.routePatternEMedford),
                     upcomingTrips = listOf(data.upcomingTripEMedford1, data.upcomingTripCMedford1),
-                    null,
-                    true
                 )
             ),
             data.resolveWith(data.staticPatternsEast, data.atypicalUpcomingTripsMap)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
@@ -277,6 +277,7 @@ class PatternsByStopTest {
                         "Out",
                         null,
                         listOf(pattern1, pattern4),
+                        upcomingTrips = emptyList(),
                         alertsHere = listOf(alert)
                     ),
                     RealtimePatterns.ByHeadsign(
@@ -284,6 +285,7 @@ class PatternsByStopTest {
                         "In",
                         null,
                         listOf(pattern2, pattern3),
+                        upcomingTrips = emptyList(),
                         alertsHere = listOf(alert)
                     )
                 )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -25,20 +25,6 @@ class RealtimePatternsTest {
         anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY)
 
     @Test
-    fun `formats as loading when null trips`() = parametricTest {
-        val now = Clock.System.now()
-
-        val objects = ObjectCollectionBuilder()
-        val route = objects.route()
-
-        assertEquals(
-            RealtimePatterns.Format.Loading,
-            RealtimePatterns.ByHeadsign(route, "", null, emptyList(), null, null)
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
-        )
-    }
-
-    @Test
     fun `formats as alert with no trips and major alert`() = parametricTest {
         val now = Clock.System.now()
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -25,20 +25,6 @@ class RealtimePatternsTest {
         anyEnumValueExcept(RouteType.COMMUTER_RAIL)
 
     @Test
-    fun `formats as loading when null trips`() = parametricTest {
-        val now = Clock.System.now()
-
-        val objects = ObjectCollectionBuilder()
-        val route = objects.route()
-
-        assertEquals(
-            RealtimePatterns.Format.Loading,
-            RealtimePatterns.ByHeadsign(route, "", null, emptyList(), null, null)
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
-        )
-    }
-
-    @Test
     fun `formats as alert with no trips and major alert`() = parametricTest {
         val now = Clock.System.now()
 
@@ -368,7 +354,14 @@ class RealtimePatternsTest {
 
         assertEquals(
             RealtimePatterns.Format.NoSchedulesToday(null),
-            RealtimePatterns.ByHeadsign(route, "", null, emptyList(), listOf(), null, false)
+            RealtimePatterns.ByHeadsign(
+                    route,
+                    "",
+                    null,
+                    emptyList(),
+                    listOf(),
+                    hasSchedulesToday = false
+                )
                 .format(now, RouteType.BUS, anyContext())
         )
     }
@@ -459,11 +452,13 @@ class RealtimePatternsTest {
         val routePattern1 = objects.routePattern(route) { directionId = 1 }
         assertEquals(
             0,
-            RealtimePatterns.ByHeadsign(route, "", null, listOf(routePattern0)).directionId()
+            RealtimePatterns.ByHeadsign(route, "", null, listOf(routePattern0), emptyList())
+                .directionId()
         )
         assertEquals(
             1,
-            RealtimePatterns.ByHeadsign(route, "", null, listOf(routePattern1)).directionId()
+            RealtimePatterns.ByHeadsign(route, "", null, listOf(routePattern1), emptyList())
+                .directionId()
         )
     }
 
@@ -474,6 +469,7 @@ class RealtimePatternsTest {
                     ObjectCollectionBuilder.Single.route(),
                     "",
                     null,
+                    emptyList(),
                     emptyList()
                 )
                 .directionId()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -348,12 +348,12 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet()
-                )
+                )!!
                 .condensed()
         )
         assertEquals(
             expected.condensed(),
-            StopDetailsDepartures(
+            StopDetailsDepartures.fromData(
                     harvard.station,
                     globalData,
                     schedules,
@@ -361,7 +361,7 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now
-                )
+                )!!
                 .asNearby()
                 .condensed()
         )
@@ -408,12 +408,12 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet()
-                )
+                )!!
                 .condensed()
         )
         assertEquals(
             expected.condensed(),
-            StopDetailsDepartures(
+            StopDetailsDepartures.fromData(
                     parkStreet.station,
                     globalData,
                     schedules,
@@ -421,7 +421,7 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now
-                )
+                )!!
                 .asNearby()
                 .condensed()
         )
@@ -469,12 +469,12 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet()
-                )
+                )!!
                 .condensed()
         )
         assertEquals(
             expected.condensed(),
-            StopDetailsDepartures(
+            StopDetailsDepartures.fromData(
                     jfkUmass.station,
                     globalData,
                     schedules,
@@ -482,7 +482,7 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now
-                )
+                )!!
                 .asNearby()
                 .condensed()
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -141,26 +141,16 @@ class TripDetailsStopListTest {
     @Test fun `fromPieces returns null with no data`() = test { assertNull(fromPieces(null, null)) }
 
     @Test
-    fun `fromPieces preserves schedules with real schedules and no predictions`() = test {
+    fun `fromPieces returns null with real schedules and no predictions`() = test {
         val sched1 = schedule("A", 10)
         val sched2 = schedule("B", 20)
         val sched3 = schedule("C", 30)
-        assertEquals(
-            stopListOf(
-                entry("A", 10, schedule = sched1),
-                entry("B", 20, schedule = sched2),
-                entry("C", 30, schedule = sched3)
-            ),
-            fromPieces(schedulesResponseOf(sched1, sched2, sched3), null)
-        )
+        assertEquals(null, fromPieces(schedulesResponseOf(sched1, sched2, sched3), null))
     }
 
     @Test
-    fun `fromPieces fabricates sequence with scheduled IDs and no predictions`() = test {
-        assertEquals(
-            stopListOf(entry("A", 997), entry("B", 998), entry("C", 999)),
-            fromPieces(schedulesResponseOf("A", "B", "C"), null)
-        )
+    fun `fromPieces returns null with scheduled IDs and no predictions`() = test {
+        assertEquals(null, fromPieces(schedulesResponseOf("A", "B", "C"), null))
     }
 
     @Test
@@ -599,7 +589,7 @@ class TripDetailsStopListTest {
         val pred = prediction(stopB.id, 20, routeCurrent.id)
 
         assertEquals(
-            stopListOf(entry(stopA.id, 10, schedule = sched, routes = listOf(routeOther))),
+            null,
             fromPieces(
                 schedulesResponseOf(sched),
                 null,


### PR DESCRIPTION
### Summary

_Ticket:_ [Shimmer loading in sheet](https://app.asana.com/0/1201654106676769/1208304466486188/f)

The [spec](https://www.notion.so/mbta-downtown-crossing/Loading-Error-States-Spec-edbb36cc74344e6aa6364f9f54458710?p=9687a4e21c224a859cf2cd2334ab5d39&pm=s) says that predictions and alerts need to be loaded before predictions, alerts, or schedules can be shown, and the shimmer-loading designs (which I will implement in a follow-up PR) imply that we should not show the nearby static data while predictions or alerts are loading.

### Testing

Updated unit tests to reflect new behavior. Manually validated my local branch with the full changes using [Comcast](https://github.com/tylertreat/comcast) to add latency and limit bandwidth since stop and trip details tend to load too fast to see the loading state.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
