### PR TITLE
test: fix an Xcode 16 issue

### DIFF
--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -61,7 +61,7 @@ final class ContentViewTests: XCTestCase {
             .vStack()
             .callOnChange(newValue: ScenePhase.background)
         wait(for: [disconnectedExpectation], timeout: 1)
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().implicitAnyView().implicitAnyView()
+        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
             .vStack().callOnChange(newValue: ScenePhase.active)
         wait(for: [connectedExpectation], timeout: 1)
     }


### PR DESCRIPTION
### Summary

_Ticket:_ none

#517 introduced an Xcode 16 test issue, but that's lower-priority than getting those changes out the door.

### Testing

Verified that the test now passes in Xcode 16.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
