### PR TITLE
feat(iOS): add option to hide maps

### DIFF
--- a/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
+++ b/iosApp/iosApp/Pages/Settings/Setting+Convenience.swift
@@ -16,6 +16,8 @@ extension Setting: Identifiable {
 
     var name: String {
         switch key {
+        case .hideMaps:
+            "Hide Maps"
         case .searchRouteResults:
             "Search - Route Results"
         case .map:
@@ -25,6 +27,8 @@ extension Setting: Identifiable {
 
     var icon: String {
         switch key {
+        case .hideMaps:
+            "map"
         case .searchRouteResults:
             "point.topleft.down.to.point.bottomright.curvepath.fill"
         case .map:
@@ -34,6 +38,8 @@ extension Setting: Identifiable {
 
     var category: SettingsSection.Category {
         switch key {
+        case .hideMaps:
+            .settings
         case .searchRouteResults:
             .featureFlags
         case .map:

--- a/iosApp/iosApp/Pages/Settings/SettingsSection.swift
+++ b/iosApp/iosApp/Pages/Settings/SettingsSection.swift
@@ -10,6 +10,7 @@ import shared
 
 struct SettingsSection: Identifiable, Equatable {
     enum Category: String {
+        case settings
         case debug
         case featureFlags
     }
@@ -17,6 +18,8 @@ struct SettingsSection: Identifiable, Equatable {
     var id: Category
     var name: String {
         switch id {
+        case .settings:
+            "Settings"
         case .debug:
             "Debug"
         case .featureFlags:
@@ -27,6 +30,8 @@ struct SettingsSection: Identifiable, Equatable {
     var settings: [Setting]
     var requiresStaging: Bool {
         switch id {
+        case .settings:
+            false
         case .debug:
             false
         case .featureFlags:

--- a/iosApp/iosApp/ViewModels/ContentViewModel.swift
+++ b/iosApp/iosApp/ViewModels/ContentViewModel.swift
@@ -12,13 +12,19 @@ import shared
 
 class ContentViewModel: ObservableObject {
     @Published var configResponse: ApiResult<ConfigResponse>?
+    @Published var hideMaps: Bool
 
     var configUseCase: ConfigUseCase
+    var settingsRepository: ISettingsRepository
 
     init(configUseCase: ConfigUseCase = UsecaseDI().configUsecase,
-         configResponse: ApiResult<ConfigResponse>? = nil) {
+         configResponse: ApiResult<ConfigResponse>? = nil,
+         settingsRepository: ISettingsRepository = RepositoryDI().settings,
+         hideMaps: Bool = false) {
         self.configUseCase = configUseCase
         self.configResponse = configResponse
+        self.settingsRepository = settingsRepository
+        self.hideMaps = hideMaps
     }
 
     func configureMapboxToken(token: String) {
@@ -31,5 +37,9 @@ class ContentViewModel: ObservableObject {
         } catch {
             configResponse = ApiResultError(code: nil, message: "\(error.localizedDescription)")
         }
+    }
+
+    @MainActor func loadHideMaps() async {
+        hideMaps = await (try? settingsRepository.getSettings().first { $0.key == .hideMaps }?.isOn) ?? false
     }
 }

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -40,6 +40,10 @@ class SettingsViewModel: ObservableObject {
             let storedSettings = try await settingsRepository.getSettings()
             settings = [
                 SettingsSection(
+                    id: .settings,
+                    settings: storedSettings.filter { $0.category == .settings }
+                ),
+                SettingsSection(
                     id: .debug,
                     settings: storedSettings.filter { $0.category == .debug }
                 ),

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -150,6 +150,14 @@ final class ContentViewTests: XCTestCase {
         wait(for: [hasAppeared, loadConfigCallback], timeout: 5)
     }
 
+    @MainActor func testHidesMap() throws {
+        let contentVM = FakeContentVM()
+        contentVM.hideMaps = true
+        let sut = ContentView(contentVM: contentVM)
+
+        XCTAssertThrowsError(try sut.inspect().find(HomeMapView.self))
+    }
+
     func testShowsMap() throws {
         let sut = withDefaultEnvironmentObjects(sut: ContentView(contentVM: FakeContentVM()))
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -37,6 +37,7 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     Map(booleanPreferencesKey("map_debug")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
+    HideMaps(booleanPreferencesKey("hide_maps")),
 }
 
 data class Setting(val key: Settings, var isOn: Boolean)


### PR DESCRIPTION
### Summary

_Ticket:_ [Setting to hide maps](https://app.asana.com/0/1205732265579288/1208572284247927/f)

As I expected, the way we broke up the ContentView makes this not difficult at all to implement.

### Testing

Added a unit test. Manually validated that everything behaves reasonably (including with VoiceOver) and [checked in Slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1729711383158839) that no changes need to be made.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
