### PR TITLE
fix: Properly align multi line direction text

### DIFF
--- a/iosApp/iosApp/ComponentViews/DirectionLabel.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionLabel.swift
@@ -38,6 +38,7 @@ struct DirectionLabel: View {
                      .textCase(.none)
                 Text(destination)
                     .font(Typography.bodySemibold)
+                    .multilineTextAlignment(.leading)
                     .textCase(.none)
             } else {
                 Text(directionNameFormatted(direction))


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix alignment of multi-line headsigns in direction toggle](https://app.asana.com/0/1205425564113216/1208672143544735/f)

Properly align direction destination labels

![Simulator Screenshot - iPhone 15 - 2024-11-01 at 17 09 53](https://github.com/user-attachments/assets/9d7f9e9e-068a-4ac1-a9d7-2e3ca33d7624)
