### PR TITLE
fix(LocationAuthButton): Don't flash in at startup

### DIFF
--- a/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
+++ b/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
@@ -76,10 +76,10 @@ struct LocationAuthButton: View {
                     )
                 }
             )
-        case .authorizedAlways, .authorizedWhenInUse:
+        case .authorizedAlways, .authorizedWhenInUse, nil:
             EmptyView()
         @unknown default:
-            Text("Location access state unknown")
+            EmptyView()
         }
     }
 }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2525,6 +2525,7 @@
       }
     },
     "Location access denied or restricted" : {
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -2565,6 +2566,7 @@
       }
     },
     "Location access state unknown" : {
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -2739,14 +2741,14 @@
         }
       }
     },
-    "Nearby Transit" : {
-      "comment" : "Header for nearby transit sheet"
-    },
     "Monday through Friday: 6:30 AM - 8 PM" : {
       "comment" : "Footnote under the More page support header, these are the hours for the support call center"
     },
     "mTicket App" : {
       "comment" : "Footnote underneath the \"Commuter Rail and Ferry tickets\" label on the More page link to the MBTA mTicket app"
+    },
+    "Nearby Transit" : {
+      "comment" : "Header for nearby transit sheet"
     },
     "Next stop" : {
       "comment" : "Label for a vehicle's next stop. For example: Next stop Alewife",
@@ -3265,6 +3267,7 @@
       }
     },
     "Settings" : {
+      "comment" : "More page section header, includes settings that the user can configure",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3302,8 +3305,7 @@
             "value" : "設定"
           }
         }
-      },
-      "comment" : "More page section header, includes settings that the user can configure"
+      }
     },
     "Severe Weather" : {
       "comment" : "Possible alert cause",

--- a/iosApp/iosApp/LocationDataManager.swift
+++ b/iosApp/iosApp/LocationDataManager.swift
@@ -13,7 +13,7 @@ import Foundation
 public class LocationDataManager: NSObject, LocationFetcherDelegate, ObservableObject {
     var locationFetcher: LocationFetcher
     @Published public var currentLocation: CLLocation?
-    @Published public var authorizationStatus = CLAuthorizationStatus.notDetermined
+    @Published public var authorizationStatus: CLAuthorizationStatus?
 
     public init(
         locationFetcher: LocationFetcher = CLLocationManager(),

--- a/iosApp/iosAppTests/LocationDataManagerTests.swift
+++ b/iosApp/iosAppTests/LocationDataManagerTests.swift
@@ -26,7 +26,7 @@ final class LocationDataManagerTests: XCTestCase {
 
         let manager = LocationDataManager(locationFetcher: locationFetcher)
 
-        XCTAssertEqual(manager.authorizationStatus, .notDetermined)
+        XCTAssertEqual(manager.authorizationStatus, nil)
         XCTAssertNil(manager.currentLocation)
         XCTAssertIdentical(manager, locationFetcher.locationFetcherDelegate)
 


### PR DESCRIPTION
### Summary

What is this PR for?
Follow up to https://github.com/mbta/mobile_app/pull/490 to prevent button flash in & out on app startup, as discussed [in slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1730235934369179).


### Testing

What testing have you done?

* Updated affected unit test
* Confirmed locally that location services button did not flash in on startup

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
