### PR TITLE
correct the alignment of the recenter button

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -113,7 +113,9 @@ struct ContentView: View {
                         }
                         if !searchObserver.isSearching, !viewportProvider.viewport.isFollowing,
                            locationDataManager.currentLocation != nil {
-                            RecenterButton { Task { viewportProvider.follow() } }
+                            VStack(alignment: .trailing) {
+                                RecenterButton { Task { viewportProvider.follow() } }
+                            }.frame(maxWidth: .infinity, alignment: .topTrailing)
                         }
                     }.frame(maxWidth: .infinity, alignment: .trailing)
                 }


### PR DESCRIPTION
### Summary

_Ticket:_ [None, quick bug fix]

What is this PR for?

Fixes the alignment of the Recenter button on the map. Currently it is pulled to the center alongside the Location Services button. 

Before:
<img width="450" alt="Screenshot 2024-10-30 at 9 16 37 AM" src="https://github.com/user-attachments/assets/508ab727-38e1-458d-b242-49c688407956">

After:
<img width="450" alt="Screenshot 2024-10-30 at 9 16 37 AM" src="https://github.com/user-attachments/assets/f9493f52-adf8-4c82-b8e0-3184a5432eb6">

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
