### PR TITLE
feat(MorePage): Settings & feature flags

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
@@ -1,0 +1,38 @@
+package com.mbta.tid.mbta_app.android.more
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.model.morePage.MoreItem
+import com.mbta.tid.mbta_app.model.morePage.MoreSection
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class MoreSectionViewTests {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testToggleItem() {
+        var toggleCallbackCalled = false
+        composeTestRule.setContent {
+            MoreSectionView(
+                section =
+                    MoreSection(
+                        MoreSection.Category.Settings,
+                        listOf(MoreItem.Toggle("Toggle 1", Settings.HideMaps, true))
+                    )
+            ) {
+                toggleCallbackCalled = true
+            }
+        }
+
+        composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Toggle 1").performClick()
+
+        assertTrue { toggleCallbackCalled }
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -1,0 +1,39 @@
+package com.mbta.tid.mbta_app.android.more
+
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class MoreViewModelTests {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testToggleSetting() = runTest {
+        var toggledHideMaps = false
+
+        val settingsRepository =
+            MockSettingsRepository(
+                settings = mapOf(Settings.HideMaps to false),
+                onSaveSettings = { settings ->
+                    if (settings.size == 1 && settings.containsKey(Settings.HideMaps)) {
+                        toggledHideMaps = true
+                    }
+                }
+            )
+
+        var vm: MoreViewModel? = null
+        composeTestRule.setContent { vm = MoreViewModel(LocalContext.current, settingsRepository) }
+
+        composeTestRule.awaitIdle()
+        vm!!.toggleSetting(Settings.HideMaps)
+        composeTestRule.awaitIdle()
+
+        assertTrue { toggledHideMaps }
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -3,10 +3,19 @@ package com.mbta.tid.mbta_app.android.pages
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.koin.compose.KoinContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import org.koin.test.KoinTest
 
-class MorePageTests {
+class MorePageTests : KoinTest {
 
     @get:Rule val composeTestRule = createComposeRule()
 
@@ -15,5 +24,35 @@ class MorePageTests {
         composeTestRule.setContent { MorePage(bottomBar = {}) }
 
         composeTestRule.onNodeWithText("MBTA Go").assertIsDisplayed()
+    }
+
+    @Test
+    fun testSettings() {
+
+        var hideMapToggleCalled = false
+
+        val koinApplication = koinApplication {
+            modules(
+                module {
+                    single<ISettingsRepository> {
+                        MockSettingsRepository(
+                            onSaveSettings = { settings ->
+                                if (settings.size == 1 && settings.containsKey(Settings.HideMaps)) {
+                                    hideMapToggleCalled = true
+                                }
+                            }
+                        )
+                    }
+                }
+            )
+        }
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
+        }
+
+        composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Hide Maps").performClick()
+
+        assertTrue { hideMapToggleCalled }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/LabeledSwitch.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/LabeledSwitch.kt
@@ -1,0 +1,30 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+
+// From https://www.magentaa11y.com/checklist-native/toggle-switch/
+@Composable
+fun LabeledSwitch(label: String, value: Boolean, onValueChange: ((Boolean) -> Unit)) {
+    Row(
+        modifier =
+            Modifier.toggleable(
+                    value = value,
+                    role = Role.Switch,
+                    onValueChange = onValueChange,
+                )
+                .fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label)
+
+        Switch(checked = value, onCheckedChange = null)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
@@ -1,0 +1,61 @@
+package com.mbta.tid.mbta_app.android.more
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.appVariant
+import com.mbta.tid.mbta_app.android.component.LabeledSwitch
+import com.mbta.tid.mbta_app.model.morePage.MoreItem
+import com.mbta.tid.mbta_app.model.morePage.MoreSection
+import com.mbta.tid.mbta_app.repositories.Settings
+
+@Composable
+fun MoreSectionView(section: MoreSection, toggleSetting: ((Settings) -> Unit)) {
+
+    val name: String? =
+        when (section.id) {
+            MoreSection.Category.Settings -> stringResource(id = R.string.more_section_settings)
+            MoreSection.Category.FeatureFlags ->
+                stringResource(id = R.string.more_section_feature_flags)
+            else -> null
+        }
+
+    val note: String? = null
+
+    if (!(section.requiresStaging && appVariant != AppVariant.Staging)) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            if (name != null) {
+                Column {
+                    Text(name, style = MaterialTheme.typography.titleMedium)
+                    if (note != null) {
+                        Text(note)
+                    }
+                }
+            }
+            Column {
+                section.items.mapIndexed { index, item ->
+                    when (item) {
+                        is MoreItem.Toggle ->
+                            ListItem({
+                                LabeledSwitch(label = item.label, value = item.value) {
+                                    toggleSetting(item.settings)
+                                }
+                            })
+                    }
+
+                    if (index < section.items.size) {
+                        androidx.compose.material3.HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -1,0 +1,76 @@
+package com.mbta.tid.mbta_app.android.more
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.morePage.MoreItem
+import com.mbta.tid.mbta_app.model.morePage.MoreSection
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class MoreViewModel(val context: Context, private val settingsRepository: ISettingsRepository) :
+    ViewModel() {
+
+    private val _settings = MutableStateFlow<Map<Settings, Boolean>>(mapOf())
+    private val _sections = MutableStateFlow<List<MoreSection>>(listOf())
+    var sections = _sections.asStateFlow()
+
+    init {
+        CoroutineScope(Dispatchers.IO).launch { loadSettings() }
+    }
+
+    fun toggleSetting(setting: Settings) {
+        setSettings(mapOf(setting to !(_settings.value[setting] ?: false)))
+    }
+
+    fun getSections(settings: Map<Settings, Boolean>): List<MoreSection> {
+
+        return listOf(
+            MoreSection(
+                id = MoreSection.Category.Settings,
+                items =
+                    listOf(
+                        MoreItem.Toggle(
+                            label = context.resources.getString(R.string.setting_toggle_hide_maps),
+                            settings = Settings.HideMaps,
+                            value = settings[Settings.HideMaps] ?: false
+                        )
+                    )
+            ),
+            MoreSection(
+                id = MoreSection.Category.FeatureFlags,
+                items =
+                    listOf(
+                        MoreItem.Toggle(
+                            label = "Debug Mode",
+                            settings = Settings.DevDebugMode,
+                            value = settings[Settings.DevDebugMode] ?: false
+                        ),
+                        MoreItem.Toggle(
+                            label = "Route Search",
+                            settings = Settings.SearchRouteResults,
+                            value = settings[Settings.SearchRouteResults] ?: false
+                        )
+                    )
+            ),
+        )
+    }
+
+    private fun setSettings(settings: Map<Settings, Boolean>) {
+        CoroutineScope(Dispatchers.IO).launch {
+            settingsRepository.setSettings(settings)
+            loadSettings()
+        }
+    }
+
+    private suspend fun loadSettings() {
+        val latestSettings = settingsRepository.getSettings()
+        _settings.value = latestSettings
+        _sections.value = getSections(latestSettings)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -6,13 +6,24 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.more.MoreSectionView
+import com.mbta.tid.mbta_app.android.more.MoreViewModel
+import org.koin.compose.koinInject
 
 @Composable
-fun MorePage(bottomBar: @Composable () -> Unit) {
+fun MorePage(
+    bottomBar: @Composable () -> Unit,
+    viewModel: MoreViewModel = MoreViewModel(LocalContext.current, koinInject())
+) {
+
+    val sections by viewModel.sections.collectAsState()
     Scaffold(bottomBar = bottomBar) { outerSheetPadding ->
         Column(Modifier.padding(outerSheetPadding)) {
             Text(
@@ -20,6 +31,9 @@ fun MorePage(bottomBar: @Composable () -> Unit) {
                 modifier = Modifier.padding(16.dp),
                 style = MaterialTheme.typography.titleLarge
             )
+            sections.map { section ->
+                MoreSectionView(section = section) { setting -> viewModel.toggleSetting(setting) }
+            }
         }
     }
 }

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -10,12 +10,16 @@
     <string name="hello_platform">Hello, %1$s!</string>
     <string name="minutes_abbr">%1$s min</string>
     <string name="more_link">More</string>
+    <string name="more_section_feature_flags">Feature Flags</string>
+    <string name="more_section_settings">Settings</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit_link">Nearby</string>
     <string name="no_service">No Service</string>
     <string name="no_stops_nearby">Your current location is outside of our search area.</string>
     <string name="no_stops_nearby_title">No nearby MBTA stops</string>
     <string name="now">Now</string>
+    <string name="setting_toggle_hide_maps">Hide Maps</string>
+    <string name="settings_link">Settings</string>
     <string name="shuttle">Shuttle</string>
     <string name="stop_closed">Stop Closed</string>
     <string name="suspension">Suspension</string>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
@@ -1,0 +1,14 @@
+package com.mbta.tid.mbta_app.model.morePage
+
+import com.mbta.tid.mbta_app.repositories.Settings
+
+sealed class MoreItem {
+
+    data class Toggle(val label: String, val settings: Settings, val value: Boolean) : MoreItem()
+
+    fun id() {
+        when (this) {
+            is Toggle -> settings.name
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
@@ -1,0 +1,15 @@
+package com.mbta.tid.mbta_app.model.morePage
+
+class MoreSection(var id: Category, var items: List<MoreItem>) {
+
+    enum class Category {
+        FeatureFlags,
+        Settings
+    }
+
+    val requiresStaging: Boolean =
+        when (this.id) {
+            Category.FeatureFlags -> true
+            else -> false
+        }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | More | Expose feature flags in settings](https://app.asana.com/0/1205732265579288/1208839363050252/f)

What is this PR for?

This PR add settings and feature flags to the more page for Android. Follows the same structure as the more page in iOS.

### Testing

What testing have you done?
Wrote unit tests, ran locally and confirmed I could toggle settings as expected
![image](https://github.com/user-attachments/assets/50c1e2b7-29ff-42a4-a6da-35945063b899)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
