### PR TITLE
feat(DebugView): trip, stop, vehicle ids

### DIFF
--- a/iosApp/iosApp/ComponentViews/DebugView.swift
+++ b/iosApp/iosApp/ComponentViews/DebugView.swift
@@ -17,7 +17,9 @@ struct DebugView<Content: View>: View {
                 .strokeBorder(Color(.text), style: .init(lineWidth: 2, dash: [10]))
             VStack(alignment: .leading) {
                 content()
+                    .font(Typography.footnote)
             }.padding(4)
         }
+        .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/iosApp/iosApp/ComponentViews/ErrorBanner.swift
+++ b/iosApp/iosApp/ComponentViews/ErrorBanner.swift
@@ -34,7 +34,7 @@ struct ErrorBanner: View {
                         DebugView {
                             ForEach(state.messages.sorted(), id: \.self) { errorName in
                                 Text(errorName)
-                            }.font(Typography.footnote)
+                            }
                         }
                     }
                 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .onAppear {
             Task { await contentVM.loadOnboardingScreens() }
+            Task { await nearbyVM.loadDebugSetting() }
         }
         .task {
             // We can't set stale caches in ResponseCache on init because of our Koin setup,

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -78,6 +78,11 @@ struct StopDetailsView: View {
                         onBack: nearbyVM.navigationStack.count > 1 ? { nearbyVM.goBack() } : nil,
                         onClose: { nearbyVM.navigationStack.removeAll() }
                     )
+                    if nearbyVM.showDebugMessages {
+                        DebugView {
+                            Text(verbatim: "stop id: \(stop.id)")
+                        }
+                    }
                     ErrorBanner(errorBannerVM).padding(.horizontal, 16)
                     if servedRoutes.count > 1 {
                         StopDetailsFilterPills(

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -75,7 +75,7 @@ struct TripDetailsPage: View {
             if nearbyVM.showDebugMessages {
                 DebugView {
                     VStack {
-                        Text(verbatim: "trip id \(tripId)")
+                        Text(verbatim: "trip id: \(tripId)")
                         Text(verbatim: "vehicle id: \(vehicleId)")
                     }
                 }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -72,6 +72,14 @@ struct TripDetailsPage: View {
     var body: some View {
         VStack(spacing: 16) {
             header
+            if nearbyVM.showDebugMessages {
+                DebugView {
+                    VStack {
+                        Text(verbatim: "trip id \(tripId)")
+                        Text(verbatim: "vehicle id: \(vehicleId)")
+                    }
+                }
+            }
             if tripPredictionsLoaded, let globalResponse, let vehicle = vehicleResponse?.vehicle,
                let stops = TripDetailsStopList.companion.fromPieces(
                    tripId: tripId,

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -37,32 +37,47 @@ class NearbyViewModel: ObservableObject {
         }}
     }
 
+    @Published
+    var showDebugMessages: Bool = false
+
     @Published var alerts: AlertsStreamDataResponse?
     @Published var nearbyState = NearbyTransitState()
     @Published var selectingLocation = false
+
     private let alertsRepository: IAlertsRepository
     private let errorBannerRepository: IErrorBannerStateRepository
     private let nearbyRepository: INearbyRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
     private var fetchNearbyTask: Task<Void, Never>?
     private var analytics: NearbyTransitAnalytics
+    private let settingsRepository: ISettingsRepository
 
     init(
         departures: StopDetailsDepartures? = nil,
         navigationStack: [SheetNavigationStackEntry] = [],
+        showDebugMessages: Bool = false,
         alertsRepository: IAlertsRepository = RepositoryDI().alerts,
         errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner,
         nearbyRepository: INearbyRepository = RepositoryDI().nearby,
         visitHistoryUsecase: VisitHistoryUsecase = UsecaseDI().visitHistoryUsecase,
-        analytics: NearbyTransitAnalytics = AnalyticsProvider.shared
+        analytics: NearbyTransitAnalytics = AnalyticsProvider.shared,
+        settingsRepository: ISettingsRepository = RepositoryDI().settings
     ) {
         self.departures = departures
         self.navigationStack = navigationStack
+        self.showDebugMessages = showDebugMessages
+
         self.alertsRepository = alertsRepository
         self.errorBannerRepository = errorBannerRepository
         self.nearbyRepository = nearbyRepository
         self.visitHistoryUsecase = visitHistoryUsecase
         self.analytics = analytics
+        self.settingsRepository = settingsRepository
+    }
+
+    @MainActor
+    func loadDebugSetting() async {
+        showDebugMessages = await (try? settingsRepository.getSettings()[.devDebugMode]?.boolValue) ?? false
     }
 
     /**

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -140,4 +140,48 @@ final class StopDetailsViewTests: XCTestCase {
         ViewHosting.host(view: sut)
         XCTAssertNil(try? sut.inspect().find(viewWithAccessibilityLabel: "Back"))
     }
+
+    func testDebugModeNotShownByDefault() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { stop in
+            stop.id = "FAKE_STOP_ID"
+        }
+
+        let nearbyVM: NearbyViewModel = .init(navigationStack: [.stopDetails(stop, nil)], showDebugMessages: false)
+        let sut = StopDetailsView(
+            stop: stop,
+            filter: nil,
+            setFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        XCTAssertThrowsError(try sut.inspect().find(text: "stop id: FAKE_STOP_ID"))
+    }
+
+    func testDebugModeShown() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { stop in
+            stop.id = "FAKE_STOP_ID"
+        }
+
+        let nearbyVM: NearbyViewModel = .init(navigationStack: [.stopDetails(stop, nil)], showDebugMessages: true)
+        let sut = StopDetailsView(
+            stop: stop,
+            filter: nil,
+            setFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        XCTAssertNotNil(try sut.inspect().find(text: "stop id: FAKE_STOP_ID"))
+    }
 }

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -603,6 +603,58 @@ final class TripDetailsPageTests: XCTestCase {
         wait(for: [vehicleLeaveExp, vehicleJoinExp], timeout: 2)
     }
 
+    func testDebugModeNotShownByDefault() throws {
+        let objects = ObjectCollectionBuilder()
+        objects.stop { _ in }
+        let sut = TripDetailsPage(
+            tripId: "tripId",
+            vehicleId: "vehicleId",
+            routeId: "routeId",
+            target: nil,
+            errorBannerVM: .init(),
+            nearbyVM: .init(),
+            mapVM: .init(),
+            tripPredictionsRepository: FakeTripPredictionsRepository(response: .init(objects: objects)),
+            tripRepository: FakeTripRepository(
+                tripResponse: .init(trip: objects.trip { _ in }),
+                scheduleResponse: TripSchedulesResponse.StopIds(stopIds: [])
+            ),
+            vehicleRepository: FakeVehicleRepository(
+                response: .init(vehicle: nil),
+                onConnect: {},
+                onDisconnect: {}
+            )
+        )
+        ViewHosting.host(view: sut)
+        XCTAssertThrowsError(try sut.inspect().find(text: "trip id: tripId"))
+    }
+
+    func testDebugModeShown() throws {
+        let objects = ObjectCollectionBuilder()
+        objects.stop { _ in }
+        let sut = TripDetailsPage(
+            tripId: "tripId",
+            vehicleId: "vehicleId",
+            routeId: "routeId",
+            target: nil,
+            errorBannerVM: .init(),
+            nearbyVM: .init(showDebugMessages: true),
+            mapVM: .init(),
+            tripPredictionsRepository: FakeTripPredictionsRepository(response: .init(objects: objects)),
+            tripRepository: FakeTripRepository(
+                tripResponse: .init(trip: objects.trip { _ in }),
+                scheduleResponse: TripSchedulesResponse.StopIds(stopIds: [])
+            ),
+            vehicleRepository: FakeVehicleRepository(
+                response: .init(vehicle: nil),
+                onConnect: {},
+                onDisconnect: {}
+            )
+        )
+        ViewHosting.host(view: sut)
+        XCTAssertNotNil(try sut.inspect().find(text: "trip id: tripId"))
+    }
+
     class FakeTripRepository: IdleTripRepository {
         let tripResponse: ApiResult<TripResponse>
         let scheduleResponse: TripSchedulesResponse


### PR DESCRIPTION
### Summary

_Ticket:_ [Debug setting to show (trip, stop, vehicle, etc) IDs](https://app.asana.com/0/1205732265579288/1208629979901034/f)

What is this PR for?

This PR adds the low hanging fruit ids - trip, stop, and vehicle. I opted to add each element in the detail view (stop in stop details, trip & vehicle in trip details). 

I didn't add anything around route patterns since our route pattern grouping logic is in flux - if we find it will be valuable, we can add that separately. I did take an initial pass at it and it would involve quite a bit of prop drilling unless we switch to using an EnvironmentObject to represent debug mode.

### Testing

What testing have you done?

Added some unit tests & ran locally. Also checked formatting to address the DebugView expanding unexpectedly as raised [in slack](https://mbta.slack.com/archives/C062QNAJZ2M/p1731098298241369)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
