### PR TITLE
i18n: Add missing strings for localization

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		9A2005C72B97B63300F562E1 /* NearbyStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005C62B97B63300F562E1 /* NearbyStopView.swift */; };
 		9A2005C92B97B65900F562E1 /* HeadsignRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005C82B97B65900F562E1 /* HeadsignRowView.swift */; };
 		9A2005CB2B97B68700F562E1 /* UpcomingTripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */; };
+		9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */; };
 		9A37F3052BACCC40001714FE /* DoubleRoundedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */; };
 		9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */; };
 		9A392C972CC0497C00DE1FBE /* ErrorBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */; };
@@ -381,6 +382,7 @@
 		9A2005C62B97B63300F562E1 /* NearbyStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyStopView.swift; sourceTree = "<group>"; };
 		9A2005C82B97B65900F562E1 /* HeadsignRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadsignRowView.swift; sourceTree = "<group>"; };
 		9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripView.swift; sourceTree = "<group>"; };
+		9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripAccessibilityFormatters.swift; sourceTree = "<group>"; };
 		9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRoundedExtension.swift; sourceTree = "<group>"; };
 		9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateExtension.swift; sourceTree = "<group>"; };
 		9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerViewModel.swift; sourceTree = "<group>"; };
@@ -925,6 +927,7 @@
 				9A52A2B22CC3035F00CC01D6 /* WithRealtimeIndicator.swift */,
 				9A7F12122CCB185D0042B0F1 /* TabLabel.swift */,
 				9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */,
+				9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */,
 			);
 			path = ComponentViews;
 			sourceTree = "<group>";
@@ -1430,6 +1433,7 @@
 				8CD79F112C46F6E200AFF17D /* MapboxBridge.swift in Sources */,
 				EDC768C72BCF6FD6008BAE58 /* RouteCard.swift in Sources */,
 				9AB44A132B911E6400E8FFB3 /* DateExtension.swift in Sources */,
+				9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */,
 				8CA485B82BDC679A00E84E1F /* VehicleExtension.swift in Sources */,
 				6E973DA72C1770B300CBF341 /* SheetNavigationLink.swift in Sources */,
 				9A9E3DC42C640071004AADC7 /* AlertDetails.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/ActionButton.swift
+++ b/iosApp/iosApp/ComponentViews/ActionButton.swift
@@ -18,11 +18,11 @@ struct ActionButton: View {
         var accessibilityLabel: String {
             switch self {
             case .back:
-                "Back"
+                NSLocalizedString("Back", comment: "VoiceOver label for a generic back button")
             case .close:
-                "Close"
+                NSLocalizedString("Close", comment: "VoiceOver label for a generic close button")
             case .clear:
-                "Clear"
+                NSLocalizedString("Clear", comment: "VoiceOver label for a generic clear button")
             }
         }
 

--- a/iosApp/iosApp/ComponentViews/DirectionLabel.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionLabel.swift
@@ -12,13 +12,17 @@ import SwiftUI
 struct DirectionLabel: View {
     let direction: Direction
 
-    private let reformatDirectionNames: Set<String> = ["North", "South", "East", "West"]
+    private let localizedDirectionNames: [String: String] = [
+        "North": NSLocalizedString("Northbound", comment: "A route direction label"),
+        "South": NSLocalizedString("Southbound", comment: "A route direction label"),
+        "East": NSLocalizedString("Eastbound", comment: "A route direction label"),
+        "West": NSLocalizedString("Westbound", comment: "A route direction label"),
+        "Inbound": NSLocalizedString("Inbound", comment: "A route direction label"),
+        "Outbound": NSLocalizedString("Outbound", comment: "A route direction label"),
+    ]
 
     private func directionNameFormatted(_ direction: Direction) -> String {
-        if reformatDirectionNames.contains(direction.name) {
-            return "\(direction.name)bound"
-        }
-        return direction.name
+        localizedDirectionNames[direction.name] ?? NSLocalizedString("Heading", comment: "A route direction label")
     }
 
     var body: some View {
@@ -26,7 +30,9 @@ struct DirectionLabel: View {
             if let destination = direction.destination {
                 Text("\(directionNameFormatted(direction)) to",
                      comment: """
-                     Label the direction a list of arrivals is for. Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound. For example, "[Northbound] to [Alewife]
+                     Label the direction a list of arrivals is for.
+                     Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.
+                     For example, "[Northbound] to [Alewife]
                      """)
                      .font(Typography.footnote)
                      .textCase(.none)

--- a/iosApp/iosApp/ComponentViews/ErrorBanner.swift
+++ b/iosApp/iosApp/ComponentViews/ErrorBanner.swift
@@ -27,20 +27,32 @@ struct ErrorBanner: View {
         let state = errorBannerVM.errorState
         switch onEnum(of: state) {
         case let .dataError(state):
-            ErrorCard { Text("Error loading data") }
-                .refreshable(label: "Reload data") {
-                    errorBannerVM.clearState()
-                    state.action()
-                }
-                .frame(minHeight: minHeight)
+            ErrorCard {
+                Text("Error loading data", comment: "Displayed when loading necessary information fails")
+            }
+            .refreshable(
+                label: NSLocalizedString("Reload data", comment: "Refresh button label")
+            ) {
+                errorBannerVM.clearState()
+                state.action()
+            }
+            .frame(minHeight: minHeight)
         case let .stalePredictions(state):
             if errorBannerVM.loadingWhenPredictionsStale {
                 ProgressView().frame(minHeight: minHeight)
             } else {
                 ErrorCard {
-                    Text("Updated \(state.minutesAgo(), specifier: "%ld") minutes ago")
+                    Text(
+                        "Updated \(state.minutesAgo(), specifier: "%ld") minutes ago",
+                        comment: "Displayed when prediction data has not been able to update for an unexpected amount of time"
+                    )
                 }
-                .refreshable(label: "Refresh predictions") {
+                .refreshable(
+                    label: NSLocalizedString(
+                        "Refresh predictions",
+                        comment: "Refresh button label for reloading predictions"
+                    )
+                ) {
                     errorBannerVM.clearState()
                     state.action()
                 }
@@ -49,11 +61,10 @@ struct ErrorBanner: View {
         case .networkError:
             ErrorCard { HStack {
                 Image(systemName: "wifi.slash")
-                Text("Unable to connect")
+                Text("Unable to connect", comment: "Displayed when the phone is not connected to the network")
                 Spacer()
             }}
         case nil:
-            // for some reason, .collect on an EmptyView doesn't work
             EmptyView()
         }
     }

--- a/iosApp/iosApp/ComponentViews/ErrorCard.swift
+++ b/iosApp/iosApp/ComponentViews/ErrorCard.swift
@@ -38,7 +38,11 @@ struct ErrorCard<Content: View>: View {
 }
 
 extension ErrorCard {
-    func refreshable(_ loading: Bool = false, label: String = "Refresh", action: @escaping () -> Void) -> ErrorCard {
+    func refreshable(
+        _ loading: Bool = false,
+        label: String = NSLocalizedString("Refresh", comment: "Refresh button label"),
+        action: @escaping () -> Void
+    ) -> ErrorCard {
         var card = self
         card.button = {
             AnyView(Button(

--- a/iosApp/iosApp/ComponentViews/LoadingCard.swift
+++ b/iosApp/iosApp/ComponentViews/LoadingCard.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct LoadingCard<Message: View>: View {
     var message: () -> Message?
 
-    init(message: @escaping () -> Message? = { Text("loading") }) {
+    init(message: @escaping () -> Message? = { Text("Loading...") }) {
         self.message = message
     }
 

--- a/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
+++ b/iosApp/iosApp/ComponentViews/LocationAuthButton.swift
@@ -40,9 +40,10 @@ struct LocationAuthButton: View {
             Button(action: {
                 showingAlert = true
             }, label: {
-                Label(title: {
-                    Text("Location Services is off")
-                }, icon: {
+                Label(title: { Text(
+                    "Location Services is off",
+                    comment: "Banner letting the user know they aren't sharing their location"
+                ) }, icon: {
                     Image(.faChevronRight)
                         .resizable()
                         .scaleEffect(0.6)
@@ -57,23 +58,29 @@ struct LocationAuthButton: View {
             .buttonStyle(LocationAuthButtonStyle())
             .accessibilityIdentifier("locationServicesButton")
             .alert(
-                "MBTA Go works best with Location Services turned on",
+                Text("MBTA Go works best with Location Services turned on"),
                 isPresented: $showingAlert,
                 actions: {
-                    Button("Turn On in Settings") {
+                    Button(NSLocalizedString(
+                        "Turn On in Settings",
+                        comment: "Prompt button linking to app settings, "
+                            + "for the user to enable location services"
+                    )) {
                         showingAlert = false
                         if let url = URL(string: UIApplication.openSettingsURLString) {
                             UIApplication.shared.open(url)
                         }
                     }
-                    Button("Keep Location Services Off") {
+                    Button(NSLocalizedString(
+                        "Keep Location Services Off",
+                        comment: "Prompt button to close the alert (and not change location service setting)"
+                    )) {
                         showingAlert = false
                     }
                 },
                 message: {
-                    Text(
-                        "You’ll see nearby transit options and get better search results when you turn on Location Services for MBTA Go."
-                    )
+                    Text("You’ll see nearby transit options and get better search results "
+                        + "when you turn on Location Services for MBTA Go.")
                 }
             )
         case .authorizedAlways, .authorizedWhenInUse, nil:

--- a/iosApp/iosApp/ComponentViews/PinButton.swift
+++ b/iosApp/iosApp/ComponentViews/PinButton.swift
@@ -21,9 +21,17 @@ struct PinButton: View {
                 Image(pinned ? .pinnedRouteActive : .pinnedRouteInactive)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .accessibilityLabel("Star route")
-                    .accessibilityHint(pinned ? "Removes route from the top of the list" :
-                        "Pins route to the top of the list")
+                    .accessibilityLabel(Text(
+                        "Star route",
+                        comment: "VoiceOver label for the button to favorite a route"
+                    ))
+                    .accessibilityHint(pinned ? NSLocalizedString(
+                        "Removes route from the top of the list",
+                        comment: "VoiceOver hint for favorite button when a route is already favorited"
+                    ) : NSLocalizedString(
+                        "Pins route to the top of the list",
+                        comment: "VoiceOver hint for favorite button when a route is not favorited"
+                    ))
             }
         )
         .accessibilityIdentifier("pinButton")

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -34,6 +34,7 @@ struct PredictionRowView: View {
         HStack(spacing: 0) {
             if let secondaryAlert = predictions.secondaryAlert {
                 Image(secondaryAlert.iconName)
+                    // TODO: Properly localize all possible alert effects for VoiceOver
                     .accessibilityLabel(secondaryAlert.alertEffect.name)
                     .frame(width: 18, height: 18)
                     .padding(.trailing, 8)

--- a/iosApp/iosApp/ComponentViews/PredictionText.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionText.swift
@@ -21,18 +21,22 @@ struct PredictionText: View {
         minutes - (hours * 60)
     }
 
-    var predictionKey: String.LocalizationValue {
-        let prediction: String.LocalizationValue = if hours >= 1 {
-            "\(hours, specifier: "%ld") hr \(remainingMinutes, specifier: "%ld") min"
+    var predictionKey: String {
+        if hours >= 1 {
+            String(format: NSLocalizedString(
+                "%ld hr %ld min",
+                comment: "Shorthand displayed number of hours and minutes until arrival, ex \"1 hr 32 min\""
+            ), hours, remainingMinutes)
         } else {
-            "\(minutes, specifier: "%ld") min"
+            String(format: NSLocalizedString(
+                "%ld min",
+                comment: "Shorthand displayed number of minutes until arrival, ex \"12 min\""
+            ), minutes)
         }
-        return prediction
     }
 
     var predictionString: AttributedString {
-        var prediction = AttributedString(localized: predictionKey,
-                                          comment: "Shorthand displayed number of minutes until arrival")
+        var prediction = AttributedString(predictionKey)
         for run in prediction.runs {
             if run.localizedNumericArgument != nil {
                 prediction[run.range].font = Typography.headlineBold
@@ -43,17 +47,23 @@ struct PredictionText: View {
         return prediction
     }
 
-    var accessibilityKey: String.LocalizationValue {
-        let prediction: String.LocalizationValue = if hours >= 1 {
-            "in \(hours, specifier: "%ld") hr \(remainingMinutes, specifier: "%ld") min"
-        } else {
-            "in \(minutes, specifier: "%ld") min"
-        }
-        return prediction
-    }
-
     var accessibilityString: String {
-        String(localized: accessibilityKey)
+        if hours >= 1 {
+            String(format: NSLocalizedString(
+                "in %ld hr %ld min",
+                comment: """
+                Shorthand displayed number of hours and minutes until arrival for VoiceOver,
+                ex 'in 1 hr 32 min'
+                """
+            ),
+            hours,
+            remainingMinutes)
+        } else {
+            String(format: NSLocalizedString(
+                "in %ld min",
+                comment: "Shorthand displayed number of minutes until arrival for VoiceOver, ex 'in 7 min'"
+            ), minutes)
+        }
     }
 
     var body: some View {

--- a/iosApp/iosApp/ComponentViews/UpcomingTripAccessibilityFormatters.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripAccessibilityFormatters.swift
@@ -1,0 +1,147 @@
+//
+//  UpcomingTripAccessibilityFormatters.swift
+//  iosApp
+//
+//  Created by esimon on 10/31/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+class UpcomingTripAccessibilityFormatters {
+    private let timeFormatter: DateFormatter = makeTimeFormatter()
+
+    public func boardingFirst(vehicleText: String) -> Text {
+        Text("\(vehicleText) boarding now",
+             comment: """
+             Describe that a vehicle is boarding now, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry). For example, 'bus boarding now'
+             """)
+    }
+
+    public func boardingOther() -> Text {
+        Text("and boarding now",
+             comment: """
+             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+              For example, '[bus arriving in 1 minute], and boarding now'
+             """)
+    }
+
+    public func arrivingFirst(vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving now",
+             comment: """
+             Describe that a vehicle is arriving now, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry). For example, 'bus arriving now'
+             """)
+    }
+
+    public func arrivingOther() -> Text {
+        Text("and arriving now",
+             comment: """
+             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+              For example, '[bus arriving in 1 minute], and arriving now'
+             """)
+    }
+
+    public func distantFutureFirst(date: Date, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date))",
+             comment: """
+             Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
+             For example, 'bus arriving at 10:30AM'
+             """)
+    }
+
+    public func distantFutureOther(date: Date) -> Text {
+        Text("and at \(timeFormatter.string(from: date))",
+             comment: """
+             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving at 10:30AM], and at 10:45 AM'
+             """)
+    }
+
+    public func scheduleTimeFirst(date: Date, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) scheduled",
+             comment: """
+             Describe the time at which a vehicle is scheduled to arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
+             For example, 'bus arriving at 10:30AM scheduled'
+             """)
+    }
+
+    public func scheduleTimeOther(date: Date) -> Text {
+        Text("and at \(timeFormatter.string(from: date)) scheduled",
+             comment: """
+             The second or more arrival in a list of scheduled upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving at 10:30AM scheduled], and at 10:45 AM scheduled'
+             """)
+    }
+
+    public func scheduleMinutesFirst(minutes: Int32, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving in \(minutes) min scheduled",
+             comment: """
+             Describe the number of minutes until a vehicle is scheduled to arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the number of minutes until it arrives
+             For example, 'bus arriving in 5 minutes, scheduled'
+             """)
+    }
+
+    public func scheduleMinutesOther(minutes: Int32) -> Text {
+        Text("and in \(minutes) min scheduled",
+             comment: """
+             The second or more scheduled arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving in 5 minutes], and in 10 minutes, scheduled'
+             """)
+    }
+
+    public func predictionMinutesFirst(minutes: Int32, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving in \(minutes) min",
+             comment: """
+             Describe the number of minutes until a vehicle will arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the number of minutes until it arrives
+             For example, 'bus arriving in 5 minutes'
+             """)
+    }
+
+    public func predictionMinutesOther(minutes: Int32) -> Text {
+        Text("and in \(minutes) min",
+             comment: """
+             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving in 5 minutes], and in 10 minutes'
+             """)
+    }
+
+    public func predictionTimeFirst(date: Date, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date))",
+             comment: """
+             Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
+             For example, 'bus arriving at 10:30AM'
+             """)
+    }
+
+    public func predictionTimeOther(date: Date) -> Text {
+        Text("and at \(timeFormatter.string(from: date))",
+             comment: """
+             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving at 10:30AM], and at 10:45 AM'
+             """)
+    }
+
+    public func cancelledFirst(date: Date, vehicleText: String) -> Text {
+        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) cancelled",
+             comment: """
+             Describe the time at which a cancelled vehicle was scheduled to arrive, as read aloud for VoiceOver users.
+             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
+             For example, 'bus arriving at 10:30AM cancelled'
+             """)
+    }
+
+    public func cancelledOther(date: Date) -> Text {
+        Text("and at \(timeFormatter.string(from: date)) cancelled",
+             comment: """
+             The second or more cancelled arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+             For example, '[bus arriving at 10:30AM], and at 10:45 AM cancelled'
+             """)
+    }
+}

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -55,7 +55,7 @@ struct UpcomingTripView: View {
                 // should have been filtered out already
                 Text(verbatim: "")
             case .now:
-                Text("Now")
+                Text("Now", comment: "Label for a trip that's arriving right now")
                     .font(Typography.headlineBold)
                     .realtime()
                     .accessibilityLabel(isFirst
@@ -121,7 +121,7 @@ struct UpcomingTripView: View {
                         : accessibilityFormatters.scheduleMinutesOther(minutes: format.minutes))
             case let .cancelled(format):
                 HStack(spacing: Self.subjectSpacing) {
-                    Text("Cancelled")
+                    Text("Cancelled", comment: "The status label for a cancelled trip")
                         .font(Typography.footnote)
                         .foregroundStyle(Color.deemphasized)
                     Text(format.scheduledTime.toNSDate(), style: .time)
@@ -140,125 +140,23 @@ struct UpcomingTripView: View {
         case let .noService(alertEffect):
             NoServiceView(effect: .from(alertEffect: alertEffect))
         case .none:
-            Text("Predictions unavailable").font(Typography.footnote)
+            Text(
+                "Predictions unavailable",
+                comment: "The status label when no predictions exist for a route and direction"
+            ).font(Typography.footnote)
         case .serviceEndedToday:
-            Text("Service ended").font(Typography.footnote)
+            Text(
+                "Service ended",
+                comment: "The status label for a route and direction when service was running earlier, but no more trips are running today"
+            ).font(Typography.footnote)
         case .noSchedulesToday:
-            Text("No service today").font(Typography.footnote)
+            Text(
+                "No service today",
+                comment: "The status label for a route when no service is running for the entire service day"
+            ).font(Typography.footnote)
         case .loading:
             ProgressView()
         }
-    }
-}
-
-class UpcomingTripAccessibilityFormatters {
-    private let timeFormatter: DateFormatter = makeTimeFormatter()
-
-    public func boardingFirst(vehicleText: String) -> Text {
-        Text("\(vehicleText) boarding now",
-             comment: """
-             Describe that a vehicle is boarding now, as read aloud for VoiceOver users.
-             First value is the type of vehicle (bus, train, ferry). For example, 'bus boarding now'
-             """)
-    }
-
-    public func boardingOther() -> Text {
-        Text("and boarding now",
-             comment: """
-             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
-              For example, '[bus arriving in 1 minute], and boarding now'
-             """)
-    }
-
-    public func arrivingFirst(vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving now",
-             comment: """
-             Describe that a vehicle is arriving now, as read aloud for VoiceOver users.
-             First value is the type of vehicle (bus, train, ferry). For example, 'bus arriving now'
-             """)
-    }
-
-    public func arrivingOther() -> Text {
-        Text("and arriving now",
-             comment: """
-             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
-              For example, '[bus arriving in 1 minute], and arriving now'
-             """)
-    }
-
-    public func distantFutureFirst(date: Date, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date))",
-             comment: """
-             Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.
-             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
-             For example, 'bus arriving at 10:30AM'
-             """)
-    }
-
-    public func distantFutureOther(date: Date) -> Text {
-        Text("and at \(timeFormatter.string(from: date))",
-             comment: """
-             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
-             For example, '[bus arriving at 10:30AM], and at 10:45 AM'
-             """)
-    }
-
-    public func scheduleTimeFirst(date: Date, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) scheduled",
-             comment: """
-             Describe the time at which a vehicle is scheduled to arrive, as read aloud for VoiceOver users.
-             First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
-             For example, 'bus arriving at 10:30AM scheduled'
-             """)
-    }
-
-    public func scheduleTimeOther(date: Date) -> Text {
-        Text("and at \(timeFormatter.string(from: date)) scheduled",
-             comment: """
-             The second or more arrival in a list of scheduled upcoming arrivals read aloud for VoiceOver users.
-             For example, '[bus arriving at 10:30AM scheduled], and at 10:45 AM scheduled'
-             """)
-    }
-
-    public func scheduleMinutesFirst(minutes: Int32, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving in \(minutes) min scheduled")
-    }
-
-    public func scheduleMinutesOther(minutes: Int32) -> Text {
-        Text("and in \(minutes) min scheduled")
-    }
-
-    public func predictionMinutesFirst(minutes: Int32, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving in \(minutes) min",
-             comment: """
-             Describe the number of minutes until a vehicle will arrive, as read aloud for VoiceOver users.
-             First value is the type of vehicle (bus, train, ferry), second is the number of minutes until it arrives
-             For example, 'bus arriving in 5 minutes'
-             """)
-    }
-
-    public func predictionMinutesOther(minutes: Int32) -> Text {
-        Text("and in \(minutes) min",
-             comment: """
-             The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
-             For example, '[bus arriving in 5 minutes], and in 10 minutes'
-             """)
-    }
-
-    public func predictionTimeFirst(date: Date, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date))")
-    }
-
-    public func predictionTimeOther(date: Date) -> Text {
-        Text("and at \(timeFormatter.string(from: date))")
-    }
-
-    public func cancelledFirst(date: Date, vehicleText: String) -> Text {
-        Text("\(vehicleText) arriving at \(timeFormatter.string(from: date)) cancelled")
-    }
-
-    public func cancelledOther(date: Date) -> Text {
-        Text("and at \(timeFormatter.string(from: date)) cancelled")
     }
 }
 
@@ -313,13 +211,13 @@ struct NoServiceView: View {
 
     var rawText: Text {
         switch effect {
-        case .detour: Text("Detour")
-        case .shuttle: Text("Shuttle")
-            .accessibilityLabel(Text("Shuttle buses replace service"))
-        case .stopClosed: Text("Stop Closed")
-        case .suspension: Text("Suspension")
-            .accessibilityLabel(Text("Service suspended"))
-        case .unknown: Text("No Service")
+        case .detour: Text("Detour", comment: "Possible alert effect")
+        case .shuttle: Text("Shuttle", comment: "Possible alert effect")
+            .accessibilityLabel(Text("Shuttle buses replace service", comment: "Shuttle alert VoiceOver text"))
+        case .stopClosed: Text("Stop Closed", comment: "Possible alert effect")
+        case .suspension: Text("Suspension", comment: "Possible alert effect")
+            .accessibilityLabel(Text("Service suspended", comment: "Suspension alert VoiceOver text"))
+        case .unknown: Text("No Service", comment: "Possible alert effect")
         }
     }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -32,6 +32,16 @@ struct ContentView: View {
         case more
     }
 
+    private func tabText(_ tab: SelectedTab) -> String {
+        switch tab {
+        case .nearby: NSLocalizedString(
+                "Nearby",
+                comment: "The label for the Nearby Transit page in the navigation bar"
+            )
+        case .more: NSLocalizedString("More", comment: "The label for the More page in the navigation bar")
+        }
+    }
+
     @State private var selectedTab = SelectedTab.nearby
 
     var body: some View {
@@ -57,13 +67,11 @@ struct ContentView: View {
             TabView(selection: $selectedTab) {
                 nearbyTab
                     .tag(SelectedTab.nearby)
-                    .tabItem { TabLabel("Nearby", image: .tabIconNearby) }
+                    .tabItem { TabLabel(tabText(.nearby), image: .tabIconNearby) }
                 MorePage(viewModel: settingsVM)
                     .tag(SelectedTab.more)
-                    .tabItem { TabLabel("More", image: .tabIconMore) }
-                    .onAppear {
-                        screenTracker.track(screen: .settings)
-                    }
+                    .tabItem { TabLabel(tabText(.more), image: .tabIconMore) }
+                    .onAppear { screenTracker.track(screen: .settings) }
             }
         } else {
             nearbyTab
@@ -85,12 +93,12 @@ struct ContentView: View {
                     viewportProvider: viewportProvider
                 )
                 .tag(SelectedTab.nearby)
-                .tabItem { TabLabel("Nearby", image: .tabIconNearby) }
+                .tabItem { TabLabel(tabText(.nearby), image: .tabIconNearby) }
                 // we want to show nothing in the sheet when the settings tab is open,
                 // but an EmptyView here causes the tab to not be listed
                 VStack {}
                     .tag(SelectedTab.more)
-                    .tabItem { TabLabel("More", image: .tabIconMore) }
+                    .tabItem { TabLabel(tabText(.more), image: .tabIconMore) }
             }
         }
     }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -3798,7 +3798,44 @@
       "comment" : "Label for a More page link to the MBTA.com terms of use"
     },
     "This vehicle is completing another trip" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este vehículo está realizando otro viaje"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Machin nan ap fè yon lòt vwayaj"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Este veículo está concluindo outra viagem"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xe này đang hoàn thành một chuyến đi khác"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该汽车正在执行其他路线任务"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "該汽車正在執行其他路線任務"
+          }
+        }
+      }
     },
     "Tie Replacement" : {
       "comment" : "Possible alert cause",

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1,49 +1,31 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "**%@** affected stops" : {
+    "**%ld** affected stops" : {
       "comment" : "The number of stops affected by an alert",
       "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@** paradas afectadas"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@** arè ki afekte yo"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@** paradas afetadas"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@** điểm dừng bị ảnh hưởng"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@**个受影响站点"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**%@**個受影響網站"
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "**%ld** affected stop"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "**%ld** affected stops"
+                }
+              }
+            }
           }
         }
       }
     },
     "%@ %@" : {
-      "comment" : "First value is the route label, second value is an alert effect, resulting in something like 'Red Line Suspension' or 'Green Line Shuttle'",
+      "comment" : "A route label and route type pair,\nex 'Red Line train' or '73 bus', used in connecting stop labels\nFirst value is the route label, second value is an alert effect, resulting in something like 'Red Line Suspension' or 'Green Line Shuttle'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -85,6 +67,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@"
+          }
+        }
+      }
+    },
+    "%@ %@ %@" : {
+      "comment" : "VoiceOver text for the vehicle status on the trip details page,\nex 'train approaching Alewife' or 'bus now at Harvard'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ %3$@"
+          }
+        }
+      }
+    },
+    "%@ %@ to %@" : {
+      "comment" : "VoiceOver text for the trip details page header,\ndescribes the route and destination of the vehicle,\nex 'Red Line train to Alewife'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ to %3$@"
           }
         }
       }
@@ -137,6 +141,7 @@
       }
     },
     "%@ arriving at %@ cancelled" : {
+      "comment" : "Describe the time at which a cancelled vehicle was scheduled to arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.\nFor example, 'bus arriving at 10:30AM cancelled'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -241,6 +246,7 @@
       }
     },
     "%@ arriving in %@ min scheduled" : {
+      "comment" : "Describe the number of minutes until a vehicle is scheduled to arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the number of minutes until it arrives\nFor example, 'bus arriving in 5 minutes, scheduled'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -332,60 +338,19 @@
         }
       }
     },
-    "%@ Bus" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Autobús %@"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Bis"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Ônibus"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Xe buýt"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@巴士"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@巴士"
-          }
-        }
-      }
-    },
-    "%@ hr %@ min" : {
-      "extractionState" : "manual",
+    "%@ is %ld stops away from %@" : {
+      "comment" : "VoiceOver label for how many stops away a vehicle is from a stop,\nex 'bus is 4 stops away from Harvard'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ hr %2$@ min"
+            "state" : "new",
+            "value" : "%1$@ is %2$ld stops away from %3$@"
           }
         }
       }
     },
     "%@ to" : {
-      "comment" : "Label the direction a list of arrivals is for. Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound. For example, \"[Northbound] to [Alewife]",
+      "comment" : "Label the direction a list of arrivals is for. \nPossible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.\nFor example, \"[Northbound] to [Alewife]",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -425,183 +390,19 @@
         }
       }
     },
-    "%ld min" : {
-      "extractionState" : "manual",
+    "%ld hr %ld min" : {
+      "comment" : "Shorthand displayed number of hours and minutes until arrival, ex \"1 hr 32 min\"",
       "localizations" : {
-        "es" : {
+        "en" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld min."
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld minit"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld min"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld phút"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld分钟"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%ld分鐘"
+            "state" : "new",
+            "value" : "%1$ld hr %2$ld min"
           }
         }
       }
     },
-    "%ld stops" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld stop"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%ld stops"
-                }
-              }
-            }
-          }
-        },
-        "es" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld parada"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld paradas"
-                }
-              }
-            }
-          }
-        },
-        "ht" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              },
-              "two" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              },
-              "zero" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld arè"
-                }
-              }
-            }
-          }
-        },
-        "pt-BR" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld parada"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld paradas"
-                }
-              }
-            }
-          }
-        },
-        "vi" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld điểm dừng"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans-CN" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld站"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hant-TW" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%ld站"
-                }
-              }
-            }
-          }
-        }
-      }
+    "%ld min" : {
+      "comment" : "Shorthand displayed number of minutes until arrival, ex \"12 min\""
     },
     "%ld stops away" : {
       "comment" : "How many stops away the vehicle is from the target stop",
@@ -668,6 +469,7 @@
       }
     },
     "Alert Details" : {
+      "comment" : "Header on the alert details page",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -748,6 +550,7 @@
       }
     },
     "All" : {
+      "comment" : "Button label for clearing selected route to display all routes at a station",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -786,6 +589,13 @@
           }
         }
       }
+    },
+    "All aboard" : {
+      "comment" : "Status for a boarding commuter rail train",
+      "extractionState" : "manual"
+    },
+    "All routes" : {
+      "comment" : "VoiceOver label for the button to clear\nselected route to display all routes at a station\""
     },
     "Allow Location Services" : {
 
@@ -996,7 +806,7 @@
       }
     },
     "and at %@ cancelled" : {
-
+      "comment" : "The second or more cancelled arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM], and at 10:45 AM cancelled'"
     },
     "and at %@ scheduled" : {
       "comment" : "The second or more arrival in a list of scheduled upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM scheduled], and at 10:45 AM scheduled'",
@@ -1122,7 +932,7 @@
       }
     },
     "and in %@ min scheduled" : {
-
+      "comment" : "The second or more scheduled arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving in 5 minutes], and in 10 minutes, scheduled'"
     },
     "Approaching" : {
       "comment" : "Label for a vehicle's next stop. For example: Approaching Alewife",
@@ -1246,6 +1056,9 @@
           }
         }
       }
+    },
+    "Back" : {
+      "comment" : "VoiceOver label for a generic back button"
     },
     "BRD" : {
       "comment" : "Shorthand for boarding",
@@ -1371,10 +1184,22 @@
       }
     },
     "Cancel" : {
-
+      "comment" : "Cancel searching, clears the search term and closes the search page"
     },
     "Cancelled" : {
-
+      "comment" : "The status label for a cancelled trip"
+    },
+    "Clear" : {
+      "comment" : "VoiceOver label for a generic clear button"
+    },
+    "clear search text" : {
+      "comment" : "VoiceOver label for clear search text button"
+    },
+    "Close" : {
+      "comment" : "VoiceOver label for a generic close button"
+    },
+    "close search page" : {
+      "comment" : "VoiceOver label for cancel search button"
     },
     "Coast Guard Restriction" : {
       "comment" : "Possible alert cause",
@@ -1461,6 +1286,20 @@
         }
       }
     },
+    "Connection to %@" : {
+      "comment" : "VoiceOver label for a single connecting route at a stop, ex 'Connection to 1 bus'"
+    },
+    "Connections to %@ and %@" : {
+      "comment" : "VoiceOver label for multiple connecting routes at a stop,\nex 'Connections to Red Line train, 71 bus, and 73 bus',\nthe first replaced value can be any number of comma separated route labels",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connections to %1$@ and %2$@"
+          }
+        }
+      }
+    },
     "Construction" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -1543,6 +1382,10 @@
         }
       }
     },
+    "Delayed" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
+    },
     "Demonstration" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -1583,6 +1426,10 @@
           }
         }
       }
+    },
+    "Departed" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
     },
     "Detour" : {
       "comment" : "Possible alert effect",
@@ -1789,6 +1636,9 @@
         }
       }
     },
+    "Eastbound" : {
+      "comment" : "A route direction label"
+    },
     "Electrical Work" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -1872,7 +1722,7 @@
       }
     },
     "Error loading data" : {
-
+      "comment" : "Displayed when loading necessary information fails"
     },
     "Fare Information" : {
       "comment" : "Label for a More page link to fare information on MBTA.com"
@@ -2179,6 +2029,9 @@
         }
       }
     },
+    "Heading" : {
+      "comment" : "A route direction label"
+    },
     "Heavy Ridership" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -2224,7 +2077,7 @@
 
     },
     "Hide maps" : {
-
+      "comment" : "Onboarding button text for setting maps to hidden"
     },
     "Hide Maps" : {
       "comment" : "A setting on the More page to remove the app component from the app"
@@ -2393,30 +2246,31 @@
         }
       }
     },
-    "in %@ hr %@ min\n" : {
-      "extractionState" : "manual",
+    "in %ld hr %ld min" : {
+      "comment" : "Shorthand displayed number of hours and minutes until arrival for VoiceOver,\nex 'in 1 hr 32 min'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "in %1$@ hr %2$@ min\n"
+            "state" : "new",
+            "value" : "in %1$ld hr %2$ld min"
           }
         }
       }
     },
-    "in %@ min" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "in %1$@ min"
-          }
-        }
-      }
+    "in %ld min" : {
+      "comment" : "Shorthand displayed number of minutes until arrival for VoiceOver, ex 'in 7 min'"
+    },
+    "Inbound" : {
+      "comment" : "A route direction label"
+    },
+    "Keep Location Services Off" : {
+      "comment" : "Prompt button to close the alert (and not change location service setting)"
+    },
+    "List remaining stops" : {
+      "comment" : "VoiceOver hint explaining what happens when 'x stops away'\nis selected (open an accordion listing those stops)"
     },
     "Live" : {
-      "comment" : "real-time",
+      "comment" : "Indicates that data is being updated in real-time",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -2452,46 +2306,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "即時"
-          }
-        }
-      }
-    },
-    "loading" : {
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "cargando"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "chajman"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "carregando"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "đang tải"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在加载"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在載入"
           }
         }
       }
@@ -2536,90 +2350,8 @@
         }
       }
     },
-    "Location access denied or restricted" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acceso a la ubicación denegado o restringido"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aksè ak anplasman an refize oswa gen restriksyon"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acesso ao local negado ou restrito"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quyền truy cập thông tin vị trí bị từ chối hoặc hạn chế"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "位置权限被拒绝或限制"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "位置許可權被拒絕或限制"
-          }
-        }
-      }
-    },
-    "Location access state unknown" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado de acceso a la ubicación desconocido"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eta aksè anplasman pa konnen"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Estado do acesso ao local desconhecido"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Trạng thái quyền truy cập thông tin vị trí không xác định"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "位置权限状态未知"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "位置許可權狀態不明"
-          }
-        }
-      }
-    },
     "Location Services is off" : {
-
+      "comment" : "Banner letting the user know they aren't sharing their location"
     },
     "Made with ♥ by the T" : {
 
@@ -2675,6 +2407,9 @@
 
     },
     "MBTA Go is in the early stages! We want your feedback as we continue making improvements and adding new features." : {
+
+    },
+    "MBTA Go works best with Location Services turned on" : {
 
     },
     "MBTA Logo" : {
@@ -2765,8 +2500,14 @@
     "Monday through Friday: 6:30 AM - 8 PM" : {
       "comment" : "Footnote under the More page support header, these are the hours for the support call center"
     },
+    "More" : {
+      "comment" : "The label for the More page in the navigation bar"
+    },
     "mTicket App" : {
       "comment" : "Footnote underneath the \"Commuter Rail and Ferry tickets\" label on the More page link to the MBTA mTicket app"
+    },
+    "Nearby" : {
+      "comment" : "The label for the Nearby Transit page in the navigation bar"
     },
     "Nearby Transit" : {
       "comment" : "Header for nearby transit sheet"
@@ -2816,6 +2557,7 @@
 
     },
     "No Service" : {
+      "comment" : "Possible alert effect",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -2856,10 +2598,13 @@
       }
     },
     "No service today" : {
-
+      "comment" : "The status label for a route when no service is running for the entire service day"
+    },
+    "Northbound" : {
+      "comment" : "A route direction label"
     },
     "Now" : {
-
+      "comment" : "Label for a trip that's arriving right now"
     },
     "Now at" : {
       "comment" : "Label for a where a vehicle is currently stopped. For example: Now at Alewife",
@@ -2902,6 +2647,10 @@
         }
       }
     },
+    "Now boarding" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
+    },
     "Open for more arrivals" : {
       "localizations" : {
         "es" : {
@@ -2941,6 +2690,9 @@
           }
         }
       }
+    },
+    "Outbound" : {
+      "comment" : "A route direction label"
     },
     "Parade" : {
       "comment" : "Possible alert cause",
@@ -2982,6 +2734,9 @@
           }
         }
       }
+    },
+    "Pins route to the top of the list" : {
+      "comment" : "VoiceOver hint for favorite button when a route is not favorited"
     },
     "Plan a route with Trip Planner" : {
       "localizations" : {
@@ -3147,13 +2902,31 @@
       }
     },
     "Predictions unavailable" : {
-
+      "comment" : "The status label when no predictions exist for a route and direction"
     },
     "Privacy Policy" : {
       "comment" : "Label for a More page link to the MBTA.com privacy policy"
     },
+    "Real-time arrivals updating live" : {
+      "comment" : "VoiceOver label for real-time indicator icon"
+    },
     "Recently Viewed" : {
 
+    },
+    "Refresh" : {
+      "comment" : "Refresh button label"
+    },
+    "Refresh predictions" : {
+      "comment" : "Refresh button label for reloading predictions"
+    },
+    "Reload data" : {
+      "comment" : "Refresh button label"
+    },
+    "Removes route from the top of the list" : {
+      "comment" : "VoiceOver hint for favorite button when a route is already favorited"
+    },
+    "Removes selected filter so that arrivals from all routes are displayed" : {
+      "comment" : "VoiceOver hint for the button to\nclear selected route to display all routes at a station"
     },
     "Resources" : {
       "comment" : "More page section header, includes links to MBTA.com and mTicket app"
@@ -3204,45 +2977,8 @@
     "See transit near you" : {
 
     },
-    "select location" : {
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "seleccionar ubicación"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "chwazi anplasman"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "selecionar local"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "chọn vị trí"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择位置"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇位置"
-          }
-        }
-      }
+    "Select location" : {
+      "comment" : "Visible when the user is panning the map to search for nearby transit"
     },
     "Select to call" : {
 
@@ -3251,9 +2987,10 @@
       "comment" : "Possible alert effect"
     },
     "Service ended" : {
-
+      "comment" : "The status label for a route and direction when service was running earlier, but no more trips are running today"
     },
     "Service suspended" : {
+      "comment" : "Suspension alert VoiceOver text",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3294,7 +3031,7 @@
       }
     },
     "Set map preference" : {
-
+      "comment" : "Onboarding screen header for asking VoiceOver users if they want to hide maps"
     },
     "Settings" : {
       "comment" : "More page section header, includes settings that the user can configure",
@@ -3379,7 +3116,7 @@
       }
     },
     "Show maps" : {
-
+      "comment" : "Onboarding button text for setting maps to shown"
     },
     "Shuttle" : {
       "comment" : "Possible alert effect",
@@ -3423,6 +3160,7 @@
       }
     },
     "Shuttle buses replace service" : {
+      "comment" : "Shuttle alert VoiceOver text",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3504,7 +3242,7 @@
       }
     },
     "Skip for now" : {
-
+      "comment" : "Button text for deferring the request for location services"
     },
     "Slippery Rail" : {
       "comment" : "Possible alert cause",
@@ -3588,6 +3326,9 @@
         }
       }
     },
+    "Southbound" : {
+      "comment" : "A route direction label"
+    },
     "Special Event" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -3669,6 +3410,9 @@
           }
         }
       }
+    },
+    "Star route" : {
+      "comment" : "VoiceOver label for the button to favorite a route"
     },
     "Start" : {
       "comment" : "Label for the start date of a disruption",
@@ -3794,6 +3538,7 @@
       }
     },
     "Stop Closed" : {
+      "comment" : "Possible alert effect",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3873,6 +3618,17 @@
           }
         }
       }
+    },
+    "Stopped %ld stops away" : {
+      "comment" : "Trip status when a vehicle is standing by at a station",
+      "extractionState" : "manual"
+    },
+    "Stopped at station" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
+    },
+    "Stops" : {
+      "comment" : "Placeholder text in the empty search field"
     },
     "Strike" : {
       "comment" : "Possible alert cause",
@@ -4041,45 +3797,8 @@
     "Terms of Use" : {
       "comment" : "Label for a More page link to the MBTA.com terms of use"
     },
-    "This vehicle is completing another trip." : {
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este vehículo está realizando otro viaje."
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Machin nan ap fè yon lòt vwayaj."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este veículo está concluindo outra viagem."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Xe này đang hoàn thành một chuyến đi khác."
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "该汽车正在执行其他路线任务。"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "該汽車正在執行其他路線任務。"
-          }
-        }
-      }
+    "This vehicle is completing another trip" : {
+
     },
     "Tie Replacement" : {
       "comment" : "Possible alert cause",
@@ -4371,8 +4090,11 @@
     "Trip Planner" : {
       "comment" : "Label for a More page link to the MBTA.com trip planner"
     },
+    "Turn On in Settings" : {
+      "comment" : "Prompt button linking to app settings, for the user to enable location services"
+    },
     "Unable to connect" : {
-
+      "comment" : "Displayed when the phone is not connected to the network"
     },
     "Unruly Passenger" : {
       "comment" : "Possible alert cause",
@@ -4457,6 +4179,7 @@
       }
     },
     "Updated %ld minutes ago" : {
+      "comment" : "Displayed when prediction data has not been able to update for an unexpected amount of time",
       "localizations" : {
         "en" : {
           "variations" : {
@@ -4682,6 +4405,9 @@
           }
         }
       }
+    },
+    "Westbound" : {
+      "comment" : "A route direction label"
     },
     "When using VoiceOver, we can skip reading out maps to keep you focused on transit information." : {
 

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -152,7 +152,7 @@ struct AlertDetails: View {
                     label: {
                         HStack(alignment: .center, spacing: 16) {
                             Text(
-                                "**\(affectedStops.count)** affected stops",
+                                "**\(affectedStops.count, specifier: "%ld")** affected stops",
                                 comment: "The number of stops affected by an alert"
                             ).multilineTextAlignment(.leading)
                             Spacer()

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
@@ -74,7 +74,7 @@ struct AlertDetailsPage: View {
                     .scaledToFit()
                     .frame(maxHeight: modeIconHeight, alignment: .topLeading)
             }
-            Text("Alert Details").font(.headline)
+            Text("Alert Details", comment: "Header on the alert details page").font(.headline)
             Spacer()
             ActionButton(kind: .close) {
                 nearbyVM.goBack()

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPageView.swift
@@ -39,7 +39,12 @@ struct NearbyTransitPageView: View {
                 SheetHeader(title: NSLocalizedString("Nearby Transit", comment: "Header for nearby transit sheet"))
                 ErrorBanner(errorBannerVM).padding(.horizontal, 16)
                 if viewportProvider.isManuallyCentering {
-                    LoadingCard { Text("select location") }.padding(.horizontal, 16).padding(.bottom, 16)
+                    LoadingCard {
+                        Text(
+                            "Select location",
+                            comment: "Visible when the user is panning the map to search for nearby transit"
+                        )
+                    }.padding(.horizontal, 16).padding(.bottom, 16)
                 } else {
                     NearbyTransitView(
                         getNearby: { global, location in

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -119,11 +119,14 @@ struct OnboardingScreenView: View {
                 VStack(alignment: .leading, spacing: 16) {
                     Spacer()
                     VStack(alignment: .leading, spacing: 16) {
-                        Text("Set map preference")
-                            .font(Typography.title1Bold)
-                            .accessibilityHeading(.h1)
-                            .accessibilityAddTraits(.isHeader)
-                            .accessibilityFocused($focusHeader, equals: .hideMaps)
+                        Text(
+                            "Set map preference",
+                            comment: "Onboarding screen header for asking VoiceOver users if they want to hide maps"
+                        )
+                        .font(Typography.title1Bold)
+                        .accessibilityHeading(.h1)
+                        .accessibilityAddTraits(.isHeader)
+                        .accessibilityFocused($focusHeader, equals: .hideMaps)
                         Text(
                             "When using VoiceOver, we can skip reading out maps to keep you focused on transit information."
                         )
@@ -136,10 +139,12 @@ struct OnboardingScreenView: View {
                     .dynamicTypeSize(...DynamicTypeSize.accessibility2)
                     Spacer()
                     Button(action: { hideMaps(true) }) {
-                        Text("Hide maps").onboardingKeyButton()
+                        Text("Hide maps", comment: "Onboarding button text for setting maps to hidden")
+                            .onboardingKeyButton()
                     }
                     Button(action: { hideMaps(false) }) {
-                        Text("Show maps").onboardingSecondaryButton()
+                        Text("Show maps", comment: "Onboarding button text for setting maps to shown")
+                            .onboardingSecondaryButton()
                     }
                 }
                 .padding(.horizontal, sidePadding)
@@ -174,7 +179,10 @@ struct OnboardingScreenView: View {
                         Text("Allow Location Services").onboardingKeyButton()
                     }
                     Button(action: advance) {
-                        Text("Skip for now").onboardingSecondaryButton()
+                        Text(
+                            "Skip for now",
+                            comment: "Button text for deferring the request for location services"
+                        ).onboardingSecondaryButton()
                     }
                 }
                 .dynamicTypeSize(...DynamicTypeSize.accessibility4)

--- a/iosApp/iosApp/Pages/Search/SearchField.swift
+++ b/iosApp/iosApp/Pages/Search/SearchField.swift
@@ -27,19 +27,25 @@ struct SearchField: View {
                     .padding(.all, 4)
                     .foregroundStyle(Color.deemphasized)
                     .accessibilityHidden(true)
-                TextField("Stops", text: $searchObserver.searchText)
-                    .accessibilityAddTraits(.isSearchField)
-                    .focused($isFocused)
-                    .submitLabel(.done)
-                    .padding(.horizontal, 2)
-                    .padding(.vertical, 8)
-                    .animation(.smooth, value: searchObserver.isSearching)
+                TextField(
+                    NSLocalizedString("Stops", comment: "Placeholder text in the empty search field"),
+                    text: $searchObserver.searchText
+                )
+                .accessibilityAddTraits(.isSearchField)
+                .focused($isFocused)
+                .submitLabel(.done)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 8)
+                .animation(.smooth, value: searchObserver.isSearching)
                 if !searchObserver.searchText.isEmpty {
                     ActionButton(kind: .clear) {
                         searchObserver.isFocused = true
                         searchObserver.clear()
                     }
-                    .accessibilityLabel("clear search text")
+                    .accessibilityLabel(Text(
+                        "clear search text",
+                        comment: "VoiceOver label for clear search text button"
+                    ))
                     .padding(.all, 4)
                 }
             }
@@ -58,7 +64,9 @@ struct SearchField: View {
                 Button(action: {
                     searchObserver.isFocused = false
                     searchObserver.clear()
-                }, label: { Text("Cancel") }).accessibilityLabel("close search page")
+                }, label: {
+                    Text("Cancel", comment: "Cancel searching, clears the search term and closes the search page")
+                }).accessibilityLabel(Text("close search page", comment: "VoiceOver label for cancel search button"))
                     .dynamicTypeSize(...DynamicTypeSize.large)
             }
         }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilterPills.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilterPills.swift
@@ -75,14 +75,26 @@ struct StopDetailsFilterPills: View {
             }
             if filter != nil {
                 Button(action: { setFilter(nil) }) {
-                    Text("All")
+                    Text("All", comment: "Button label for clearing selected route to display all routes at a station")
                         .foregroundStyle(Color.fill1)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 7)
                         .background(Color.contrast)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .accessibilityLabel("All routes")
-                        .accessibilityHint("Removes selected filter so that arrivals from all routes are displayed")
+                        .accessibilityLabel(Text(
+                            "All routes",
+                            comment: """
+                            VoiceOver label for the button to clear
+                            selected route to display all routes at a station"
+                            """
+                        ))
+                        .accessibilityHint(Text(
+                            "Removes selected filter so that arrivals from all routes are displayed",
+                            comment: """
+                            VoiceOver hint for the button to
+                            clear selected route to display all routes at a station
+                            """
+                        ))
                 }
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
                 .padding(.trailing, 16)

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsHeader.swift
@@ -28,7 +28,14 @@ struct TripDetailsHeader: View {
                 .accessibilityElement()
                 .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h1)
-                .accessibilityLabel("\(route.label) \(route.type.typeText(isOnly: true)) to \(trip.headsign)")
+                .accessibilityLabel(Text(
+                    "\(route.label) \(route.type.typeText(isOnly: true)) to \(trip.headsign)",
+                    comment: """
+                    VoiceOver text for the trip details page header,
+                    describes the route and destination of the vehicle,
+                    ex 'Red Line train to Alewife'
+                    """
+                ))
             }
             Spacer()
             ActionButton(kind: .close, action: onClose)
@@ -43,12 +50,15 @@ struct TripDetailsHeader: View {
             Image(.liveData)
                 .resizable()
                 .frame(width: 16, height: 16)
-            Text("Live", comment: "real-time")
+            Text("Live", comment: "Indicates that data is being updated in real-time")
                 .font(Typography.footnote)
         }
         .accessibilityElement()
         .accessibilityAddTraits(.isHeader)
-        .accessibilityLabel("Real-time arrivals updating live")
+        .accessibilityLabel(Text(
+            "Real-time arrivals updating live",
+            comment: "VoiceOver label for real-time indicator icon"
+        ))
     }
 
     func toHeadsign(_ headsign: String) -> some View {

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
@@ -15,34 +15,49 @@ struct TripDetailsStopListSplitView: View {
     let onTapLink: (SheetNavigationStackEntry, TripDetailsStopList.Entry, String?) -> Void
     let routeType: RouteType?
 
+    private var routeTypeText: String { routeType?.typeText(isOnly: true) ?? "" }
+    private var stopsAway: Int { splitStops.collapsedStops.count }
+    private var target: TripDetailsStopList.Entry { splitStops.targetStop }
+
     var body: some View {
         List {
             if !splitStops.collapsedStops.isEmpty {
-                DisclosureGroup(content: {
-                                    ForEach(splitStops.collapsedStops, id: \.stopSequence) { stop in
-                                        TripDetailsStopView(
-                                            stop: stop,
-                                            now: now,
-                                            onTapLink: onTapLink,
-                                            routeType: routeType
-                                        )
-                                    }
-                                },
-                                label: { Text("\(splitStops.collapsedStops.count, specifier: "%ld") stops away",
-                                              comment: "How many stops away the vehicle is from the target stop")
-                                })
-                                .padding(.bottom, 16)
-                                .accessibilityElement()
-                                .accessibilityAddTraits(.isHeader)
-                                .accessibilityHeading(.h2)
-                                .accessibilityLabel(
-                                    LocalizedStringKey(
-                                        "\(routeType?.typeText(isOnly: true) ?? "") is \(splitStops.collapsedStops.count, specifier: "%ld") stops away from \(splitStops.targetStop.stop.name)"
-                                    )
-                                )
-                                .accessibilityHint("List remaining stops")
+                DisclosureGroup(
+                    content: {
+                        ForEach(splitStops.collapsedStops, id: \.stopSequence) { stop in
+                            TripDetailsStopView(
+                                stop: stop,
+                                now: now,
+                                onTapLink: onTapLink,
+                                routeType: routeType
+                            )
+                        }
+                    },
+                    label: { Text(
+                        "\(stopsAway, specifier: "%ld") stops away",
+                        comment: "How many stops away the vehicle is from the target stop"
+                    ) }
+                )
+                .padding(.bottom, 16)
+                .accessibilityElement()
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityHeading(.h2)
+                .accessibilityLabel(Text(
+                    "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
+                    comment: """
+                    VoiceOver label for how many stops away a vehicle is from a stop,
+                    ex 'bus is 4 stops away from Harvard'
+                    """
+                ))
+                .accessibilityHint(Text(
+                    "List remaining stops",
+                    comment: """
+                    VoiceOver hint explaining what happens when 'x stops away'
+                    is selected (open an accordion listing those stops)
+                    """
+                ))
             }
-            TripDetailsStopView(stop: splitStops.targetStop, now: now, onTapLink: onTapLink, routeType: routeType)
+            TripDetailsStopView(stop: target, now: now, onTapLink: onTapLink, routeType: routeType)
                 .listRowBackground(Color.keyInverse.opacity(0.15))
             ForEach(splitStops.followingStops, id: \.stopSequence) { stop in
                 TripDetailsStopView(stop: stop, now: now, onTapLink: onTapLink, routeType: routeType)

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -31,24 +31,47 @@ struct TripDetailsStopView: View {
                     .accessibilityHeading(.h2)
                 }
             )
-            scrollRoutes
-                .accessibilityElement()
-                .accessibilityLabel(scrollRoutesAccessibilityLabel)
+            if !stop.routes.isEmpty {
+                scrollRoutes
+                    .accessibilityElement()
+                    .accessibilityLabel(scrollRoutesAccessibilityLabel)
+            }
         }
+    }
+
+    func connectionLabel(route: Route) -> String {
+        String(format: NSLocalizedString(
+            "%@ %@",
+            comment: """
+            A route label and route type pair,
+            ex 'Red Line train' or '73 bus', used in connecting stop labels
+            """
+        ), route.label, route.type.typeText(isOnly: true))
     }
 
     var scrollRoutesAccessibilityLabel: String {
         if stop.routes.isEmpty {
             return ""
         } else if stop.routes.count == 1 {
-            return "Connection to \(stop.routes.first!.label) \(stop.routes.first!.type.typeText(isOnly: true))"
+            return String(format: NSLocalizedString(
+                "Connection to %@",
+                comment: "VoiceOver label for a single connecting route at a stop, ex 'Connection to 1 bus'"
+            ), connectionLabel(route: stop.routes.first!))
         } else {
-            let lastConnection = stop.routes.last
-            return "Connections to" + stop.routes.prefix(stop.routes.count - 1).map {
-                "\($0.label) \($0.type.typeText(isOnly: true))"
-            }
-            .joined(separator: ", ") +
-            " and \(lastConnection!.label) \(lastConnection!.type.typeText(isOnly: true))"
+            let firstConnections = stop.routes.prefix(stop.routes.count - 1)
+            let lastConnection = stop.routes.last!
+            return String(
+                format: NSLocalizedString(
+                    "Connections to %@ and %@",
+                    comment: """
+                    VoiceOver label for multiple connecting routes at a stop,
+                    ex 'Connections to Red Line train, 71 bus, and 73 bus',
+                    the first replaced value can be any number of comma separated route labels
+                    """
+                ),
+                firstConnections.map(connectionLabel).joined(separator: ", "),
+                connectionLabel(route: lastConnection)
+            )
         }
     }
 

--- a/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
@@ -74,7 +74,8 @@ struct VehicleOnTripView: View {
                 "\(route.type.typeText(isOnly: true)) \(vehicleStatusText(vehicle.currentStatus)) \(stop.name)",
                 comment: """
                 VoiceOver text for the vehicle status on the trip details page,
-                ex 'train approaching Alewife' or 'bus now at Harvard'
+                ex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard]'
+                Possible values for the vehicle status are "Approaching", "Next stop", or "Now at"
                 """
             ))
         } else {

--- a/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/VehicleCardView.swift
@@ -70,11 +70,15 @@ struct VehicleOnTripView: View {
             .accessibilityElement()
             .accessibilityAddTraits(.isHeader)
             .accessibilityHeading(.h2)
-            .accessibilityLabel(
-                "\(route.type.typeText(isOnly: true)) \(vehicleStatusText(vehicle.currentStatus)) \(stop.name)"
-            )
+            .accessibilityLabel(Text(
+                "\(route.type.typeText(isOnly: true)) \(vehicleStatusText(vehicle.currentStatus)) \(stop.name)",
+                comment: """
+                VoiceOver text for the vehicle status on the trip details page,
+                ex 'train approaching Alewife' or 'bus now at Harvard'
+                """
+            ))
         } else {
-            Text("This vehicle is completing another trip.")
+            Text("This vehicle is completing another trip")
                 .font(Typography.headlineBold)
                 .foregroundColor(textColor)
                 .accessibilityAddTraits(.isHeader)
@@ -93,12 +97,18 @@ struct VehicleOnTripView: View {
         _ vehicleStatus: __Bridge__Vehicle_CurrentStatus
     ) -> String {
         switch vehicleStatus {
-        case .incomingAt: NSLocalizedString("Approaching",
-                                            comment: "Label for a vehicle's next stop. For example: Approaching Alewife")
-        case .inTransitTo: NSLocalizedString("Next stop",
-                                             comment: "Label for a vehicle's next stop. For example: Next stop Alewife")
-        case .stoppedAt: NSLocalizedString("Now at",
-                                           comment: "Label for a where a vehicle is currently stopped. For example: Now at Alewife")
+        case .incomingAt: NSLocalizedString(
+                "Approaching",
+                comment: "Label for a vehicle's next stop. For example: Approaching Alewife"
+            )
+        case .inTransitTo: NSLocalizedString(
+                "Next stop",
+                comment: "Label for a vehicle's next stop. For example: Next stop Alewife"
+            )
+        case .stoppedAt: NSLocalizedString(
+                "Now at",
+                comment: "Label for a where a vehicle is currently stopped. For example: Now at Alewife"
+            )
         }
     }
 

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageViewTests.swift
@@ -32,7 +32,7 @@ final class NearbyTransitPageViewTests: XCTestCase {
             nearbyVM: .init(),
             viewportProvider: viewportProvider
         )
-        XCTAssertNotNil(try sut.inspect().find(text: "select location"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Select location"))
     }
 
     func testClearsNearbyStateWhenManuallyCentering() throws {

--- a/iosApp/iosAppTests/Pages/Onboarding/OnboardingScreenViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Onboarding/OnboardingScreenViewTests.swift
@@ -62,7 +62,8 @@ final class OnboardingScreenViewTests: XCTestCase {
             advance: { advanceExp.fulfill() }
         )
         XCTAssertNotNil(try sut.inspect().find(
-            text: "MBTA Go is in the early stages! We want your feedback as we continue making improvements and adding new features."
+            text: "MBTA Go is in the early stages! We want your feedback" +
+                " as we continue making improvements and adding new features."
         ))
         try sut.inspect().find(button: "Get started").tap()
         wait(for: [advanceExp], timeout: 1)

--- a/iosApp/iosAppTests/Pages/TripDetails/VehicleCardViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/VehicleCardViewTests.swift
@@ -31,7 +31,7 @@ final class VehicleCardViewTests: XCTestCase {
         let stop = objects.stop { _ in }
 
         let sut = VehicleCardView(vehicle: vehicle, route: route, stop: stop, trip: trip)
-        XCTAssertNotNil(try sut.inspect().find(text: "This vehicle is completing another trip."))
+        XCTAssertNotNil(try sut.inspect().find(text: "This vehicle is completing another trip"))
     }
 
     func testVehicleApproaching() {

--- a/iosApp/iosAppTests/Views/LoadingCardTests.swift
+++ b/iosApp/iosAppTests/Views/LoadingCardTests.swift
@@ -16,7 +16,7 @@ final class LoadingCardTests: XCTestCase {
     func testDefault() throws {
         let sut = LoadingCard()
         XCTAssertNotNil(try sut.inspect().find(ViewType.ProgressView.self))
-        XCTAssertNotNil(try sut.inspect().find(text: "loading"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Loading..."))
     }
 
     func testCustomMessage() throws {


### PR DESCRIPTION
### Summary

_Ticket:_ [Fill in missing comments for translators](https://app.asana.com/0/1205732265579288/1208643843115469/f)

Stacked onto #503 

Audited all strings in the app, I added a dummy language with all strings replaced with a specific character to make sure that everything was being properly translated, and updated a handful of places that weren't being replaced. I also tested using VoiceOver, in both english and the dummy language, to make sure all of the accessibility text was also being properly localized. Also added comments to any potentially ambiguous strings, and cleaned up some copy that snuck through the cracks.

### Testing

Manual testing with alternate locales and VoiceOver
