### PR TITLE
use predictions v2 and fix bug in decodeRawMessage

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -190,7 +190,7 @@ class NearbyTransitPageTest : KoinTest {
                             onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
                             onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit
                         ) {
-                            /* no-op */
+                            onJoin(ApiResult.Ok(PredictionsByStopJoinResponse(builder)))
                         }
 
                         override var lastUpdated: Instant? = null

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -185,7 +185,7 @@ class NearbyTransitViewTest : KoinTest {
                             onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
                             onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit
                         ) {
-                            /* no-op */
+                            onJoin(ApiResult.Ok(PredictionsByStopJoinResponse(builder)))
                         }
 
                         override var lastUpdated: Instant? = null

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SubscribeToPredictionsTest.kt
@@ -24,17 +24,17 @@ class SubscribeToPredictionsTest {
 
     @Test
     fun testPredictions() = runTest {
-        fun buildSomePredictions(): PredictionsStreamDataResponse {
+        fun buildSomePredictions(): PredictionsByStopJoinResponse {
             val objects = ObjectCollectionBuilder()
             objects.prediction()
             objects.prediction()
-            return PredictionsStreamDataResponse(objects)
+            return PredictionsByStopJoinResponse(objects)
         }
 
         val predictionsRepo =
             object : IPredictionsRepository {
                 val stopIdsChannel = Channel<List<String>>()
-                lateinit var onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit
+                lateinit var onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit
                 val disconnectChannel = Channel<Unit>()
 
                 var isConnected = false
@@ -43,10 +43,7 @@ class SubscribeToPredictionsTest {
                     stopIds: List<String>,
                     onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit
                 ) {
-                    check(!isConnected) { "called connect when already connected" }
-                    isConnected = true
-                    launch { stopIdsChannel.send(stopIds) }
-                    this.onReceive = onReceive
+                    /* null-op */
                 }
 
                 override fun connectV2(
@@ -54,7 +51,10 @@ class SubscribeToPredictionsTest {
                     onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
                     onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit
                 ) {
-                    /* no-op */
+                    check(!isConnected) { "called connect when already connected" }
+                    isConnected = true
+                    launch { stopIdsChannel.send(stopIds) }
+                    this.onJoin = onJoin
                 }
 
                 override var lastUpdated: Instant? = null
@@ -81,20 +81,20 @@ class SubscribeToPredictionsTest {
         assertNull(predictions)
 
         val expectedPredictions1 = buildSomePredictions()
-        predictionsRepo.onReceive(ApiResult.Ok(expectedPredictions1))
+        predictionsRepo.onJoin(ApiResult.Ok(expectedPredictions1))
         composeTestRule.awaitIdle()
-        assertEquals(expectedPredictions1, predictions)
+        assertEquals(expectedPredictions1.toPredictionsStreamDataResponse(), predictions)
 
         stopIds = listOf("place-b")
         composeTestRule.awaitIdle()
         predictionsRepo.disconnectChannel.receive()
         assertEquals(listOf("place-b"), predictionsRepo.stopIdsChannel.receive())
-        assertEquals(expectedPredictions1, predictions)
+        assertEquals(expectedPredictions1.toPredictionsStreamDataResponse(), predictions)
 
         val expectedPredictions2 = buildSomePredictions()
-        predictionsRepo.onReceive(ApiResult.Ok(expectedPredictions2))
+        predictionsRepo.onJoin(ApiResult.Ok(expectedPredictions2))
         composeTestRule.awaitIdle()
-        assertEquals(expectedPredictions2, predictions)
+        assertEquals(expectedPredictions2.toPredictionsStreamDataResponse(), predictions)
 
         unmounted = true
         composeTestRule.awaitIdle()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SocketMessage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SocketMessage.kt
@@ -1,42 +1,25 @@
 package com.mbta.tid.mbta_app.android.util
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 import org.phoenixframework.Message
 
 fun decodeMessage(rawMessage: String): Message {
-    // https://github.com/dsrees/JavaPhoenixClient/blob/1.3.1/src/main/kotlin/org/phoenixframework/Defaults.kt#L68
-    val parseValue: (String) -> String? = { value ->
-        when (value) {
-            "null" -> null
-            else -> value.replace("\"", "")
-        }
-    }
+    val message = Json.parseToJsonElement(rawMessage).jsonArray
+    val joinRef = message[0].jsonPrimitive.content
 
-    var message = rawMessage
-    message = message.removeRange(0, 1) // remove '['
+    val ref = message[1].jsonPrimitive.content
+    val topic = message[2].jsonPrimitive.content
+    val event = message[3].jsonPrimitive.content
 
-    val joinRef = message.takeWhile { it != ',' } // take "join ref", "null" or "\"5\""
-    message = message.removeRange(0, joinRef.length) // remove join ref
-    message = message.removeRange(0, 1) // remove ','
-
-    val ref = message.takeWhile { it != ',' } // take ref, "null" or "\"5\""
-    message = message.removeRange(0, ref.length) // remove ref
-    message = message.removeRange(0, 1) // remove ','
-
-    val topic = message.takeWhile { it != ',' } // take topic, "\"topic\""
-    message = message.removeRange(0, topic.length)
-    message = message.removeRange(0, 1) // remove ','
-
-    val event = message.takeWhile { it != ',' } // take event, "\"phx_reply\""
-    message = message.removeRange(0, event.length)
-    message = message.removeRange(0, 1) // remove ','
-
-    val payloadJson = message.removeRange(message.length - 1, message.length) // remove ']'
+    val payloadJson = message[4].toString()
 
     return Message(
-        joinRef = parseValue(joinRef),
-        ref = parseValue(ref) ?: "",
-        topic = parseValue(topic) ?: "",
-        event = parseValue(event) ?: "",
+        joinRef = joinRef,
+        ref = ref,
+        topic = topic,
+        event = event,
         rawPayload = emptyMap(),
         payloadJson = payloadJson
     )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SocketMessage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SocketMessage.kt
@@ -1,25 +1,26 @@
 package com.mbta.tid.mbta_app.android.util
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import org.phoenixframework.Message
 
 fun decodeMessage(rawMessage: String): Message {
     val message = Json.parseToJsonElement(rawMessage).jsonArray
-    val joinRef = message[0].jsonPrimitive.content
+    val joinRef = message[0].jsonPrimitive.contentOrNull
 
-    val ref = message[1].jsonPrimitive.content
-    val topic = message[2].jsonPrimitive.content
-    val event = message[3].jsonPrimitive.content
+    val ref = message[1].jsonPrimitive.contentOrNull
+    val topic = message[2].jsonPrimitive.contentOrNull
+    val event = message[3].jsonPrimitive.contentOrNull
 
     val payloadJson = message[4].toString()
 
     return Message(
         joinRef = joinRef,
-        ref = ref,
-        topic = topic,
-        event = event,
+        ref = ref ?: "",
+        topic = topic ?: "",
+        event = event ?: "",
         rawPayload = emptyMap(),
         payloadJson = payloadJson
     )


### PR DESCRIPTION
### Summary

_Ticket:_ [Use predictions v2 channel in Android app](https://app.asana.com/0/1205732265579288/1208501775350660/f)

What is this PR for?

Use the same, more scalable endpoint as iOS for the predictions real time data. This PR also fixes a parsing issue with the `decodeRawMessage` function.

- [x] If you added any user facing strings on iOS, are they included in Localizable.xcstrings?

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
