### PR TITLE
feat: Combine existing trip details into new combined stop page

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -148,7 +148,7 @@ fun NearbyTransitPage(
                             fun updateStopDepartures(departures: StopDetailsDepartures?) {
                                 stopDetailsDepartures = departures
                                 if (departures != null && stopDetailsFilter == null) {
-                                    stopDetailsFilter = departures.autoFilter()
+                                    stopDetailsFilter = departures.autoStopFilter()
                                 }
                             }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -92,7 +92,7 @@ fun StopDetailsView(
                 departures,
                 globalResponse,
                 now,
-                filter ?: departures.autoFilter(),
+                filter ?: departures.autoStopFilter(),
                 togglePinnedRoute,
                 pinnedRoutes,
                 updateStopFilter

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		9A2005CB2B97B68700F562E1 /* UpcomingTripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */; };
 		9A2BCBDE2CED365200FB2913 /* StopDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */; };
 		9A2BCBE02CED366300FB2913 /* StopDetailsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */; };
+		9A2BCBE22CEE8A9F00FB2913 /* StopDetailsPageHandlerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBE12CEE8A9F00FB2913 /* StopDetailsPageHandlerExtension.swift */; };
 		9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */; };
 		9A37F3052BACCC40001714FE /* DoubleRoundedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */; };
 		9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */; };
@@ -393,6 +394,7 @@
 		9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripView.swift; sourceTree = "<group>"; };
 		9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsPageTests.swift; sourceTree = "<group>"; };
 		9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsViewTests.swift; sourceTree = "<group>"; };
+		9A2BCBE12CEE8A9F00FB2913 /* StopDetailsPageHandlerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsPageHandlerExtension.swift; sourceTree = "<group>"; };
 		9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripAccessibilityFormatters.swift; sourceTree = "<group>"; };
 		9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRoundedExtension.swift; sourceTree = "<group>"; };
 		9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateExtension.swift; sourceTree = "<group>"; };
@@ -1057,6 +1059,7 @@
 			isa = PBXGroup;
 			children = (
 				9ACE4FCF2CE6707900FEB006 /* StopDetailsPage.swift */,
+				9A2BCBE12CEE8A9F00FB2913 /* StopDetailsPageHandlerExtension.swift */,
 				9ACE4FD12CE6709B00FEB006 /* StopDetailsView.swift */,
 				9ACE4FD32CE6D17D00FEB006 /* TripDetailsView.swift */,
 			);
@@ -1485,6 +1488,7 @@
 				6E2027902BD989AC0037554F /* ProductionAppView.swift in Sources */,
 				6E04D4302C1A17340055FD99 /* StopDeparturesSummaryList.swift in Sources */,
 				9A74A2112BE2D71400E57102 /* AnnotationLabel.swift in Sources */,
+				9A2BCBE22CEE8A9F00FB2913 /* StopDetailsPageHandlerExtension.swift in Sources */,
 				6EEF219E2BF2927E0023A3E9 /* VehicleCardView.swift in Sources */,
 				9A9E7DCF2C2200C9000DA1FD /* LineHeader.swift in Sources */,
 				8C05C5812CD568DE000381E8 /* MoreNavLink.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		9ACA9DF32BA1EC8B003F0E9E /* HomeMapViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACA9DF22BA1EC8B003F0E9E /* HomeMapViewUITests.swift */; };
 		9ACE4FD02CE6707900FEB006 /* StopDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE4FCF2CE6707900FEB006 /* StopDetailsPage.swift */; };
 		9ACE4FD22CE6709B00FEB006 /* StopDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE4FD12CE6709B00FEB006 /* StopDetailsView.swift */; };
+		9ACE4FD42CE6D17D00FEB006 /* TripDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACE4FD32CE6D17D00FEB006 /* TripDetailsView.swift */; };
 		9AD039362CCFC5E8008D9318 /* LocationAuthButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */; };
 		9AD1D1FE2BA4D5C600182060 /* ViewportProviderTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD1D1FD2BA4D5C600182060 /* ViewportProviderTest.swift */; };
 		9ADB849D2BAD05BC006581CE /* Inspection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB849C2BAD05BC006581CE /* Inspection.swift */; };
@@ -456,6 +457,7 @@
 		9ACA9DF22BA1EC8B003F0E9E /* HomeMapViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMapViewUITests.swift; sourceTree = "<group>"; };
 		9ACE4FCF2CE6707900FEB006 /* StopDetailsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsPage.swift; sourceTree = "<group>"; };
 		9ACE4FD12CE6709B00FEB006 /* StopDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsView.swift; sourceTree = "<group>"; };
+		9ACE4FD32CE6D17D00FEB006 /* TripDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailsView.swift; sourceTree = "<group>"; };
 		9AD039352CCFC5E8008D9318 /* LocationAuthButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationAuthButton.swift; sourceTree = "<group>"; };
 		9AD1D1FD2BA4D5C600182060 /* ViewportProviderTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewportProviderTest.swift; sourceTree = "<group>"; };
 		9ADB849C2BAD05BC006581CE /* Inspection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inspection.swift; sourceTree = "<group>"; };
@@ -1042,6 +1044,7 @@
 			children = (
 				9ACE4FCF2CE6707900FEB006 /* StopDetailsPage.swift */,
 				9ACE4FD12CE6709B00FEB006 /* StopDetailsView.swift */,
+				9ACE4FD32CE6D17D00FEB006 /* TripDetailsView.swift */,
 			);
 			path = StopDetails;
 			sourceTree = "<group>";
@@ -1496,6 +1499,7 @@
 				9A4850572CB56A1600F50EE7 /* RouteTypeExtension.swift in Sources */,
 				8C97F7D02CCC01E200A06B34 /* OnboardingScreenView.swift in Sources */,
 				EDE92FA82C408A32007AD2F6 /* SettingsViewModel.swift in Sources */,
+				9ACE4FD42CE6D17D00FEB006 /* TripDetailsView.swift in Sources */,
 				8CA1FB752BF7EB3500384658 /* TripDetailsStopListSplitView.swift in Sources */,
 				8CE014122BBDB96900918FAE /* StopDetailsRouteView.swift in Sources */,
 				8CA1FB732BF7E69000384658 /* TripDetailsStopView.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -119,6 +119,8 @@
 		9A2005C72B97B63300F562E1 /* NearbyStopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005C62B97B63300F562E1 /* NearbyStopView.swift */; };
 		9A2005C92B97B65900F562E1 /* HeadsignRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005C82B97B65900F562E1 /* HeadsignRowView.swift */; };
 		9A2005CB2B97B68700F562E1 /* UpcomingTripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */; };
+		9A2BCBDE2CED365200FB2913 /* StopDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */; };
+		9A2BCBE02CED366300FB2913 /* StopDetailsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */; };
 		9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */; };
 		9A37F3052BACCC40001714FE /* DoubleRoundedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */; };
 		9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */; };
@@ -389,6 +391,8 @@
 		9A2005C62B97B63300F562E1 /* NearbyStopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyStopView.swift; sourceTree = "<group>"; };
 		9A2005C82B97B65900F562E1 /* HeadsignRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeadsignRowView.swift; sourceTree = "<group>"; };
 		9A2005CA2B97B68700F562E1 /* UpcomingTripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripView.swift; sourceTree = "<group>"; };
+		9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsPageTests.swift; sourceTree = "<group>"; };
+		9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsViewTests.swift; sourceTree = "<group>"; };
 		9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripAccessibilityFormatters.swift; sourceTree = "<group>"; };
 		9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRoundedExtension.swift; sourceTree = "<group>"; };
 		9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateExtension.swift; sourceTree = "<group>"; };
@@ -894,6 +898,15 @@
 			path = Search;
 			sourceTree = "<group>";
 		};
+		9A2BCBDC2CED35FF00FB2913 /* StopDetails */ = {
+			isa = PBXGroup;
+			children = (
+				9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */,
+				9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */,
+			);
+			path = StopDetails;
+			sourceTree = "<group>";
+		};
 		9A392C952CC03ACF00DE1FBE /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -960,6 +973,7 @@
 				6EF64C012C1B7C17005F365D /* NearbyTransit */,
 				8CD423F02CD009E300C8569E /* Onboarding */,
 				8CD81A222BE55B150090585F /* Settings */,
+				9A2BCBDC2CED35FF00FB2913 /* StopDetails */,
 				8CB823D72BC5EDBF002C87E0 /* LegacyStopDetails */,
 				8CD58ECB2BEC114A0004E031 /* TripDetails */,
 			);
@@ -1357,6 +1371,7 @@
 				8CD423F12CD009E300C8569E /* OnboardingPageTests.swift in Sources */,
 				8CD423F22CD009E300C8569E /* OnboardingScreenViewTests.swift in Sources */,
 				8CB823D62BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift in Sources */,
+				9A2BCBDE2CED365200FB2913 /* StopDetailsPageTests.swift in Sources */,
 				8C9B68D02C90F474007E74EA /* PredictionRowViewTests.swift in Sources */,
 				9A52B3382C6A99790028EEAB /* AlertDetailsPageTests.swift in Sources */,
 				6EA00B6E2C519DCD00B1334C /* MapHttpInterceptorTests.swift in Sources */,
@@ -1379,6 +1394,7 @@
 				6E4C375E2C4BDC9F00EA67CF /* ContentViewModelTests.swift in Sources */,
 				8CA606A92CC02FBC0019C448 /* ViewInspectorExtensions.swift in Sources */,
 				9A7B7CA92B98E41B0045214F /* NonNilModifierTests.swift in Sources */,
+				9A2BCBE02CED366300FB2913 /* StopDetailsViewTests.swift in Sources */,
 				6E973DA92C178BF500CBF341 /* ActionButtonTests.swift in Sources */,
 				6EED5EAB2B3E1B550052A1B8 /* ContentViewTests.swift in Sources */,
 				ED5C93F62C4A1AD70086D017 /* TripDetailsHeaderTests.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -60,6 +60,9 @@ struct ContentView: View {
                 _ = try await RepositoryDI().global.getGlobalData()
             } catch {}
         }
+        .onChange(of: selectedTab) { _ in
+            Task { await nearbyVM.loadDebugSetting() }
+        }
         .onChange(of: scenePhase) { newPhase in
             if newPhase == .active {
                 socketProvider.socket.attach()
@@ -256,7 +259,7 @@ struct ContentView: View {
                 case .alertDetails:
                     EmptyView()
 
-                case let .stopDetails(stopId: stopId, stopFilter: stopFilter, tripFilter: _):
+                case let .stopDetails(stopId, stopFilter, tripFilter):
                     // Wrapping in a TabView helps the page to animate in as a single unit
                     // Otherwise only the header animates
                     TabView {
@@ -264,8 +267,10 @@ struct ContentView: View {
                             viewportProvider: viewportProvider,
                             stopId: stopId,
                             stopFilter: stopFilter,
+                            tripFilter: tripFilter,
                             errorBannerVM: errorBannerVM,
-                            nearbyVM: nearbyVM
+                            nearbyVM: nearbyVM,
+                            mapVM: mapVM
                         )
 
                         .toolbar(.hidden, for: .tabBar)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -264,15 +264,14 @@ struct ContentView: View {
                     // Otherwise only the header animates
                     TabView {
                         StopDetailsPage(
-                            viewportProvider: viewportProvider,
                             stopId: stopId,
                             stopFilter: stopFilter,
                             tripFilter: tripFilter,
                             errorBannerVM: errorBannerVM,
                             nearbyVM: nearbyVM,
-                            mapVM: mapVM
+                            mapVM: mapVM,
+                            viewportProvider: viewportProvider
                         )
-
                         .toolbar(.hidden, for: .tabBar)
                         .onAppear {
                             let filtered = stopFilter != nil

--- a/iosApp/iosApp/Fetchers/ViewportProvider.swift
+++ b/iosApp/iosApp/Fetchers/ViewportProvider.swift
@@ -16,6 +16,7 @@ class ViewportProvider: ObservableObject {
         static let animation: ViewportAnimation = .easeInOut(duration: 1)
         static let center: CLLocationCoordinate2D = .init(latitude: 42.3575, longitude: -71.0601)
         static let zoom: CGFloat = MapDefaults.shared.defaultZoomThreshold
+        static let overviewPadding: EdgeInsets = .init(top: 75, leading: 50, bottom: 75, trailing: 50)
     }
 
     @Published private(set) var isManuallyCentering: Bool
@@ -54,6 +55,14 @@ class ViewportProvider: ObservableObject {
         withViewportAnimation(animation) {
             self.viewport = .followPuck(zoom: cameraStateSubject.value.zoom)
         }
+    }
+
+    func vehicleOverview(vehicle: Vehicle, stop: Stop) {
+        animateTo(viewport: .overview(
+            geometry: MultiPoint([vehicle.coordinate, stop.coordinate]),
+            geometryPadding: Defaults.overviewPadding,
+            maxZoom: 16
+        ))
     }
 
     func followVehicle(vehicle: Vehicle, target: Stop?) {
@@ -160,7 +169,7 @@ class ViewportProvider: ObservableObject {
         center: CLLocationCoordinate2D,
         inView: [CLLocationCoordinate2D],
         // Insets with different horizontal/vertical values will result in the center point being off center
-        padding: EdgeInsets = .init(top: 75, leading: 50, bottom: 75, trailing: 50)
+        padding: EdgeInsets = Defaults.overviewPadding
     ) -> Viewport {
         let reflectedPoints = inView.map { point in
             CLLocationCoordinate2D(

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
@@ -94,7 +94,7 @@ struct AlertDetailsPage: View {
                     line: line,
                     routes: routes,
                     affectedStops: affectedStops,
-                    stopId: nearbyVM.navigationStack.lastStop?.id,
+                    stopId: nearbyVM.navigationStack.lastStopId,
                     now: now
                 )
             } else {

--- a/iosApp/iosApp/Pages/LegacyStopDetails/LegacyStopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/LegacyStopDetailsPage.swift
@@ -273,7 +273,7 @@ struct LegacyStopDetailsPage: View {
         } else {
             nil
         }
-        if filter == nil, let newFilter = newDepartures?.autoFilter() {
+        if filter == nil, let newFilter = newDepartures?.autoStopFilter() {
             nearbyVM.setLastStopDetailsFilter(stop.id, newFilter)
         }
 

--- a/iosApp/iosApp/Pages/LegacyStopDetails/LegacyStopDetailsView.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/LegacyStopDetailsView.swift
@@ -80,7 +80,7 @@ struct LegacyStopDetailsView: View {
                     )
                     if nearbyVM.showDebugMessages {
                         DebugView {
-                            Text(verbatim: "stop id: \(stop.id ?? "nil stop")")
+                            Text(verbatim: "stop id: \(stop.id)")
                         }
                     }
                     ErrorBanner(errorBannerVM).padding(.horizontal, 16)
@@ -103,7 +103,7 @@ struct LegacyStopDetailsView: View {
                         now: now.toKotlinInstant(),
                         filter: filter,
                         setFilter: setFilter,
-                        pushNavEntry: nearbyVM.pushNavEntry,
+                        pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                         pinRoute: togglePinnedRoute,
                         pinnedRoutes: pinnedRoutes
                     ).frame(maxHeight: .infinity)

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -121,7 +121,7 @@ struct AnnotatedMap: View {
                         .selected(isSelected)
                         .allowOverlap(true)
                         .allowOverlapWithPuck(true)
-                        .visible(zoomLevel >= StopLayerGenerator.shared.stopZoomThreshold)
+                        .visible(zoomLevel >= StopLayerGenerator.shared.stopZoomThreshold || isSelected)
                     }
                 }
             }

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -127,10 +127,10 @@ struct HomeMapView: View {
                 handleGlobalMapDataChange(now: now)
             }
             .onChange(of: nearbyVM.departures) { _ in
-                if case let .legacyStopDetails(_, filter) = lastNavEntry, let stopMapData {
+                if case let .stopDetails(stopId: _, stopFilter: filter, tripFilter: _) = lastNavEntry, let stopMapData {
                     updateStopDetailsLayers(stopMapData, filter, nearbyVM.departures)
                 }
-                if case let .stopDetails(stopId: _, stopFilter: filter, tripFilter: _) = lastNavEntry, let stopMapData {
+                if case let .legacyStopDetails(_, filter) = lastNavEntry, let stopMapData {
                     updateStopDetailsLayers(stopMapData, filter, nearbyVM.departures)
                 }
             }
@@ -184,7 +184,10 @@ struct HomeMapView: View {
 
     @ViewBuilder
     var annotatedMap: some View {
-        let selectedVehicle: Vehicle? = if case .tripDetails = nearbyVM.navigationStack.last {
+        let nav = nearbyVM.navigationStack.last
+        let selectedVehicle: Vehicle? = if case .tripDetails = nav {
+            mapVM.selectedVehicle
+        } else if case .stopDetails = nav {
             mapVM.selectedVehicle
         } else { nil }
         let vehicles: [Vehicle]? = vehiclesData?.filter { $0.id != selectedVehicle?.id }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -118,13 +118,14 @@ struct NearbyTransitView: View {
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(transit, id: \.id) { nearbyTransit in
-                            switch onEnum(of: nearbyTransit) {
+                            let nearby: StopsAssociated = nearbyTransit
+                            switch onEnum(of: nearby) {
                             case let .withRoute(nearbyRoute):
                                 NearbyRouteView(
                                     nearbyRoute: nearbyRoute,
                                     pinned: pinnedRoutes.contains(nearbyRoute.route.id),
                                     onPin: { id in toggledPinnedRoute(id) },
-                                    pushNavEntry: nearbyVM.pushNavEntry,
+                                    pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                                     now: now.toKotlinInstant()
                                 )
                             case let .withLine(nearbyLine):
@@ -132,7 +133,7 @@ struct NearbyTransitView: View {
                                     nearbyLine: nearbyLine,
                                     pinned: pinnedRoutes.contains(nearbyLine.line.id),
                                     onPin: { id in toggledPinnedRoute(id) },
-                                    pushNavEntry: nearbyVM.pushNavEntry,
+                                    pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                                     now: now.toKotlinInstant()
                                 )
                             }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPageHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPageHandlerExtension.swift
@@ -1,0 +1,183 @@
+//
+//  StopDetailsPageHandlerExtension.swift
+//  iosApp
+//
+//  Created by esimon on 11/20/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import shared
+import SwiftPhoenixClient
+import SwiftUI
+
+extension StopDetailsPage {
+    func loadEverything() {
+        loadGlobalData()
+        fetchStopData(stopId)
+        loadPinnedRoutes()
+    }
+
+    @MainActor
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            globalResponse = globalData
+        }
+    }
+
+    func loadGlobalData() {
+        Task(priority: .high) {
+            await activateGlobalListener()
+        }
+        Task {
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "StopDetailsPage.loadGlobalData",
+                getData: { try await globalRepository.getGlobalData() },
+                onRefreshAfterError: loadEverything
+            )
+        }
+    }
+
+    func loadPinnedRoutes() {
+        Task {
+            do {
+                pinnedRoutes = try await pinnedRouteRepository.getPinnedRoutes()
+            } catch is CancellationError {
+                // do nothing on cancellation
+            } catch {
+                // getPinnedRoutes shouldn't actually fail
+                debugPrint(error)
+            }
+        }
+    }
+
+    func togglePinnedRoute(_ routeId: String) {
+        Task {
+            do {
+                _ = try await togglePinnedUsecase.execute(route: routeId)
+                loadPinnedRoutes()
+            } catch is CancellationError {
+                // do nothing on cancellation
+            } catch {
+                // execute shouldn't actually fail
+                debugPrint(error)
+            }
+        }
+    }
+
+    func changeStop(_ stopId: String) {
+        leavePredictions()
+        fetchStopData(stopId)
+    }
+
+    func fetchStopData(_ stopId: String) {
+        getSchedule(stopId)
+        joinPredictions(stopId)
+        updateDepartures(stopId: stopId)
+    }
+
+    func getSchedule(_ stopId: String) {
+        Task {
+            schedulesResponse = nil
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "StopDetailsPage.getSchedule",
+                getData: { try await schedulesRepository.getSchedule(stopIds: [stopId]) },
+                onSuccess: { schedulesResponse = $0 },
+                onRefreshAfterError: loadEverything
+            )
+        }
+    }
+
+    func joinPredictions(_ stopId: String) {
+        // no error handling since persistent errors cause stale predictions
+        predictionsRepository.connectV2(stopIds: [stopId], onJoin: { outcome in
+            DispatchQueue.main.async {
+                if case let .ok(result) = onEnum(of: outcome) {
+                    predictionsByStop = result.data
+                    checkPredictionsStale()
+                }
+                errorBannerVM.loadingWhenPredictionsStale = false
+            }
+        }, onMessage: { outcome in
+            DispatchQueue.main.async {
+                if case let .ok(result) = onEnum(of: outcome) {
+                    if let existingPredictionsByStop = predictionsByStop {
+                        predictionsByStop = existingPredictionsByStop.mergePredictions(updatedPredictions: result.data)
+                    } else {
+                        predictionsByStop = PredictionsByStopJoinResponse(
+                            predictionsByStop: [result.data.stopId: result.data.predictions],
+                            trips: result.data.trips,
+                            vehicles: result.data.vehicles
+                        )
+                    }
+                    checkPredictionsStale()
+                }
+                errorBannerVM.loadingWhenPredictionsStale = false
+            }
+
+        })
+    }
+
+    func leavePredictions() {
+        predictionsRepository.disconnect()
+    }
+
+    func checkPredictionsStale() {
+        if let lastPredictions = predictionsRepository.lastUpdated {
+            errorBannerVM.errorRepository.checkPredictionsStale(
+                predictionsLastUpdated: lastPredictions,
+                predictionQuantity: Int32(
+                    predictionsByStop?.predictionQuantity() ?? 0
+                ),
+                action: {
+                    leavePredictions()
+                    joinPredictions(stopId)
+                }
+            )
+        }
+    }
+
+    func setTripFilter(departures: StopDetailsDepartures? = nil, stopFilter: StopDetailsFilter? = nil) {
+        let tripFilter = (departures ?? internalDepartures)?.autoTripFilter(
+            stopFilter: stopFilter ?? self.stopFilter,
+            currentTripFilter: tripFilter,
+            filterAtTime: now.toKotlinInstant()
+        )
+        nearbyVM.setLastTripDetailsFilter(stopId, tripFilter)
+    }
+
+    func updateDepartures(
+        stopId: String? = nil,
+        globalResponse: GlobalResponse? = nil,
+        pinnedRoutes: Set<String>? = nil,
+        predictionsByStop: PredictionsByStopJoinResponse? = nil,
+        schedulesResponse: ScheduleResponse? = nil
+    ) {
+        let stopId = stopId ?? self.stopId
+        let globalResponse = globalResponse ?? self.globalResponse
+
+        let newDepartures: StopDetailsDepartures? = if let globalResponse {
+            StopDetailsDepartures.companion.fromData(
+                stopId: stopId,
+                global: globalResponse,
+                schedules: schedulesResponse ?? self.schedulesResponse,
+                predictions: (predictionsByStop ?? self.predictionsByStop)?.toPredictionsStreamDataResponse(),
+                alerts: nearbyVM.alerts,
+                pinnedRoutes: pinnedRoutes ?? self.pinnedRoutes,
+                filterAtTime: now.toKotlinInstant(),
+                useTripHeadsigns: nearbyVM.tripHeadsignsEnabled
+            )
+        } else {
+            nil
+        }
+
+        let nextStopFilter = stopFilter ?? newDepartures?.autoStopFilter()
+        if stopFilter != nextStopFilter {
+            nearbyVM.setLastStopDetailsFilter(stopId, nextStopFilter)
+        }
+
+        internalDepartures = newDepartures
+        nearbyVM.setDepartures(stopId, newDepartures)
+    }
+}

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -21,11 +21,13 @@ struct StopDetailsView: View {
     var stopFilter: StopDetailsFilter?
     var tripFilter: TripDetailsFilter?
     var setStopFilter: (StopDetailsFilter?) -> Void
+    var setTripFilter: (TripDetailsFilter?) -> Void
     var departures: StopDetailsDepartures?
     var now = Date.now
     var servedRoutes: [StopDetailsFilterPills.FilterBy] = []
     @ObservedObject var errorBannerVM: ErrorBannerViewModel
     @ObservedObject var nearbyVM: NearbyViewModel
+    @ObservedObject var mapVM: MapViewModel
     let pinnedRoutes: Set<String>
     @State var predictions: PredictionsStreamDataResponse?
 
@@ -38,11 +40,13 @@ struct StopDetailsView: View {
         globalRepository: IGlobalRepository = RepositoryDI().global,
         stopId: String,
         stopFilter: StopDetailsFilter?,
-        tripFilter _: TripDetailsFilter?,
+        tripFilter: TripDetailsFilter?,
         setStopFilter: @escaping (StopDetailsFilter?) -> Void,
+        setTripFilter: @escaping (TripDetailsFilter?) -> Void,
         departures: StopDetailsDepartures?,
         errorBannerVM: ErrorBannerViewModel,
         nearbyVM: NearbyViewModel,
+        mapVM: MapViewModel,
         now: Date,
         pinnedRoutes: Set<String>,
         togglePinnedRoute: @escaping (String) -> Void
@@ -50,10 +54,13 @@ struct StopDetailsView: View {
         self.globalRepository = globalRepository
         self.stopId = stopId
         self.stopFilter = stopFilter
+        self.tripFilter = tripFilter
         self.setStopFilter = setStopFilter
+        self.setTripFilter = setTripFilter
         self.departures = departures
         self.errorBannerVM = errorBannerVM
         self.nearbyVM = nearbyVM
+        self.mapVM = mapVM
         self.now = now
         self.pinnedRoutes = pinnedRoutes
         self.togglePinnedRoute = togglePinnedRoute
@@ -109,12 +116,26 @@ struct StopDetailsView: View {
                         now: now.toKotlinInstant(),
                         filter: stopFilter,
                         setFilter: setStopFilter,
-                        pushNavEntry: nearbyVM.pushNavEntry,
+                        pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                         pinRoute: togglePinnedRoute,
                         pinnedRoutes: pinnedRoutes
                     ).frame(maxHeight: .infinity)
                 } else {
                     loadingBody()
+                }
+
+                if let stopFilter, let tripFilter {
+                    TripDetailsView(
+                        tripId: tripFilter.tripId,
+                        vehicleId: tripFilter.vehicleId,
+                        routeId: stopFilter.routeId,
+                        stopId: stopId,
+                        stopSequence: tripFilter.stopSequence?.intValue,
+                        global: globalResponse,
+                        errorBannerVM: errorBannerVM,
+                        nearbyVM: nearbyVM,
+                        mapVM: mapVM
+                    )
                 }
             }
         }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -93,7 +93,7 @@ struct StopDetailsView: View {
                     )
                     if nearbyVM.showDebugMessages {
                         DebugView {
-                            Text(verbatim: "stop id: \(stop?.id ?? "nil stop")")
+                            Text(verbatim: "stop id: \(stopId)")
                         }
                     }
                     ErrorBanner(errorBannerVM).padding(.horizontal, 16)

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -1,0 +1,312 @@
+//
+//  TripDetailsView.swift
+//  iosApp
+//
+//  Created by esimon on 11/14/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Combine
+import shared
+import SwiftPhoenixClient
+import SwiftUI
+
+struct TripDetailsView: View {
+    let tripId: String
+    let vehicleId: String?
+    let routeId: String
+    let stopId: String
+    let stopSequence: Int?
+
+    var global: GlobalResponse?
+
+    @ObservedObject var errorBannerVM: ErrorBannerViewModel
+    @ObservedObject var nearbyVM: NearbyViewModel
+    @ObservedObject var mapVM: MapViewModel
+    @State var tripPredictionsRepository: ITripPredictionsRepository
+    @State var tripPredictions: PredictionsStreamDataResponse?
+    @State var tripPredictionsLoaded: Bool = false
+    @State var tripRepository: ITripRepository
+    @State var trip: Trip?
+    @State var tripSchedulesResponse: TripSchedulesResponse?
+    @State var vehicleRepository: IVehicleRepository
+    @State var vehicleResponse: VehicleStreamDataResponse?
+
+    let analytics: TripDetailsAnalytics
+
+    @State var now = Date.now.toKotlinInstant()
+
+    let inspection = Inspection<Self>()
+
+    private var routeType: RouteType? {
+        global?.routes[routeId]?.type
+    }
+
+    init(
+        tripId: String,
+        vehicleId: String?,
+        routeId: String,
+        stopId: String,
+        stopSequence: Int?,
+        global: GlobalResponse?,
+        errorBannerVM: ErrorBannerViewModel,
+        nearbyVM: NearbyViewModel,
+        mapVM: MapViewModel,
+        tripPredictionsRepository: ITripPredictionsRepository = RepositoryDI().tripPredictions,
+        tripRepository: ITripRepository = RepositoryDI().trip,
+        vehicleRepository: IVehicleRepository = RepositoryDI().vehicle,
+        analytics: TripDetailsAnalytics = AnalyticsProvider.shared
+    ) {
+        self.tripId = tripId
+        self.vehicleId = vehicleId
+        self.routeId = routeId
+        self.stopId = stopId
+        self.stopSequence = stopSequence
+        self.global = global
+        self.errorBannerVM = errorBannerVM
+        self.nearbyVM = nearbyVM
+        self.mapVM = mapVM
+        self.tripPredictionsRepository = tripPredictionsRepository
+        self.tripRepository = tripRepository
+        self.vehicleRepository = vehicleRepository
+        self.analytics = analytics
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if nearbyVM.showDebugMessages {
+                DebugView {
+                    VStack {
+                        Text(verbatim: "trip id \(tripId)")
+                        Text(verbatim: "vehicle id: \(vehicleId)")
+                    }
+                }
+            }
+            if tripPredictionsLoaded, let global, let vehicle = vehicleResponse?.vehicle,
+               let stops = TripDetailsStopList.companion.fromPieces(
+                   tripId: tripId,
+                   directionId: trip?.directionId ?? vehicle.directionId,
+                   tripSchedules: tripSchedulesResponse,
+                   tripPredictions: tripPredictions,
+                   vehicle: vehicle,
+                   alertsData: nearbyVM.alerts,
+                   globalData: global
+               ) {
+                vehicleCardView
+                if let stopSequence, let splitStops = stops.splitForTarget(
+                    targetStopId: stopId,
+                    targetStopSequence: Int32(stopSequence),
+                    globalData: global
+                ) {
+                    TripDetailsStopListSplitView(
+                        splitStops: splitStops,
+                        now: now,
+                        onTapLink: onTapStop,
+                        routeType: routeType
+                    )
+                    .onAppear { didLoadData?(self) }
+                } else {
+                    TripDetailsStopListView(stops: stops, now: now, onTapLink: onTapStop, routeType: routeType)
+                        .onAppear { didLoadData?(self) }
+                }
+            } else {
+                loadingBody()
+            }
+        }
+        .task { loadEverything(tripId: tripId) }
+        .task { now = Date.now.toKotlinInstant() }
+        .onAppear { joinRealtime() }
+        .onDisappear { leaveRealtime() }
+        .onChange(of: tripId) { nextTripId in
+            mapVM.selectedVehicle = nil
+            trip = nil
+            tripSchedulesResponse = nil
+            leavePredictions()
+            tripPredictions = nil
+            errorBannerVM.errorRepository.clearDataError(key: "TripDetailsView.loadTripSchedules")
+            errorBannerVM.errorRepository.clearDataError(key: "TripDetailsView.loadTrip")
+            loadTripSchedules(tripId: nextTripId)
+            loadTrip(tripId: nextTripId)
+            joinPredictions(tripId: nextTripId)
+        }
+        .onChange(of: vehicleId) { vehicleId in
+            leaveVehicle()
+            joinVehicle(vehicleId: vehicleId)
+        }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        .withScenePhaseHandlers(
+            onActive: {
+                if let tripPredictions,
+                   tripPredictionsRepository
+                   .shouldForgetPredictions(predictionCount: tripPredictions.predictionQuantity()) {
+                    self.tripPredictions = nil
+                }
+                joinRealtime()
+            },
+            onInactive: leaveRealtime,
+            onBackground: { leaveRealtime() }
+        )
+    }
+
+    var didLoadData: ((Self) -> Void)?
+
+    @ViewBuilder private func loadingBody() -> some View {
+        TripDetailsStopListView(
+            stops: LoadingPlaceholders.shared.tripDetailsStops(),
+            now: now,
+            onTapLink: { _, _, _ in },
+            routeType: nil
+        )
+        .loadingPlaceholder()
+    }
+
+    private func loadEverything(tripId: String) {
+        loadTripSchedules(tripId: tripId)
+        loadTrip(tripId: tripId)
+    }
+
+    private func loadTripSchedules(tripId: String) {
+        Task {
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "TripDetailsPage.loadTripSchedules",
+                getData: { try await tripRepository.getTripSchedules(tripId: tripId) },
+                onSuccess: { tripSchedulesResponse = $0 },
+                onRefreshAfterError: { loadEverything(tripId: tripId) }
+            )
+        }
+    }
+
+    private func loadTrip(tripId: String) {
+        Task {
+            let response: ApiResult<TripResponse> = try await tripRepository.getTrip(tripId: tripId)
+            let errorKey = "TripDetailsPage.loadTrip"
+            switch onEnum(of: response) {
+            case let .ok(okResponse):
+                errorBannerVM.errorRepository.clearDataError(key: errorKey)
+                trip = okResponse.data.trip
+            case .error:
+                errorBannerVM.errorRepository.setDataError(key: errorKey, action: { loadEverything(tripId: tripId) })
+                trip = nil
+            }
+        }
+    }
+
+    private func joinRealtime() {
+        joinPredictions(tripId: tripId)
+        joinVehicle(vehicleId: vehicleId)
+    }
+
+    private func leaveRealtime() {
+        leavePredictions()
+        leaveVehicle()
+    }
+
+    private func joinPredictions(tripId: String) {
+        tripPredictionsRepository.connect(tripId: tripId) { outcome in
+            DispatchQueue.main.async {
+                // no error handling since persistent errors cause stale predictions
+                switch onEnum(of: outcome) {
+                case let .ok(result): tripPredictions = result.data
+                case .error: break
+                }
+                tripPredictionsLoaded = true
+            }
+        }
+    }
+
+    private func leavePredictions() {
+        tripPredictionsLoaded = false
+        tripPredictionsRepository.disconnect()
+    }
+
+    private func joinVehicle(vehicleId: String?) {
+        guard let vehicleId else { return }
+        vehicleRepository.connect(vehicleId: vehicleId) { outcome in
+            DispatchQueue.main.async {
+                let errorKey = "TripDetailsPage.joinVehicle"
+                switch onEnum(of: outcome) {
+                case let .ok(result):
+                    errorBannerVM.errorRepository.clearDataError(key: errorKey)
+                    vehicleResponse = result.data
+                    mapVM.selectedVehicle = result.data.vehicle
+                case .error:
+                    errorBannerVM.errorRepository.setDataError(
+                        key: errorKey,
+                        action: { loadEverything(tripId: tripId) }
+                    )
+                    vehicleResponse = nil
+                }
+            }
+        }
+    }
+
+    private func leaveVehicle() {
+        vehicleRepository.disconnect()
+        if mapVM.selectedVehicle?.id == vehicleId {
+            mapVM.selectedVehicle = nil
+        }
+    }
+
+    @ViewBuilder
+    var vehicleCardView: some View {
+        let trip: Trip? = tripPredictions?.trips[tripId]
+        let vehicle: Vehicle? = vehicleResponse?.vehicle
+        let vehicleStop: Stop? = if let stopId = vehicle?.stopId, let allStops = global?.stops {
+            allStops[stopId]?.resolveParent(stops: allStops)
+        } else {
+            nil
+        }
+        let route: Route? = if let routeId = trip?.routeId ?? vehicle?.routeId {
+            global?.routes[routeId]
+        } else {
+            nil
+        }
+        VehicleCardView(
+            vehicle: vehicle,
+            route: route,
+            stop: vehicleStop,
+            tripId: tripId
+        )
+    }
+
+    @ViewBuilder
+    var header: some View {
+        let trip: Trip? = tripPredictions?.trips[tripId]
+        let vehicle: Vehicle? = vehicleResponse?.vehicle
+        let route: Route? = if let routeId = trip?.routeId ?? vehicle?.routeId {
+            global?.routes[routeId]
+        } else {
+            nil
+        }
+        TripDetailsHeader(
+            route: route,
+            line: global?.getLine(lineId: route?.lineId),
+            trip: trip,
+            onBack: nearbyVM.goBack,
+            onClose: { nearbyVM.navigationStack.removeAll() }
+        )
+    }
+
+    func onTapStop(
+        entry: SheetNavigationStackEntry,
+        stop: TripDetailsStopList.Entry,
+        connectingRouteId: String?
+    ) {
+        // resolve parent stop before following link
+        let realEntry = switch entry {
+        case let .legacyStopDetails(stop, filter): SheetNavigationStackEntry.legacyStopDetails(
+                stop.resolveParent(stops: global?.stops ?? [:]),
+                filter
+            )
+        default: entry
+        }
+        nearbyVM.pushNavEntry(realEntry)
+        analytics.tappedDownstreamStop(
+            routeId: trip?.routeId ?? "",
+            stopId: stop.stop.id,
+            tripId: tripId,
+            connectingRouteId: connectingRouteId
+        )
+    }
+}

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -23,19 +23,20 @@ struct TripDetailsView: View {
     @ObservedObject var errorBannerVM: ErrorBannerViewModel
     @ObservedObject var nearbyVM: NearbyViewModel
     @ObservedObject var mapVM: MapViewModel
+
     @State var tripPredictionsRepository: ITripPredictionsRepository
+    @State var tripRepository: ITripRepository
+    @State var vehicleRepository: IVehicleRepository
+
+    @State var trip: Trip?
     @State var tripPredictions: PredictionsStreamDataResponse?
     @State var tripPredictionsLoaded: Bool = false
-    @State var tripRepository: ITripRepository
-    @State var trip: Trip?
     @State var tripSchedulesResponse: TripSchedulesResponse?
-    @State var vehicleRepository: IVehicleRepository
     @State var vehicleResponse: VehicleStreamDataResponse?
-
-    let analytics: TripDetailsAnalytics
 
     @State var now = Date.now.toKotlinInstant()
 
+    let analytics: TripDetailsAnalytics
     let inspection = Inspection<Self>()
 
     private var routeType: RouteType? {
@@ -52,6 +53,7 @@ struct TripDetailsView: View {
         errorBannerVM: ErrorBannerViewModel,
         nearbyVM: NearbyViewModel,
         mapVM: MapViewModel,
+
         tripPredictionsRepository: ITripPredictionsRepository = RepositoryDI().tripPredictions,
         tripRepository: ITripRepository = RepositoryDI().trip,
         vehicleRepository: IVehicleRepository = RepositoryDI().vehicle,
@@ -66,9 +68,11 @@ struct TripDetailsView: View {
         self.errorBannerVM = errorBannerVM
         self.nearbyVM = nearbyVM
         self.mapVM = mapVM
+
         self.tripPredictionsRepository = tripPredictionsRepository
         self.tripRepository = tripRepository
         self.vehicleRepository = vehicleRepository
+
         self.analytics = analytics
     }
 
@@ -77,7 +81,7 @@ struct TripDetailsView: View {
             if nearbyVM.showDebugMessages {
                 DebugView {
                     VStack {
-                        Text(verbatim: "trip id \(tripId)")
+                        Text(verbatim: "trip id: \(tripId)")
                         Text(verbatim: "vehicle id: \(vehicleId)")
                     }
                 }

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -14,12 +14,6 @@ struct TripDetailsTarget: Hashable {
     let stopSequence: Int?
 }
 
-struct TripDetailsFilter: Hashable {
-    let tripId: String
-    let vehicleId: String?
-    let stopSequence: Int?
-}
-
 enum SheetNavigationStackEntry: Hashable, Identifiable {
     case stopDetails(stopId: String, stopFilter: StopDetailsFilter?, tripFilter: TripDetailsFilter?)
     case legacyStopDetails(Stop, StopDetailsFilter?)
@@ -34,6 +28,14 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
     func stop() -> Stop? {
         switch self {
         case let .legacyStopDetails(stop, _): stop
+        case _: nil
+        }
+    }
+
+    func stopId() -> String? {
+        switch self {
+        case let .legacyStopDetails(stop, _): stop.id
+        case let .stopDetails(stopId, _, _): stopId
         case _: nil
         }
     }
@@ -59,6 +61,7 @@ struct NearbySheetItem: Identifiable {
 
     var id: String {
         switch stackEntry {
+        case let .stopDetails(stopId, _, _): stopId
         case let .legacyStopDetails(stop, _): stop.id
         case let .tripDetails(tripId, _, _, _, _): tripId
         case .nearby: "nearby"

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -120,6 +120,7 @@ final class StopDetailsViewTests: XCTestCase {
         )
 
         ViewHosting.host(view: sut)
+        XCTAssertNotNil(try? sut.inspect().find(TripDetailsView.self))
     }
 
     func testCloseButtonCloses() throws {

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -1,0 +1,224 @@
+//
+//  StopDetailsViewTests.swift
+//  iosAppTests
+//
+//  Created by Brady, Kayla on 6/20/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Foundation
+@testable import iosApp
+import shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class StopDetailsViewTests: XCTestCase {
+    override func setUp() {
+        executionTimeAllowance = 60
+    }
+
+    func testFiltersInSameOrderAsDepartures() throws {
+        let objects = ObjectCollectionBuilder()
+        let routeDefaultSort0 = objects.route { route in
+            route.sortOrder = 0
+            route.type = .bus
+            route.shortName = "Should be second"
+        }
+        let routeDefaultSort1 = objects.route { route in
+            route.sortOrder = 1
+            route.type = .bus
+            route.shortName = "Should be first"
+        }
+        let stop = objects.stop { _ in }
+
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: .init(routes: [
+                .init(route: routeDefaultSort1, stop: stop, patterns: []),
+                .init(route: routeDefaultSort0, stop: stop, patterns: []),
+            ]),
+            errorBannerVM: .init(),
+            nearbyVM: .init(),
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        let routePills = try sut.inspect().find(StopDetailsFilterPills.self).findAll(RoutePill.self)
+        XCTAssertEqual(2, routePills.count)
+        XCTAssertNotNil(try routePills[0].find(text: "Should be first"))
+        XCTAssertNotNil(try routePills[1].find(text: "Should be second"))
+    }
+
+    func testSkipsPillsIfOneRoute() throws {
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { route in
+            route.shortName = "57"
+        }
+        let stop = objects.stop { _ in }
+
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: .init(routes: [
+                .init(route: route, stop: stop, patterns: []),
+            ]),
+            errorBannerVM: .init(),
+            nearbyVM: .init(combinedStopAndTrip: true),
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        XCTAssertNil(try? sut.inspect().find(StopDetailsFilterPills.self))
+        XCTAssertNil(try? sut.inspect().find(button: "All"))
+    }
+
+    func testCloseButtonCloses() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+
+        let nearbyVM: NearbyViewModel = .init(
+            navigationStack: [.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)],
+            combinedStopAndTrip: true
+        )
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        try? sut.inspect().find(viewWithAccessibilityLabel: "Close").button().tap()
+        XCTAssert(nearbyVM.navigationStack.isEmpty)
+    }
+
+    func testBackButtonGoesBack() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+
+        let initialNavStack: [SheetNavigationStackEntry] = [
+            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
+            .tripDetails(tripId: "", vehicleId: "", target: nil, routeId: "", directionId: 0),
+            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
+        ]
+        let nearbyVM: NearbyViewModel = .init(navigationStack: initialNavStack)
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        try? sut.inspect().find(viewWithAccessibilityLabel: "Back").button().tap()
+        XCTAssertEqual(initialNavStack.dropLast(), nearbyVM.navigationStack)
+    }
+
+    func testBackButtonHiddenWhenNearbyIsBack() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+
+        let nearbyVM: NearbyViewModel = .init(navigationStack: [
+            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
+        ])
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        XCTAssertNil(try? sut.inspect().find(viewWithAccessibilityLabel: "Back"))
+    }
+
+    func testDebugModeNotShownByDefault() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { stop in
+            stop.id = "FAKE_STOP_ID"
+        }
+
+        let nearbyVM: NearbyViewModel = .init(
+            navigationStack: [.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)],
+            showDebugMessages: false
+        )
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        XCTAssertThrowsError(try sut.inspect().find(text: "stop id: FAKE_STOP_ID"))
+    }
+
+    func testDebugModeShown() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { stop in
+            stop.id = "FAKE_STOP_ID"
+        }
+
+        let nearbyVM: NearbyViewModel = .init(
+            navigationStack: [.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)],
+            showDebugMessages: true
+        )
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            now: Date.now,
+            pinnedRoutes: [], togglePinnedRoute: { _ in }
+        )
+
+        ViewHosting.host(view: sut)
+        try sut.inspect().findAll(ViewType.Text.self).forEach { view in try print(view.string()) }
+        XCTAssertNotNil(try sut.inspect().find(text: "stop id: FAKE_STOP_ID"))
+    }
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -42,11 +42,13 @@ final class StopDetailsViewTests: XCTestCase {
                 .init(route: routeDefaultSort1, stop: stop, patterns: []),
                 .init(route: routeDefaultSort0, stop: stop, patterns: []),
             ]),
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -72,16 +74,52 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: []),
             ]),
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
         XCTAssertNil(try? sut.inspect().find(StopDetailsFilterPills.self))
         XCTAssertNil(try? sut.inspect().find(button: "All"))
+    }
+
+    func testDisplaysVehicleData() throws {
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { route in
+            route.shortName = "57"
+        }
+        let stop = objects.stop { _ in }
+        let routePattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: routePattern) { _ in }
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.tripId = trip.id
+            vehicle.currentStatus = .inTransitTo
+        }
+
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: .init(routeId: route.id, directionId: 0),
+            tripFilter: .init(tripId: trip.id, vehicleId: vehicle.id, stopSequence: 1, selectionLock: false),
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: .init(routes: [
+                .init(route: route, stop: stop, patterns: []),
+            ]),
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
+            errorBannerVM: .init(),
+            nearbyVM: .init(combinedStopAndTrip: true),
+            mapVM: .init()
+        )
+
+        ViewHosting.host(view: sut)
     }
 
     func testCloseButtonCloses() throws {
@@ -99,11 +137,13 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -128,11 +168,13 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -154,11 +196,13 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -182,11 +226,13 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -210,11 +256,13 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            global: .init(objects: objects),
+            pinnedRoutes: [],
+            togglePinnedRoute: { _ in },
+            now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init(),
-            now: Date.now,
-            pinnedRoutes: [], togglePinnedRoute: { _ in }
+            mapVM: .init()
         )
 
         ViewHosting.host(view: sut)

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -140,16 +140,13 @@ final class ContentViewTests: XCTestCase {
         )
         let sut = ContentView(contentVM: fakeVM)
 
-        let newConfig: ApiResult<ConfigResponse>? = ApiResultOk(data: .init(mapboxPublicToken: "FAKE_TOKEN"))
-
         let hasAppeared = sut.inspection.inspect(after: 2) { view in
-
             try view.actualView().mapVM.lastMapboxErrorSubject.send(Date.now)
         }
 
         ViewHosting.host(view: withDefaultEnvironmentObjects(sut: sut))
 
-        wait(for: [hasAppeared, loadConfigCallback], timeout: 5)
+        wait(for: [hasAppeared, loadConfigCallback], timeout: 6)
     }
 
     @MainActor func testHidesMap() throws {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -435,6 +435,13 @@ sealed class RealtimePatterns {
             now: Instant,
             upcomingTrip: UpcomingTrip,
             routeType: RouteType,
+            context: TripInstantDisplay.Context
+        ) = formatUpcomingTrip(now, upcomingTrip, routeType, context, routeType.isSubway())
+
+        fun formatUpcomingTrip(
+            now: Instant,
+            upcomingTrip: UpcomingTrip,
+            routeType: RouteType,
             context: TripInstantDisplay.Context,
             isSubway: Boolean
         ): Format.Some.FormatWithId? {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsFilter.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsFilter.kt
@@ -1,0 +1,13 @@
+package com.mbta.tid.mbta_app.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TripDetailsFilter(
+    val tripId: String,
+    val vehicleId: String?,
+    val stopSequence: Int?,
+    // This is true when manually selecting a vehicle, so that stop details continues focusing on
+    // a vehicle selected from the map, even after the prediction for that vehicle isn't displayed
+    val selectionLock: Boolean = false
+)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.greenRoutes
@@ -85,13 +86,21 @@ class VehiclesRepository(private val socket: PhoenixSocket) : IVehiclesRepositor
     }
 }
 
-class MockVehiclesRepository(val vehicles: List<Vehicle> = emptyList()) : IVehiclesRepository {
+class MockVehiclesRepository(val response: VehiclesStreamDataResponse) : IVehiclesRepository {
+    constructor(
+        vehicles: List<Vehicle> = emptyList()
+    ) : this(response = VehiclesStreamDataResponse(vehicles.associateBy { it.id }))
+
+    constructor(
+        objects: ObjectCollectionBuilder
+    ) : this(response = VehiclesStreamDataResponse(objects.vehicles))
+
     override fun connect(
         routeId: String,
         directionId: Int,
         onReceive: (ApiResult<VehiclesStreamDataResponse>) -> Unit
     ) {
-        onReceive(ApiResult.Ok(VehiclesStreamDataResponse(vehicles.associateBy { it.id })))
+        onReceive(ApiResult.Ok(response))
     }
 
     override fun disconnect() {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -967,9 +967,9 @@ class StopDetailsDeparturesTest {
 
             assertEquals(
                 StopDetailsFilter(routeId = route.id, directionId = routePattern.directionId),
-                checkNotNull(departures).autoFilter()
+                checkNotNull(departures).autoStopFilter()
             )
-        }
+    }
 
     @Test
     fun `StopDetailsDepartures provides a null filter value given multiple routes and directions`() =
@@ -1005,6 +1005,6 @@ class StopDetailsDeparturesTest {
                     useTripHeadsigns = anyBoolean(),
                 )
 
-            assertEquals(null, checkNotNull(departures).autoFilter())
+            assertEquals(null, checkNotNull(departures).autoStopFilter())
         }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -941,7 +941,7 @@ class StopDetailsDeparturesTest {
     }
 
     @Test
-    fun `StopDetailsDepartures provides a default StopDetailsFilter given a single route and direction`() =
+    fun `autoStopFilter provides a default StopDetailsFilter given a single route and direction`() =
         parametricTest {
             val objects = ObjectCollectionBuilder()
             val stop = objects.stop()
@@ -972,7 +972,7 @@ class StopDetailsDeparturesTest {
     }
 
     @Test
-    fun `StopDetailsDepartures provides a null filter value given multiple routes and directions`() =
+    fun `autoStopFilter provides a null stop filter value given multiple routes and directions`() =
         parametricTest {
             val objects = ObjectCollectionBuilder()
             val stop = objects.stop()
@@ -1006,5 +1006,541 @@ class StopDetailsDeparturesTest {
                 )
 
             assertEquals(null, checkNotNull(departures).autoStopFilter())
+        }
+
+    @Test
+    fun `autoTripFilter provides a trip filter with the first trip selected`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+            val trip1 = objects.trip(routePattern1)
+            val trip2 = objects.trip(routePattern2)
+            val vehicle = objects.vehicle {
+                tripId = trip2.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+                vehicleId = vehicle.id
+            }
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(
+                TripDetailsFilter(trip2.id, vehicle.id, 0, false),
+                checkNotNull(departures).autoTripFilter(
+                    StopDetailsFilter(route2.id, routePattern2.directionId), null, time)
+            )
+        }
+
+    @Test
+    fun `autoTripFilter provides a null trip filter when no stop filter exists`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(null, checkNotNull(departures).autoTripFilter(null, null, time))
+        }
+
+    @Test
+    fun `autoTripFilter provides a null trip filter when no trips exists`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(null, checkNotNull(departures)
+                .autoTripFilter(StopDetailsFilter(
+                    route1.id, routePattern1.directionId), null, time
+                ))
+        }
+
+    @Test
+    fun `autoTripFilter provides current trip filter when trip is still upcoming`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+            val trip1 = objects.trip(routePattern1)
+            val trip2 = objects.trip(routePattern2)
+            val trip3 = objects.trip(routePattern2)
+            val vehicle = objects.vehicle {
+                tripId = trip2.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip3
+                departureTime = time.plus(9.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip3
+                departureTime = time.plus(9.minutes)
+                vehicleId = vehicle.id
+            }
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(
+                TripDetailsFilter(trip3.id, vehicle.id, 0, false),
+                checkNotNull(departures).autoTripFilter(
+                    StopDetailsFilter(route2.id, routePattern2.directionId),
+                    TripDetailsFilter(trip3.id, vehicle.id, 0, false),
+                    time
+                )
+            )
+        }
+
+    @Test
+    fun `autoTripFilter provides next trip when current trip has passed the stop`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+            val trip0 = objects.trip(routePattern2)
+            val trip1 = objects.trip(routePattern1)
+            val trip2 = objects.trip(routePattern2)
+
+            val vehicle0 = objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            val vehicle1 = objects.vehicle {
+                tripId = trip2.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+                vehicleId = vehicle0.id
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+                vehicleId = vehicle1.id
+            }
+
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(
+                TripDetailsFilter(trip2.id, vehicle1.id, 0, false),
+                checkNotNull(departures).autoTripFilter(
+                    StopDetailsFilter(route2.id, routePattern2.directionId),
+                    TripDetailsFilter(trip0.id, vehicle0.id, 0, false),
+                    time
+                )
+            )
+        }
+
+    @Test
+    fun `autoTripFilter provides current trip when current trip has passed the stop and is locked`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+            val trip0 = objects.trip(routePattern2)
+            val trip1 = objects.trip(routePattern1)
+            val trip2 = objects.trip(routePattern2)
+
+            val vehicle0 = objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            val vehicle1 = objects.vehicle {
+                tripId = trip2.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+                vehicleId = vehicle0.id
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+                vehicleId = vehicle1.id
+            }
+
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(
+                TripDetailsFilter(trip0.id, vehicle0.id, 0, true),
+                checkNotNull(departures).autoTripFilter(
+                    StopDetailsFilter(route2.id, routePattern2.directionId),
+                    TripDetailsFilter(trip0.id, vehicle0.id, 0, true),
+                    time
+                )
+            )
+        }
+
+    @Test
+    fun `stopDetailsFormattedTrips provides upcoming trips in a route and direction`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route()
+
+            val routePattern1 =
+                objects.routePattern(route1) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "A" }
+                }
+            val route2 = objects.route()
+            val routePattern2 =
+                objects.routePattern(route2) {
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "B" }
+                }
+
+            val time = Instant.parse("2024-03-19T14:16:17-04:00")
+            val trip0 = objects.trip(routePattern2)
+            val trip1 = objects.trip(routePattern1)
+            val trip2 = objects.trip(routePattern2)
+
+            val vehicle0 = objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            val vehicle1 = objects.vehicle {
+                tripId = trip2.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+            }
+            objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            val schedule2 = objects.schedule {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip0
+                departureTime = time.minus(3.minutes)
+                vehicleId = vehicle0.id
+            }
+            objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip1
+                departureTime = time.plus(2.minutes)
+            }
+            val prediction2 = objects.prediction {
+                stopId = stop.id
+                stopSequence = 0
+                trip = trip2
+                departureTime = time.plus(5.minutes)
+                vehicleId = vehicle1.id
+            }
+
+            val departures =
+                StopDetailsDepartures.fromData(
+                    stop,
+                    GlobalResponse(
+                        objects,
+                        mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
+                    ),
+                    ScheduleResponse(objects),
+                    PredictionsStreamDataResponse(objects),
+                    AlertsStreamDataResponse(objects),
+                    emptySet(),
+                    time,
+                    useTripHeadsigns = anyBoolean(),
+                )
+
+            assertEquals(
+                listOf(
+                    TripAndFormat(
+                        UpcomingTrip(
+                            trip2, schedule2, prediction2, vehicle1
+                        ),
+                        RealtimePatterns.Format.Some.FormatWithId(
+                            trip2.id, route1.type, TripInstantDisplay.Minutes(minutes = 5))
+                    )
+                ),
+                checkNotNull(departures).stopDetailsFormattedTrips(
+                    route2.id, routePattern2.directionId, time)
+            )
         }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Combined stop + trip details: barebones UX](https://app.asana.com/0/1205732265579288/1208725410378675/f)

Stacked onto #554 

This takes the existing trip details page and inserts it into the existing stop details page. Also updates the map to display the stop and vehicle whenever the vehicle filter changes.

![Simulator Screenshot - iPhone 15 - 2024-11-21 at 14 56 46](https://github.com/user-attachments/assets/3351b9c6-9707-40f4-b0e4-420a29feb47c) ![Simulator Screenshot - iPhone 15 - 2024-11-21 at 14 57 06](https://github.com/user-attachments/assets/2ec2fd8e-f085-449a-ab95-3b6ecd5fc4db)


~- [ ] If you added any user facing strings on iOS, are they included in Localizable.xcstrings?~

### Testing

Added tests for new views and kotlin methods, confirmed behavior with feature toggle on and off