### PR TITLE
fix: Consume global data from a flow

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/GetGlobalDataTest.kt
@@ -6,6 +6,9 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -26,6 +29,9 @@ class GetGlobalDataTest {
         val requestSync = Channel<Unit>(Channel.RENDEZVOUS)
         val globalRepo =
             object : IGlobalRepository {
+                override val state: StateFlow<GlobalResponse?> =
+                    MutableStateFlow<GlobalResponse?>(globalData).asStateFlow()
+
                 override suspend fun getGlobalData(): ApiResult<GlobalResponse> {
                     requestSync.receive()
                     return ApiResult.Ok(globalData)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ okio = "3.9.1"
 sentry = "0.9.0"
 skie = "0.9.3"
 spatialk = "0.3.0"
+turbine = "1.2.0"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
@@ -64,6 +65,7 @@ sentry = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sent
 skie-configuration-annotations = { module = "co.touchlab.skie:configuration-annotations", version.ref = "skie" }
 spatialk-geojson = { module = "io.github.dellisd.spatialk:geojson", version.ref = "spatialk" }
 spatialk-turf = { module = "io.github.dellisd.spatialk:turf", version.ref = "spatialk" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a2b59b5f418a8d823aba805c1d48e270cea70150d3532564422dca3335b31290",
+  "originHash" : "e617080b0d8c905c709b45cc004aaf8646fc086a0dbbe47ba9df4d3cf913bc0d",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "7d2688de038d5484866d835acb47b379722d610e",
         "version" : "10.19.0"
-      }
-    },
-    {
-      "identity" : "appcues-ios-sdk",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/appcues/appcues-ios-sdk",
-      "state" : {
-        "revision" : "5b3668a18154dcfc37a5b551658c29985a5f80e1",
-        "version" : "3.2.0"
       }
     },
     {
@@ -137,15 +128,6 @@
       }
     },
     {
-      "identity" : "polyline",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/raphaelmor/Polyline.git",
-      "state" : {
-        "revision" : "353f80378dcd8f17eefe8550090c6b1ae3c9da23",
-        "version" : "5.1.0"
-      }
-    },
-    {
       "identity" : "promises",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
@@ -177,8 +159,16 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/davidstump/SwiftPhoenixClient",
       "state" : {
-        "revision" : "588bf6baab5d049752748e19a4bff32421ea40ec",
-        "version" : "5.3.2"
+        "revision" : "4e548e4ce4d46574a20b8a539d52d367fb0eae24"
+      }
+    },
+    {
+      "identity" : "swiftui-shimmer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/markiv/SwiftUI-Shimmer",
+      "state" : {
+        "revision" : "0226e21f9bf355d40e07e5f5e1c33679d50e167f",
+        "version" : "1.5.1"
       }
     },
     {
@@ -195,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "7b1732802ffe30e6a67754bda6c7819e5cb0eb70",
-        "version" : "0.9.11"
+        "revision" : "5acfa0a3c095ac9ad050abe51c60d1831e8321da",
+        "version" : "0.10.0"
       }
     }
   ],

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -36,6 +36,13 @@ struct ContentView: View {
     var body: some View {
         contents
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
+            .task {
+                // We can't set stale caches in ResponseCache on init because of our Koin setup,
+                // so this is here to get the cached data into the global flow and kick off an async request asap.
+                do {
+                    let _ = try await RepositoryDI().global.getGlobalData()
+                } catch {}
+            }
     }
 
     @ViewBuilder
@@ -52,7 +59,6 @@ struct ContentView: View {
                         screenTracker.track(screen: .settings)
                     }
             }
-
         } else {
             nearbyTab
         }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -156,11 +156,11 @@
     "and in %@ min" : {
       "comment" : "The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving in 5 minutes], and in 10 minutes'"
     },
-    "Approaching" : {
-      "comment" : "Label for a vehicle's next stop. For example: Approaching Alewife"
-    },
     "and in %@ min scheduled" : {
 
+    },
+    "Approaching" : {
+      "comment" : "Label for a vehicle's next stop. For example: Approaching Alewife"
     },
     "ARR" : {
       "comment" : "Shorthand for arriving"

--- a/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
@@ -36,20 +36,27 @@ extension HomeMapView {
         mapVM.layerManager = layerManager
     }
 
-    func initializeLayers(_ layerManager: IMapLayerManager) {
-        let routeSourceData = railRouteShapes?.routesWithSegmentedShapes ?? []
+    func handleSetRailSources(railRouteShapes: MapFriendlyRouteResponse?) {
+        guard let railRouteShapes else { return }
+        let routeSourceData = railRouteShapes.routesWithSegmentedShapes
         mapVM.allRailSourceData = routeSourceData
         mapVM.routeSourceData = routeSourceData
+    }
 
+    func handleSetStopSources() {
         let snappedStopRouteLines = RouteFeaturesBuilder.shared.generateRouteLines(
-            routeData: routeSourceData,
+            routeData: mapVM.allRailSourceData,
             routesById: globalData?.routes,
             stopsById: globalData?.stops,
             alertsByStop: globalMapData?.alertsByStop
         )
         mapVM.snappedStopRouteLines = snappedStopRouteLines
-
         mapVM.stopSourceData = .init(selectedStopId: lastNavEntry?.stop()?.id)
+    }
+
+    func initializeLayers(_ layerManager: IMapLayerManager) {
+        handleSetRailSources(railRouteShapes: railRouteShapes)
+        handleSetStopSources()
 
         addLayers(layerManager)
     }
@@ -80,41 +87,32 @@ extension HomeMapView {
         _ filter: StopDetailsFilter?,
         _ departures: StopDetailsDepartures?
     ) {
-        if let filter {
-            mapVM.routeSourceData = RouteFeaturesBuilder.shared.filteredRouteShapesForStop(
-                stopMapData: stopMapData,
-                filter: filter,
-                departures: departures
-            )
-        } else {
-            mapVM.routeSourceData = RouteFeaturesBuilder.shared.forRailAtStop(
-                stopShapes: stopMapData.routeShapes,
-                railShapes: mapVM.allRailSourceData,
-                routesById: globalData?.routes
-            )
+        Task {
+            if let filter {
+                mapVM.routeSourceData = RouteFeaturesBuilder.shared.filteredRouteShapesForStop(
+                    stopMapData: stopMapData,
+                    filter: filter,
+                    departures: departures
+                )
+            } else {
+                mapVM.routeSourceData = RouteFeaturesBuilder.shared.forRailAtStop(
+                    stopShapes: stopMapData.routeShapes,
+                    railShapes: mapVM.allRailSourceData,
+                    routesById: globalData?.routes
+                )
+            }
         }
     }
 
     func updateGlobalMapDataSources() {
-        updateStopSource(stopData: mapVM.stopSourceData)
-        updateRouteSources(routeData: mapVM.routeSourceData)
+        mapVM.updateSources(globalData: globalData, globalMapData: globalMapData)
     }
 
-    func updateRouteSources(routeData: [MapFriendlyRouteResponse.RouteWithSegmentedShapes]) {
-        mapVM.updateRouteSource(routeLines: RouteFeaturesBuilder.shared.generateRouteLines(
-            routeData: routeData,
-            routesById: globalData?.routes,
-            stopsById: globalData?.stops,
-            alertsByStop: globalMapData?.alertsByStop
-        ))
+    func updateRouteSource() {
+        mapVM.updateRouteSource(globalData: globalData, globalMapData: globalMapData)
     }
 
-    func updateStopSource(stopData: StopSourceData) {
-        mapVM.updateStopSource(StopFeaturesBuilder.shared.buildCollection(
-            stopData: stopData,
-            stops: globalMapData?.mapStops ?? [:],
-            linesToSnap: mapVM.snappedStopRouteLines
-        )
-        .toMapbox())
+    func updateStopSource() {
+        mapVM.updateStopSource(globalMapData: globalMapData)
     }
 }

--- a/iosApp/iosApp/Pages/Map/MapLayerManager.swift
+++ b/iosApp/iosApp/Pages/Map/MapLayerManager.swift
@@ -32,27 +32,35 @@ class MapLayerManager: IMapLayerManager {
 
     func addIcons(recreate: Bool = false) {
         for iconId in StopIcons.shared.all + AlertIcons.shared.all {
-            do {
+            Task {
                 guard let image = UIImage(named: iconId) else { throw MapImageError() }
-                if map.imageExists(withId: iconId) {
-                    if recreate {
-                        try map.removeImage(withId: iconId)
-                    } else {
-                        continue
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    do {
+                        if map.imageExists(withId: iconId) {
+                            if recreate {
+                                try map.removeImage(withId: iconId)
+                            } else {
+                                return
+                            }
+                        }
+                        try map.addImage(image, id: iconId)
+                    } catch {
+                        Logger().error("Failed to add map icon image \(iconId)\n\(error)")
                     }
                 }
-                try map.addImage(image, id: iconId)
-            } catch {
-                Logger().error("Failed to add map icon image \(iconId)\n\(error)")
             }
         }
     }
 
     private func addSource(source: GeoJSONSource) {
-        do {
-            try map.addSource(source)
-        } catch {
-            Logger().error("Failed to add source \(source.id)\n\(error)")
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            do {
+                try map.addSource(source)
+            } catch {
+                Logger().error("Failed to add source \(source.id)\n\(error)")
+            }
         }
     }
 
@@ -64,31 +72,36 @@ class MapLayerManager: IMapLayerManager {
      https://docs.mapbox.com/ios/maps/api/11.5.0/documentation/mapboxmaps/stylemanager/addpersistentlayer(_:layerposition:)
      */
     func addLayers(colorScheme: ColorScheme, recreate: Bool = false) {
-        let colorPalette = getColorPalette(colorScheme: colorScheme)
-        currentScheme = colorScheme
-        let layers: [MapboxMaps.Layer] = RouteLayerGenerator.shared.createAllRouteLayers(colorPalette: colorPalette)
-            .map { $0.toMapbox() } + StopLayerGenerator.shared.createStopLayers(
-                colorPalette: colorPalette
-            ).map { $0.toMapbox() }
+        Task {
+            let colorPalette = getColorPalette(colorScheme: colorScheme)
+            currentScheme = colorScheme
+            let layers: [MapboxMaps.Layer] = RouteLayerGenerator.shared.createAllRouteLayers(colorPalette: colorPalette)
+                .map { $0.toMapbox() } + StopLayerGenerator.shared.createStopLayers(
+                    colorPalette: colorPalette
+                ).map { $0.toMapbox() }
 
-        for layer in layers {
-            do {
-                if map.layerExists(withId: layer.id) {
-                    if recreate {
-                        try map.removeLayer(withId: layer.id)
-                    } else {
-                        // Skip attempting to add layer if it already exists
-                        continue
+            for layer in layers {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    do {
+                        if map.layerExists(withId: layer.id) {
+                            if recreate {
+                                try map.removeLayer(withId: layer.id)
+                            } else {
+                                // Skip attempting to add layer if it already exists
+                                return
+                            }
+                        }
+
+                        if map.layerExists(withId: "puck") {
+                            try map.addPersistentLayer(layer, layerPosition: .below("puck"))
+                        } else {
+                            try map.addPersistentLayer(layer)
+                        }
+                    } catch {
+                        Logger().error("Failed to add layer \(layer.id)\n\(error)")
                     }
                 }
-
-                if map.layerExists(withId: "puck") {
-                    try map.addPersistentLayer(layer, layerPosition: .below("puck"))
-                } else {
-                    try map.addPersistentLayer(layer)
-                }
-            } catch {
-                Logger().error("Failed to add layer \(layer.id)\n\(error)")
             }
         }
     }
@@ -102,12 +115,15 @@ class MapLayerManager: IMapLayerManager {
     }
 
     func updateSourceData(sourceId: String, data: MapboxMaps.FeatureCollection) {
-        if map.sourceExists(withId: sourceId) {
-            map.updateGeoJSONSource(withId: sourceId, data: .featureCollection(data))
-        } else {
-            var source = GeoJSONSource(id: sourceId)
-            source.data = .featureCollection(data)
-            addSource(source: source)
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if map.sourceExists(withId: sourceId) {
+                map.updateGeoJSONSource(withId: sourceId, data: .featureCollection(data))
+            } else {
+                var source = GeoJSONSource(id: sourceId)
+                source.data = .featureCollection(data)
+                addSource(source: source)
+            }
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -128,13 +128,22 @@ struct StopDetailsPage: View {
         loadPinnedRoutes()
     }
 
+    @MainActor
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            globalResponse = globalData
+        }
+    }
+
     func loadGlobalData() {
+        Task(priority: .high) {
+            await activateGlobalListener()
+        }
         Task {
             await fetchApi(
                 errorBannerVM.errorRepository,
                 errorKey: "StopDetailsPage.loadGlobalData",
                 getData: { try await globalRepository.getGlobalData() },
-                onSuccess: { globalResponse = $0 },
                 onRefreshAfterError: loadEverything
             )
         }

--- a/iosApp/iosApp/Utils/FetchApi.swift
+++ b/iosApp/iosApp/Utils/FetchApi.swift
@@ -17,7 +17,7 @@ func fetchApi<T>(
     _ errorBannerRepo: IErrorBannerStateRepository,
     errorKey: String,
     getData: () async throws -> ApiResult<T>,
-    onSuccess: @MainActor (T) -> Void,
+    onSuccess: @MainActor (T) -> Void = { _ in },
     onRefreshAfterError: @escaping () -> Void
 ) async {
     var result: ApiResult<T>

--- a/iosApp/iosApp/ViewModels/MapViewModel.swift
+++ b/iosApp/iosApp/ViewModels/MapViewModel.swift
@@ -17,8 +17,8 @@ class MapViewModel: ObservableObject {
     @Published var stopSourceData: StopSourceData = .init()
     @Published var stopMapData: StopMapResponse?
     @Published var allRailSourceData: [MapFriendlyRouteResponse.RouteWithSegmentedShapes] = []
-    var stopUpdateTask: Task<Void, Error>? = nil
-    var routeUpdateTask: Task<Void, Error>? = nil
+    var stopUpdateTask: Task<Void, Error>?
+    var routeUpdateTask: Task<Void, Error>?
     var snappedStopRouteLines: [RouteLineData] = []
 
     var lastMapboxErrorSubject: PassthroughSubject<Date?, Never>

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -122,10 +122,10 @@ class NearbyViewModel: ObservableObject {
             await fetchApi(
                 errorBannerRepository,
                 errorKey: "NearbyViewModel.getNearby",
-                getData: { try await nearbyRepository.getNearby(global: global, location: location.coordinateKt) },
+                getData: { try await self.nearbyRepository.getNearby(global: global, location: location.coordinateKt) },
                 onSuccess: {
-                    nearbyState.nearbyByRouteAndStop = $0
-                    nearbyState.loadedLocation = location
+                    self.nearbyState.nearbyByRouteAndStop = $0
+                    self.nearbyState.loadedLocation = location
                 },
                 onRefreshAfterError: { self.getNearby(global: global, location: location) }
             )

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
@@ -14,21 +14,6 @@ import ViewInspector
 import XCTest
 
 final class AlertDetailsPageTests: XCTestCase {
-    class FakeGlobalRepository: IGlobalRepository {
-        let response: GlobalResponse
-        let notifier: any Subject<Void, Never>
-
-        init(response: GlobalResponse, notifier: any Subject<Void, Never>) {
-            self.response = response
-            self.notifier = notifier
-        }
-
-        func __getGlobalData() async throws -> ApiResult<GlobalResponse> {
-            notifier.send()
-            return ApiResultOk(data: response)
-        }
-    }
-
     @MainActor func testAlertDetailsPageParentStopResolution() throws {
         let objects = ObjectCollectionBuilder()
 
@@ -117,9 +102,9 @@ final class AlertDetailsPageTests: XCTestCase {
             line: nil,
             routes: [route],
             nearbyVM: nearbyVM,
-            globalRepository: FakeGlobalRepository(
+            globalRepository: MockGlobalRepository(
                 response: .init(objects: objects, patternIdsByStop: [:]),
-                notifier: globalDataLoaded
+                onGet: { globalDataLoaded.send() }
             )
         )
 

--- a/iosApp/iosAppTests/Pages/Map/MapViewModelTests.swift
+++ b/iosApp/iosAppTests/Pages/Map/MapViewModelTests.swift
@@ -28,7 +28,7 @@ final class MapViewModelTests: XCTestCase {
         })
 
         let mapVM = MapViewModel(layerManager: layerManager)
-        mapVM.updateRouteSource(routeLines: [])
+        mapVM.updateRouteSource(globalData: nil, globalMapData: nil)
 
         wait(for: [updateRouteSourceCalled], timeout: 1)
     }

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
@@ -54,20 +54,6 @@ final class NearbyTransitPageViewTests: XCTestCase {
     }
 
     @MainActor func testReloadsWhenLocationChanges() throws {
-        class FakeGlobalRepository: IGlobalRepository {
-            let notifier: any Subject<Void, Never>
-
-            init(notifier: any Subject<Void, Never>) {
-                self.notifier = notifier
-            }
-
-            func __getGlobalData() async throws -> ApiResult<GlobalResponse> {
-                debugPrint("FakeGlobalRepo getting global")
-                notifier.send()
-                return ApiResultOk(data: GlobalResponse(objects: .init(), patternIdsByStop: [:]))
-            }
-        }
-
         class FakeNearbyVM: NearbyViewModel {
             let expectation: XCTestExpectation
             let closure: (CLLocationCoordinate2D) -> Void
@@ -88,7 +74,7 @@ final class NearbyTransitPageViewTests: XCTestCase {
         let globalDataLoaded = PassthroughSubject<Void, Never>()
 
         loadKoinMocks(repositories: MockRepositories.companion
-            .buildWithDefaults(global: FakeGlobalRepository(notifier: globalDataLoaded)))
+            .buildWithDefaults(global: MockGlobalRepository(onGet: { globalDataLoaded.send() })))
 
         let getNearbyExpectation = expectation(description: "getNearby")
         getNearbyExpectation.assertForOverFulfill = false

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -63,7 +63,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
+            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: tripPredictionsRepository,
             tripRepository: tripRepository,
             vehicleRepository: MockVehicleRepository(outcome: ApiResultOk(data: .init(vehicle: vehicle)))
@@ -130,7 +130,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
+            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: tripPredictionsRepository,
             tripRepository: tripRepository,
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
@@ -180,7 +180,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
+            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripPredictionsRepository: FakeTripPredictionsRepository(response: .init(objects: objects)),
             tripRepository: tripRepository,
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
@@ -287,7 +287,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: globalData),
+            globalRepository: MockGlobalRepository(response: globalData),
             tripPredictionsRepository: tripPredictionsRepository,
             tripRepository: tripRepository,
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
@@ -346,7 +346,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: .init(),
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: globalData),
+            globalRepository: MockGlobalRepository(response: globalData),
             tripPredictionsRepository: tripPredictionsRepository,
             tripRepository: tripRepository,
             vehicleRepository: FakeVehicleRepository(response: .init(vehicle: vehicle))
@@ -505,7 +505,7 @@ final class TripDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            globalRepository: FakeGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
+            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
             tripRepository: FakeTripRepository(
                 tripResponse: .init(trip: trip),
                 scheduleResponse: .Unknown.shared,
@@ -603,18 +603,6 @@ final class TripDetailsPageTests: XCTestCase {
         try sut.inspect().implicitAnyView().vStack().callOnChange(newValue: "newTripId", index: 1)
 
         wait(for: [vehicleLeaveExp, vehicleJoinExp], timeout: 2)
-    }
-
-    class FakeGlobalRepository: IGlobalRepository {
-        let response: GlobalResponse
-
-        init(response: GlobalResponse) {
-            self.response = response
-        }
-
-        func __getGlobalData() async throws -> ApiResult<GlobalResponse> {
-            ApiResultOk(data: response)
-        }
     }
 
     class FakeTripRepository: IdleTripRepository {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -68,6 +68,7 @@ kotlin {
                 implementation(libs.kotlin.test)
                 implementation(libs.ktor.client.mock)
                 implementation(libs.okio.fakefilesystem)
+                implementation(libs.turbine)
             }
         }
         val androidMain by getting {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -50,6 +50,7 @@ import com.mbta.tid.mbta_app.usecases.GetSettingUsecase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.koin.core.module.Module
@@ -96,13 +97,16 @@ fun endToEndModule(): Module {
         single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
         single<IGlobalRepository> {
             object : IGlobalRepository {
-                override suspend fun getGlobalData(): ApiResult<GlobalResponse> =
-                    ApiResult.Ok(
+                override val state =
+                    MutableStateFlow(
                         GlobalResponse(
                             objects,
                             mapOf(stopParkStreet.id to listOf(patternAlewife.id, patternAshmont.id))
                         )
                     )
+
+                override suspend fun getGlobalData(): ApiResult<GlobalResponse> =
+                    ApiResult.Ok(state.value)
             }
         }
         single<INearbyRepository> {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/cache/ResponseCacheTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/cache/ResponseCacheTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.cache
 
+import app.cash.turbine.test
 import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -20,12 +21,14 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import okio.FileSystem
@@ -357,6 +360,74 @@ class ResponseCacheTest {
             }
         )
         assertTrue(didFetch)
+    }
+
+    @Test
+    fun `passes stale data into flow immediately`() = runBlocking {
+        val oldObjects = ObjectCollectionBuilder()
+        val oldData = GlobalResponse(oldObjects, emptyMap())
+
+        val newObjects = ObjectCollectionBuilder()
+        newObjects.stop()
+        newObjects.stop()
+        newObjects.route()
+        val newData = GlobalResponse(newObjects, emptyMap())
+
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(json.encodeToString(newData)),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json")
+            )
+        }
+        val client = MobileBackendClient(mockEngine, AppVariant.Staging)
+
+        val cache = ResponseCache.create<GlobalResponse>(cacheKey = "test")
+
+        val mockPaths = MockSystemPaths(data = "data", cache = "cache")
+        val fileSystem = FakeFileSystem()
+        fileSystem.createDirectories(mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY)
+        fileSystem.write(mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY / "test-meta.json") {
+            writeUtf8(
+                json.encodeToString(
+                    ResponseMetadata(
+                        null,
+                        TimeSource.Monotonic.markNow().minus(cache.maxAge + 1.minutes)
+                    )
+                )
+            )
+        }
+        fileSystem.write(mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY / "test.json") {
+            writeUtf8(json.encodeToString(oldData))
+        }
+
+        startKoin {
+            modules(
+                module {
+                    single<SystemPaths> { mockPaths }
+                    single<FileSystem> { fileSystem }
+                }
+            )
+        }
+
+        var didFetch = false
+
+        assertNull(cache.state.value)
+        launch {
+            cache.state.test {
+                assertEquals(oldData, awaitItem())
+                assertEquals(newData, awaitItem())
+            }
+        }
+
+        val result =
+            cache.getOrFetch {
+                didFetch = true
+                client.get { url { path("api/global") } }
+            }
+
+        assertTrue(didFetch)
+        assertEquals(ApiResult.Ok(newData), result)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -21,6 +21,7 @@ import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.fakefilesystem.FakeFileSystem
@@ -127,7 +128,9 @@ class GlobalRepositoryTest : KoinTest {
             )
         }
         runBlocking {
-            val response = GlobalRepository().getGlobalData()
+            val repo = GlobalRepository()
+            assertNull(repo.state.value)
+            val response = repo.getGlobalData()
             val route =
                 Route(
                     id = "Shuttle-AirportGovernmentCenterLocal",
@@ -182,6 +185,7 @@ class GlobalRepositoryTest : KoinTest {
                     trips = mapOf("62145526_2" to trip)
                 )
             assertEquals(ApiResult.Ok(expectedResponse), response)
+            assertEquals(expectedResponse, repo.state.value)
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.ios.kt
@@ -6,9 +6,9 @@ import okio.Path.Companion.toPath
 import platform.Foundation.NSApplicationSupportDirectory
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSLocalDomainMask
 import platform.Foundation.NSSearchPathDirectory
 import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
 
 @OptIn(ExperimentalForeignApi::class)
 class IOSSystemPaths() : SystemPaths {
@@ -25,7 +25,7 @@ class IOSSystemPaths() : SystemPaths {
     private fun getURL(directory: NSSearchPathDirectory): NSURL? {
         return NSFileManager.defaultManager.URLForDirectory(
             directory = directory,
-            inDomain = NSLocalDomainMask,
+            inDomain = NSUserDomainMask,
             appropriateForURL = null,
             create = true,
             error = null,

--- a/shared/src/iosTest/kotlin/com/mbta/tid/mbta_app/utils/SystemPathsTest.ios.kt
+++ b/shared/src/iosTest/kotlin/com/mbta/tid/mbta_app/utils/SystemPathsTest.ios.kt
@@ -1,13 +1,13 @@
 package com.mbta.tid.mbta_app.utils
 
 import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SystemPathsTest {
     @Test
     fun testPaths() {
         val paths = IOSSystemPaths()
-        assertEquals("/Library/Application Support", paths.data.toString())
-        assertEquals("/Library/Caches", paths.cache.toString())
+        assertTrue(paths.data.toString().endsWith("/Library/Application Support"))
+        assertTrue(paths.cache.toString().endsWith("/Library/Caches"))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Make cached data flow through a stream](https://app.asana.com/0/1205732265579288/1208254208398831/f)

This makes it possible for stale cached data to be displayed to the user while the API request is being performed to check whether or not the data is still stale. This will allow users on slow internet connections to see data earlier, and once 
[Cache route shape requests](https://app.asana.com/0/1205732265579288/1208254208398835/f) is completed, it will display map layers quickly on slow internet connections, and prevent blank maps when either request fails.

This also turned into a bit of a hunt for map performance issues in general, I moved a bunch of the map source and layer logic into tasks to prevent as much logic as possible from happening on the main thread and freezing the map. This includes making source updates cancellable, so that if a new update is called while one is currently ongoing, the out of date call can bail as quickly as possible and allow just the latest update to complete.

### Testing

Added new tests for some added behavior, but in general for the views that are now consuming from a flow, the existing tests passing is validation that this is working as expected.