### PR TITLE
ci(android): build and deploy staging, not prod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,15 +149,15 @@ jobs:
           MAPBOX_SECRET_TOKEN: ${{ secrets.MAPBOX_SECRET_TOKEN }}
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
         run: |
-          bundle exec fastlane android build flavor:Prod
+          bundle exec fastlane android build flavor:Staging
       - uses: actions/upload-artifact@v4
         with:
           name: android-apk
-          path: androidApp/build/outputs/apk/prod/release/androidApp-prod-release.apk
+          path: androidApp/build/outputs/apk/staging/release/androidApp-staging-release.apk
       - uses: actions/upload-artifact@v4
         with:
           name: android-aab
-          path: androidApp/build/outputs/bundle/prodRelease/androidApp-prod-release.aab
+          path: androidApp/build/outputs/bundle/stagingRelease/androidApp-staging-release.aab
   deploy-android:
     name: Upload to Google Play
     if: github.event_name != 'pull_request'
@@ -177,7 +177,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: android-aab
-          path: androidApp/build/outputs/bundle/prodRelease
+          path: androidApp/build/outputs/bundle/stagingRelease
       - uses: ./.github/actions/setup
         with:
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -185,4 +185,4 @@ jobs:
           ruby: true
       - name: Upload to Google Play
         run: |
-          bundle exec fastlane android internal flavor:Prod
+          bundle exec fastlane android internal flavor:Staging


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up separate staging and prod Android builds](https://app.asana.com/0/1205732265579288/1208788669093059/f)

In #552 we couldn't deploy to the staging app yet, but now we can. We'll need a separate workflow for prod deploys for Android, but we can set that up later.

### Testing

Checked `fastlane android build flavor:Staging` locally.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
