### PR TITLE
refactor: Move some stop details logic into a VM

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -197,6 +197,7 @@
 		9ADB849D2BAD05BC006581CE /* Inspection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB849C2BAD05BC006581CE /* Inspection.swift */; };
 		9ADB84A02BAD1B84006581CE /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB849F2BAD1B84006581CE /* DebouncerTests.swift */; };
 		9ADB84A22BAE37C0006581CE /* StopExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADB84A12BAE37C0006581CE /* StopExtension.swift */; };
+		9AE98DAB2CF4CCAE00EE80AA /* StopDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE98DAA2CF4CCAD00EE80AA /* StopDetailsViewModel.swift */; };
 		9AF093782BD943A4001DF39F /* DirectionPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF093772BD943A4001DF39F /* DirectionPicker.swift */; };
 		9AF0937A2BD962FF001DF39F /* DirectionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF093792BD962FF001DF39F /* DirectionPickerTests.swift */; };
 		9AF88E052B48913C00E08C7C /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 9AF88E042B48913C00E08C7C /* Localizable.xcstrings */; };
@@ -283,7 +284,6 @@
 		6E4C37572C4AEF3E00EA67CF /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
 		6E4C375D2C4BDC9F00EA67CF /* ContentViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModelTests.swift; sourceTree = "<group>"; };
 		6E4EACFB2B7A82AC0011AB8B /* MockLocationFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLocationFetcher.swift; sourceTree = "<group>"; };
-		6E50E54D2C4FEFCC004566C5 /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
 		6E55C17E2C247D480086A424 /* LegacyStopDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyStopDetailsView.swift; sourceTree = "<group>"; };
 		6E55C1852C249EF20086A424 /* LegacyStopDetailsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyStopDetailsViewTests.swift; sourceTree = "<group>"; };
 		6E6D45F62CC6E865002A3663 /* zh-Hant-TW */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant-TW"; path = "zh-Hant-TW.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -469,6 +469,7 @@
 		9ADB849C2BAD05BC006581CE /* Inspection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inspection.swift; sourceTree = "<group>"; };
 		9ADB849F2BAD1B84006581CE /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		9ADB84A12BAE37C0006581CE /* StopExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopExtension.swift; sourceTree = "<group>"; };
+		9AE98DAA2CF4CCAD00EE80AA /* StopDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsViewModel.swift; sourceTree = "<group>"; };
 		9AF093772BD943A4001DF39F /* DirectionPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionPicker.swift; sourceTree = "<group>"; };
 		9AF093792BD962FF001DF39F /* DirectionPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionPickerTests.swift; sourceTree = "<group>"; };
 		9AF0937C2BDC1FC5001DF39F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
@@ -917,6 +918,7 @@
 				6E04E32E2BE95A8D006F8131 /* NearbyViewModel.swift */,
 				9A4DB7772C937EE300E8755B /* SearchViewModel.swift */,
 				EDE92FA72C408A32007AD2F6 /* SettingsViewModel.swift */,
+				9AE98DAA2CF4CCAD00EE80AA /* StopDetailsViewModel.swift */,
 				9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */,
 			);
 			path = ViewModels;
@@ -1441,6 +1443,7 @@
 			files = (
 				9A6A51EF2C652BB100E3AC13 /* AlertActivePeriodFormattingExtension.swift in Sources */,
 				8C7726152BE58FE30088D423 /* TripDetailsPage.swift in Sources */,
+				9AE98DAB2CF4CCAE00EE80AA /* StopDetailsViewModel.swift in Sources */,
 				8C2752EF2C6D5CA900F0B0A5 /* TripDetailsAnalytics.swift in Sources */,
 				9A52A2B32CC3035F00CC01D6 /* WithRealtimeIndicator.swift in Sources */,
 				9A5B275C2BB237DE009A6FC6 /* RecenterButton.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @StateObject var mapVM = MapViewModel()
     @StateObject var searchVM = SearchViewModel()
     @StateObject var settingsVM = SettingsViewModel()
+    @StateObject var stopDetailsVM = StopDetailsViewModel()
 
     let transition: AnyTransition = .asymmetric(insertion: .push(from: .bottom), removal: .opacity)
     var screenTracker: ScreenTracker = AnalyticsProvider.shared
@@ -270,6 +271,7 @@ struct ContentView: View {
                             errorBannerVM: errorBannerVM,
                             nearbyVM: nearbyVM,
                             mapVM: mapVM,
+                            stopDetailsVM: stopDetailsVM,
                             viewportProvider: viewportProvider
                         )
                         .toolbar(.hidden, for: .tabBar)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -99,7 +99,7 @@ struct StopDetailsPage: View {
                     joinPredictions()
                 },
                 onInactive: stopDetailsVM.leavePredictions,
-                onBackground: { @MainActor in
+                onBackground: {
                     stopDetailsVM.leavePredictions()
                     errorBannerVM.loadingWhenPredictionsStale = true
                 }

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -227,7 +227,7 @@ struct TripDetailsView: View {
     private func joinVehicle(vehicleId: String?) {
         guard let vehicleId else { return }
         vehicleRepository.connect(vehicleId: vehicleId) { outcome in
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 let errorKey = "TripDetailsPage.joinVehicle"
                 switch onEnum(of: outcome) {
                 case let .ok(result):

--- a/iosApp/iosApp/Utils/ScenePhaseChangeModifier.swift
+++ b/iosApp/iosApp/Utils/ScenePhaseChangeModifier.swift
@@ -16,7 +16,7 @@ struct ScenePhaseChangeModifier: ViewModifier {
     let onBackground: () -> Void
 
     func body(content: Content) -> some View {
-        content.onChange(of: scenePhase) { newPhase in
+        content.onChange(of: scenePhase) { @MainActor newPhase in
             if newPhase == .active {
                 onActive()
             } else if newPhase == .inactive {

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -1,0 +1,145 @@
+//
+//  StopDetailsViewModel.swift
+//  iosApp
+//
+//  Created by esimon on 11/25/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import shared
+import SwiftPhoenixClient
+import SwiftUI
+
+class StopDetailsViewModel: ObservableObject {
+    @Published var global: GlobalResponse?
+    @Published var pinnedRoutes: Set<String> = []
+    @Published var predictionsByStop: PredictionsByStopJoinResponse?
+    @Published var schedulesResponse: ScheduleResponse?
+
+    let globalRepository: IGlobalRepository
+    let pinnedRoutesRepository: IPinnedRoutesRepository
+    let predictionsRepository: IPredictionsRepository
+    let schedulesRepository: ISchedulesRepository
+    let tripPredictionsRepository: ITripPredictionsRepository
+    let tripRepository: ITripRepository
+    let vehicleRepository: IVehicleRepository
+
+    let togglePinnedUsecase = UsecaseDI().toggledPinnedRouteUsecase
+
+    init(
+        globalRepository: IGlobalRepository = RepositoryDI().global,
+        pinnedRoutesRepository: IPinnedRoutesRepository = RepositoryDI().pinnedRoutes,
+        predictionsRepository: IPredictionsRepository = RepositoryDI().predictions,
+        schedulesRepository: ISchedulesRepository = RepositoryDI().schedules,
+        tripPredictionsRepository: ITripPredictionsRepository = RepositoryDI().tripPredictions,
+        tripRepository: ITripRepository = RepositoryDI().trip,
+        vehicleRepository: IVehicleRepository = RepositoryDI().vehicle
+    ) {
+        self.globalRepository = globalRepository
+        self.pinnedRoutesRepository = pinnedRoutesRepository
+        self.predictionsRepository = predictionsRepository
+        self.schedulesRepository = schedulesRepository
+        self.tripPredictionsRepository = tripPredictionsRepository
+        self.tripRepository = tripRepository
+        self.vehicleRepository = vehicleRepository
+    }
+
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            Task { @MainActor in global = globalData }
+        }
+    }
+
+    func getDepartures(
+        stopId: String,
+        alerts: AlertsStreamDataResponse?,
+        useTripHeadsigns: Bool,
+        now: Date
+    ) -> StopDetailsDepartures? {
+        if let global {
+            StopDetailsDepartures.companion.fromData(
+                stopId: stopId,
+                global: global,
+                schedules: schedulesResponse,
+                predictions: predictionsByStop?.toPredictionsStreamDataResponse(),
+                alerts: alerts,
+                pinnedRoutes: pinnedRoutes,
+                filterAtTime: now.toKotlinInstant(),
+                useTripHeadsigns: useTripHeadsigns
+            )
+        } else {
+            nil
+        }
+    }
+
+    func joinPredictions(_ stopId: String, onSuccess: @escaping () -> Void, onComplete: @escaping () -> Void) {
+        // no error handling since persistent errors cause stale predictions
+        predictionsRepository.connectV2(stopIds: [stopId], onJoin: { outcome in
+            Task { @MainActor in
+                if case let .ok(result) = onEnum(of: outcome) {
+                    self.predictionsByStop = result.data
+                    onSuccess()
+                }
+                onComplete()
+            }
+        }, onMessage: { outcome in
+            if case let .ok(result) = onEnum(of: outcome) {
+                let nextPredictions = if let existingPredictionsByStop = self.predictionsByStop {
+                    existingPredictionsByStop.mergePredictions(updatedPredictions: result.data)
+                } else {
+                    PredictionsByStopJoinResponse(
+                        predictionsByStop: [result.data.stopId: result.data.predictions],
+                        trips: result.data.trips,
+                        vehicles: result.data.vehicles
+                    )
+                }
+                Task { @MainActor in
+                    self.predictionsByStop = nextPredictions
+                    onSuccess()
+                }
+            }
+
+            Task { @MainActor in onComplete() }
+        })
+    }
+
+    func leavePredictions() {
+        predictionsRepository.disconnect()
+    }
+
+    func loadPinnedRoutes() {
+        Task {
+            do {
+                let nextPinned = try await pinnedRoutesRepository.getPinnedRoutes()
+                Task { @MainActor in pinnedRoutes = nextPinned }
+            } catch is CancellationError {
+                // do nothing on cancellation
+            } catch {
+                // getPinnedRoutes shouldn't actually fail
+                debugPrint(error)
+            }
+        }
+    }
+
+    func togglePinnedRoute(_ routeId: String) {
+        Task {
+            do {
+                _ = try await togglePinnedUsecase.execute(route: routeId)
+                loadPinnedRoutes()
+            } catch is CancellationError {
+                // do nothing on cancellation
+            } catch {
+                // execute shouldn't actually fail
+                debugPrint(error)
+            }
+        }
+    }
+
+    func returnFromBackground() {
+        if let predictionsByStop,
+           predictionsRepository
+           .shouldForgetPredictions(predictionCount: predictionsByStop.predictionQuantity()) {
+            Task { @MainActor in self.predictionsByStop = nil }
+        }
+    }
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -40,6 +40,11 @@ final class StopDetailsPageTests: XCTestCase {
             }
         }
 
+        let stopDetailsVM = StopDetailsViewModel(
+            predictionsRepository: MockPredictionsRepository(),
+            schedulesRepository: MockScheduleRepository(scheduleResponse: .init(objects: objects), callback: callback)
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -47,9 +52,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository(scheduleResponse: .init(objects: objects), callback: callback)
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         ViewHosting.host(view: sut)
@@ -107,15 +111,7 @@ final class StopDetailsPageTests: XCTestCase {
         nearbyVM.alerts = .init(alerts: [:])
 
         let schedulesLoadedPublisher = PassthroughSubject<Bool, Never>()
-
-        let sut = StopDetailsPage(
-            stopId: stop.id,
-            stopFilter: stopFilter,
-            tripFilter: nil,
-            errorBannerVM: .init(),
-            nearbyVM: nearbyVM,
-            mapVM: .init(),
-            viewportProvider: viewportProvider,
+        let stopDetailsVM = StopDetailsViewModel(
             globalRepository: MockGlobalRepository(response: .init(objects: objects)),
             predictionsRepository: MockPredictionsRepository(
                 connectV2Outcome: .init(objects: objects)
@@ -124,6 +120,17 @@ final class StopDetailsPageTests: XCTestCase {
                 scheduleResponse: .init(objects: objects),
                 callback: { _ in schedulesLoadedPublisher.send(true) }
             )
+        )
+
+        let sut = StopDetailsPage(
+            stopId: stop.id,
+            stopFilter: stopFilter,
+            tripFilter: nil,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
+            mapVM: .init(),
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         XCTAssertNotNil(nearbyVM.navigationStack.lastStopDetailsFilter)
@@ -161,6 +168,15 @@ final class StopDetailsPageTests: XCTestCase {
         let nearbyVM = NearbyViewModel(combinedStopAndTrip: true)
         nearbyVM.alerts = .init(alerts: [:])
 
+        let stopDetailsVM = StopDetailsViewModel(
+            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
+            schedulesRepository: MockScheduleRepository(
+                scheduleResponse: .init(objects: objects),
+                callback: { _ in schedulesLoadedPublisher.send(true) }
+            )
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -168,13 +184,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            globalRepository: MockGlobalRepository(response: .init(objects: objects, patternIdsByStop: [:])),
-            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .companion.empty),
-            schedulesRepository: MockScheduleRepository(
-                scheduleResponse: .init(objects: objects),
-                callback: { _ in schedulesLoadedPublisher.send(true) }
-            )
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         let exp = sut.inspection.inspect(onReceive: schedulesLoadedPublisher, after: 1) { view in
@@ -208,6 +219,11 @@ final class StopDetailsPageTests: XCTestCase {
             .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
         ]
 
+        let stopDetailsVM = StopDetailsViewModel(
+            predictionsRepository: MockPredictionsRepository(),
+            schedulesRepository: MockScheduleRepository()
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: nil,
@@ -215,9 +231,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: .init(),
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository()
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: .init()
         )
 
         try sut.inspect().find(viewWithAccessibilityLabel: "Back").button().tap()
@@ -238,6 +253,11 @@ final class StopDetailsPageTests: XCTestCase {
             combinedStopAndTrip: true
         )
 
+        let stopDetailsVM = StopDetailsViewModel(
+            predictionsRepository: MockPredictionsRepository(),
+            schedulesRepository: MockScheduleRepository()
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: nil,
@@ -245,9 +265,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: .init(),
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository()
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: .init()
         )
 
         try sut.inspect().find(viewWithAccessibilityLabel: "Close").button().tap()
@@ -274,6 +293,12 @@ final class StopDetailsPageTests: XCTestCase {
             connectOutcome: nil,
             connectV2Outcome: nil
         )
+
+        let stopDetailsVM = StopDetailsViewModel(
+            predictionsRepository: predictionsRepo,
+            schedulesRepository: MockScheduleRepository()
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -281,9 +306,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            predictionsRepository: predictionsRepo,
-            schedulesRepository: MockScheduleRepository()
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         ViewHosting.host(view: sut)
@@ -318,6 +342,12 @@ final class StopDetailsPageTests: XCTestCase {
             connectOutcome: nil,
             connectV2Outcome: nil
         )
+
+        let stopDetailsVM = StopDetailsViewModel(
+            predictionsRepository: predictionsRepo,
+            schedulesRepository: MockScheduleRepository()
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -325,9 +355,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            predictionsRepository: predictionsRepo,
-            schedulesRepository: MockScheduleRepository()
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         ViewHosting.host(view: sut)
@@ -359,13 +388,15 @@ final class StopDetailsPageTests: XCTestCase {
         )
         nearbyVM.alerts = .init(alerts: [:])
 
-        let globalDataLoaded = PassthroughSubject<Void, Never>()
-
-        let globalResponse: GlobalResponse = .init(
-            objects: objects,
-            patternIdsByStop: [stop.id: [pattern.id]]
+        let stopDetailsVM = StopDetailsViewModel(
+            globalRepository: MockGlobalRepository(),
+            predictionsRepository: MockPredictionsRepository(),
+            schedulesRepository: MockScheduleRepository()
         )
-        let predictionsRepo = MockPredictionsRepository()
+        stopDetailsVM.global = .init(objects: objects, patternIdsByStop: [stop.id: [pattern.id]])
+        stopDetailsVM.predictionsByStop = .init(objects: objects)
+        stopDetailsVM.schedulesResponse = .init(objects: objects)
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -373,26 +404,20 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            globalRepository: MockGlobalRepository(
-                response: globalResponse,
-                onGet: { globalDataLoaded.send() }
-            ),
-            predictionsRepository: predictionsRepo,
-            schedulesRepository: MockScheduleRepository()
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         XCTAssertNil(nearbyVM.departures)
-        let hasAppeared = sut.inspection.inspect(onReceive: globalDataLoaded, after: 1) { view in
-            try view.find(StopDetailsView.self)
-                .callOnChange(newValue: PredictionsByStopJoinResponse(objects: objects))
+
+        let hasSetDepartures = sut.inspection.inspect { view in
             XCTAssertNotNil(nearbyVM.departures)
             // Keeps internal departures in sync with VM departures
             XCTAssertEqual(try view.actualView().internalDepartures, nearbyVM.departures)
         }
         ViewHosting.host(view: sut)
 
-        wait(for: [hasAppeared], timeout: 5)
+        wait(for: [hasSetDepartures], timeout: 2)
     }
 
     @MainActor
@@ -429,6 +454,15 @@ final class StopDetailsPageTests: XCTestCase {
         )
         nearbyVM.alerts = .init(alerts: [:])
 
+        let stopDetailsVM = StopDetailsViewModel(
+            globalRepository: MockGlobalRepository(response: .init(objects: objects)),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .init(objects: objects)),
+            schedulesRepository: MockScheduleRepository(
+                scheduleResponse: .init(objects: objects),
+                callback: { _ in schedulesLoadedPublisher.send() }
+            )
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: nil,
@@ -436,13 +470,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            globalRepository: MockGlobalRepository(response: .init(objects: objects)),
-            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .init(objects: objects)),
-            schedulesRepository: MockScheduleRepository(
-                scheduleResponse: .init(objects: objects),
-                callback: { _ in schedulesLoadedPublisher.send() }
-            )
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         let stopFilterExp = sut.inspection.inspect(onReceive: schedulesLoadedPublisher) { _ in
@@ -483,11 +512,6 @@ final class StopDetailsPageTests: XCTestCase {
         objects.prediction(schedule: schedule) { prediction in
             prediction.departureTime = (Date.now + 10 * 60).toKotlinInstant()
         }
-//        objects.vehicle { vehicle in
-//            vehicle.currentStopSequence = 0
-//            vehicle.currentStatus = .inTransitTo
-//            vehicle.tripId = trip.id
-//        }
 
         let schedulesLoadedPublisher = PassthroughSubject<Void, Never>()
 
@@ -499,6 +523,15 @@ final class StopDetailsPageTests: XCTestCase {
         )
         nearbyVM.alerts = .init(alerts: [:])
 
+        let stopDetailsVM = StopDetailsViewModel(
+            globalRepository: MockGlobalRepository(response: .init(objects: objects)),
+            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .init(objects: objects)),
+            schedulesRepository: MockScheduleRepository(
+                scheduleResponse: .init(objects: objects),
+                callback: { _ in schedulesLoadedPublisher.send() }
+            )
+        )
+
         let sut = StopDetailsPage(
             stopId: stop.id,
             stopFilter: stopFilter,
@@ -506,13 +539,8 @@ final class StopDetailsPageTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            viewportProvider: viewportProvider,
-            globalRepository: MockGlobalRepository(response: .init(objects: objects)),
-            predictionsRepository: MockPredictionsRepository(connectV2Outcome: .init(objects: objects)),
-            schedulesRepository: MockScheduleRepository(
-                scheduleResponse: .init(objects: objects),
-                callback: { _ in schedulesLoadedPublisher.send() }
-            )
+            stopDetailsVM: stopDetailsVM,
+            viewportProvider: viewportProvider
         )
 
         let vehicleFilterExp = sut.inspection.inspect(onReceive: schedulesLoadedPublisher) { _ in

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -42,13 +42,13 @@ final class StopDetailsViewTests: XCTestCase {
                 .init(route: routeDefaultSort1, stop: stop, patterns: []),
                 .init(route: routeDefaultSort0, stop: stop, patterns: []),
             ]),
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init(
+                globalRepository: MockGlobalRepository(response: .init(objects: objects))
+            )
         )
 
         ViewHosting.host(view: sut)
@@ -74,13 +74,11 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: []),
             ]),
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -110,13 +108,11 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: []),
             ]),
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(combinedStopAndTrip: true),
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -138,13 +134,11 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -169,13 +163,11 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -197,13 +189,11 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -227,13 +217,11 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)
@@ -257,13 +245,11 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
-            global: .init(objects: objects),
-            pinnedRoutes: [],
-            togglePinnedRoute: { _ in },
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
-            mapVM: .init()
+            mapVM: .init(),
+            stopDetailsVM: .init()
         )
 
         ViewHosting.host(view: sut)


### PR DESCRIPTION
### Summary

_Ticket:_ [Combined stop + trip details: departure list UI](https://app.asana.com/0/1205732265579288/1208725410378678/f)

Discussed in https://github.com/mbta/mobile_app/pull/551#discussion_r1854636220, this moves a chunk of the logic in the stop details extension into a new stop details VM. I didn't include any logic that touched other VMs (nearby and errordetails), so about half of the logic still lives in the extension.

This should probably also include any required trip details calls, but we can do that as part of [Combined stop + trip details: Trip details UI](https://app.asana.com/0/1205732265579288/1208725410378682/f).

~- [ ] If you added any user facing strings on iOS, are they included in Localizable.xcstrings?~

### Testing

Updated tests to use the VM instead of passing repos directly into the view