### PR TITLE
ci: retry network commands

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -1,10 +1,32 @@
-#!/bin/sh
+#!/bin/zsh
 
 # Fail this script if any subcommand fails.
 set -e
 
+# Outgoing network connections from Xcode Cloud frequently just break, so retry everything a lot.
+# https://unix.stackexchange.com/a/137639
+function retry() {
+  local n=1
+  # for some reason, the syntax for "$foo or bar if $foo is unset" is ${foo-bar}
+  local max=${RETRIES-5}
+  local delay=5
+  while true; do
+    if "$@"; then
+      break
+    else
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay
+      else
+        return 1
+      fi
+    fi
+  done
+}
+
 # Install SwiftLint
-brew install swiftlint
+retry brew install swiftlint
 
 # Install Java
 JDK_PATH="${CI_DERIVED_DATA_PATH}/JDK"
@@ -17,9 +39,9 @@ if [ -d $JDK_PATH ]; then
   exit
 fi
 
-brew install asdf
-asdf plugin-add java
-asdf install java
+retry brew install asdf
+retry asdf plugin-add java
+retry asdf install java
 DEFAULT_JAVA_PATH="$(asdf where java)"
 DEFAULT_JAVA_ROOT_DIR="$(dirname DEFAULT_JAVA_PATH)"
 rm -rf $JDK_PATH
@@ -30,11 +52,11 @@ mv $DEFAULT_JAVA_PATH "${DEFAULT_JAVA_ROOT_DIR}/JDK"
 mv "${DEFAULT_JAVA_ROOT_DIR}/JDK" $CI_DERIVED_DATA_PATH
 
 # Install cocoapods
-brew install cocoapods
+retry brew install cocoapods
 cd "${CI_PRIMARY_REPOSITORY_PATH}"
-./gradlew :shared:generateDummyFramework
+retry ./gradlew :shared:generateDummyFramework
 cd "${CI_PRIMARY_REPOSITORY_PATH}/iosApp"
-pod install
+retry pod install
 cd ..
 
 # Configure Mapbox token for installation
@@ -49,7 +71,7 @@ echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 if [ $CI_XCODEBUILD_ACTION == "build-for-testing" ]; then
   echo "Running shared tests"
   cd $CI_PRIMARY_REPOSITORY_PATH
-  ./gradlew shared:iosX64Test
+  RETRIES=2 retry ./gradlew shared:iosX64Test
 fi
 
 echo "Adding build environment variables"

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 # Fail this script if any subcommand fails.
 set -e
@@ -34,7 +34,7 @@ JDK_PATH="${CI_DERIVED_DATA_PATH}/JDK"
 echo "Checking for cached JDK"
 # If the JDK isn't already installed, download it JDK and move it to JDK_PATH
 # JAVA_HOME env var must be manually configured to match JDK_PATH
-if [[ -d "$JDK_PATH" ]]; then
+if [ -d $JDK_PATH ]; then
   echo "JDK already found, skipping download"
   exit
 fi
@@ -44,12 +44,12 @@ retry asdf plugin-add java
 retry asdf install java
 DEFAULT_JAVA_PATH="$(asdf where java)"
 DEFAULT_JAVA_ROOT_DIR="$(dirname DEFAULT_JAVA_PATH)"
-rm -rf "$JDK_PATH"
-mkdir -p "$JDK_PATH"
+rm -rf $JDK_PATH
+mkdir -p $JDK_PATH
 # Temporary move into generically named JDK folder
-mv "$DEFAULT_JAVA_PATH" "${DEFAULT_JAVA_ROOT_DIR}/JDK"
+mv $DEFAULT_JAVA_PATH "${DEFAULT_JAVA_ROOT_DIR}/JDK"
 # Move into JDK_PATH so that it can be referenced by JAVA_HOME env var
-mv "${DEFAULT_JAVA_ROOT_DIR}/JDK" "$CI_DERIVED_DATA_PATH"
+mv "${DEFAULT_JAVA_ROOT_DIR}/JDK" $CI_DERIVED_DATA_PATH
 
 # Install cocoapods
 retry brew install cocoapods
@@ -60,7 +60,7 @@ retry pod install
 cd ..
 
 # Configure Mapbox token for installation
-cd "$CI_PRIMARY_REPOSITORY_PATH"
+cd $CI_PRIMARY_REPOSITORY_PATH
 touch ~/.netrc
 echo "machine api.mapbox.com" > ~/.netrc
 echo "login mapbox" >> ~/.netrc
@@ -68,14 +68,14 @@ echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 
 
 # Run tests from shared directory
-if [[ "$CI_XCODEBUILD_ACTION" == "build-for-testing" ]]; then
+if [ $CI_XCODEBUILD_ACTION == "build-for-testing" ]; then
   echo "Running shared tests"
-  cd "$CI_PRIMARY_REPOSITORY_PATH"
+  cd $CI_PRIMARY_REPOSITORY_PATH
   RETRIES=2 retry ./gradlew shared:iosX64Test
 fi
 
 echo "Adding build environment variables"
-cd "${CI_PRIMARY_REPOSITORY_PATH}"
+cd ${CI_PRIMARY_REPOSITORY_PATH}
 touch .envrc
 echo "export SENTRY_DSN=${SENTRY_DSN}" >> .envrc
 echo "export SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}" >> .envrc

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -34,7 +34,7 @@ JDK_PATH="${CI_DERIVED_DATA_PATH}/JDK"
 echo "Checking for cached JDK"
 # If the JDK isn't already installed, download it JDK and move it to JDK_PATH
 # JAVA_HOME env var must be manually configured to match JDK_PATH
-if [ -d "$JDK_PATH" ]; then
+if [[ -d "$JDK_PATH" ]]; then
   echo "JDK already found, skipping download"
   exit
 fi
@@ -68,7 +68,7 @@ echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 
 
 # Run tests from shared directory
-if [ "$CI_XCODEBUILD_ACTION" == "build-for-testing" ]; then
+if [[ "$CI_XCODEBUILD_ACTION" == "build-for-testing" ]]; then
   echo "Running shared tests"
   cd "$CI_PRIMARY_REPOSITORY_PATH"
   RETRIES=2 retry ./gradlew shared:iosX64Test

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -34,7 +34,7 @@ JDK_PATH="${CI_DERIVED_DATA_PATH}/JDK"
 echo "Checking for cached JDK"
 # If the JDK isn't already installed, download it JDK and move it to JDK_PATH
 # JAVA_HOME env var must be manually configured to match JDK_PATH
-if [ -d $JDK_PATH ]; then
+if [ -d "$JDK_PATH" ]; then
   echo "JDK already found, skipping download"
   exit
 fi
@@ -44,12 +44,12 @@ retry asdf plugin-add java
 retry asdf install java
 DEFAULT_JAVA_PATH="$(asdf where java)"
 DEFAULT_JAVA_ROOT_DIR="$(dirname DEFAULT_JAVA_PATH)"
-rm -rf $JDK_PATH
-mkdir -p $JDK_PATH
+rm -rf "$JDK_PATH"
+mkdir -p "$JDK_PATH"
 # Temporary move into generically named JDK folder
-mv $DEFAULT_JAVA_PATH "${DEFAULT_JAVA_ROOT_DIR}/JDK"
+mv "$DEFAULT_JAVA_PATH" "${DEFAULT_JAVA_ROOT_DIR}/JDK"
 # Move into JDK_PATH so that it can be referenced by JAVA_HOME env var
-mv "${DEFAULT_JAVA_ROOT_DIR}/JDK" $CI_DERIVED_DATA_PATH
+mv "${DEFAULT_JAVA_ROOT_DIR}/JDK" "$CI_DERIVED_DATA_PATH"
 
 # Install cocoapods
 retry brew install cocoapods
@@ -60,7 +60,7 @@ retry pod install
 cd ..
 
 # Configure Mapbox token for installation
-cd $CI_PRIMARY_REPOSITORY_PATH
+cd "$CI_PRIMARY_REPOSITORY_PATH"
 touch ~/.netrc
 echo "machine api.mapbox.com" > ~/.netrc
 echo "login mapbox" >> ~/.netrc
@@ -68,14 +68,14 @@ echo "password ${MAPBOX_SECRET_TOKEN}" >> ~/.netrc
 
 
 # Run tests from shared directory
-if [ $CI_XCODEBUILD_ACTION == "build-for-testing" ]; then
+if [ "$CI_XCODEBUILD_ACTION" == "build-for-testing" ]; then
   echo "Running shared tests"
-  cd $CI_PRIMARY_REPOSITORY_PATH
+  cd "$CI_PRIMARY_REPOSITORY_PATH"
   RETRIES=2 retry ./gradlew shared:iosX64Test
 fi
 
 echo "Adding build environment variables"
-cd ${CI_PRIMARY_REPOSITORY_PATH}
+cd "${CI_PRIMARY_REPOSITORY_PATH}"
 touch .envrc
 echo "export SENTRY_DSN=${SENTRY_DSN}" >> .envrc
 echo "export SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}" >> .envrc


### PR DESCRIPTION
### Summary

_Ticket:_ [Retry ci_post_clone script steps if failures](https://app.asana.com/0/1205425564113216/1208581804426730/f)

The fact that we can't retry PR builds when they fail means this is suddenly much higher priority.

### Testing

Checked the `retry` function locally (and caught an error in my shell syntax).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
