### PR TITLE
fix: don't crash opening trip details on a multi-route trip

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -139,9 +139,14 @@ data class TripDetailsStopList(val stops: List<Entry>) {
 
             var predictions = emptyList<Prediction>()
             if (tripPredictions != null) {
+                val tripRoute = tripPredictions.trips.values.singleOrNull()?.routeId
+                val tripPredictionsWithCorrectRoute =
+                    tripPredictions.predictions.values.filter {
+                        tripRoute == null || it.routeId == tripRoute
+                    }
                 predictions =
                     deduplicatePredictionsByStopSequence(
-                        tripPredictions.predictions.values,
+                        tripPredictionsWithCorrectRoute,
                         tripSchedules,
                         globalData
                     )


### PR DESCRIPTION
### Summary

_Ticket:_ [[duplicate prediction bugfix]](https://app.asana.com/0/1205732265579288/1208788669093055/f)
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1731701471451859?thread_ts=1731524220.060079&cid=C05QMG9GS9M)

Fixes a bug where multi-route trips with duplicated predictions on each route were causing trip details to crash since the logic there can't actually handle redundant predictions with the same stop sequence.

I'm hoping that there aren't secretly cases where this will cause problems of its own - I don't think it should be possible for there to be predictions on the wrong route without corresponding predictions on the right route.

### Testing

Validated that this fixes the bug as reported. Added a unit test to detect regressions.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
