### PR TITLE
feat(Android): use custom map styles

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -26,7 +26,6 @@ import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.RenderedQueryGeometry
 import com.mapbox.maps.RenderedQueryOptions
-import com.mapbox.maps.Style
 import com.mapbox.maps.ViewAnnotationAnchor
 import com.mapbox.maps.extension.compose.DisposableMapEffect
 import com.mapbox.maps.extension.compose.MapEffect
@@ -45,6 +44,7 @@ import com.mapbox.maps.plugin.viewport.data.DefaultViewportTransitionOptions
 import com.mapbox.maps.viewannotation.annotationAnchor
 import com.mapbox.maps.viewannotation.geometry
 import com.mapbox.maps.viewannotation.viewAnnotationOptions
+import com.mbta.tid.mbta_app.android.appVariant
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.state.getRailRouteShapes
@@ -263,7 +263,11 @@ fun HomeMapView(
             compass = {},
             scaleBar = {},
             mapViewportState = viewportProvider.viewport,
-            style = { MapStyle(style = if (isDarkMode) Style.DARK else Style.LIGHT) }
+            style = {
+                MapStyle(
+                    style = if (isDarkMode) appVariant.darkMapStyle else appVariant.lightMapStyle
+                )
+            }
         ) {
             LaunchedEffect(currentNavEntry) { handleNavChange() }
             LaunchedEffect(railRouteShapes, globalResponse, globalMapData) {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Map | Mapbox styles updated](https://app.asana.com/0/1205732265579288/1208852051039921/f)

I wish every ticket was this easy.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource

### Testing

Verified that the map looks different on the current staging build than it does on this branch.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
