### PR TITLE
fix: ensure gradle knows pods are installed

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -63,6 +63,7 @@ retry ./gradlew :shared:generateDummyFramework
 cd "${CI_PRIMARY_REPOSITORY_PATH}/iosApp"
 retry bundle exec pod install
 cd ..
+retry ./gradlew :shared:podInstallSyntheticIos
 
 # Install Node.js and GitHub CLI for codegen
 retry brew install node gh

--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -63,7 +63,7 @@ retry ./gradlew :shared:generateDummyFramework
 cd "${CI_PRIMARY_REPOSITORY_PATH}/iosApp"
 retry bundle exec pod install
 cd ..
-retry ./gradlew :shared:podInstallSyntheticIos
+retry bundle exec ./gradlew :shared:podInstallSyntheticIos
 
 # Install Node.js and GitHub CLI for codegen
 retry brew install node gh


### PR DESCRIPTION
### Summary

_Ticket:_ none

Builds on `main` are failing right now, and from the error message I think this is why.

### Testing

When I get the same error message locally, this is how I fix it, but I have no idea if it'll fix the non-test Xcode Cloud targets until we merge this (unless we want to temporarily add archive or analyze to the PR workflow).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
