### PR TITLE
fix: Make sheet animate away on nav to more

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -180,7 +180,10 @@ struct ContentView: View {
         } else {
             mapSection
                 .sheet(
-                    isPresented: .constant(!(searchObserver.isSearching && nav == .nearby)),
+                    isPresented: .constant(
+                        !(searchObserver.isSearching && nav == .nearby)
+                            && selectedTab == .nearby
+                    ),
                     content: {
                         GeometryReader { proxy in
                             VStack {

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -47,7 +47,7 @@ struct MorePage: View {
                     }
                     HStack(alignment: .center, spacing: 16) {
                         Image(.mbtaLogo).resizable().frame(width: 64, height: 64)
-                        Text("Made with ♥ in Boston, for Boston").font(Typography.callout)
+                        Text("Made with ♥ by the T").font(Typography.callout)
                     }
                 }
                 .padding(.horizontal, 16)


### PR DESCRIPTION
### Summary

_Ticket:_ [More tab](https://app.asana.com/0/1205732265579288/1208468599574774/f)

There was a visual bug when navigating to the More page where the area that the sheet was in would display as a blank rectangle on top of the more page, then flash away. This explicitly tells the sheet to hide when navigating to more, which causes it to animate away when navigating.

### Testing

Verified the expected behavior on a physical device.