### PR TITLE
feat: extend non-typical upcoming cutoff to 120 min

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -768,7 +768,7 @@ fun NearbyStaticData.withRealtimeInfo(
             alerts,
             filterAtTime,
             showAllPatternsWhileLoading = false,
-            hideNonTypicalPatternsBeyondNext = 90.minutes,
+            hideNonTypicalPatternsBeyondNext = 120.minutes,
             filterCancellations = true,
             pinnedRoutes
         )
@@ -781,7 +781,7 @@ fun NearbyStaticData.withRealtimeInfo(
             alerts,
             filterAtTime,
             showAllPatternsWhileLoading = false,
-            hideNonTypicalPatternsBeyondNext = 90.minutes,
+            hideNonTypicalPatternsBeyondNext = 120.minutes,
             filterCancellations = true,
             pinnedRoutes
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -1008,14 +1008,14 @@ class NearbyResponseTest {
             }
         val deviationOutboundPrediction =
             objects.prediction {
-                departureTime = time + 89.minutes
+                departureTime = time + 119.minutes
                 routeId = route1.id
                 stopId = stop1.id
                 tripId = deviationOutbound.representativeTripId
             }
         val deviationInboundPrediction =
             objects.prediction {
-                departureTime = time + 91.minutes
+                departureTime = time + 121.minutes
                 routeId = route1.id
                 stopId = stop1.id
                 tripId = deviationInbound.representativeTripId
@@ -1172,7 +1172,7 @@ class NearbyResponseTest {
             objects.schedule {
                 stopId = stop1.id
                 trip = objects.trip(scheduleLater)
-                departureTime = time + 91.minutes
+                departureTime = time + 121.minutes
             }
         val predictionPastPrediction =
             objects.prediction {
@@ -1204,7 +1204,7 @@ class NearbyResponseTest {
             objects.prediction {
                 stopId = stop1.id
                 trip = objects.trip(predictionLater)
-                departureTime = time + 91.minutes
+                departureTime = time + 121.minutes
             }
 
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ [Update lookahead from 90 to 120 minutes](https://app.asana.com/0/1205732265579288/1208643635653118/f)

There are no longer references to 90 minutes anywhere in the app.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource

### Testing

Updated the unit tests. Did not spend a ton of time trying to find a case where a pattern is filtered in at 120 minutes that was filtered out at 90, but it should be fine.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
