### PR TITLE
fix(downstreamAlerts): Ignore alerts without stops specified

### DIFF
--- a/iosApp/iosApp/Utils/AlertExtension.swift
+++ b/iosApp/iosApp/Utils/AlertExtension.swift
@@ -18,6 +18,7 @@ extension shared.Alert {
         case .snowRoute: Text("Snow route", comment: "Possible alert effect")
         case .stopClosure: Text("Stop closed", comment: "Possible alert effect")
         case .suspension: Text("Service suspended", comment: "Possible alert effect")
+        case .serviceChange: Text("Service change", comment: "Possible alert effect")
         default: Text("Alert", comment: "Possible alert effect")
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -29,6 +29,8 @@ data class Alert(
             else -> StopAlertState.Issue
         }
 
+    val hasStopsSpecified = informedEntity.all { it.stop != null }
+
     val significance =
         when (effect) {
             // suspensions or shuttles can reasonably apply to an entire route
@@ -40,9 +42,7 @@ data class Alert(
                 Effect.DockClosure,
                 Effect.Detour,
                 Effect.SnowRoute
-            ) ->
-                if (informedEntity.all { it.stop != null }) AlertSignificance.Major
-                else AlertSignificance.Secondary
+            ) -> if (hasStopsSpecified) AlertSignificance.Major else AlertSignificance.Secondary
             // service changes are always secondary
             Effect.ServiceChange -> AlertSignificance.Secondary
             else -> AlertSignificance.None
@@ -240,6 +240,7 @@ data class Alert(
 
         /**
          * Gets the alerts of the first stop that is downstream of the target stop which has alerts.
+         * Considers only alerts that have specified stops.
          *
          * @param alerts: The full list of alerts
          * @param trip: The trip used to calculate downstream stops
@@ -251,6 +252,8 @@ data class Alert(
             targetStopWithChildren: Set<String>,
         ): List<Alert> {
             val stopIds = trip.stopIds ?: emptyList()
+
+            val alerts = alerts.filter { it.hasStopsSpecified }
 
             val indexOfTargetStopInPattern =
                 stopIds.indexOfFirst { targetStopWithChildren.contains(it) }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -316,4 +316,42 @@ class AlertTest {
 
         assertEquals(listOf(firstBoardAlert), downstreamAlerts)
     }
+
+
+    @Test
+    fun `downstreamAlerts ignores alert without stops specified`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+        val targetStop = objects.stop()
+        val nextStop = objects.stop()
+
+        val alert =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board),
+                    route = route.id,
+                    directionId = null
+                )
+            }
+
+        val trip =
+            objects.trip {
+                routeId = route.id
+                directionId = 0
+                stopIds =
+                    listOf(
+                        targetStop.id,
+                        nextStop.id,
+                    )
+            }
+
+        val downstreamAlerts =
+            Alert.downstreamAlerts(
+                listOf(alert),
+                trip,
+                setOf(targetStop.id)
+            )
+
+        assertEquals(listOf(), downstreamAlerts)
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display downstream disruptions](https://app.asana.com/0/1205732265579288/1208643635656242/f)

What is this PR for?

Follow up to https://github.com/mbta/mobile_app/pull/539 for fixes observed during GL service change yesterday. 
* Alerts without stops specified should not be considered for downstream alerts
* Missing Service change text description

- [ ] If you added any user facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

### Testing

What testing have you done?
* Added unit test
* Created test alerts & confirmed expected behavior
    * Blue Line - service change without stops specified
    * Orange Line - service change with stops specified
    
![IMG_0204](https://github.com/user-attachments/assets/150d6bce-b858-4337-804b-266f811c60ca)
![IMG_0205](https://github.com/user-attachments/assets/a23db99e-6c79-42ae-a152-35ce0b56ed41)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
