### PR TITLE
fix(TripInstantDisplay): Hide past cancellations

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -63,14 +63,6 @@ sealed class TripInstantDisplay {
                 }
                 return Hidden
             }
-            if (
-                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
-                    schedule?.scheduleTime != null &&
-                    routeType?.isSubway() == false &&
-                    context == Context.StopDetailsFiltered
-            ) {
-                return Cancelled(schedule.scheduleTime)
-            }
             val departureTime =
                 if (prediction != null) {
                     prediction.departureTime
@@ -92,6 +84,15 @@ sealed class TripInstantDisplay {
                 allowArrivalOnly && !(arrivalTime == null || arrivalTime < now)
             if (!(hasDepartureToDisplay || hasArrivalToDisplay)) {
                 return Hidden
+            }
+
+            if (
+                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
+                    schedule?.scheduleTime != null &&
+                    routeType?.isSubway() == false &&
+                    context == Context.StopDetailsFiltered
+            ) {
+                return Cancelled(schedule.scheduleTime)
             }
 
             val scheduleBasedRouteType =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -63,6 +63,17 @@ sealed class TripInstantDisplay {
                 }
                 return Hidden
             }
+
+            val isScheduleUpcoming = schedule?.scheduleTime?.let { it >= now } ?: false
+            if (
+                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
+                    schedule?.scheduleTime != null &&
+                    isScheduleUpcoming &&
+                    routeType?.isSubway() == false &&
+                    context == Context.StopDetailsFiltered
+            ) {
+                return Cancelled(schedule.scheduleTime)
+            }
             val departureTime =
                 if (prediction != null) {
                     prediction.departureTime
@@ -84,15 +95,6 @@ sealed class TripInstantDisplay {
                 allowArrivalOnly && !(arrivalTime == null || arrivalTime < now)
             if (!(hasDepartureToDisplay || hasArrivalToDisplay)) {
                 return Hidden
-            }
-
-            if (
-                prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
-                    schedule?.scheduleTime != null &&
-                    routeType?.isSubway() == false &&
-                    context == Context.StopDetailsFiltered
-            ) {
-                return Cancelled(schedule.scheduleTime)
             }
 
             val scheduleBasedRouteType =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -708,6 +708,28 @@ class TripInstantDisplayTest {
     }
 
     @Test
+    fun `scheduled trip cancelled in past is hidden`() = parametricTest {
+        val now = Clock.System.now()
+        assertEquals(
+            TripInstantDisplay.Hidden,
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+                        arrivalTime = null
+                        departureTime = null
+                    },
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule { departureTime = now - 15.minutes },
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = TripInstantDisplay.Context.StopDetailsFiltered
+            )
+        )
+    }
+
+    @Test
     fun `cancelled subway trip is hidden`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: old cancelled trips appearing in filtered stop details](https://app.asana.com/0/1205732265579288/1208468599574761/f)

What is this PR for?

Hides old cancelled trips in stop details

### Testing

What testing have you done?
* Added a unit test
* Confirmed before & after - cancelled trip in past no longer shows up on the 86

![image](https://github.com/user-attachments/assets/1ed79878-5fc2-446d-af45-be6374f09e5b)
![IMG_0168](https://github.com/user-attachments/assets/b277c574-5b95-4248-8bfd-f2e853dbcd87)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
