### PR TITLE
i18n: Add possible CR status override strings

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1016,6 +1016,10 @@
         }
       }
     },
+    "Arriving" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
+    },
     "Autos Impeding Service" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -1141,6 +1145,10 @@
           }
         }
       }
+    },
+    "Bus substitution" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
     },
     "buses" : {
       "comment" : "buses",
@@ -2648,6 +2656,10 @@
       }
     },
     "Now boarding" : {
+      "comment" : "Status for a commuter rail train",
+      "extractionState" : "manual"
+    },
+    "On time" : {
       "comment" : "Status for a commuter rail train",
       "extractionState" : "manual"
     },


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

@boringcactus flagged a few more possible prediction status text overrides we can get for CR. We're not handling them yet, but we want to include them in the localization file we send to the translators so that they're ready when we do.