### PR TITLE
fix(iOS): show loading state on recenter

### DIFF
--- a/iosApp/iosApp/Fetchers/ViewportProvider.swift
+++ b/iosApp/iosApp/Fetchers/ViewportProvider.swift
@@ -19,6 +19,7 @@ class ViewportProvider: ObservableObject {
     }
 
     @Published private(set) var isManuallyCentering: Bool
+    @Published private(set) var isFollowingPuck: Bool = false
     @Published private(set) var isFollowingVehicle: Bool = false
     @Published private(set) var followedVehicle: Vehicle?
 
@@ -35,6 +36,7 @@ class ViewportProvider: ObservableObject {
 
     init(viewport: Viewport? = nil, isManuallyCentering: Bool = false) {
         self.viewport = viewport ?? .camera(center: Defaults.center, zoom: Defaults.zoom)
+        isFollowingPuck = viewport?.isFollowing ?? false
         let viewportCamera = viewport?.camera
         let initialCameraState = CameraState(
             center: viewportCamera?.center ?? Defaults.center,
@@ -48,6 +50,7 @@ class ViewportProvider: ObservableObject {
     }
 
     func follow(animation: ViewportAnimation = Defaults.animation) {
+        isFollowingPuck = true
         withViewportAnimation(animation) {
             self.viewport = .followPuck(zoom: cameraStateSubject.value.zoom)
         }
@@ -141,6 +144,7 @@ class ViewportProvider: ObservableObject {
     func setIsManuallyCentering(_ isManuallyCentering: Bool) {
         self.isManuallyCentering = isManuallyCentering
         if isManuallyCentering {
+            isFollowingPuck = false
             isFollowingVehicle = false
         }
     }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
@@ -70,6 +70,13 @@ struct NearbyTransitPageView: View {
                     location = nil
                 }
             }
+            .onChange(of: viewportProvider.isFollowingPuck) { isFollowingPuck in
+                if isFollowingPuck {
+                    // The user just recentered the map, clear the nearby state
+                    nearbyVM.nearbyState = .init()
+                    location = nil
+                }
+            }
         }
     }
 }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -197,7 +197,12 @@ struct NearbyTransitView: View {
     func getNearby(location: CLLocationCoordinate2D?, globalData: GlobalResponse?) {
         self.location = location
         self.globalData = globalData
-        guard let location, let globalData else { return }
+        guard let location, let globalData else {
+            debugPrint("forgetting loaded data")
+            predictionsByStop = nil
+            scheduleResponse = nil
+            return
+        }
         getNearby(globalData, location)
     }
 

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -197,8 +197,9 @@ struct NearbyTransitView: View {
     func getNearby(location: CLLocationCoordinate2D?, globalData: GlobalResponse?) {
         self.location = location
         self.globalData = globalData
-        guard let location, let globalData else {
-            debugPrint("forgetting loaded data")
+        guard let globalData else { return }
+        guard let location else {
+            // if location was set to nil, forget previously loaded data
             predictionsByStop = nil
             scheduleResponse = nil
             return


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1729783255982609)

Treats the recenter button like panning the map, and forgets stale data in both cases.

### Testing

Manually verified that this works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
