### PR TITLE
fix: don't filter out temporary terminal if predictions suppressed

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalFilter.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalFilter.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.utils.resolveParentId
 
 /**
  * When part of a subway line is closed, should the headsign be the temporary terminal or the
@@ -96,8 +97,15 @@ class TemporaryTerminalFilter(
                             predictionsByRoute[pattern.routeId].orEmpty().any {
                                 it.routePatternId() == pattern.id
                             }
+                        val parallelPredictedHere =
+                            predictionsByRoute[pattern.routeId].orEmpty().any {
+                                it.routePatternId() != pattern.id &&
+                                    it.directionId == pattern.directionId &&
+                                    globalData.stops.resolveParentId(it.stopId) ==
+                                        stopPatterns.stop.id
+                            }
                         val typical = pattern.typicality == RoutePattern.Typicality.Typical
-                        scheduled && !predicted && !typical
+                        scheduled && !predicted && parallelPredictedHere && !typical
                     }
                 }
         )


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1731950568783199)

### Testing

Updated existing unit tests to still pass. Added a new unit test to check new functionality.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
