### PR TITLE
Location Services Button

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		9AC10BDA2B80067400EA4605 /* ColorHexExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC10BD92B80067400EA4605 /* ColorHexExtension.swift */; };
 		9AC4FDF12BACE216004479BF /* NearbyTransitPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC4FDF02BACE216004479BF /* NearbyTransitPageView.swift */; };
 		9ACA9DF32BA1EC8B003F0E9E /* HomeMapViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACA9DF22BA1EC8B003F0E9E /* HomeMapViewUITests.swift */; };
+		9AD039362CCFC5E8008D9318 /* LocationAuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */; };
 		9AD1D1FE2BA4D5C600182060 /* ViewportProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD1D1FD2BA4D5C600182060 /* ViewportProviderTest.swift */; };
 		9ADB849D2BAD05BC006581CE /* Inspection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB849C2BAD05BC006581CE /* Inspection.swift */; };
 		9ADB84A02BAD1B84006581CE /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB849F2BAD1B84006581CE /* DebouncerTests.swift */; };
@@ -425,6 +426,7 @@
 		9AC10BD92B80067400EA4605 /* ColorHexExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorHexExtension.swift; sourceTree = "<group>"; };
 		9AC4FDF02BACE216004479BF /* NearbyTransitPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyTransitPageView.swift; sourceTree = "<group>"; };
 		9ACA9DF22BA1EC8B003F0E9E /* HomeMapViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMapViewUITests.swift; sourceTree = "<group>"; };
+		9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAuthButton.swift; sourceTree = "<group>"; };
 		9AD1D1FD2BA4D5C600182060 /* ViewportProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportProviderTest.swift; sourceTree = "<group>"; };
 		9ADB849C2BAD05BC006581CE /* Inspection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inspection.swift; sourceTree = "<group>"; };
 		9ADB849F2BAD1B84006581CE /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
@@ -879,6 +881,7 @@
 				9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */,
 				9A52A2B22CC3035F00CC01D6 /* WithRealtimeIndicator.swift */,
 				9A7F12122CCB185D0042B0F1 /* TabLabel.swift */,
+				9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */,
 			);
 			path = ComponentViews;
 			sourceTree = "<group>";
@@ -1388,6 +1391,7 @@
 				6EA00B6A2C5137A800B1334C /* MockSocket.swift in Sources */,
 				ED24EADC2C1A95A900A7BE4D /* StopDetailsAnalytics.swift in Sources */,
 				9A4E8E592B7EC4B90066B936 /* RoutePill.swift in Sources */,
+				9AD039362CCFC5E8008D9318 /* LocationAuthButton.swift in Sources */,
 				9A9E3DC22C62AE12004AADC7 /* AlertDetailsPage.swift in Sources */,
 				9A4DB7782C937EE300E8755B /* SearchViewModel.swift in Sources */,
 				6E2027902BD989AC0037554F /* ProductionAppView.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
+++ b/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
@@ -57,7 +57,7 @@ struct LocationAuthButton: View {
             .buttonStyle(LocationAuthButtonStyle())
             .accessibilityIdentifier("locationServicesButton")
             .alert(
-                "Maps work best with Location Services turned on",
+                "MBTA Go works best with Location Services turned on",
                 isPresented: $showingAlert,
                 actions: {
                     Button("Turn On in Settings") {
@@ -66,7 +66,7 @@ struct LocationAuthButton: View {
                             UIApplication.shared.open(url)
                         }
                     }
-                    Button("Keep Location Services off") {
+                    Button("Keep Location Services Off") {
                         showingAlert = false
                     }
                 },

--- a/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
+++ b/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
@@ -46,6 +46,7 @@ struct LocationAuthButton: View {
                     Image(.faChevronRight)
                         .resizable()
                         .scaleEffect(0.6)
+                        .aspectRatio(contentMode: .fit)
                         .frame(width: 20, height: 20, alignment: .center)
                         .backgroundStyle(.white)
                         .background(in: .circle)

--- a/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
+++ b/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
@@ -1,0 +1,84 @@
+//
+//  LocationAuthButton.swift
+//  iosApp
+//
+//  Created by Jack Curtis on 10/28/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct LocationAuthButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding()
+            .background(Color.key)
+            .foregroundStyle(.white)
+            .clipShape(Capsule())
+    }
+}
+
+struct LocationAuthLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .center, spacing: 8) {
+            configuration.title
+            configuration.icon
+        }
+        .fontWeight(.bold)
+    }
+}
+
+struct LocationAuthButton: View {
+    @EnvironmentObject var locationDataManager: LocationDataManager
+
+    @Binding var showingAlert: Bool
+
+    var body: some View {
+        switch locationDataManager.authorizationStatus {
+        case .notDetermined, .denied, .restricted:
+            Button(action: {
+                showingAlert = true
+            }, label: {
+                Label(title: {
+                    Text("Location Services is off")
+                }, icon: {
+                    Image(.faChevronRight)
+                        .resizable()
+                        .scaleEffect(0.6)
+                        .frame(width: 20, height: 20, alignment: .center)
+                        .backgroundStyle(.white)
+                        .background(in: .circle)
+                        .foregroundColor(Color.key)
+                })
+                .labelStyle(LocationAuthLabelStyle())
+            })
+            .buttonStyle(LocationAuthButtonStyle())
+            .accessibilityIdentifier("locationServicesButton")
+            .alert(
+                "Maps work best with Location Services turned on",
+                isPresented: $showingAlert,
+                actions: {
+                    Button("Turn On in Settings") {
+                        showingAlert = false
+                        if let url = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                    Button("Keep Location Services off") {
+                        showingAlert = false
+                    }
+                },
+                message: {
+                    Text(
+                        "You’ll see nearby transit options and get better search results when you turn on Location Services for MBTA Go."
+                    )
+                }
+            )
+        case .authorizedAlways, .authorizedWhenInUse:
+            EmptyView()
+        @unknown default:
+            Text("Location access state unknown")
+        }
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -106,9 +106,10 @@ struct ContentView: View {
                     VStack(alignment: .center, spacing: 0) {
                         if nearbyVM.navigationStack.lastSafe() == .nearby {
                             SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
-                        }
-                        if !searchObserver.isSearching {
-                            LocationAuthButton(showingAlert: $showingLocationPermissionAlert)
+
+                            if !searchObserver.isSearching {
+                                LocationAuthButton(showingAlert: $showingLocationPermissionAlert)
+                            }
                         }
                         if !searchObserver.isSearching, !viewportProvider.viewport.isFollowing,
                            locationDataManager.currentLocation != nil {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -168,16 +168,11 @@ struct ContentView: View {
         } else {
             mapSection
                 .sheet(
-<<<<<<< HEAD
                     isPresented: .constant(
                         !(searchObserver.isSearching && nav == .nearby)
                             && selectedTab == .nearby
                             && !showingLocationPermissionAlert
                     ),
-=======
-                    isPresented: .constant(!showingLocationPermissionAlert &&
-                        !(searchObserver.isSearching && nav == .nearby)),
->>>>>>> 1ce4a580 (fix rebase issues)
                     content: {
                         GeometryReader { proxy in
                             VStack {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -143,7 +143,7 @@ struct ContentView: View {
                             UIApplication.shared.open(url)
                         }
                     }
-                    Button("Keep Location Services off", role: .cancel) {
+                    Button("Keep Location Services off") {
                         showingLocationPermissionAlert = false
                     }
                 },
@@ -173,28 +173,17 @@ struct ContentView: View {
             } else {
                 ZStack(alignment: .top) {
                     mapWithSheets
-                    VStack(alignment: .trailing, spacing: 0) {
+                    VStack(alignment: .center, spacing: 0) {
                         if nearbyVM.navigationStack.lastSafe() == .nearby {
                             SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
                         }
+                        locationAuthButton
                         if !searchObserver.isSearching, !viewportProvider.viewport.isFollowing,
                            locationDataManager.currentLocation != nil {
                             RecenterButton { Task { viewportProvider.follow() } }
                         }
                     }.frame(maxWidth: .infinity, alignment: .trailing)
                 }
-            ZStack(alignment: .top) {
-                mapWithSheets
-                VStack(alignment: .center, spacing: 0) {
-                    if nearbyVM.navigationStack.lastSafe() == .nearby {
-                        SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
-                    }
-                    locationAuthButton
-                    if !searchObserver.isSearching, !viewportProvider.viewport.isFollowing,
-                       locationDataManager.currentLocation != nil {
-                        RecenterButton { Task { viewportProvider.follow() } }
-                    }
-                }.frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
         .onAppear {
@@ -246,11 +235,16 @@ struct ContentView: View {
         } else {
             mapSection
                 .sheet(
+<<<<<<< HEAD
                     isPresented: .constant(
                         !(searchObserver.isSearching && nav == .nearby)
                             && selectedTab == .nearby
                             && !showingLocationPermissionAlert
                     ),
+=======
+                    isPresented: .constant(!showingLocationPermissionAlert &&
+                        !(searchObserver.isSearching && nav == .nearby)),
+>>>>>>> 1ce4a580 (fix rebase issues)
                     content: {
                         GeometryReader { proxy in
                             VStack {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -91,13 +91,48 @@ struct ContentView: View {
         }
     }
 
+    struct LocationAuthButtonStyle: ButtonStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .padding()
+                .background(Color.key)
+                .foregroundStyle(.white)
+                .clipShape(Capsule())
+        }
+    }
+
+    struct LocationAuthLabelStyle: LabelStyle {
+        func makeBody(configuration: Configuration) -> some View {
+            HStack(alignment: .center, spacing: 8) {
+                configuration.title
+                configuration.icon
+            }
+            .fontWeight(.bold)
+        }
+    }
+
     @ViewBuilder
     var locationAuthButton: some View {
         switch locationDataManager.authorizationStatus {
         case .notDetermined, .denied, .restricted:
-            Button("Location Services is off", action: {
+            Button(action: {
                 showingLocationPermissionAlert = true
+            }, label: {
+                Label(title: {
+                    Text("Location Services is off")
+                }, icon: {
+                    Image(.faChevronRight)
+                        .resizable()
+                        .scaleEffect(0.6)
+                        .frame(width: 20, height: 20, alignment: .center)
+                        .backgroundStyle(.white)
+                        .background(in: .circle)
+                        .foregroundColor(Color.key)
+                })
+                .labelStyle(LocationAuthLabelStyle())
             })
+            .buttonStyle(LocationAuthButtonStyle())
+            .accessibilityIdentifier("locationServicesButton")
             .alert(
                 "Maps work best with Location Services turned on",
                 isPresented: $showingLocationPermissionAlert,
@@ -150,7 +185,7 @@ struct ContentView: View {
                 }
             ZStack(alignment: .top) {
                 mapWithSheets
-                VStack(alignment: .trailing, spacing: 0) {
+                VStack(alignment: .center, spacing: 0) {
                     if nearbyVM.navigationStack.lastSafe() == .nearby {
                         SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
                     }
@@ -214,6 +249,7 @@ struct ContentView: View {
                     isPresented: .constant(
                         !(searchObserver.isSearching && nav == .nearby)
                             && selectedTab == .nearby
+                            && !showingLocationPermissionAlert
                     ),
                     content: {
                         GeometryReader { proxy in

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -319,6 +319,9 @@
     "Made with ♥ in Boston, for Boston" : {
 
     },
+    "Location Services is off" : {
+
+    },
     "Maintenance" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -313,10 +313,10 @@
     "Location access state unknown" : {
 
     },
-    "Made with ♥ in Boston, for Boston" : {
+    "Location Services is off" : {
 
     },
-    "Location Services is off" : {
+    "Made with ♥ by the T" : {
 
     },
     "Maintenance" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -198,9 +198,6 @@
     "Crossing Malfunction" : {
       "comment" : "Possible alert cause"
     },
-    "Custom message" : {
-
-    },
     "Demonstration" : {
       "comment" : "Possible alert cause"
     },

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -198,6 +198,9 @@
     "Crossing Malfunction" : {
       "comment" : "Possible alert cause"
     },
+    "Custom message" : {
+
+    },
     "Demonstration" : {
       "comment" : "Possible alert cause"
     },
@@ -308,9 +311,6 @@
 
     },
     "Loading..." : {
-
-    },
-    "Location access denied or restricted" : {
 
     },
     "Location access state unknown" : {
@@ -529,6 +529,9 @@
     },
     "Weather" : {
       "comment" : "Possible alert cause"
+    },
+    "You'll get turn-by-turn directions, estimated travel times, and improved search results when you turn on Location Services for Maps" : {
+
     },
     "Your current location is outside of our search area." : {
 

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -530,7 +530,7 @@
     "Weather" : {
       "comment" : "Possible alert cause"
     },
-    "You'll get turn-by-turn directions, estimated travel times, and improved search results when you turn on Location Services for Maps" : {
+    "You’ll see nearby transit options and get better search results when you turn on Location Services for MBTA Go." : {
 
     },
     "Your current location is outside of our search area." : {

--- a/iosApp/iosAppUITests/HomeMapViewUITests.swift
+++ b/iosApp/iosAppUITests/HomeMapViewUITests.swift
@@ -62,6 +62,26 @@ final class HomeMapViewUITests: XCTestCase {
         map.swipeDown()
         XCTAssertFalse(recenterButton.exists)
     }
+
+    func testLocationServicesButtonWithNoLocation() throws {
+        app.activate()
+        app.launch()
+
+        denyLocationPermissionAlert(timeout: 10)
+        let map = app.otherElements.matching(identifier: "transitMap").element
+        XCTAssert(map.waitForExistence(timeout: 30))
+
+        let locationServicesButton = app.buttons.matching(identifier: "locationServicesButton").element
+        XCTAssert(locationServicesButton.exists)
+
+        locationServicesButton.tap()
+
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+        let alert = app.alerts.firstMatch
+        XCTAssert(alert.waitForExistence(timeout: 10))
+        XCTAssert(alert.labelContains(text: "turned on"))
+    }
 }
 
 extension XCUIElement {


### PR DESCRIPTION
### Summary

_Ticket:_ [Location services button](https://app.asana.com/0/1205732265579288/1208304466486202/f)

What is this PR for?

Adds a button to link the user to Settings when Location functionality is disabled.

<img width="431" alt="Screenshot 2024-10-25 at 2 07 06 PM" src="https://github.com/user-attachments/assets/0392d762-a1ca-4440-8514-69b292b75415">

<img width="408" alt="Screenshot 2024-10-25 at 2 08 18 PM" src="https://github.com/user-attachments/assets/58153a7e-7948-4e76-a990-6dcf1e2d10cc">

### Testing

What testing have you done?

UI test for the button and alert popup

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
