### PR TITLE
fix: always join alerts on app startup

### DIFF
--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -37,8 +37,9 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
-            .vStack().callOnChange(newValue: ScenePhase.background)
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
+            .vStack()
+            .callOnChange(newValue: ScenePhase.background)
         wait(for: [disconnectedExpectation], timeout: 5)
     }
 
@@ -56,8 +57,9 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
-            .vStack().callOnChange(newValue: ScenePhase.background)
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
+            .vStack()
+            .callOnChange(newValue: ScenePhase.background)
         wait(for: [disconnectedExpectation], timeout: 1)
         try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
             .vStack().callOnChange(newValue: ScenePhase.active)
@@ -77,7 +79,7 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
             .vStack().callOnChange(newValue: ScenePhase.active)
         wait(for: [joinAlertsExp], timeout: 5)
     }
@@ -93,8 +95,8 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
-            .vStack().callOnChange(newValue: ScenePhase.background)
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().vStack()
+            .callOnChange(newValue: ScenePhase.background)
         wait(for: [leavesAlertsExp], timeout: 5)
     }
 
@@ -123,7 +125,7 @@ final class ContentViewTests: XCTestCase {
 
         let newConfig: ApiResult<ConfigResponse>? = ApiResultOk(data: .init(mapboxPublicToken: "FAKE_TOKEN"))
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
             .vStack()
             .callOnChange(newValue: newConfig)
         wait(for: [tokenConfigExpectation], timeout: 5)


### PR DESCRIPTION
### Summary

Hotfix, no ticket

What is this PR for?

This PR fixes an issue where after the onboarding flow, users would get stuck on a shimmer loading screen. 
The cause was that by the time the nearby transit sheet popped after onboarding, there was no scene phase to trigger joining. Moved to the top of the view hierarchy so that it is always called on app startup.

### Testing

What testing have you done?

Tested locally & updated existing unit tests. I moved the map config handling logic to the same top level because fiddling with the list of `implicitAnyViews` was giving me trouble. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
