### PR TITLE
fix: Fix bolded prediction times

### DIFF
--- a/iosApp/iosApp/ComponentViews/PredictionText.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionText.swift
@@ -24,27 +24,23 @@ struct PredictionText: View {
     var predictionKey: String {
         if hours >= 1 {
             String(format: NSLocalizedString(
-                "%ld hr %ld min",
+                "**%ld** hr **%ld** min",
                 comment: "Shorthand displayed number of hours and minutes until arrival, ex \"1 hr 32 min\""
             ), hours, remainingMinutes)
         } else {
             String(format: NSLocalizedString(
-                "%ld min",
+                "**%ld** min",
                 comment: "Shorthand displayed number of minutes until arrival, ex \"12 min\""
             ), minutes)
         }
     }
 
     var predictionString: AttributedString {
-        var prediction = AttributedString(predictionKey)
-        for run in prediction.runs {
-            if run.localizedNumericArgument != nil {
-                prediction[run.range].font = Typography.headlineBold
-            } else {
-                prediction[run.range].font = Typography.body
-            }
+        do {
+            return try AttributedString(markdown: predictionKey)
+        } catch {
+            return AttributedString(predictionKey.filter { $0 != "*" })
         }
-        return prediction
     }
 
     var accessibilityString: String {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -24,6 +24,20 @@
         }
       }
     },
+    "**%ld** hr **%ld** min" : {
+      "comment" : "Shorthand displayed number of hours and minutes until arrival, ex \"1 hr 32 min\"",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "**%1$ld** hr **%2$ld** min"
+          }
+        }
+      }
+    },
+    "**%ld** min" : {
+      "comment" : "Shorthand displayed number of minutes until arrival, ex \"12 min\""
+    },
     "%@ %@" : {
       "comment" : "A route label and route type pair,\nex 'Red Line train' or '73 bus', used in connecting stop labels\nFirst value is the route label, second value is an alert effect, resulting in something like 'Red Line Suspension' or 'Green Line Shuttle'",
       "localizations" : {
@@ -389,20 +403,6 @@
           }
         }
       }
-    },
-    "%ld hr %ld min" : {
-      "comment" : "Shorthand displayed number of hours and minutes until arrival, ex \"1 hr 32 min\"",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$ld hr %2$ld min"
-          }
-        }
-      }
-    },
-    "%ld min" : {
-      "comment" : "Shorthand displayed number of minutes until arrival, ex \"12 min\""
     },
     "%ld stops away" : {
       "comment" : "How many stops away the vehicle is from the target stop",


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

Raised during app QA, prediction times were no longer being bolded because of how translations were changed.