### PR TITLE
feat: rearchitect everything to use trip headsigns

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
@@ -113,7 +113,8 @@ class StopDetailsFilteredRouteViewTest {
                             PredictionsStreamDataResponse(builder),
                             AlertsStreamDataResponse(emptyMap()),
                             emptySet(),
-                            now
+                            now,
+                            useTripHeadsigns = false,
                         )
                     ),
                 global = globalResponse,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
@@ -109,7 +109,8 @@ class StopDetailsRoutesViewTest {
                             PredictionsStreamDataResponse(builder),
                             AlertsStreamDataResponse(emptyMap()),
                             emptySet(),
-                            now
+                            now,
+                            useTripHeadsigns = false,
                         )
                     ),
                 global = globalResponse,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -72,7 +72,8 @@ fun NearbyTransitView(
                 predictions,
                 alertData,
                 now,
-                pinnedRoutes.orEmpty()
+                pinnedRoutes.orEmpty(),
+                useTripHeadsigns = false,
             )
         }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -58,7 +58,8 @@ fun StopDetailsPage(
                     predictionsResponse,
                     alertData,
                     pinnedRoutes.orEmpty(),
-                    now
+                    now,
+                    useTripHeadsigns = false,
                 )
             } else null
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.util.getGlobalData
 import com.mbta.tid.mbta_app.android.util.timer
-import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -62,7 +61,7 @@ fun StopDetailsView(
             if (patterns != null) {
                 val defaultDirectionId =
                     patterns.patterns
-                        .flatMap { it.patterns.map(RoutePattern::directionId) }
+                        .flatMap { it.patterns.mapNotNull { it?.directionId } }
                         .minOrNull()
                         ?: 0
                 updateStopFilter(StopDetailsFilter(filterId, defaultDirectionId))

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7841,6 +7841,9 @@
         }
       }
     },
+    "Trip Headsigns" : {
+      "comment" : "A setting on the More page to use the destination/headsign on each individual trip in Nearby Transit (only visible for developers)"
+    },
     "Trip Planner" : {
       "comment" : "Label for a More page link to the MBTA.com trip planner",
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7841,9 +7841,6 @@
         }
       }
     },
-    "Trip Headsigns" : {
-      "comment" : "A setting on the More page to use the destination/headsign on each individual trip in Nearby Transit (only visible for developers)"
-    },
     "Trip Planner" : {
       "comment" : "Label for a More page link to the MBTA.com trip planner",
       "localizations" : {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -169,6 +169,7 @@ struct NearbyTransitView: View {
     var didLoadData: ((Self) -> Void)?
 
     private func loadEverything() {
+        nearbyVM.loadTripHeadsigns()
         getGlobal()
         getNearby(location: location, globalData: globalData)
         joinPredictions(state.nearbyByRouteAndStop?.stopIds())
@@ -350,7 +351,8 @@ struct NearbyTransitView: View {
             predictions: predictions,
             alerts: alerts,
             filterAtTime: filterAtTime,
-            pinnedRoutes: pinnedRoutes
+            pinnedRoutes: pinnedRoutes,
+            useTripHeadsigns: nearbyVM.tripHeadsignsEnabled
         )
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -268,7 +268,8 @@ struct StopDetailsPage: View {
                 predictions: targetPredictions,
                 alerts: nearbyVM.alerts,
                 pinnedRoutes: pinnedRoutes,
-                filterAtTime: now.toKotlinInstant()
+                filterAtTime: now.toKotlinInstant(),
+                useTripHeadsigns: nearbyVM.tripHeadsignsEnabled
             )
         } else {
             nil

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -151,7 +151,8 @@ struct StopDetailsView: View {
         else { return }
         analytics.tappedRouteFilter(routeId: patterns.routeIdentifier, stopId: stop.id)
         let defaultDirectionId = patterns.patterns.flatMap { headsign in
-            headsign.patterns.map { pattern in pattern.directionId }
+            // RealtimePatterns.patterns is a List<RoutePattern?> but that gets bridged as [Any] for some reason
+            headsign.patterns.compactMap { pattern in (pattern as? RoutePattern)?.directionId }
         }.min() ?? 0
         setFilter(.init(routeId: filterId, directionId: defaultDirectionId))
     }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -48,7 +48,6 @@ class NearbyViewModel: ObservableObject {
     private let alertsRepository: IAlertsRepository
     private let errorBannerRepository: IErrorBannerStateRepository
     private let nearbyRepository: INearbyRepository
-    private let settingsRepository: ISettingsRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
     private var fetchNearbyTask: Task<Void, Never>?
     private var analytics: NearbyTransitAnalytics
@@ -61,7 +60,6 @@ class NearbyViewModel: ObservableObject {
         alertsRepository: IAlertsRepository = RepositoryDI().alerts,
         errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner,
         nearbyRepository: INearbyRepository = RepositoryDI().nearby,
-        settingsRepository: ISettingsRepository = RepositoryDI().settings,
         visitHistoryUsecase: VisitHistoryUsecase = UsecaseDI().visitHistoryUsecase,
         analytics: NearbyTransitAnalytics = AnalyticsProvider.shared,
         settingsRepository: ISettingsRepository = RepositoryDI().settings
@@ -73,7 +71,6 @@ class NearbyViewModel: ObservableObject {
         self.alertsRepository = alertsRepository
         self.errorBannerRepository = errorBannerRepository
         self.nearbyRepository = nearbyRepository
-        self.settingsRepository = settingsRepository
         self.visitHistoryUsecase = visitHistoryUsecase
         self.analytics = analytics
         self.settingsRepository = settingsRepository

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -40,9 +40,11 @@ class NearbyViewModel: ObservableObject {
     @Published var alerts: AlertsStreamDataResponse?
     @Published var nearbyState = NearbyTransitState()
     @Published var selectingLocation = false
+    @Published var tripHeadsignsEnabled = false
     private let alertsRepository: IAlertsRepository
     private let errorBannerRepository: IErrorBannerStateRepository
     private let nearbyRepository: INearbyRepository
+    private let settingsRepository: ISettingsRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
     private var fetchNearbyTask: Task<Void, Never>?
     private var analytics: NearbyTransitAnalytics
@@ -53,6 +55,7 @@ class NearbyViewModel: ObservableObject {
         alertsRepository: IAlertsRepository = RepositoryDI().alerts,
         errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner,
         nearbyRepository: INearbyRepository = RepositoryDI().nearby,
+        settingsRepository: ISettingsRepository = RepositoryDI().settings,
         visitHistoryUsecase: VisitHistoryUsecase = UsecaseDI().visitHistoryUsecase,
         analytics: NearbyTransitAnalytics = AnalyticsProvider.shared
     ) {
@@ -61,6 +64,7 @@ class NearbyViewModel: ObservableObject {
         self.alertsRepository = alertsRepository
         self.errorBannerRepository = errorBannerRepository
         self.nearbyRepository = nearbyRepository
+        self.settingsRepository = settingsRepository
         self.visitHistoryUsecase = visitHistoryUsecase
         self.analytics = analytics
     }
@@ -157,6 +161,13 @@ class NearbyViewModel: ObservableObject {
 
     func leaveAlertsChannel() {
         alertsRepository.disconnect()
+    }
+
+    func loadTripHeadsigns() {
+        Task {
+            let result = try await settingsRepository.getSettings()[.tripHeadsigns]?.boolValue ?? false
+            DispatchQueue.main.async { self.tripHeadsignsEnabled = result }
+        }
     }
 }
 

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -95,10 +95,8 @@ class SettingsViewModel: ObservableObject {
                         value: settings[.searchRouteResults] ?? false
                     ),
                     .toggle(
-                        label: NSLocalizedString(
-                            "Trip Headsigns",
-                            comment: "A setting on the More page to use the destination/headsign on each individual trip in Nearby Transit (only visible for developers)"
-                        ),
+                        // not localized since it's a feature flag
+                        label: "Trip Headsigns",
                         setting: .tripHeadsigns,
                         value: settings[.tripHeadsigns] ?? false
                     ),

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -94,6 +94,14 @@ class SettingsViewModel: ObservableObject {
                         setting: .searchRouteResults,
                         value: settings[.searchRouteResults] ?? false
                     ),
+                    .toggle(
+                        label: NSLocalizedString(
+                            "Trip Headsigns",
+                            comment: "A setting on the More page to use the destination/headsign on each individual trip in Nearby Transit (only visible for developers)"
+                        ),
+                        setting: .tripHeadsigns,
+                        value: settings[.tripHeadsigns] ?? false
+                    ),
                 ]),
                 MoreSection(id: .other, items: [
                     .link(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
@@ -1,0 +1,457 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.NearbyHierarchy.DirectionOrHeadsign
+import com.mbta.tid.mbta_app.model.NearbyHierarchy.LineOrRoute
+import com.mbta.tid.mbta_app.model.NearbyHierarchy.NearbyLeaf
+import com.mbta.tid.mbta_app.model.NearbyHierarchy.RouteAtStop
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import io.github.dellisd.spatialk.geojson.Position
+import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
+import io.github.dellisd.spatialk.turf.distance
+import kotlinx.datetime.Instant
+
+private typealias InnerLayer = Map<DirectionOrHeadsign, NearbyLeaf>
+
+private typealias MiddleLayerData = RouteAtStop<List<Direction>, InnerLayer>
+
+private typealias MiddleLayer = Map<Stop, MiddleLayerData>
+
+private typealias OuterLayer = Map<LineOrRoute, MiddleLayer>
+
+data class NearbyHierarchy(private val data: OuterLayer) {
+    sealed interface LineOrRoute {
+        data class Line(
+            val line: com.mbta.tid.mbta_app.model.Line,
+            val routes: Set<com.mbta.tid.mbta_app.model.Route>
+        ) : LineOrRoute
+
+        data class Route(val route: com.mbta.tid.mbta_app.model.Route) : LineOrRoute
+    }
+
+    data class RouteAtStop<StopData, T>(val stopData: StopData, val data: T) {
+        fun <U> map(f: (T) -> U): RouteAtStop<StopData, U> = RouteAtStop(stopData, f(data))
+    }
+
+    sealed interface DirectionOrHeadsign {
+        data class Direction(val direction: com.mbta.tid.mbta_app.model.Direction) :
+            DirectionOrHeadsign
+
+        data class Headsign(val headsign: String, val route: Route, val line: Line?) :
+            DirectionOrHeadsign
+    }
+
+    data class PartialHierarchy<StopData, T>(
+        val data: Map<LineOrRoute, Map<Stop, RouteAtStop<StopData, T>>>
+    ) {
+        fun <U> map(f: (T) -> U): PartialHierarchy<StopData, U> =
+            data
+                .mapValues { (_, routeData) ->
+                    routeData.mapValues { (_, routeAtStop) -> routeAtStop.map(f) }
+                }
+                .let(::PartialHierarchy)
+
+        fun <SD2, U> map(
+            processStopData: (StopData) -> SD2,
+            processData: (T) -> U
+        ): PartialHierarchy<SD2, U> =
+            data
+                .mapValues { (_, routeData) ->
+                    routeData.mapValues { (_, routeAtStop) ->
+                        RouteAtStop(
+                            processStopData(routeAtStop.stopData),
+                            processData(routeAtStop.data)
+                        )
+                    }
+                }
+                .let(::PartialHierarchy)
+
+        fun <U> mapInContext(
+            f: (LineOrRoute, Stop, StopData, T) -> U
+        ): PartialHierarchy<StopData, U> =
+            data
+                .mapValues { (lineOrRoute, routeData) ->
+                    routeData.mapValues { (stop, routeAtStop) ->
+                        routeAtStop.map { f(lineOrRoute, stop, routeAtStop.stopData, it) }
+                    }
+                }
+                .let(::PartialHierarchy)
+
+        fun <SD2> mapStopDataInContext(
+            f: (LineOrRoute, Stop, StopData, T) -> SD2
+        ): PartialHierarchy<SD2, T> =
+            data
+                .mapValues { (lineOrRoute, routeData) ->
+                    routeData.mapValues { (stop, routeAtStop) ->
+                        RouteAtStop(
+                            f(lineOrRoute, stop, routeAtStop.stopData, routeAtStop.data),
+                            routeAtStop.data
+                        )
+                    }
+                }
+                .let(::PartialHierarchy)
+
+        fun <SD2, U> zip(
+            other: PartialHierarchy<SD2, U>
+        ): PartialHierarchy<Pair<StopData?, SD2?>, Pair<T?, U?>> =
+            (data.keys + other.data.keys)
+                .associateWith { lineOrRoute ->
+                    (data[lineOrRoute]?.keys.orEmpty() + other.data[lineOrRoute]?.keys.orEmpty())
+                        .associateWith { stop ->
+                            val ownData = data[lineOrRoute]?.get(stop)
+                            val otherData = other.data[lineOrRoute]?.get(stop)
+                            RouteAtStop(
+                                Pair(ownData?.stopData, otherData?.stopData),
+                                Pair(ownData?.data, otherData?.data)
+                            )
+                        }
+                }
+                .let(::PartialHierarchy)
+    }
+
+    fun <U> mapEntries(f: (Map.Entry<LineOrRoute, MiddleLayer>) -> U): List<U> = data.map(f)
+
+    data class NearbyLeaf(
+        val childStopIds: Set<String>,
+        val routePatterns: Set<RoutePattern?>,
+        val upcomingTrips: List<UpcomingTrip>,
+    ) {
+        fun filterCancellations(isSubway: Boolean) =
+            this.copy(upcomingTrips = upcomingTrips.filterCancellations(isSubway))
+    }
+
+    data class MutableNearbyLeaf(
+        val childStopIds: MutableSet<String>,
+        val routePatterns: MutableSet<RoutePattern?>,
+        val upcomingTrips: MutableList<UpcomingTrip>,
+    ) {
+        constructor() : this(mutableSetOf(), mutableSetOf(), mutableListOf())
+
+        fun finished() = NearbyLeaf(childStopIds, routePatterns, upcomingTrips)
+    }
+
+    companion object {
+        /**
+         * Groups route patterns at the nearby stops into a [PartialHierarchy], keeping child stop
+         * IDs listed separately under their parent stop.
+         *
+         * Keeps redundant stops on the same route pattern since we need to filter those later to
+         * account for unexpected realtime data.
+         */
+        fun fromStatic(
+            global: GlobalResponse,
+            nearby: NearbyResponse,
+        ): PartialHierarchy<List<Direction>, Map<String, Set<RoutePattern>>> {
+            val result =
+                mutablePartialHierarchy<List<Direction>, MutableMap<String, Set<RoutePattern>>>()
+            for (childStopId in nearby.stopIds) {
+                val parentStop = parentStop(global, childStopId) ?: continue
+                val allRoutePatterns =
+                    global.patternIdsByStop[childStopId].orEmpty().mapNotNull {
+                        global.routePatterns[it]
+                    }
+                for ((routeId, routePatterns) in allRoutePatterns.groupBy { it.routeId }) {
+                    val lineOrRoute = lineOrRoute(global, routeId) ?: continue
+                    result
+                        .getOrPut(lineOrRoute, ::mutableMapOf)
+                        .getOrPut(
+                            parentStop,
+                            { RouteAtStop(stopData = TODO(), data = mutableMapOf()) }
+                        )
+                        .data[childStopId] = routePatterns.toSet()
+                }
+            }
+            return PartialHierarchy(result).map { it }
+        }
+
+        fun fromSchedules(
+            global: GlobalResponse,
+            schedules: ScheduleResponse,
+        ): PartialHierarchy<Unit, List<Schedule>> {
+            val result = mutablePartialHierarchy<Unit, MutableList<Schedule>>()
+
+            for (schedule in schedules.schedules) {
+                val parentStop = parentStop(global, schedule.stopId) ?: continue
+                val lineOrRoute = lineOrRoute(global, schedule.routeId) ?: continue
+                result
+                    .getOrPut(lineOrRoute, ::mutableMapOf)
+                    .getOrPut(parentStop) { RouteAtStop(Unit, mutableListOf()) }
+                    .data
+                    .add(schedule)
+            }
+
+            return PartialHierarchy(result).map { it }
+        }
+
+        fun fromPredictions(
+            global: GlobalResponse,
+            predictions: PredictionsStreamDataResponse,
+        ): PartialHierarchy<Unit, List<Prediction>> {
+            val result = mutablePartialHierarchy<Unit, MutableList<Prediction>>()
+
+            for (prediction in predictions.predictions.values) {
+                val parentStop = parentStop(global, prediction.stopId) ?: continue
+                val lineOrRoute = lineOrRoute(global, prediction.routeId) ?: continue
+                result
+                    .getOrPut(lineOrRoute, ::mutableMapOf)
+                    .getOrPut(parentStop) { RouteAtStop(Unit, mutableListOf()) }
+                    .data
+                    .add(prediction)
+            }
+
+            return PartialHierarchy(result).map { it }
+        }
+
+        fun fromRealtime(
+            global: GlobalResponse,
+            schedules: ScheduleResponse?,
+            predictions: PredictionsStreamDataResponse,
+            filterAtTime: Instant,
+        ): PartialHierarchy<Unit, List<UpcomingTrip>> =
+            schedules
+                ?.let { fromSchedules(global, it) }
+                .orEmpty()
+                .zip(fromPredictions(global, predictions))
+                .map(
+                    {},
+                    { (schedulesHere, predictionsHere) ->
+                        UpcomingTrip.tripsFromData(
+                            global.stops,
+                            schedulesHere.orEmpty(),
+                            predictionsHere.orEmpty(),
+                            schedules?.trips.orEmpty() + predictions.trips,
+                            predictions.vehicles,
+                            filterAtTime,
+                        )
+                    }
+                )
+
+        fun fromStaticData(
+            staticData: NearbyStaticData
+        ): PartialHierarchy<List<Direction>, Map<String, Set<RoutePattern>>> {
+            val routePatternsInHierarchy =
+                staticData.data.associate { transitWithStops ->
+                    val lineOrRoute =
+                        when (transitWithStops) {
+                            is NearbyStaticData.TransitWithStops.ByLine ->
+                                LineOrRoute.Line(
+                                    transitWithStops.line,
+                                    transitWithStops.routes.filterNot { it.isShuttle }.toSet()
+                                )
+                            is NearbyStaticData.TransitWithStops.ByRoute ->
+                                LineOrRoute.Route(transitWithStops.route)
+                        }
+                    val stopPatterns =
+                        transitWithStops.patternsByStop.associate { stopPatterns ->
+                            val stop = stopPatterns.stop
+                            val patternsByChildStop =
+                                mutableMapOf<String, MutableSet<RoutePattern>>()
+                            for (staticPattern in stopPatterns.patterns) {
+                                staticPattern.stopIds.forEach { stopId ->
+                                    patternsByChildStop
+                                        .getOrPut(stopId, ::mutableSetOf)
+                                        .addAll(staticPattern.patterns)
+                                }
+                            }
+                            val routeAtStop =
+                                RouteAtStop(
+                                    stopPatterns.directions,
+                                    patternsByChildStop.mapValues { it.value.toSet() }
+                                )
+                            Pair(stop, routeAtStop)
+                        }
+                    Pair(lineOrRoute, stopPatterns)
+                }
+            return PartialHierarchy(routePatternsInHierarchy)
+        }
+
+        private fun lineOrRoute(global: GlobalResponse, routeId: String): LineOrRoute? {
+            val route = global.routes[routeId] ?: return null
+            return if (NearbyStaticData.groupedLines.contains(route.lineId)) {
+                val line = global.lines[route.lineId] ?: return null
+                val routes =
+                    global.routes.values.filter { it.lineId == line.id && !it.isShuttle }.toSet()
+                LineOrRoute.Line(line, routes)
+            } else {
+                LineOrRoute.Route(route)
+            }
+        }
+
+        private fun parentStop(global: GlobalResponse, stopId: String): Stop? {
+            val stop = global.stops[stopId] ?: return null
+            return stop.resolveParent(global.stops)
+        }
+
+        private fun <StopData, T> mutablePartialHierarchy():
+            MutableMap<LineOrRoute, MutableMap<Stop, RouteAtStop<StopData, T>>> = mutableMapOf()
+    }
+}
+
+fun <SD, T> NearbyHierarchy.PartialHierarchy<SD, T>?.orEmpty():
+    NearbyHierarchy.PartialHierarchy<SD, T> = this ?: NearbyHierarchy.PartialHierarchy(emptyMap())
+
+fun NearbyHierarchy.PartialHierarchy<
+    Pair<List<Direction>?, Unit?>, Pair<Map<String, Set<RoutePattern>>?, List<UpcomingTrip>?>
+>
+    .withLabels(global: GlobalResponse): NearbyHierarchy {
+    return this.mapInContext { lineOrRoute, stop, _, (routePatternsByChildStop, upcomingTrips) ->
+            val groupedDirectionForPattern: Map<String, Direction?> =
+                when (lineOrRoute) {
+                    is LineOrRoute.Line -> {
+                        val allPatterns = routePatternsByChildStop.orEmpty().flatMap { it.value }
+
+                        val patternsByDirection =
+                            allPatterns
+                                .groupBy { pattern ->
+                                    val route =
+                                        global.routes[pattern.routeId] ?: return@groupBy null
+                                    Direction.getDirectionForPattern(global, stop, route, pattern)
+                                }
+                                .filter { it.key != null && it.value.size > 1 }
+
+                        patternsByDirection.entries
+                            .flatMap { (direction, patterns) ->
+                                patterns.map { pattern -> pattern.id to direction }
+                            }
+                            .toMap()
+                    }
+                    is LineOrRoute.Route -> emptyMap()
+                }
+
+            val result = mutableMapOf<DirectionOrHeadsign, NearbyHierarchy.MutableNearbyLeaf>()
+
+            fun leaf(direction: Direction) =
+                result.getOrPut(DirectionOrHeadsign.Direction(direction)) {
+                    NearbyHierarchy.MutableNearbyLeaf()
+                }
+            fun leaf(headsign: String, route: Route, line: Line?) =
+                result.getOrPut(DirectionOrHeadsign.Headsign(headsign, route, line)) {
+                    NearbyHierarchy.MutableNearbyLeaf()
+                }
+
+            for ((childStopId, allRoutePatterns) in routePatternsByChildStop.orEmpty()) {
+                allRoutePatterns
+                    .groupBy { groupedDirectionForPattern[it.id] }
+                    .forEach { (direction, routePatterns) ->
+                        if (direction != null) {
+                            val leaf = leaf(direction)
+                            leaf.childStopIds.add(childStopId)
+                            leaf.routePatterns.addAll(routePatterns)
+                        } else {
+                            for (routePattern in routePatterns) {
+                                val headsign =
+                                    global.trips[routePattern.representativeTripId]?.headsign
+                                        ?: continue
+                                val route = global.routes[routePattern.routeId] ?: continue
+                                val line = (lineOrRoute as? LineOrRoute.Line)?.line
+                                val leaf = leaf(headsign, route, line)
+                                leaf.childStopIds.add(childStopId)
+                                leaf.routePatterns.add(routePattern)
+                            }
+                        }
+                    }
+            }
+
+            for (upcomingTrip in upcomingTrips.orEmpty()) {
+                val direction = groupedDirectionForPattern[upcomingTrip.trip.routePatternId]
+                val leaf =
+                    if (direction != null) {
+                        leaf(direction)
+                    } else {
+                        val route = global.routes[upcomingTrip.trip.routeId] ?: continue
+                        val line = (lineOrRoute as? LineOrRoute.Line)?.line
+                        leaf(upcomingTrip.trip.headsign, route, line)
+                    }
+                val stopId = upcomingTrip.stopId
+                if (stopId != null) {
+                    leaf.childStopIds.add(upcomingTrip.stopId)
+                }
+                // allow null here since an added trip may actually have a null route pattern
+                val routePattern = global.routePatterns[upcomingTrip.trip.routePatternId]
+                leaf.routePatterns.add(routePattern)
+                leaf.upcomingTrips.add(upcomingTrip)
+            }
+
+            result.mapValues { it.value.finished() }
+        }
+        .mapStopDataInContext({ lineOrRoute, stop, (stopDirections, _), dataWithinStop ->
+            stopDirections
+                ?: when (lineOrRoute) {
+                    is LineOrRoute.Line -> {
+                        listOf(0, 1).map { directionId ->
+                            val typicalHere =
+                                dataWithinStop.filterValues { leaf ->
+                                    leaf.routePatterns.any { pattern ->
+                                        pattern?.typicality == RoutePattern.Typicality.Typical &&
+                                            pattern.directionId == directionId
+                                    }
+                                }
+                            if (typicalHere.isEmpty()) {
+                                Direction(directionId, lineOrRoute.routes.first())
+                            } else if (typicalHere.size > 1) {
+                                Direction(
+                                    lineOrRoute.routes.first().directionNames[directionId] ?: "",
+                                    null,
+                                    directionId
+                                )
+                            } else {
+                                val typicalEntry = typicalHere.entries.single()
+                                when (val key = typicalEntry.key) {
+                                    is DirectionOrHeadsign.Direction -> key.direction
+                                    // TODO check this vs the ForLine.groupedDirection edge case
+                                    is DirectionOrHeadsign.Headsign ->
+                                        Direction(
+                                            key.route.directionNames[directionId] ?: "",
+                                            key.headsign,
+                                            directionId
+                                        )
+                                }
+                            }
+                        }
+                    }
+                    is LineOrRoute.Route ->
+                        listOf(Direction(0, lineOrRoute.route), Direction(1, lineOrRoute.route))
+                }
+        })
+        .let { NearbyHierarchy(it.data) }
+}
+
+@OptIn(ExperimentalTurfApi::class)
+fun MiddleLayer.pickOnlyNearest(sortByDistanceFrom: Position?): MiddleLayer {
+    if (sortByDistanceFrom == null) {
+        // in nearby transit, we always pass sortByDistanceFrom, so this means we're in unfiltered
+        // stop details, where there's only one stop anyway
+        return this
+    }
+    val result =
+        mutableMapOf<
+            Stop, RouteAtStop<List<Direction>, MutableMap<DirectionOrHeadsign, NearbyLeaf>>
+        >()
+    val routePatternIdsShown = mutableSetOf<String?>()
+
+    for ((stop, routeAtStop) in
+        this.entries.sortedBy { distance(it.key.position, sortByDistanceFrom) }) {
+        val newRoutePatternIds =
+            routeAtStop.data.values
+                .flatMap { it.routePatterns.map { it?.id } }
+                .distinct()
+                .filterNot { routePatternIdsShown.contains(it) }
+        for ((directionOrHeadsign, leaf) in routeAtStop.data) {
+            val newRoutePatterns = leaf.routePatterns.filter { newRoutePatternIds.contains(it?.id) }
+            val newUpcomingTrips =
+                leaf.upcomingTrips.filter { newRoutePatternIds.contains(it.trip.routePatternId) }
+            result
+                .getOrPut(stop) { RouteAtStop(routeAtStop.stopData, mutableMapOf()) }
+                .data[directionOrHeadsign] =
+                leaf.copy(
+                    routePatterns = newRoutePatterns.toSet(),
+                    upcomingTrips = newUpcomingTrips
+                )
+            routePatternIdsShown.addAll(newRoutePatternIds)
+        }
+    }
+
+    return result.mapValues { it.value.map { it } }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
@@ -354,6 +354,10 @@ fun NearbyHierarchy.PartialHierarchy<
                                             pattern.directionId == directionId
                                     }
                                 }
+                            // Directions in this fallback will not check overrides, but this only
+                            // happens if an entire route-at-stop is only present in the realtime
+                            // data, and StaticPatterns.ForLine.groupedDirection also doesn't check
+                            // overrides, so it's probably fine
                             if (typicalHere.isEmpty()) {
                                 Direction(directionId, lineOrRoute.routes.first())
                             } else if (typicalHere.size > 1) {
@@ -366,7 +370,6 @@ fun NearbyHierarchy.PartialHierarchy<
                                 val typicalEntry = typicalHere.entries.single()
                                 when (val key = typicalEntry.key) {
                                     is DirectionOrHeadsign.Direction -> key.direction
-                                    // TODO check this vs the ForLine.groupedDirection edge case
                                     is DirectionOrHeadsign.Headsign ->
                                         Direction(
                                             key.route.directionNames[directionId] ?: "",

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
@@ -119,6 +119,13 @@ data class NearbyHierarchy(private val data: OuterLayer) {
     ) {
         fun filterCancellations(isSubway: Boolean) =
             this.copy(upcomingTrips = upcomingTrips.filterCancellations(isSubway))
+
+        fun filterPatterns(predicate: (RoutePattern?) -> Boolean): NearbyLeaf {
+            val newPatterns = routePatterns.filter(predicate).toSet()
+            val newPatternIds = newPatterns.map { it?.id }
+            val newTrips = upcomingTrips.filter { it.trip.routePatternId in newPatternIds }
+            return this.copy(routePatterns = newPatterns, upcomingTrips = newTrips)
+        }
     }
 
     data class MutableNearbyLeaf(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -658,12 +658,6 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
 
     val allDataLoaded = schedules != null
 
-    val rewrittenThis =
-        if (schedules == null) this
-        else
-            TemporaryTerminalFilter(this, predictions, globalData, activeRelevantAlerts, schedules)
-                .filtered()
-
     // add predictions and apply filtering
     val cutoffTime = hideNonTypicalPatternsBeyondNext?.let { filterAtTime + it }
     val hasSchedulesTodayByPattern = NearbyStaticData.getSchedulesTodayByPattern(schedules)
@@ -688,7 +682,7 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
     }
 
     val nearbyHierarchy =
-        NearbyHierarchy.fromStaticData(rewrittenThis)
+        NearbyHierarchy.fromStaticData(this)
             .zip(NearbyHierarchy.fromRealtime(globalData, schedules, predictions, filterAtTime))
             .withLabels(globalData)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -203,6 +203,7 @@ class ObjectCollectionBuilder {
 
         fun representativeTrip(block: TripBuilder.() -> Unit = {}) =
             this@ObjectCollectionBuilder.trip {
+                    routeId = this@RoutePatternBuilder.routeId
                     routePatternId = this@RoutePatternBuilder.id
                     directionId = this@RoutePatternBuilder.directionId
                     block()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -101,7 +101,6 @@ data class PatternsByStop(
                         )
                     is NearbyHierarchy.DirectionOrHeadsign.Direction ->
                         resolveRealtimePatternForDirection(
-                            // TODO route not yet possible
                             checkNotNull(lineOrRoute as? NearbyHierarchy.LineOrRoute.Line),
                             directionOrHeadsign,
                             leaf,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -68,6 +68,55 @@ data class PatternsByStop(
     )
 
     constructor(
+        lineOrRoute: NearbyHierarchy.LineOrRoute,
+        stop: Stop,
+        directions: List<Direction>,
+        stopData: Map<NearbyHierarchy.DirectionOrHeadsign, NearbyHierarchy.NearbyLeaf>,
+        patternsPredicate: (RealtimePatterns) -> Boolean,
+        alerts: Collection<Alert>,
+        hasSchedulesTodayByPattern: Map<String, Boolean>?,
+        allDataLoaded: Boolean,
+    ) : this(
+        when (lineOrRoute) {
+            is NearbyHierarchy.LineOrRoute.Route -> listOf(lineOrRoute.route)
+            is NearbyHierarchy.LineOrRoute.Line -> lineOrRoute.routes.sorted()
+        },
+        when (lineOrRoute) {
+            is NearbyHierarchy.LineOrRoute.Route -> null
+            is NearbyHierarchy.LineOrRoute.Line -> lineOrRoute.line
+        },
+        stop,
+        stopData
+            .flatMap { (directionOrHeadsign, leaf) ->
+                when (directionOrHeadsign) {
+                    is NearbyHierarchy.DirectionOrHeadsign.Headsign ->
+                        listOf(
+                            RealtimePatterns.ByHeadsign(
+                                directionOrHeadsign,
+                                leaf,
+                                alerts,
+                                hasSchedulesTodayByPattern,
+                                allDataLoaded
+                            )
+                        )
+                    is NearbyHierarchy.DirectionOrHeadsign.Direction ->
+                        resolveRealtimePatternForDirection(
+                            // TODO route not yet possible
+                            checkNotNull(lineOrRoute as? NearbyHierarchy.LineOrRoute.Line),
+                            directionOrHeadsign,
+                            leaf,
+                            alerts,
+                            hasSchedulesTodayByPattern,
+                            allDataLoaded
+                        )
+                }
+            }
+            .filter(patternsPredicate)
+            .sortedWith(PatternSorting.compareRealtimePatterns()),
+        directions
+    )
+
+    constructor(
         route: Route,
         stop: Stop,
         patterns: List<RealtimePatterns>
@@ -76,8 +125,7 @@ data class PatternsByStop(
     @OptIn(ExperimentalTurfApi::class)
     fun distanceFrom(position: Position) = distance(position, this.position)
 
-    fun allUpcomingTrips(): List<UpcomingTrip> =
-        this.patterns.flatMap { it.upcomingTrips ?: emptyList() }.sorted()
+    fun allUpcomingTrips(): List<UpcomingTrip> = this.patterns.flatMap { it.upcomingTrips }.sorted()
 
     fun alertsHereFor(directionId: Int, global: GlobalResponse): List<Alert> {
         val patternsInDirection = this.patterns.filter { it.directionId() == directionId }
@@ -87,7 +135,7 @@ data class PatternsByStop(
                 .flatMap { realtime ->
                     realtime.patterns.mapNotNull { pattern ->
                         stopIds.firstOrNull {
-                            global.trips[pattern.representativeTripId]?.stopIds?.contains(it)
+                            global.trips[pattern?.representativeTripId]?.stopIds?.contains(it)
                                 ?: false
                         }
                     }
@@ -182,6 +230,73 @@ data class PatternsByStop(
             )
         }
 
+        fun resolveRealtimePatternForDirection(
+            line: NearbyHierarchy.LineOrRoute.Line,
+            direction: NearbyHierarchy.DirectionOrHeadsign.Direction,
+            leaf: NearbyHierarchy.NearbyLeaf,
+            alerts: Collection<Alert>,
+            hasSchedulesTodayByPattern: Map<String, Boolean>?,
+            allDataLoaded: Boolean,
+        ): List<RealtimePatterns> {
+            val typicalPatternsByRoute = getTypicalPatternsByRoute(leaf)
+
+            // If data hasn't loaded, or there are more than one typical routes in this direction,
+            // we never want to split into individual headsign rows.
+            if (!allDataLoaded || typicalPatternsByRoute.size > 1) {
+                return listOf(
+                    RealtimePatterns.ByDirection(
+                        line,
+                        direction,
+                        leaf,
+                        alerts,
+                        hasSchedulesTodayByPattern,
+                        allDataLoaded
+                    )
+                )
+            }
+
+            val patternsById = leaf.routePatterns.associateBy { it?.id }
+            val headsignsAndPatternsToDisplayByRoute =
+                getHeadsignsAndPatternsToDisplayByRoute(leaf, typicalPatternsByRoute)
+
+            // If there is only a single route with predicted or typical trips, we want to break up
+            // the grouped direction instead into individual headsign rows.
+            val firstDisplayedRoute =
+                line.routes.firstOrNull {
+                    it.id == headsignsAndPatternsToDisplayByRoute.keys.firstOrNull()
+                }
+            if (headsignsAndPatternsToDisplayByRoute.size == 1 && firstDisplayedRoute != null) {
+                val headsignsToDisplay =
+                    (headsignsAndPatternsToDisplayByRoute[firstDisplayedRoute.id] ?: emptyMap())
+                return headsignsToDisplay.map { (headsign, patternIds) ->
+                    val patternsForHeadsign = patternIds.mapNotNull { patternsById[it] }
+                    RealtimePatterns.ByHeadsign(
+                        NearbyHierarchy.DirectionOrHeadsign.Headsign(
+                            headsign,
+                            firstDisplayedRoute,
+                            line.line
+                        ),
+                        // TODO filter patterns
+                        leaf,
+                        alerts,
+                        hasSchedulesTodayByPattern,
+                        allDataLoaded
+                    )
+                }
+            }
+
+            return listOf(
+                RealtimePatterns.ByDirection(
+                    line,
+                    direction,
+                    leaf,
+                    alerts,
+                    hasSchedulesTodayByPattern,
+                    allDataLoaded
+                )
+            )
+        }
+
         private fun getHeadsignsAndPatternsToDisplayByRoute(
             staticData: NearbyStaticData.StaticPatterns.ByDirection,
             upcomingTripsMap: UpcomingTripsMap?,
@@ -227,6 +342,48 @@ data class PatternsByStop(
                 .toMap()
         }
 
+        private fun getHeadsignsAndPatternsToDisplayByRoute(
+            leaf: NearbyHierarchy.NearbyLeaf,
+            typicalPatternsByRoute: Map<String, List<String>>,
+        ): Map<String, Map<String, Set<String?>>> {
+            val tripsByPattern = getTripsByPattern(leaf)
+            val predictedPatternsByRoute = getPredictedPatternsByRoute(leaf, tripsByPattern)
+            val upcomingPatternsByRouteAndHeadsign =
+                tripsByPattern.values
+                    .flatten()
+                    .groupBy({ it.trip.routeId }, { it.trip.headsign to it.trip.routePatternId })
+                    .mapValues { routeEntry ->
+                        routeEntry.value.groupBy({ it.first }, { it.second })
+                    }
+
+            // We don't have access to global data or representative trips here, so the only way
+            // that we can determine headsigns is by looking at the actual upcoming trips.
+            return upcomingPatternsByRouteAndHeadsign
+                .mapNotNull {
+                    val headsignsToDisplay =
+                        it.value
+                            .mapNotNull { headsignsToPatterns ->
+                                val patternsToDisplay =
+                                    (typicalPatternsByRoute[it.key].orEmpty() +
+                                            predictedPatternsByRoute[it.key].orEmpty())
+                                        .toSet()
+                                        .intersect(headsignsToPatterns.value.toSet())
+                                if (patternsToDisplay.isEmpty()) {
+                                    null
+                                } else {
+                                    headsignsToPatterns.key to patternsToDisplay
+                                }
+                            }
+                            .toMap()
+                    if (headsignsToDisplay.isEmpty()) {
+                        null
+                    } else {
+                        it.key to headsignsToDisplay
+                    }
+                }
+                .toMap()
+        }
+
         private fun getPredictedPatternsByRoute(
             staticData: NearbyStaticData.StaticPatterns.ByDirection,
             tripsByPattern: Map<String, List<UpcomingTrip>>
@@ -234,6 +391,24 @@ data class PatternsByStop(
             return staticData.patterns
                 .filter { tripsByPattern[it.id]?.any { trip -> trip.prediction != null } == true }
                 .groupBy({ it.routeId }, { it.id })
+        }
+
+        private fun getPredictedPatternsByRoute(
+            leaf: NearbyHierarchy.NearbyLeaf,
+            tripsByPattern: Map<String?, List<UpcomingTrip>>
+        ): Map<String, List<String?>> {
+            return leaf.routePatterns
+                .filter { tripsByPattern[it?.id]?.any { trip -> trip.prediction != null } == true }
+                .groupBy(
+                    { pattern ->
+                        pattern?.routeId
+                            ?: leaf.upcomingTrips
+                                .first { it.trip.routePatternId == pattern?.id }
+                                .trip
+                                .routeId
+                    },
+                    { it?.id }
+                )
         }
 
         private fun getTripsByPattern(
@@ -261,10 +436,25 @@ data class PatternsByStop(
                 .toMap()
         }
 
+        private fun getTripsByPattern(
+            leaf: NearbyHierarchy.NearbyLeaf,
+        ): Map<String?, List<UpcomingTrip>> {
+            return leaf.upcomingTrips.groupBy { it.trip.routePatternId }
+        }
+
         private fun getTypicalPatternsByRoute(
             staticData: NearbyStaticData.StaticPatterns.ByDirection
         ): Map<String, List<String>> {
             return staticData.patterns
+                .filter { it.typicality == RoutePattern.Typicality.Typical }
+                .groupBy({ it.routeId }, { it.id })
+        }
+
+        private fun getTypicalPatternsByRoute(
+            leaf: NearbyHierarchy.NearbyLeaf
+        ): Map<String, List<String>> {
+            return leaf.routePatterns
+                .filterNotNull()
                 .filter { it.typicality == RoutePattern.Typicality.Typical }
                 .groupBy({ it.routeId }, { it.id })
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -254,7 +254,6 @@ data class PatternsByStop(
                 )
             }
 
-            val patternsById = leaf.routePatterns.associateBy { it?.id }
             val headsignsAndPatternsToDisplayByRoute =
                 getHeadsignsAndPatternsToDisplayByRoute(leaf, typicalPatternsByRoute)
 
@@ -268,15 +267,13 @@ data class PatternsByStop(
                 val headsignsToDisplay =
                     (headsignsAndPatternsToDisplayByRoute[firstDisplayedRoute.id] ?: emptyMap())
                 return headsignsToDisplay.map { (headsign, patternIds) ->
-                    val patternsForHeadsign = patternIds.mapNotNull { patternsById[it] }
                     RealtimePatterns.ByHeadsign(
                         NearbyHierarchy.DirectionOrHeadsign.Headsign(
                             headsign,
                             firstDisplayedRoute,
                             line.line
                         ),
-                        // TODO filter patterns
-                        leaf,
+                        leaf.filterPatterns { it?.id in patternIds },
                         alerts,
                         hasSchedulesTodayByPattern,
                         allDataLoaded

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -41,6 +41,7 @@ sealed class RealtimePatterns {
 
     abstract val id: String
 
+    // contains null if an added trip with no pattern is included in the upcoming trips
     abstract val patterns: List<RoutePattern?>
     abstract val upcomingTrips: List<UpcomingTrip>
     abstract val alertsHere: List<Alert>?

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -41,7 +41,8 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             predictions: PredictionsStreamDataResponse?,
             alerts: AlertsStreamDataResponse?,
             pinnedRoutes: Set<String>,
-            filterAtTime: Instant
+            filterAtTime: Instant,
+            useTripHeadsigns: Boolean,
         ): StopDetailsDepartures? {
             val allStopIds =
                 if (global.patternIdsByStop.containsKey(stop.id)) {
@@ -52,19 +53,33 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
 
             val staticData = NearbyStaticData(global, NearbyResponse(allStopIds))
             val routes =
-                staticData
-                    .withRealtimeInfo(
-                        global,
-                        null,
-                        schedules,
-                        predictions,
-                        alerts,
-                        filterAtTime,
-                        showAllPatternsWhileLoading = true,
-                        hideNonTypicalPatternsBeyondNext = null,
-                        filterCancellations = false,
-                        pinnedRoutes
-                    )
+                if (useTripHeadsigns) {
+                        staticData.withRealtimeInfoViaTripHeadsigns(
+                            global,
+                            null,
+                            schedules,
+                            predictions,
+                            alerts,
+                            filterAtTime,
+                            showAllPatternsWhileLoading = true,
+                            hideNonTypicalPatternsBeyondNext = null,
+                            filterCancellations = false,
+                            pinnedRoutes
+                        )
+                    } else {
+                        staticData.withRealtimeInfoWithoutTripHeadsigns(
+                            global,
+                            null,
+                            schedules,
+                            predictions,
+                            alerts,
+                            filterAtTime,
+                            showAllPatternsWhileLoading = true,
+                            hideNonTypicalPatternsBeyondNext = null,
+                            filterCancellations = false,
+                            pinnedRoutes
+                        )
+                    }
                     ?.flatMap { it.patternsByStop }
 
             return routes?.let { StopDetailsDepartures(it) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -47,6 +47,11 @@ data class UpcomingTrip(
             schedule?.scheduleTime
         }
 
+    val stopId: String? = run {
+        // don't check that they match since prediction may be physical stop ID and schedule logical
+        prediction?.stopId ?: schedule?.stopId
+    }
+
     val stopSequence: Int? = run {
         if (schedule != null && prediction?.stopSequence != null) {
             check(schedule.stopSequence == prediction.stopSequence)
@@ -120,18 +125,13 @@ data class UpcomingTrip(
                     val schedulesHere = schedulesMap?.get(upcomingTripKey)
                     val predictionsHere = predictionsMap?.get(upcomingTripKey)
                     tripsFromData(
-                            stops,
-                            schedulesHere.orEmpty(),
-                            predictionsHere.orEmpty(),
-                            trips,
-                            predictions?.vehicles.orEmpty()
-                        )
-                        .filter { upcomingTrip ->
-                            if (upcomingTrip.prediction != null) return@filter true
-                            val scheduleTime =
-                                upcomingTrip.schedule?.scheduleTime ?: return@filter true
-                            scheduleTime >= filterAtTime
-                        }
+                        stops,
+                        schedulesHere.orEmpty(),
+                        predictionsHere.orEmpty(),
+                        trips,
+                        predictions?.vehicles.orEmpty(),
+                        filterAtTime
+                    )
                 }
             } else {
                 null
@@ -147,7 +147,8 @@ data class UpcomingTrip(
             schedules: List<Schedule>,
             predictions: List<Prediction>,
             trips: Map<String, Trip>,
-            vehicles: Map<String, Vehicle>
+            vehicles: Map<String, Vehicle>,
+            filterAtTime: Instant
         ): List<UpcomingTrip> {
             data class UpcomingTripKey(
                 val tripId: String,
@@ -186,6 +187,11 @@ data class UpcomingTrip(
                     )
                 }
                 .sorted()
+                .filter { upcomingTrip ->
+                    if (upcomingTrip.prediction != null) return@filter true
+                    val scheduleTime = upcomingTrip.schedule?.scheduleTime ?: return@filter true
+                    scheduleTime >= filterAtTime
+                }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -38,6 +38,7 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
+    TripHeadsigns(booleanPreferencesKey("tripHeadsigns_featureFlag")),
     HideMaps(booleanPreferencesKey("hide_maps")),
 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -719,7 +719,8 @@ class RealtimePatternsTest {
                 PredictionsStreamDataResponse(objects),
                 AlertsStreamDataResponse(objects),
                 Clock.System.now(),
-                emptySet()
+                emptySet(),
+                useTripHeadsigns = false,
             )
 
         assertEquals(
@@ -814,7 +815,8 @@ class RealtimePatternsTest {
                 PredictionsStreamDataResponse(objects),
                 AlertsStreamDataResponse(objects),
                 now,
-                emptySet()
+                emptySet(),
+                useTripHeadsigns = false,
             )
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -414,7 +414,8 @@ class UpcomingTripTest {
                 objects.schedules.values.toList(),
                 objects.predictions.values.toList(),
                 objects.trips,
-                objects.vehicles
+                objects.vehicles,
+                Clock.System.now()
             )
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -39,6 +39,7 @@ class SettingsRepositoryTest : KoinTest {
             mapOf(
                 Settings.DevDebugMode to true,
                 Settings.SearchRouteResults to false,
+                Settings.TripHeadsigns to false,
                 Settings.HideMaps to false,
             ),
             repo.getSettings()


### PR DESCRIPTION
### Summary

_Ticket:_ [Use trip headsigns in Nearby Transit](https://app.asana.com/0/1205732265579288/1208759166078934/f)

It probably makes sense to keep this behind a feature flag for a bit.

- [x] If you added any user facing strings on iOS, are they included in Localizable.xcstrings?

### Testing

Manually verified that the new logic works correctly. Made existing unit tests parametric to check both old and new code paths. Added a new unit test to ensure that the new code path delivers on its stated goals.

I have not written unit tests that directly check the NearbyHierarchy itself; I could do that, but this PR is already too large.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
