### PR TITLE
fix: Move scrolling to encompass entire stop page

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -8722,7 +8722,7 @@
       }
     },
     "Waiting to depart" : {
-      "comment" : "Label for a vehicle stopped at a terminal station waiting to start a trip. For example: Waiting to depart Alewife",
+      "comment" : "Label for a vehicle stopped at a terminal station waiting to start a trip.\nFor example: Waiting to depart Alewife",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -48,9 +48,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                 .fill(Color.halo)
                 .frame(height: 2)
                 .frame(maxWidth: .infinity)
-            // This unscrollable scroll view is necessary to prevent the sheet from messing up the layout
-            // of the contents and cutting off the header when not in large detent.
-            ScrollView([], showsIndicators: false) {
+            ScrollView(.vertical, showsIndicators: false) {
                 VStack(spacing: 16) {
                     ScrollViewReader { view in
                         DirectionPicker(

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -79,87 +79,84 @@ struct TripStops: View {
     }
 
     var body: some View {
-        ScrollView(.vertical, showsIndicators: false) {
-            VStack(alignment: .center, spacing: 0) {
-                if let splitStops, let target {
-                    if !splitStops.collapsedStops.isEmpty, let stopsAway {
-                        DisclosureGroup(
-                            isExpanded: $stopsExpanded,
-                            content: {
-                                VStack(spacing: 0) {
-                                    HaloSeparator().overlay(alignment: .leading) {
-                                        // Lil 1x4 pt route color bar to maintain an
-                                        // unbroken route color line over the separator
-                                        ColoredRouteLine(routeAccents.color).padding(.leading, 42)
-                                    }
-                                    stopList(list: splitStops.collapsedStops)
+        VStack(alignment: .center, spacing: 0) {
+            if let splitStops, let target {
+                if !splitStops.collapsedStops.isEmpty, let stopsAway {
+                    DisclosureGroup(
+                        isExpanded: $stopsExpanded,
+                        content: {
+                            VStack(spacing: 0) {
+                                HaloSeparator().overlay(alignment: .leading) {
+                                    // Lil 1x4 pt route color bar to maintain an
+                                    // unbroken route color line over the separator
+                                    ColoredRouteLine(routeAccents.color).padding(.leading, 42)
                                 }
-                            },
-                            label: {
-                                HStack(spacing: 0) {
-                                    VStack(spacing: 0) {
-                                        if stopsExpanded {
-                                            ColoredRouteLine(routeAccents.color)
-                                        } else {
-                                            routeLineTwist
-                                        }
-                                    }
-                                    .transition(.opacity.animation(.easeInOut(duration: 0.2)))
-                                    .frame(minWidth: 24)
-
-                                    Text(
-                                        "\(stopsAway, specifier: "%ld") stops away",
-                                        comment: "How many stops away the vehicle is from the target stop"
-                                    )
-                                    .foregroundStyle(Color.text)
-                                    .padding(.leading, 16)
-                                    Spacer()
-                                }.frame(maxWidth: .infinity, minHeight: 56)
+                                stopList(list: splitStops.collapsedStops)
                             }
-                        )
-                        .disclosureGroupStyle(.tripDetails)
-                        .accessibilityElement()
-                        .accessibilityAddTraits(.isHeader)
-                        .accessibilityHeading(.h2)
-                        .accessibilityLabel(Text(
-                            "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
-                            comment: """
-                            VoiceOver label for how many stops away a vehicle is from a stop,
-                            ex 'bus is 4 stops away from Harvard'
-                            """
-                        ))
-                        .accessibilityHint(Text(
-                            "List remaining stops",
-                            comment: """
-                            VoiceOver hint explaining what happens when 'x stops away'
-                            is selected (open an accordion listing those stops)
-                            """
-                        ))
-                    }
-                    TripStopRow(
-                        stop: target,
-                        now: now.toKotlinInstant(),
-                        onTapLink: onTapLink,
-                        routeAccents: routeAccents,
-                        targeted: true
+                        },
+                        label: {
+                            HStack(spacing: 0) {
+                                VStack(spacing: 0) {
+                                    if stopsExpanded {
+                                        ColoredRouteLine(routeAccents.color)
+                                    } else {
+                                        routeLineTwist
+                                    }
+                                }
+                                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+                                .frame(minWidth: 24)
+
+                                Text(
+                                    "\(stopsAway, specifier: "%ld") stops away",
+                                    comment: "How many stops away the vehicle is from the target stop"
+                                )
+                                .foregroundStyle(Color.text)
+                                .padding(.leading, 16)
+                                Spacer()
+                            }.frame(maxWidth: .infinity, minHeight: 56)
+                        }
                     )
-                    .background(Color.fill3)
-                    stopList(list: splitStops.followingStops)
-                } else {
-                    stopList(list: stops.stops)
+                    .disclosureGroupStyle(.tripDetails)
+                    .accessibilityElement()
+                    .accessibilityAddTraits(.isHeader)
+                    .accessibilityHeading(.h2)
+                    .accessibilityLabel(Text(
+                        "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
+                        comment: """
+                        VoiceOver label for how many stops away a vehicle is from a stop,
+                        ex 'bus is 4 stops away from Harvard'
+                        """
+                    ))
+                    .accessibilityHint(Text(
+                        "List remaining stops",
+                        comment: """
+                        VoiceOver hint explaining what happens when 'x stops away'
+                        is selected (open an accordion listing those stops)
+                        """
+                    ))
                 }
+                TripStopRow(
+                    stop: target,
+                    now: now.toKotlinInstant(),
+                    onTapLink: onTapLink,
+                    routeAccents: routeAccents,
+                    targeted: true
+                )
+                .background(Color.fill3)
+                stopList(list: splitStops.followingStops)
+            } else {
+                stopList(list: stops.stops)
             }
-            .padding(.top, vehicleShown ? 56 : 0)
-            .overlay(alignment: .topLeading) {
-                ColoredRouteLine(routeAccents.color).frame(maxHeight: vehicleShown ? 56 : 0).padding(.leading, 42)
-            }
-            .background(Color.fill2)
-            .scrollBounceBehavior(.basedOnSize, axes: [.vertical])
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .padding(1)
-            .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
-            .padding(.horizontal, 10)
-            .padding(.bottom, 48)
         }
+        .padding(.top, vehicleShown ? 56 : 0)
+        .overlay(alignment: .topLeading) {
+            ColoredRouteLine(routeAccents.color).frame(maxHeight: vehicleShown ? 56 : 0).padding(.leading, 42)
+        }
+        .background(Color.fill2)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .padding(1)
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
+        .padding(.horizontal, 10)
+        .padding(.bottom, 48)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, [slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1734017693325669)

Anna brought up in slack that the separate inner scroll container for the trip stops wasn't ideal and requested that the whole page scroll under the header instead.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings? ~
~  - [ ] Add temporary machine translations, marked "Needs Review"~
android
~- [ ] All user-facing strings added to strings resource~

### Testing

Manual testing to ensure that the new scroll behavior works as intended