### PR TITLE
fix: never call Map.getValue in shared code

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,4 +1,5 @@
 import co.touchlab.skie.configuration.DefaultArgumentInterop
+import com.diffplug.spotless.FormatterFunc
 import com.mbta.tid.mbta_app.gradle.CachedExecTask
 import com.mbta.tid.mbta_app.gradle.CycloneDxBomTransformTask
 import com.mbta.tid.mbta_app.gradle.DependencyCodegenTask
@@ -105,6 +106,27 @@ skie {
     features {
         group { DefaultArgumentInterop.MaximumDefaultArgumentCount(8) }
         enableSwiftUIObservingPreview = true
+    }
+}
+
+spotless {
+    kotlin {
+        target("src/*Main/**/*.kt")
+        custom(
+            "ban getValue outside tests",
+            FormatterFunc.NeedsFile { text, file ->
+                val lines = text.lines()
+                for (line in lines.withIndex()) {
+                    val column = line.value.indexOf("getValue(")
+                    if (column != -1) {
+                        throw IllegalStateException(
+                            "${file.path}:${line.index + 1}:${column + 1} calls getValue"
+                        )
+                    }
+                }
+                text
+            }
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
@@ -55,25 +55,24 @@ typealias JSONArray = List<JSONValue>
 typealias JSONObject = Map<String, JSONValue>
 
 data class FeatureProperties(val data: JSONObject) {
-    operator fun get(property: FeatureProperty<Boolean>): Boolean =
-        data.getValue(property.key).boolean
+    operator fun get(property: FeatureProperty<Boolean>): Boolean? = data[property.key]?.boolean
 
-    operator fun get(property: FeatureProperty<Number>): Number = data.getValue(property.key).number
+    operator fun get(property: FeatureProperty<Number>): Number? = data[property.key]?.number
 
-    operator fun get(property: FeatureProperty<String>): String = data.getValue(property.key).string
+    operator fun get(property: FeatureProperty<String>): String? = data[property.key]?.string
 
-    operator fun get(property: FeatureProperty<List<String>>): List<String> =
-        data.getValue(property.key).array.map { it.string }
+    operator fun get(property: FeatureProperty<List<String>>): List<String>? =
+        data[property.key]?.array?.map { it.string }
 
     @JvmName("getMapStringString")
-    operator fun get(property: FeatureProperty<Map<String, String>>): Map<String, String> =
-        data.getValue(property.key).`object`.mapValues { it.value.string }
+    operator fun get(property: FeatureProperty<Map<String, String>>): Map<String, String>? =
+        data[property.key]?.`object`?.mapValues { it.value.string }
 
     @JvmName("getMapStringListString")
     operator fun get(
         property: FeatureProperty<Map<String, List<String>>>
-    ): Map<String, List<String>> =
-        data.getValue(property.key).`object`.mapValues { it.value.array.map { it.string } }
+    ): Map<String, List<String>>? =
+        data[property.key]?.`object`?.mapValues { it.value.array.map { it.string } }
 }
 
 class FeaturePropertiesBuilder(private val data: MutableMap<String, JSONValue> = mutableMapOf()) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -209,7 +209,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             val fullStopIds = mutableMapOf<String, MutableSet<String>>()
 
             nearby.stopIds.forEach { stopId ->
-                val stop = stops.getValue(stopId)
+                val stop = stops[stopId] ?: return@forEach
                 val newPatternIds =
                     patternIdsByStop
                         .getOrElse(stop.id) { emptyList() }
@@ -218,7 +218,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
 
                 val newPatternsByRoute =
                     newPatternIds
-                        .map { patternId -> routePatterns.getValue(patternId) }
+                        .mapNotNull { patternId -> routePatterns[patternId] }
                         .groupBy { it.routeId }
 
                 val stopKey =
@@ -228,13 +228,13 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                             .add(stop.id)
                         // Parents should be disjoint, but if somehow a parent has its own patterns,
                         // find it in the regular stops list
-                        stops.getValue(parentStationId)
+                        stops[parentStationId]
                     }
                         ?: stop
 
-                newPatternsByRoute.forEach { (routeId, routePatterns) ->
-                    val routeStops =
-                        patternsByRouteAndStop.getOrPut(routes.getValue(routeId)) { mutableMapOf() }
+                for ((routeId, routePatterns) in newPatternsByRoute) {
+                    val route = routes[routeId] ?: continue
+                    val routeStops = patternsByRouteAndStop.getOrPut(route) { mutableMapOf() }
                     val patternsForStop = routeStops.getOrPut(stopKey) { mutableListOf() }
                     patternsForStop += routePatterns
                 }
@@ -308,7 +308,9 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             global: GlobalResponse
         ): StopPatterns.ForRoute {
             val patternsByHeadsign =
-                patterns.groupBy { global.trips.getValue(it.representativeTripId).headsign }
+                patterns
+                    .groupBy { global.trips[it.representativeTripId]?.headsign }
+                    .filterKeys { it != null }
 
             return StopPatterns.ForRoute(
                 route = route,
@@ -318,7 +320,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                         .map { (headsign, routePatterns) ->
                             StaticPatterns.ByHeadsign(
                                 route,
-                                headsign,
+                                checkNotNull(headsign),
                                 null,
                                 routePatterns.sorted(),
                                 filterStopsByPatterns(routePatterns, global, allStopIds)
@@ -362,13 +364,13 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                     if (directionRoutes.filter { !it.id.startsWith("Shuttle-") }.size == 1) {
                         val route = directionRoutes.first()
                         val patternsByHeadsign =
-                            directionPatterns.groupBy {
-                                global.trips.getValue(it.representativeTripId).headsign
-                            }
+                            directionPatterns
+                                .groupBy { global.trips[it.representativeTripId]?.headsign }
+                                .filterKeys { it != null }
                         return@flatMap patternsByHeadsign.map { (headsign, patterns) ->
                             StaticPatterns.ByHeadsign(
                                 route,
-                                headsign,
+                                checkNotNull(headsign),
                                 line,
                                 patterns.sorted(),
                                 filterStopsByPatterns(patterns, global, allStopIds),
@@ -511,18 +513,18 @@ fun NearbyStaticData.withRealtimeInfo(
                 schedules,
                 predictions,
                 scheduleKey = { schedule, scheduleData ->
-                    val trip = scheduleData.trips.getValue(schedule.tripId)
+                    val trip = scheduleData.trips[schedule.tripId]
                     RealtimePatterns.UpcomingTripKey.ByRoutePattern(
                         schedule.routeId,
-                        trip.routePatternId,
+                        trip?.routePatternId,
                         globalStops.resolveParentId(schedule.stopId)
                     )
                 },
                 predictionKey = { prediction, streamData ->
-                    val trip = streamData.trips.getValue(prediction.tripId)
+                    val trip = streamData.trips[prediction.tripId]
                     RealtimePatterns.UpcomingTripKey.ByRoutePattern(
                         prediction.routeId,
-                        trip.routePatternId,
+                        trip?.routePatternId,
                         globalStops.resolveParentId(prediction.stopId)
                     )
                 },
@@ -536,7 +538,7 @@ fun NearbyStaticData.withRealtimeInfo(
                 schedules,
                 predictions,
                 scheduleKey = { schedule, scheduleData ->
-                    val trip = scheduleData.trips.getValue(schedule.tripId)
+                    val trip = scheduleData.trips[schedule.tripId] ?: return@tripsMappedBy null
                     RealtimePatterns.UpcomingTripKey.ByDirection(
                         schedule.routeId,
                         trip.directionId,
@@ -544,7 +546,7 @@ fun NearbyStaticData.withRealtimeInfo(
                     )
                 },
                 predictionKey = { prediction, streamData ->
-                    val trip = streamData.trips.getValue(prediction.tripId)
+                    val trip = streamData.trips[prediction.tripId] ?: return@tripsMappedBy null
                     RealtimePatterns.UpcomingTripKey.ByDirection(
                         prediction.routeId,
                         trip.directionId,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -120,7 +120,7 @@ class ObjectCollectionBuilder {
         var vehicleId: String? = null
 
         var trip: Trip
-            get() = trips.getValue(tripId)
+            get() = checkNotNull(trips[tripId])
             set(trip) {
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it }
                 tripId = trip.id
@@ -234,7 +234,7 @@ class ObjectCollectionBuilder {
         var tripId = ""
 
         var trip: Trip
-            get() = trips.getValue(tripId)
+            get() = checkNotNull(trips[tripId])
             set(trip) {
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it }
                 tripId = trip.id
@@ -382,22 +382,22 @@ class ObjectCollectionBuilder {
 
     fun upcomingTrip(schedule: Schedule, prediction: Prediction, vehicle: Vehicle): UpcomingTrip {
         check(schedule.tripId == prediction.tripId)
-        return UpcomingTrip(trips.getValue(prediction.tripId), schedule, prediction, vehicle)
+        return UpcomingTrip(checkNotNull(trips[prediction.tripId]), schedule, prediction, vehicle)
     }
 
     fun upcomingTrip(schedule: Schedule, prediction: Prediction): UpcomingTrip {
         check(schedule.tripId == prediction.tripId)
-        return UpcomingTrip(trips.getValue(prediction.tripId), schedule, prediction, null)
+        return UpcomingTrip(checkNotNull(trips[prediction.tripId]), schedule, prediction, null)
     }
 
     fun upcomingTrip(prediction: Prediction, vehicle: Vehicle) =
-        UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, vehicle)
+        UpcomingTrip(checkNotNull(trips[prediction.tripId]), null, prediction, vehicle)
 
     fun upcomingTrip(schedule: Schedule) =
-        UpcomingTrip(trips.getValue(schedule.tripId), schedule, null, null)
+        UpcomingTrip(checkNotNull(trips[schedule.tripId]), schedule, null, null)
 
     fun upcomingTrip(prediction: Prediction) =
-        UpcomingTrip(trips.getValue(prediction.tripId), null, prediction, null)
+        UpcomingTrip(checkNotNull(trips[prediction.tripId]), null, prediction, null)
 
     private fun <Built : BackendObject, Builder : ObjectBuilder<Built>> build(
         source: MutableMap<String, Built>,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
@@ -33,8 +33,8 @@ data class Stop(
          */
         fun equalOrFamily(stopId1: String, stopId2: String, stops: Map<String, Stop>): Boolean {
             if (stopId1 == stopId2) return true
-            val stop1 = stops.getValue(stopId1)
-            val stop2 = stops.getValue(stopId2)
+            val stop1 = stops[stopId1] ?: return false
+            val stop2 = stops[stopId2] ?: return false
             val parent1 = stop1.resolveParent(stops)
             val parent2 = stop2.resolveParent(stops)
             return parent1.id == parent2.id

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -184,9 +184,9 @@ data class TripDetailsStopList(val stops: List<Entry>) {
                             it.value.stopSequence < vehicle.currentStopSequence
                         }
                     }
-                    .map {
+                    .mapNotNull {
                         Entry(
-                            globalData.stops.getValue(it.value.stopId),
+                            globalData.stops[it.value.stopId] ?: return@mapNotNull null,
                             it.value.stopSequence,
                             getAlert(it.value, alertsData, globalData, tripId, directionId),
                             it.value.schedule,
@@ -235,7 +235,7 @@ data class TripDetailsStopList(val stops: List<Entry>) {
             entry: WorkingEntry,
             globalData: GlobalResponse
         ): List<Route> {
-            val stop = globalData.stops.getValue(entry.stopId)
+            val stop = globalData.stops[entry.stopId] ?: return emptyList()
             val selfOrParent =
                 if (stop.parentStationId == null) stop
                 else globalData.stops[stop.parentStationId] ?: return emptyList()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -96,8 +96,8 @@ data class UpcomingTrip(
             stops: Map<String, Stop>,
             schedules: ScheduleResponse?,
             predictions: PredictionsStreamDataResponse?,
-            scheduleKey: (Schedule, ScheduleResponse) -> Key,
-            predictionKey: (Prediction, PredictionsStreamDataResponse) -> Key,
+            scheduleKey: (Schedule, ScheduleResponse) -> Key?,
+            predictionKey: (Prediction, PredictionsStreamDataResponse) -> Key?,
             filterAtTime: Instant
         ): Map<Key, List<UpcomingTrip>>? {
 
@@ -115,7 +115,9 @@ data class UpcomingTrip(
                 }
             return if (schedulesMap != null || predictionsMap != null) {
                 val trips = schedules?.trips.orEmpty() + predictions?.trips.orEmpty()
-                val upcomingTripKeys = schedulesMap?.keys.orEmpty() + predictionsMap?.keys.orEmpty()
+                val upcomingTripKeys =
+                    schedulesMap?.keys.orEmpty().filterNotNull() +
+                        predictionsMap?.keys.orEmpty().filterNotNull()
                 upcomingTripKeys.associateWith { upcomingTripKey ->
                     val schedulesHere = schedulesMap?.get(upcomingTripKey)
                     val predictionsHere = predictionsMap?.get(upcomingTripKey)
@@ -177,9 +179,9 @@ data class UpcomingTrip(
             val keys = schedulesMap.keys + predictionsMap.keys
 
             return keys
-                .map { key ->
+                .mapNotNull { key ->
                     UpcomingTrip(
-                        trips.getValue(key.tripId),
+                        trips[key.tripId] ?: return@mapNotNull null,
                         schedulesMap[key],
                         predictionsMap[key],
                         predictionsMap[key]?.let { vehicles[it.vehicleId] }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
@@ -11,7 +11,7 @@ sealed class TripSchedulesResponse {
     @SerialName("schedules")
     data class Schedules(val schedules: List<Schedule>) : TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
-            schedules.map { globalData.stops.getValue(it.stopId) }
+            schedules.mapNotNull { globalData.stops[it.stopId] }
     }
 
     @Serializable
@@ -19,7 +19,7 @@ sealed class TripSchedulesResponse {
     data class StopIds(@SerialName("stop_ids") val stopIds: List<String>) :
         TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
-            stopIds.map { globalData.stops.getValue(it) }
+            stopIds.mapNotNull { globalData.stops[it] }
     }
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
@@ -41,12 +41,12 @@ class NearbyRepository : KoinComponent, INearbyRepository {
 
             val nearbyStopsAndSiblings =
                 nearbyLeafStops.flatMapTo(mutableSetOf()) { (stopId, distance) ->
-                    val stop = global.stops.getValue(stopId)
+                    val stop = global.stops[stopId] ?: return@flatMapTo emptyList()
                     val stopSiblings =
                         if (stop.parentStationId != null)
-                            global.stops
-                                .getValue(stop.parentStationId)
-                                .childStopIds
+                            global.stops[stop.parentStationId]
+                                ?.childStopIds
+                                .orEmpty()
                                 .mapNotNull(global.stops::get)
                         else listOf(stop)
                     val selectedStops =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -324,13 +324,13 @@ class StopFeaturesBuilderTest {
         val alewifeFeature = collection.features.find { it.id == "place-alfcl" }
         assertNotNull(alewifeFeature)
         val alewifeServiceStatus =
-            alewifeFeature.properties.get(StopFeaturesBuilder.propServiceStatusKey)
+            checkNotNull(alewifeFeature.properties[StopFeaturesBuilder.propServiceStatusKey])
         assertEquals(StopAlertState.Shuttle.name, alewifeServiceStatus[MapStopRoute.RED.name])
 
         val assemblyFeature = collection.features.find { it.id == "place-astao" }
         assertNotNull(assemblyFeature)
         val assemblyServiceStatus =
-            assemblyFeature.properties.get(StopFeaturesBuilder.propServiceStatusKey)
+            checkNotNull(assemblyFeature.properties[StopFeaturesBuilder.propServiceStatusKey])
         assertEquals(
             StopAlertState.Suspension.name,
             assemblyServiceStatus[MapStopRoute.ORANGE.name]


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix missing trip crash ](https://app.asana.com/0/1205732265579288/1208639731566258/f)

Removes all calls to Map.getValue in shared code, and adds a custom Spotless lint to ensure we don't add any more in the future.

I'm not quite sure if adding the Spotless lint is worth it - if it fails, it'll fail in the pre-commit step rather than somewhere more visible, and if we need to call a different function that is coincidentally also named getValue, this'll make that really annoying.

### Testing

Ensured that all shared unit tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
