### PR TITLE
feat: Add realtime indicators next to predictions

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -74,16 +74,16 @@ class UpcomingTripViewTest {
     fun testUpcomingTripViewWithSomeAsTime() {
         val instant = Instant.fromEpochSeconds(1722535384)
         composeTestRule.setContent {
-            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.AsTime(instant)))
+            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Time(instant)))
         }
         composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
     }
 
     @Test
-    fun testUpcomingTripViewWithSomeSchedule() {
+    fun testUpcomingTripViewWithSomeScheduleTime() {
         val instant = Instant.fromEpochSeconds(1722535384)
         composeTestRule.setContent {
-            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Schedule(instant)))
+            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.ScheduleTime(instant)))
         }
         composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
     }
@@ -92,6 +92,15 @@ class UpcomingTripViewTest {
     fun testUpcomingTripViewWithSomeMinutes() {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(5)))
+        }
+        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeScheduleMinutes() {
+        val instant = Instant.fromEpochSeconds(1722535384)
+        composeTestRule.setContent {
+            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.ScheduleMinutes(5)))
         }
         composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -22,6 +23,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mbta.tid.mbta_app.android.R
@@ -94,7 +96,7 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                         text = stringResource(R.string.approaching_abbr),
                         modifier = modifier
                     )
-                is TripInstantDisplay.AsTime ->
+                is TripInstantDisplay.Time ->
                     Text(
                         formatTime(state.trip.predictionTime),
                         modifier,
@@ -102,22 +104,29 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                         style = MaterialTheme.typography.headlineMedium,
                         fontWeight = FontWeight.Bold
                     )
-                is TripInstantDisplay.Schedule ->
-                    Row(modifier, verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            formatTime(state.trip.scheduleTime),
-                            textAlign = TextAlign.End,
-                            style = MaterialTheme.typography.headlineMedium,
-                            fontWeight = FontWeight.Bold,
-                            fontSize = 13.sp,
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Icon(painterResource(R.drawable.baseline_access_time_24), "Scheduled")
-                    }
+                is TripInstantDisplay.ScheduleTime ->
+                    Text(
+                        formatTime(state.trip.scheduledTime),
+                        modifier.then(Modifier.alpha(0.6F)),
+                        textAlign = TextAlign.End,
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        fontSize =
+                            if (state.trip.headline) {
+                                TextUnit.Unspecified
+                            } else {
+                                13.sp
+                            }
+                    )
                 is TripInstantDisplay.Minutes ->
                     BoldedTripStatus(
                         text = stringResource(R.string.minutes_abbr, state.trip.minutes),
                         modifier = modifier
+                    )
+                is TripInstantDisplay.ScheduleMinutes ->
+                    BoldedTripStatus(
+                        text = stringResource(R.string.minutes_abbr, state.trip.minutes),
+                        modifier = modifier.then(Modifier.alpha(0.6F))
                     )
                 is TripInstantDisplay.Cancelled ->
                     Row(modifier, verticalAlignment = Alignment.CenterVertically) {
@@ -204,10 +213,18 @@ fun NoServiceView(effect: NoServiceViewEffect, modifier: Modifier = Modifier) {
 @Preview
 @Composable
 fun UpcomingTripViewPreview() {
-    Row {
+    Column(horizontalAlignment = Alignment.End) {
+        UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Now))
         UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(5)))
         UpcomingTripView(
-            UpcomingTripViewState.Some(TripInstantDisplay.Schedule(Clock.System.now() + 10.minutes))
+            UpcomingTripViewState.Some(
+                TripInstantDisplay.ScheduleTime(Clock.System.now() + 10.minutes, true)
+            )
+        )
+        UpcomingTripView(
+            UpcomingTripViewState.Some(
+                TripInstantDisplay.ScheduleTime(Clock.System.now() + 10.minutes)
+            )
         )
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/getSchedule.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/getSchedule.kt
@@ -27,7 +27,9 @@ fun getSchedule(
             withContext(Dispatchers.IO) {
                 when (val data = schedulesRepository.getSchedule(stopIds, now)) {
                     is ApiResult.Ok -> schedules = data.data
-                    is ApiResult.Error -> TODO("handle errors")
+                    is ApiResult.Error -> {
+                        /* TODO("handle errors") */
+                    }
                 }
             }
         }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -121,7 +121,7 @@
 		9A4DB7812CA5A23200E8755B /* TextFieldObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB7802CA5A23200E8755B /* TextFieldObserver.swift */; };
 		9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E8E582B7EC4B90066B936 /* RoutePill.swift */; };
 		9A4F3B9F2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */; };
-		9A52A2B32CC3035F00CC01D6 /* RealtimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */; };
+		9A52A2B32CC3035F00CC01D6 /* WithRealtimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52A2B22CC3035F00CC01D6 /* WithRealtimeIndicator.swift */; };
 		9A52B3362C6A93390028EEAB /* AlertDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */; };
 		9A52B3382C6A99790028EEAB /* AlertDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3372C6A99790028EEAB /* AlertDetailsPageTests.swift */; };
 		9A52B33A2C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3392C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift */; };
@@ -365,7 +365,7 @@
 		9A4DB7802CA5A23200E8755B /* TextFieldObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldObserver.swift; sourceTree = "<group>"; };
 		9A4E8E582B7EC4B90066B936 /* RoutePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePill.swift; sourceTree = "<group>"; };
 		9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsAlertHeaderTests.swift; sourceTree = "<group>"; };
-		9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeIndicator.swift; sourceTree = "<group>"; };
+		9A52A2B22CC3035F00CC01D6 /* WithRealtimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithRealtimeIndicator.swift; sourceTree = "<group>"; };
 		9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsTests.swift; sourceTree = "<group>"; };
 		9A52B3372C6A99790028EEAB /* AlertDetailsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsPageTests.swift; sourceTree = "<group>"; };
 		9A52B3392C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsAnalytics.swift; sourceTree = "<group>"; };
@@ -856,7 +856,7 @@
 				9A9E7DD22C2203BE000DA1FD /* TransitCard.swift */,
 				9A9E7DD02C2200F4000DA1FD /* TransitHeader.swift */,
 				9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */,
-				9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */,
+				9A52A2B22CC3035F00CC01D6 /* WithRealtimeIndicator.swift */,
 			);
 			path = ComponentViews;
 			sourceTree = "<group>";
@@ -1319,7 +1319,7 @@
 				6E4C37602C4E94D200EA67CF /* AppCheckRepository.swift in Sources */,
 				8C7726152BE58FE30088D423 /* TripDetailsPage.swift in Sources */,
 				8C2752EF2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift in Sources */,
-				9A52A2B32CC3035F00CC01D6 /* RealtimeIndicator.swift in Sources */,
+				9A52A2B32CC3035F00CC01D6 /* WithRealtimeIndicator.swift in Sources */,
 				9A5B275C2BB237DE009A6FC6 /* RecenterButton.swift in Sources */,
 				6E99CBB72B9892C80047E78D /* SocketProvider.swift in Sources */,
 				ED5C93F42C496FB90086D017 /* TripDetailsHeader.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		9A4DB7812CA5A23200E8755B /* TextFieldObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4DB7802CA5A23200E8755B /* TextFieldObserver.swift */; };
 		9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4E8E582B7EC4B90066B936 /* RoutePill.swift */; };
 		9A4F3B9F2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */; };
+		9A52A2B32CC3035F00CC01D6 /* RealtimeIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */; };
 		9A52B3362C6A93390028EEAB /* AlertDetailsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */; };
 		9A52B3382C6A99790028EEAB /* AlertDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3372C6A99790028EEAB /* AlertDetailsPageTests.swift */; };
 		9A52B33A2C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A52B3392C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift */; };
@@ -364,6 +365,7 @@
 		9A4DB7802CA5A23200E8755B /* TextFieldObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldObserver.swift; sourceTree = "<group>"; };
 		9A4E8E582B7EC4B90066B936 /* RoutePill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutePill.swift; sourceTree = "<group>"; };
 		9A4F3B9E2C580C820040D6C9 /* StopDetailsAlertHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsAlertHeaderTests.swift; sourceTree = "<group>"; };
+		9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealtimeIndicator.swift; sourceTree = "<group>"; };
 		9A52B3352C6A93390028EEAB /* AlertDetailsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsTests.swift; sourceTree = "<group>"; };
 		9A52B3372C6A99790028EEAB /* AlertDetailsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsPageTests.swift; sourceTree = "<group>"; };
 		9A52B3392C6E7C7D0028EEAB /* AlertDetailsAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertDetailsAnalytics.swift; sourceTree = "<group>"; };
@@ -854,6 +856,7 @@
 				9A9E7DD22C2203BE000DA1FD /* TransitCard.swift */,
 				9A9E7DD02C2200F4000DA1FD /* TransitHeader.swift */,
 				9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */,
+				9A52A2B22CC3035F00CC01D6 /* RealtimeIndicator.swift */,
 			);
 			path = ComponentViews;
 			sourceTree = "<group>";
@@ -1316,6 +1319,7 @@
 				6E4C37602C4E94D200EA67CF /* AppCheckRepository.swift in Sources */,
 				8C7726152BE58FE30088D423 /* TripDetailsPage.swift in Sources */,
 				8C2752EF2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift in Sources */,
+				9A52A2B32CC3035F00CC01D6 /* RealtimeIndicator.swift in Sources */,
 				9A5B275C2BB237DE009A6FC6 /* RecenterButton.swift in Sources */,
 				6E99CBB72B9892C80047E78D /* SocketProvider.swift in Sources */,
 				ED5C93F42C496FB90086D017 /* TripDetailsHeader.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/RealtimeIndicator.swift
+++ b/iosApp/iosApp/ComponentViews/RealtimeIndicator.swift
@@ -1,0 +1,49 @@
+//
+//  RealtimeIndicator.swift
+//  iosApp
+//
+//  Created by esimon on 10/18/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct RealtimeIndicator: View {
+    private static let subjectSpacing: CGFloat = 4
+    @ScaledMetric private var iconSize: CGFloat = 12
+    let prediction: any View
+
+    init(_ prediction: () -> any View) {
+        self.prediction = prediction()
+    }
+
+    init(_ prediction: any View) {
+        self.prediction = prediction
+    }
+
+    var body: some View {
+        HStack(spacing: Self.subjectSpacing) {
+            Image(.liveData)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: iconSize, height: iconSize)
+                .padding(4)
+                .foregroundStyle(Color.text)
+                .opacity(0.6)
+                .accessibilityHidden(true)
+            AnyView(prediction)
+        }
+    }
+}
+
+struct RealtimeIndicatorModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        RealtimeIndicator(content)
+    }
+}
+
+extension View {
+    func realtime() -> some View {
+        modifier(RealtimeIndicatorModifier())
+    }
+}

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -50,32 +50,40 @@ struct UpcomingTripView: View {
         case let .some(prediction):
             switch onEnum(of: prediction) {
             case let .overridden(overridden):
-                Text(overridden.textWithLocale())
+                Text(overridden.textWithLocale()).realtime()
             case .hidden, .skipped:
                 // should have been filtered out already
                 Text(verbatim: "")
             case .now:
-                Text("Now").font(Typography.headlineBold)
+                Text("Now")
+                    .font(Typography.headlineBold)
+                    .realtime()
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters
                         .arrivingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.arrivingOther())
             case .boarding:
-                Text("BRD").font(Typography.headlineBold)
+                Text("BRD")
+                    .font(Typography.headlineBold)
+                    .realtime()
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters
                         .boardingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.boardingOther())
             case .arriving:
-                Text("ARR").font(Typography.headlineBold)
+                Text("ARR")
+                    .font(Typography.headlineBold)
+                    .realtime()
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters
                         .arrivingFirst(vehicleText: routeType?.typeText(isOnly: isOnly) ?? "")
                         : accessibilityFormatters.arrivingOther())
             case .approaching:
-                PredictionText(minutes: 1)
-            case let .asTime(format):
+                PredictionText(minutes: 1).realtime()
+            case let .time(format):
                 Text(Date(instant: format.predictionTime), style: .time)
+                    .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
+                    .realtime()
                     .accessibilityLabel(isFirst
                         ? accessibilityFormatters.distantFutureFirst(
                             date: format.predictionTime.toNSDate(),
@@ -83,51 +91,51 @@ struct UpcomingTripView: View {
                         )
                         : accessibilityFormatters
                         .distantFutureOther(date: format.predictionTime.toNSDate()))
-                    .font(Typography.footnoteSemibold)
-            case let .schedule(schedule):
-                HStack(spacing: Self.subjectSpacing) {
-                    Text(schedule.scheduleTime.toNSDate(), style: .time)
-                        .accessibilityLabel(isFirst
-                            ? accessibilityFormatters.scheduledFirst(
-                                date: schedule.scheduleTime.toNSDate(),
-                                vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
-                            )
-                            : accessibilityFormatters
-                            .scheduledOther(date: schedule.scheduleTime.toNSDate()))
-                        .font(Typography.footnoteSemibold)
-                    Image(.faClock)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: iconSize, height: iconSize)
-                        .padding(4)
-                        .foregroundStyle(Color.deemphasized)
-                }
             case let .minutes(format):
                 PredictionText(minutes: format.minutes)
+                    .realtime()
                     .accessibilityLabel(isFirst
-                        ? accessibilityFormatters.predictionMinutesFirst(minutes: format.minutes,
-                                                                         vehicleText: routeType?
-                                                                             .typeText(isOnly: isOnly) ?? "")
+                        ? accessibilityFormatters.predictionMinutesFirst(
+                            minutes: format.minutes,
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                        )
                         : accessibilityFormatters.predictionMinutesOther(minutes: format.minutes))
-            case let .cancelled(schedule):
+            case let .scheduleTime(format):
+                Text(format.scheduledTime.toNSDate(), style: .time)
+                    .opacity(0.6)
+                    .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
+                    .accessibilityLabel(isFirst
+                        ? accessibilityFormatters.scheduleTimeFirst(
+                            date: format.scheduledTime.toNSDate(),
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                        )
+                        : accessibilityFormatters.scheduleTimeOther(date: format.scheduledTime.toNSDate()))
+            case let .scheduleMinutes(format):
+                PredictionText(minutes: format.minutes)
+                    .opacity(0.6)
+                    .accessibilityLabel(isFirst
+                        ? accessibilityFormatters.scheduleMinutesFirst(
+                            minutes: format.minutes,
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                        )
+                        : accessibilityFormatters.scheduleMinutesOther(minutes: format.minutes))
+            case let .cancelled(format):
                 HStack(spacing: Self.subjectSpacing) {
                     Text("Cancelled")
                         .font(Typography.footnote)
                         .foregroundStyle(Color.deemphasized)
-                    Text(schedule.scheduledTime.toNSDate(), style: .time)
+                    Text(format.scheduledTime.toNSDate(), style: .time)
                         .font(Typography.footnoteSemibold)
                         .strikethrough()
                         .foregroundStyle(Color.deemphasized)
                 }
                 .accessibilityElement(children: .ignore)
-                .accessibilityLabel(
-                    isFirst
-                        ? accessibilityFormatters.scheduledFirst(
-                            date: schedule.scheduledTime.toNSDate(),
-                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
-                        )
-                        : accessibilityFormatters.scheduledOther(date: schedule.scheduledTime.toNSDate())
-                )
+                .accessibilityLabel(isFirst
+                    ? accessibilityFormatters.scheduleTimeFirst(
+                        date: format.scheduledTime.toNSDate(),
+                        vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                    )
+                    : accessibilityFormatters.scheduleTimeOther(date: format.scheduledTime.toNSDate()))
             }
         case let .noService(alertEffect):
             NoServiceView(effect: .from(alertEffect: alertEffect))
@@ -170,12 +178,20 @@ class UpcomingTripAccessibilityFormatters {
         Text("and at \(timeFormatter.string(from: date))")
     }
 
-    public func scheduledFirst(date: Date, vehicleText: String) -> Text {
+    public func scheduleTimeFirst(date: Date, vehicleText: String) -> Text {
         Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) scheduled")
     }
 
-    public func scheduledOther(date: Date) -> Text {
+    public func scheduleTimeOther(date: Date) -> Text {
         Text("and at \(timeFormatter.string(from: date)) scheduled")
+    }
+
+    public func scheduleMinutesFirst(minutes: Int32, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving in \(minutes) min scheduled")
+    }
+
+    public func scheduleMinutesOther(minutes: Int32) -> Text {
+        Text("and in \(minutes) min scheduled")
     }
 
     public func predictionMinutesFirst(minutes: Int32, vehicleText: String) -> Text {

--- a/iosApp/iosApp/ComponentViews/WithRealtimeIndicator.swift
+++ b/iosApp/iosApp/ComponentViews/WithRealtimeIndicator.swift
@@ -1,5 +1,5 @@
 //
-//  RealtimeIndicator.swift
+//  WithRealtimeIndicator.swift
 //  iosApp
 //
 //  Created by esimon on 10/18/24.
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct RealtimeIndicator: View {
+struct WithRealtimeIndicator: View {
     private static let subjectSpacing: CGFloat = 4
     @ScaledMetric private var iconSize: CGFloat = 12
     let prediction: any View
@@ -36,14 +36,14 @@ struct RealtimeIndicator: View {
     }
 }
 
-struct RealtimeIndicatorModifier: ViewModifier {
+struct WithRealtimeIndicatorModifier: ViewModifier {
     func body(content: Content) -> some View {
-        RealtimeIndicator(content)
+        WithRealtimeIndicator(content)
     }
 }
 
 extension View {
     func realtime() -> some View {
-        modifier(RealtimeIndicatorModifier())
+        modifier(WithRealtimeIndicatorModifier())
     }
 }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -55,6 +55,16 @@
         }
       }
     },
+    "%@ arriving in %@ min scheduled" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ arriving in %2$@ min scheduled"
+          }
+        }
+      }
+    },
     "%@ arriving now" : {
 
     },
@@ -143,6 +153,9 @@
     "and in %@ min" : {
 
     },
+    "and in %@ min scheduled" : {
+
+    },
     "ARR" : {
 
     },
@@ -178,6 +191,9 @@
     },
     "Crossing Malfunction" : {
       "comment" : "Possible alert cause"
+    },
+    "Custom message" : {
+
     },
     "Demonstration" : {
       "comment" : "Possible alert cause"

--- a/iosApp/iosApp/Utils/Typography.swift
+++ b/iosApp/iosApp/Utils/Typography.swift
@@ -23,7 +23,9 @@ enum Typography {
     static let title3 = Font.custom("Inter", size: 20, relativeTo: .title3).monospacedDigit()
     static let title3Semibold = title3.weight(.semibold)
 
-    static let headlineBold = Font.custom("Inter", size: 17, relativeTo: .headline).monospacedDigit().bold()
+    static let headline = Font.custom("Inter", size: 17, relativeTo: .headline).monospacedDigit()
+    static let headlineSemibold = headline.weight(.semibold)
+    static let headlineBold = headline.bold()
     static let headlineBoldItalic = headlineBold.italic()
 
     static let body = Font.custom("Inter", size: 17, relativeTo: .body).monospacedDigit()

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -59,7 +59,6 @@ final class TripDetailsPageTests: XCTestCase {
         let showsStopsExp = sut.inspection.inspect(onReceive: tripSchedulesLoaded, after: 1) { view in
             XCTAssertNotNil(try view.find(text: "Somewhere"))
             XCTAssertNotNil(try view.find(text: "Elsewhere"))
-            XCTAssertNotNil(try view.find(text: "Elsewhere").parent().find(text: "ARR"))
         }
 
         ViewHosting.host(view: sut)

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
@@ -77,29 +77,4 @@ final class TripDetailsStopViewTests: XCTestCase {
         try sut.inspect().find(button: "Boylston").tap()
         wait(for: [exp], timeout: 5)
     }
-
-    func testShowsNowForBus() throws {
-        let now = Date.now
-        let objects = ObjectCollectionBuilder()
-        let stop = objects.stop { _ in }
-        let prediction = objects.prediction { prediction in
-            prediction.arrivalTime = now.addingTimeInterval(15).toKotlinInstant()
-        }
-        let sut = TripDetailsStopView(
-            stop: .init(
-                stop: stop,
-                stopSequence: 1,
-                alert: nil,
-                schedule: nil,
-                prediction: prediction,
-                vehicle: nil,
-                routes: []
-            ),
-            now: now.toKotlinInstant(),
-            onTapLink: { _, _, _ in },
-            routeType: .bus
-        )
-
-        XCTAssertNotNil(try sut.inspect().find(text: "Now"))
-    }
 }

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -243,15 +243,16 @@ final class NearbyTransitViewTests: XCTestCase {
             let upcomingSchedule = try patterns[0].find(UpcomingTripView.self)
             XCTAssertEqual(
                 try upcomingSchedule.actualView().prediction,
-                .some(.Schedule(scheduleTime: time1))
+                .some(.ScheduleMinutes(minutes: 45))
             )
-            XCTAssertEqual(try upcomingSchedule.find(ViewType.Image.self).actualImage().name(), "fa-clock")
 
             XCTAssertEqual(try patterns[1].actualView().headsign, "Charles River Loop")
+            let upcomingPrediction = try patterns[1].find(UpcomingTripView.self)
             XCTAssertEqual(
-                try patterns[1].find(UpcomingTripView.self).actualView().prediction,
+                try upcomingPrediction.actualView().prediction,
                 .some(.Minutes(minutes: 10))
             )
+            XCTAssertEqual(try upcomingPrediction.find(ViewType.Image.self).actualImage().name(), "live-data")
 
             XCTAssertEqual(try patterns[2].actualView().headsign, "Watertown Yard")
             XCTAssertEqual(try patterns[2].find(UpcomingTripView.self).actualView().prediction, .serviceEndedToday)

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -74,7 +74,7 @@ final class UpcomingTripViewTests: XCTestCase {
 
     func testFirstScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().scheduledFirst(date: date, vehicleText: "buses")
+        let text: any View = UpcomingTripAccessibilityFormatters().scheduleTimeFirst(date: date, vehicleText: "buses")
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 
@@ -83,7 +83,7 @@ final class UpcomingTripViewTests: XCTestCase {
 
     func testScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
-        let text: any View = UpcomingTripAccessibilityFormatters().scheduledOther(date: date)
+        let text: any View = UpcomingTripAccessibilityFormatters().scheduleTimeOther(date: date)
         let foundText: String = try text.inspect().text()
             .string(locale: Locale(identifier: "en"))
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
@@ -8,6 +9,7 @@ import kotlinx.serialization.Serializable
 val ARRIVAL_CUTOFF = 30.seconds
 val APPROACH_CUTOFF = 60.seconds
 val BOARDING_CUTOFF = 90.seconds
+val SCHEDULE_CLOCK_CUTOFF = 60.minutes
 
 @Serializable
 data class Prediction(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -419,7 +419,9 @@ sealed class RealtimePatterns {
                 it.format is TripInstantDisplay.Hidden ||
                     it.format is TripInstantDisplay.Skipped ||
                     // API best practices call for hiding scheduled times on subway
-                    (isSubway && it.format is TripInstantDisplay.Schedule)
+                    (isSubway &&
+                        (it.format is TripInstantDisplay.ScheduleTime ||
+                            it.format is TripInstantDisplay.ScheduleMinutes))
             }
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -21,8 +21,8 @@ class RealtimePatternsTest {
     private fun ParametricTest.anyContext() =
         anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
 
-    private fun ParametricTest.anyNonCommuterRailRouteType() =
-        anyEnumValueExcept(RouteType.COMMUTER_RAIL)
+    private fun ParametricTest.anyNonScheduleBasedRouteType() =
+        anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY)
 
     @Test
     fun `formats as loading when null trips`() = parametricTest {
@@ -34,7 +34,7 @@ class RealtimePatternsTest {
         assertEquals(
             RealtimePatterns.Format.Loading,
             RealtimePatterns.ByHeadsign(route, "", null, emptyList(), null, null)
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
+                .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
     }
 
@@ -50,7 +50,7 @@ class RealtimePatternsTest {
         assertEquals(
             RealtimePatterns.Format.NoService(alert),
             RealtimePatterns.ByHeadsign(route, "", null, emptyList(), emptyList(), listOf(alert))
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
+                .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
     }
 
@@ -124,7 +124,7 @@ class RealtimePatternsTest {
                     listOf(upcomingTrip),
                     listOf(alert)
                 )
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
+                .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
     }
 
@@ -189,7 +189,7 @@ class RealtimePatternsTest {
                     emptyList(),
                     hasSchedulesToday = true
                 )
-                .format(now, anyNonCommuterRailRouteType(), anyContext())
+                .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
     }
 
@@ -264,7 +264,7 @@ class RealtimePatternsTest {
 
         val upcomingTrip1 = objects.upcomingTrip(prediction1)
         val upcomingTrip2 = objects.upcomingTrip(prediction2)
-        val routeType = anyNonCommuterRailRouteType()
+        val routeType = anyNonScheduleBasedRouteType()
         assertEquals(
             RealtimePatterns.Format.Some(
                 listOf(
@@ -338,7 +338,7 @@ class RealtimePatternsTest {
                     RealtimePatterns.Format.Some.FormatWithId(
                         trip1.id,
                         RouteType.BUS,
-                        TripInstantDisplay.Schedule(now + 5.minutes)
+                        TripInstantDisplay.ScheduleMinutes(5)
                     ),
                     RealtimePatterns.Format.Some.FormatWithId(
                         trip2.id,
@@ -530,7 +530,7 @@ class RealtimePatternsTest {
                 listOf(upcomingTrip1, upcomingTrip2, upcomingTrip3, upcomingTrip4)
             )
 
-        val routeType = anyNonCommuterRailRouteType()
+        val routeType = anyNonScheduleBasedRouteType()
         assertEquals(
             RealtimePatterns.Format.Some(
                 listOf(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.parametric.ParametricTest
 import com.mbta.tid.mbta_app.parametric.parametricTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -9,6 +10,18 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
 
 class TripInstantDisplayTest {
+
+    private fun ParametricTest.subway() =
+        anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY, RouteType.BUS)
+
+    private fun ParametricTest.scheduleBased() = anyOf(RouteType.COMMUTER_RAIL, RouteType.FERRY)
+
+    private fun ParametricTest.nonScheduleBased() =
+        anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY)
+
+    private fun ParametricTest.nonTripDetails() =
+        anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+
     @Test
     fun `status is non-null`() = parametricTest {
         assertEquals(
@@ -111,7 +124,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+                context = nonTripDetails()
             )
         )
         assertEquals(
@@ -126,11 +139,11 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 now = now,
                 routeType = null,
-                context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+                context = nonTripDetails()
             )
         )
         assertEquals(
-            TripInstantDisplay.AsTime(now + 3.minutes),
+            TripInstantDisplay.Time(now + 3.minutes),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -139,13 +152,13 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = null,
+                routeType = nonScheduleBased(),
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )
         )
         assertEquals(
-            TripInstantDisplay.Schedule(now + 3.minutes),
+            TripInstantDisplay.ScheduleTime(now + 3.minutes),
             TripInstantDisplay.from(
                 prediction = null,
                 schedule =
@@ -154,7 +167,7 @@ class TripInstantDisplayTest {
                         arrivalTime = now + 3.minutes
                     },
                 vehicle = null,
-                routeType = null,
+                routeType = nonScheduleBased(),
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )
@@ -165,15 +178,28 @@ class TripInstantDisplayTest {
     fun `schedule instead of prediction`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(
-            TripInstantDisplay.Schedule(now + 15.minutes),
+            TripInstantDisplay.ScheduleMinutes(15),
             TripInstantDisplay.from(
                 prediction = null,
                 schedule =
                     ObjectCollectionBuilder.Single.schedule { departureTime = now + 15.minutes },
                 vehicle = null,
-                routeType = null,
+                routeType = RouteType.BUS,
                 now = now,
-                context = anyEnumValue()
+                context = nonTripDetails()
+            )
+        )
+
+        assertEquals(
+            TripInstantDisplay.ScheduleTime(now + 75.minutes, false),
+            TripInstantDisplay.from(
+                prediction = null,
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule { departureTime = now + 75.minutes },
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = nonTripDetails()
             )
         )
     }
@@ -213,7 +239,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValue()
+                context = nonTripDetails()
             )
         )
     }
@@ -241,7 +267,7 @@ class TripInstantDisplayTest {
                 vehicle = vehicle,
                 now = now,
                 routeType = null,
-                context = anyEnumValue()
+                context = nonTripDetails()
             )
         )
     }
@@ -268,9 +294,9 @@ class TripInstantDisplayTest {
                         },
                     schedule = null,
                     vehicle = vehicle,
-                    routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                    routeType = nonScheduleBased(),
                     now = now,
-                    context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+                    context = nonTripDetails()
                 )
             )
         }
@@ -367,7 +393,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValue()
+                context = nonTripDetails()
             )
         )
         assertEquals(
@@ -381,7 +407,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValue()
+                context = nonTripDetails()
             )
         )
     }
@@ -401,7 +427,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+                context = nonTripDetails()
             )
         )
         assertEquals(
@@ -415,7 +441,7 @@ class TripInstantDisplayTest {
                 vehicle = null,
                 routeType = null,
                 now = now,
-                context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+                context = nonTripDetails()
             )
         )
     }
@@ -424,7 +450,7 @@ class TripInstantDisplayTest {
     fun `seconds less than 60 in trip details`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(
-            TripInstantDisplay.AsTime(now + 45.seconds),
+            TripInstantDisplay.Time(now + 45.seconds),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -439,7 +465,7 @@ class TripInstantDisplayTest {
             )
         )
         assertEquals(
-            TripInstantDisplay.AsTime(now + 40.seconds),
+            TripInstantDisplay.Time(now + 40.seconds),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -457,7 +483,7 @@ class TripInstantDisplayTest {
     @Test
     fun `minutes in the distant future`() = parametricTest {
         val now = Clock.System.now()
-        val context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+        val context = nonTripDetails()
 
         val futureMinutes = 61
         val moreFutureMinutes = futureMinutes + 38
@@ -486,7 +512,21 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
+                now = now,
+                context = context
+            )
+        )
+        assertEquals(
+            TripInstantDisplay.Time(now.plus(moreFutureMinutes.minutes), true),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = now.plus(moreFutureMinutes.minutes)
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = scheduleBased(),
                 now = now,
                 context = context
             )
@@ -496,7 +536,7 @@ class TripInstantDisplayTest {
     @Test
     fun `minutes less than 20 outside trip details`() = parametricTest {
         val now = Clock.System.now()
-        val context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
+        val context = nonTripDetails()
         assertEquals(
             TripInstantDisplay.Minutes(1),
             TripInstantDisplay.from(
@@ -506,7 +546,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
                 now = now,
                 context = context
             )
@@ -520,7 +560,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
                 now = now,
                 context = context
             )
@@ -534,7 +574,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
                 now = now,
                 context = context
             )
@@ -548,7 +588,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
                 now = now,
                 context = context
             )
@@ -562,7 +602,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
                 now = now,
                 context = context
             )
@@ -576,7 +616,22 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
+                routeType = nonScheduleBased(),
+                now = now,
+                context = context
+            )
+        )
+
+        assertEquals(
+            TripInstantDisplay.Time(predictionTime = now.plus(45.minutes), true),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = now.plus(45.minutes)
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = scheduleBased(),
                 now = now,
                 context = context
             )
@@ -587,35 +642,7 @@ class TripInstantDisplayTest {
     fun `minutes less than 20 in trip details`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(
-            TripInstantDisplay.Now,
-            TripInstantDisplay.from(
-                prediction =
-                    ObjectCollectionBuilder.Single.prediction {
-                        departureTime = now.plus(15.seconds)
-                    },
-                schedule = null,
-                vehicle = null,
-                routeType = RouteType.BUS,
-                now = now,
-                context = TripInstantDisplay.Context.TripDetails
-            )
-        )
-        assertEquals(
-            TripInstantDisplay.Minutes(1),
-            TripInstantDisplay.from(
-                prediction =
-                    ObjectCollectionBuilder.Single.prediction {
-                        departureTime = now.plus(31.seconds)
-                    },
-                schedule = null,
-                vehicle = null,
-                routeType = RouteType.BUS,
-                now = now,
-                context = TripInstantDisplay.Context.TripDetails
-            )
-        )
-        assertEquals(
-            TripInstantDisplay.AsTime(now + 90.seconds),
+            TripInstantDisplay.Time(now + 90.seconds),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -623,13 +650,13 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
+                routeType = null,
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )
         )
         assertEquals(
-            TripInstantDisplay.AsTime(now + 149.seconds),
+            TripInstantDisplay.Time(now + 149.seconds),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -638,12 +665,12 @@ class TripInstantDisplayTest {
                 schedule = null,
                 vehicle = null,
                 now = now,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
+                routeType = null,
                 context = TripInstantDisplay.Context.TripDetails
             )
         )
         assertEquals(
-            TripInstantDisplay.AsTime(now + 45.minutes),
+            TripInstantDisplay.Time(now + 45.minutes),
             TripInstantDisplay.from(
                 prediction =
                     ObjectCollectionBuilder.Single.prediction {
@@ -651,7 +678,7 @@ class TripInstantDisplayTest {
                     },
                 schedule = null,
                 vehicle = null,
-                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS),
+                routeType = null,
                 now = now,
                 context = TripInstantDisplay.Context.TripDetails
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -21,15 +21,15 @@ class UpcomingTripTest {
         private fun ParametricTest.anyContext() =
             anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
 
-        private fun ParametricTest.subwayOrFerry() =
-            anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.BUS)
+        private fun ParametricTest.subway() =
+            anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY, RouteType.BUS)
 
         @Test
         fun `status is non-null`() = parametricTest {
             assertEquals(
                 TripInstantDisplay.Overridden("Custom Text"),
                 UpcomingTrip(trip {}, prediction { status = "Custom Text" })
-                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
+                    .format(Clock.System.now(), subway(), anyContext())
             )
         }
 
@@ -45,7 +45,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         },
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -59,7 +59,7 @@ class UpcomingTripTest {
                             scheduleRelationship = Prediction.ScheduleRelationship.Skipped
                         }
                     )
-                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
+                    .format(Clock.System.now(), subway(), anyContext())
             )
         }
 
@@ -68,12 +68,12 @@ class UpcomingTripTest {
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, prediction { departureTime = null })
-                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
+                    .format(Clock.System.now(), subway(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Hidden,
                 UpcomingTrip(trip {}, schedule { departureTime = null })
-                    .format(Clock.System.now(), subwayOrFerry(), anyContext())
+                    .format(Clock.System.now(), subway(), anyContext())
             )
         }
 
@@ -81,9 +81,9 @@ class UpcomingTripTest {
         fun `schedule instead of prediction`() = parametricTest {
             val now = Clock.System.now()
             assertEquals(
-                TripInstantDisplay.Schedule(now + 15.minutes),
+                TripInstantDisplay.ScheduleMinutes(15),
                 UpcomingTrip(trip {}, schedule { departureTime = now + 15.minutes })
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -99,7 +99,7 @@ class UpcomingTripTest {
                             departureTime = now.minus(2.seconds)
                         }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -147,7 +147,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(10.seconds)
                         }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -171,7 +171,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -196,7 +196,7 @@ class UpcomingTripTest {
                             },
                             vehicle
                         )
-                        .format(now, subwayOrFerry(), anyContext())
+                        .format(now, subway(), anyContext())
                 )
             }
 
@@ -221,7 +221,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
             // wrong stop ID
             vehicle = vehicle {
@@ -241,7 +241,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
             // wrong trip ID
             vehicle = vehicle {
@@ -261,7 +261,7 @@ class UpcomingTripTest {
                         },
                         vehicle
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -277,12 +277,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(20.seconds)
                         }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Arriving,
                 UpcomingTrip(trip {}, prediction { departureTime = now.plus(15.seconds) })
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -298,12 +298,12 @@ class UpcomingTripTest {
                             departureTime = now.plus(50.seconds)
                         }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Approaching,
                 UpcomingTrip(trip {}, (prediction { departureTime = now.plus(40.seconds) }))
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
@@ -322,7 +322,7 @@ class UpcomingTripTest {
                             departureTime = now.plus(futureMinutes.minutes).plus(1.minutes)
                         }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
             assertEquals(
                 TripInstantDisplay.Minutes(moreFutureMinutes),
@@ -330,14 +330,14 @@ class UpcomingTripTest {
                         trip {},
                         prediction { departureTime = now.plus(moreFutureMinutes.minutes) }
                     )
-                    .format(now, subwayOrFerry(), anyContext())
+                    .format(now, subway(), anyContext())
             )
         }
 
         @Test
         fun `minutes less than 20`() = parametricTest {
             val now = Clock.System.now()
-            val routeType = subwayOrFerry()
+            val routeType = subway()
             val context = anyContext()
             assertEquals(
                 TripInstantDisplay.Minutes(1),


### PR DESCRIPTION
### Summary

_Ticket:_ [Update real-time indicator](https://app.asana.com/0/1205732265579288/1208468599574768/f), [Fix: Bus trip details show minutes, not timestamps](https://app.asana.com/0/1205732265579288/1208468599574706/f)

Add realtime indicators next to realtime predictions, remove schedule clock icon, show only clock times for CR and ferry, and restyle displayed schedules to be greyed out. Also fixes trip details for bus showing countdown times because I was updating that code already.

![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 13 05 45](https://github.com/user-attachments/assets/daa689c5-2ef0-4b0d-ab1c-79cd376349da)![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 13 07 47](https://github.com/user-attachments/assets/65035f52-e4ee-4105-a916-d2b9bab6af2b)![Simulator Screenshot - iPhone 15 Pro - 2024-10-21 at 13 09 06](https://github.com/user-attachments/assets/c4deec3d-da18-4e83-b58f-707014359a08)



### Testing

Added and updated tests to match the new behavior.