### PR TITLE
fix: Fix formatting of alert details text

### DIFF
--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -98,6 +98,18 @@ struct AlertDetails: View {
         }
     }
 
+    private var affectedStopsLabel: AttributedString {
+        let text = String(format: NSLocalizedString(
+            "**%ld** affected stops",
+            comment: "The number of stops affected by an alert"
+        ), affectedStops.count)
+        do {
+            return try AttributedString(markdown: text)
+        } catch {
+            return AttributedString(text.filter { $0 != "*" })
+        }
+    }
+
     @ViewBuilder
     private var alertTitle: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -151,10 +163,7 @@ struct AlertDetails: View {
                     },
                     label: {
                         HStack(alignment: .center, spacing: 16) {
-                            Text(
-                                "**\(affectedStops.count, specifier: "%ld")** affected stops",
-                                comment: "The number of stops affected by an alert"
-                            ).multilineTextAlignment(.leading)
+                            Text(affectedStopsLabel).multilineTextAlignment(.leading)
                             Spacer()
                             Image(.faChevronRight)
                                 .resizable()

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
@@ -111,7 +111,7 @@ final class AlertDetailsPageTests: XCTestCase {
         let exp = sut.inspection.inspect(onReceive: globalDataLoaded, after: 1) { view in
             XCTAssertNotNil(try view.find(text: "Orange Line Stop Closure"))
             XCTAssertNotNil(try view.find(text: "Fire"))
-            XCTAssertNotNil(try view.find(text: "**3** affected stops"))
+            XCTAssertNotNil(try view.find(text: "3 affected stops"))
             XCTAssertNotNil(try view.find(text: "Stop 1"))
             XCTAssertNotNil(try view.find(text: "Stop 2"))
             XCTAssertNotNil(try view.find(text: "Stop 3"))

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
@@ -45,7 +45,7 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "Red Line Stop Closure"))
         XCTAssertNotNil(try sut.inspect().find(text: "Unruly Passenger"))
         XCTAssertNotNil(try sut.inspect().find(text: String(alert.activePeriod[0].formatStart().characters)))
-        XCTAssertNotNil(try sut.inspect().find(text: "**3** affected stops"))
+        XCTAssertNotNil(try sut.inspect().find(text: "3 affected stops"))
         XCTAssertNotNil(try sut.inspect().find(ViewType.DisclosureGroup.self))
         XCTAssertNotNil(try sut.inspect().find(text: stop1.name))
         XCTAssertNotNil(try sut.inspect().find(text: stop2.name))
@@ -159,7 +159,7 @@ final class AlertDetailsTests: XCTestCase {
         )
 
         try print(sutWithoutStops.inspect().findAll(ViewType.Text.self).map { text in try text.string() })
-        XCTAssertNil(try? sutWithoutStops.inspect().find(text: "**3** affected stops"))
+        XCTAssertNil(try? sutWithoutStops.inspect().find(text: "3 affected stops"))
         XCTAssertNotNil(try? sutWithoutStops.inspect().find(text: "Alert description"))
         XCTAssertNotNil(try? sutWithoutStops.inspect().find(text: "Affected stops:\nStop 1\nStop 2\nStop 3"))
         XCTAssertNotNil(try? sutWithoutStops.inspect().find(text: "More details"))
@@ -170,7 +170,7 @@ final class AlertDetailsTests: XCTestCase {
         )
 
         XCTAssertNotNil(try? sutWithStops.inspect().find(text: "Alert description"))
-        XCTAssertNotNil(try? sutWithStops.inspect().find(text: "**3** affected stops"))
+        XCTAssertNotNil(try? sutWithStops.inspect().find(text: "3 affected stops"))
         XCTAssertNil(try? sutWithStops.inspect().find(text: "Affected stops:\nStop 1\nStop 2\nStop 3"))
         XCTAssertNotNil(try? sutWithStops.inspect().find(text: "More details"))
     }


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

Raised during app QA, markdown formatting was somehow broken after adding a Text comment.