### PR TITLE
fix(VoiceControl): accessibilityInputLabel for links within sheet

### DIFF
--- a/iosApp/iosApp/ComponentViews/DirectionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionRowView.swift
@@ -29,7 +29,6 @@ struct DirectionRowView: View {
             DirectionLabel(direction: direction)
                 .foregroundStyle(Color.text)
         }
-        .accessibilityInputLabels([direction.destination ?? direction.name])
     }
 }
 

--- a/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
+++ b/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
@@ -31,7 +31,6 @@ struct HeadsignRowView: View {
                 .font(Typography.bodySemibold)
                 .multilineTextAlignment(.leading)
         }
-        .accessibilityInputLabels([headsign])
     }
 }
 

--- a/iosApp/iosApp/Pages/NearbyTransit/StopDeparturesSummaryList.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/StopDeparturesSummaryList.swift
@@ -22,6 +22,12 @@ struct StopDeparturesSummaryList: View {
             Array(patternsByStop.patterns.enumerated()),
             id: \.element.id
         ) { index, patterns in
+
+            let inputLabel = switch onEnum(of: patterns) {
+            case let .byHeadsign(byHeadsign): byHeadsign.headsign
+            case let .byDirection(byDirection): byDirection.direction.destination ?? byDirection.direction.name
+            }
+
             VStack(spacing: 0) {
                 SheetNavigationLink(
                     value: .stopDetails(
@@ -36,6 +42,7 @@ struct StopDeparturesSummaryList: View {
                         condenseHeadsignPredictions: condenseHeadsignPredictions
                     )
                 }
+                .accessibilityInputLabels([inputLabel])
                 .padding(8)
                 .frame(minHeight: 44)
                 .padding(.leading, 8)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredRouteView.swift
@@ -199,6 +199,7 @@ struct StopDetailsFilteredRouteView: View {
                                                     .onRow(route: row.route) : .none
                                             )
                                         }
+                                        .accessibilityInputLabels([row.headsign])
                                         .padding(.vertical, 10)
                                         .padding(.horizontal, 16)
 

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -30,7 +30,7 @@ struct TripDetailsStopView: View {
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h2)
                 }
-            )
+            ).accessibilityInputLabels([stop.stop.name])
             if !stop.routes.isEmpty {
                 scrollRoutes
                     .accessibilityElement()


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket. Took a quick look at voice control for nearby transit and noticed that saying "Tap Braintree" didn't automatically work - you then had to say "Tap 3". It seems like the accessibilityInputLabel was applying to each child element individually and creating 3 duplicate labels. 

There may be a cleaner approach than this, but it made sense to me to move the label to the button itself.

### Testing

What testing have you done?
* Ran with Voice Control on, confirmed I could say just "Tap Braintree" to navigate from Nearby => Stop Details, "Tap Braintree" from Stop Details => Trip Details, and "Tap Park" From Trip Details => Stop Details
* Ran with Voice Over on and confirmed elements still read as expected

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
