### PR TITLE
fix: Fix hide maps location changes

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -167,6 +167,12 @@ struct ContentView: View {
                         nearbyVM.goBack()
                     }
                 }, content: coverContents)
+                .onAppear {
+                    viewportProvider.updateCameraState(locationDataManager.currentLocation)
+                }
+                .onChange(of: locationDataManager.currentLocation) { location in
+                    viewportProvider.updateCameraState(location)
+                }
         } else {
             mapSection
                 .sheet(

--- a/iosApp/iosApp/Fetchers/ViewportProvider.swift
+++ b/iosApp/iosApp/Fetchers/ViewportProvider.swift
@@ -102,6 +102,13 @@ class ViewportProvider: ObservableObject {
         }
     }
 
+    func updateCameraState(_ location: CLLocation?) {
+        guard let coordinate = location?.coordinate else { return }
+        updateCameraState(
+            .init(center: coordinate, padding: .zero, zoom: 0, bearing: 0, pitch: 0)
+        )
+    }
+
     func updateCameraState(_ state: CameraState) {
         cameraStateSubject.send(state)
     }

--- a/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
+++ b/iosApp/iosAppTests/Fetchers/ViewportProviderTest.swift
@@ -86,6 +86,22 @@ final class ViewportProviderTest: XCTestCase {
         XCTAssertEqual(provider.viewport.camera?.zoom, newZoom)
     }
 
+    func testUpdateCameraLocationFromCoordinate() throws {
+        let updatedExp = expectation(description: "updated camera")
+        let startCenter: CLLocationCoordinate2D = .init(latitude: 0, longitude: 0)
+        let provider = ViewportProvider(viewport: .camera(center: startCenter, zoom: 16.0))
+
+        let newCenter: CLLocationCoordinate2D = .init(latitude: 1, longitude: 1)
+        provider.updateCameraState(CLLocation(latitude: 1, longitude: 1))
+        let cancelSink = provider.cameraStatePublisher.sink { cameraUpdate in
+            XCTAssertEqual(cameraUpdate.center, newCenter)
+            updatedExp.fulfill()
+        }
+
+        wait(for: [updatedExp], timeout: 1)
+        cancelSink.cancel()
+    }
+
     func testSavePanned() throws {
         let provider = ViewportProvider(viewport: .idle)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Location doesn't update when Hide Maps is turned on](https://app.asana.com/0/1205732265579288/1208660630503484/f)

Fix an issue where the current location was never updating the nearby transit location when "Hide Maps" was toggled on.

### Testing

Added a test for new ViewportProvider helper function