### PR TITLE
feat: convert iOS translations to Android format

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.mbta.tid.mbta_app.gradle.ConvertIosLocalizationTask
 import com.mbta.tid.mbta_app.gradle.ConvertIosMapIconsTask
 import java.io.BufferedReader
 import java.io.StringReader
@@ -56,6 +57,10 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
     kotlinOptions { jvmTarget = "1.8" }
+    androidResources {
+        @Suppress("UnstableApiUsage")
+        generateLocaleConfig = true
+    }
 }
 
 dependencies {
@@ -98,6 +103,11 @@ tasks.cyclonedxBom {
 task<ConvertIosMapIconsTask>("convertIosIconsToAssets") {
     assetsToRender = listOf("alert-large-*", "alert-small-*", "map-stop-*")
     assetsToReturnByName = listOf("alert-borderless-*")
+}
+
+task<ConvertIosLocalizationTask>("convertIosLocalization") {
+    xcstrings = layout.projectDirectory.file("../iosApp/iosApp/Localizable.xcstrings")
+    resources = layout.projectDirectory.dir("src/main/res")
 }
 
 // https://github.com/mapbox/mapbox-gl-native-android/blob/7f03a710afbd714368084e4b514d3880bad11c27/gradle/gradle-config.gradle
@@ -147,6 +157,8 @@ task("envVars") {
 }
 
 gradle.projectsEvaluated {
-    tasks.getByPath("preBuild").dependsOn("mapboxTempToken", "convertIosIconsToAssets")
+    tasks
+        .getByPath("preBuild")
+        .dependsOn("mapboxTempToken", "convertIosIconsToAssets", "convertIosLocalization")
     tasks.getByPath("check").dependsOn("checkMapboxBridge")
 }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -160,5 +160,6 @@ gradle.projectsEvaluated {
     tasks
         .getByPath("preBuild")
         .dependsOn("mapboxTempToken", "convertIosIconsToAssets", "convertIosLocalization")
+    tasks.getByPath("spotlessKotlin").mustRunAfter("convertIosLocalization")
     tasks.getByPath("check").dependsOn("checkMapboxBridge")
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -93,7 +93,7 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
                     )
                 is TripInstantDisplay.Approaching ->
                     BoldedTripStatus(
-                        text = stringResource(R.string.approaching_abbr),
+                        text = stringResource(R.string.minutes_abbr, 1),
                         modifier = modifier
                     )
                 is TripInstantDisplay.Time ->

--- a/androidApp/src/main/res/resources.properties
+++ b/androidApp/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en

--- a/androidApp/src/main/res/values-b+es/strings.xml
+++ b/androidApp/src/main/res/values-b+es/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="hello_platform">¡Hola, %1$s!</string>
 </resources>

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">versión %1$s</string>
+    <string name="arriving_abbr">LLEGAN.</string>
+    <string name="boarding_abbr">ABORD.</string>
+    <string name="cancelled">Cancelado</string>
+    <string name="detour">Desvío</string>
+    <string name="directionTo">%1$s a</string>
+    <string name="feedback_link_form">Enviar comentarios sobre la aplicación</string>
+    <string name="filterShowAll">Todos</string>
+    <string name="more_link">Más</string>
+    <string name="more_page_footer">Hecho con ♥ por T</string>
+    <string name="more_section_feature_flags">Banderas de características</string>
+    <string name="more_section_resources">Recursos</string>
+    <string name="more_section_settings">Configuración</string>
+    <string name="more_section_support">Información general y soporte de MBTA</string>
+    <string name="more_section_support_note">De lunes a viernes de 6:30 a. m. a 8:00 p. m.</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">Cerca</string>
+    <string name="no_service">Sin servicio</string>
+    <string name="no_stops_nearby">Estás fuera del área de servicio de MBTA.</string>
+    <string name="no_stops_nearby_title">No hay paradas cercanas</string>
+    <string name="now">Ahora</string>
+    <string name="other_link_privacy_policy">Política de privacidad</string>
+    <string name="other_link_source_code">Ver código fuente en GitHub</string>
+    <string name="other_link_tos">Términos de uso</string>
+    <string name="resources_link_fare_info">Información de tarifas</string>
+    <string name="resources_link_mticket">Boletos de tren de cercanías y ferri</string>
+    <string name="resources_link_mticket_note">mTicket App</string>
+    <string name="resources_link_trip_planner">Planificador de viaje</string>
+    <string name="setting_toggle_hide_maps">Ocultar Mapas</string>
+    <string name="settings_link">Configuración</string>
+    <string name="shuttle">Autobús de enlace</string>
+    <string name="stop_closed">Parada cerrada</string>
+    <string name="suspension">Suspensión</string>
+</resources>

--- a/androidApp/src/main/res/values-b+ht/strings.xml
+++ b/androidApp/src/main/res/values-b+ht/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">vèsyon %1$s</string>
+    <string name="arriving_abbr">ARR</string>
+    <string name="boarding_abbr">BRD</string>
+    <string name="cancelled">Anile</string>
+    <string name="detour">Detou</string>
+    <string name="directionTo">%1$s pou</string>
+    <string name="feedback_link_form">Voye kòmantè sou aplikasyon</string>
+    <string name="filterShowAll">Tout</string>
+    <string name="more_link">Plis</string>
+    <string name="more_page_footer">Ki fèt ak ♥ pa T a</string>
+    <string name="more_section_feature_flags">Drapo Opsyon</string>
+    <string name="more_section_resources">Resous</string>
+    <string name="more_section_settings">Paramèt</string>
+    <string name="more_section_support">Enfòmasyon ak Sipò Jeneral MBTA</string>
+    <string name="more_section_support_note">Lendi rive vandredi: 6:30 AM - 8 PM</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">Toupre</string>
+    <string name="no_service">Pa gen Sèvis</string>
+    <string name="no_stops_nearby">Ou andeyò zòn sèvis MBTA a.</string>
+    <string name="no_stops_nearby_title">Pa gen arè ki tou pre</string>
+    <string name="now">Kounye a</string>
+    <string name="other_link_privacy_policy">Règleman sou Vi Prive</string>
+    <string name="other_link_source_code">Gade sous sou GitHub</string>
+    <string name="other_link_tos">Kondisyon itilizasyon</string>
+    <string name="resources_link_fare_info">Enfòmasyon Tarif</string>
+    <string name="resources_link_mticket">Tikè Tren Vil la ak Bato</string>
+    <string name="resources_link_mticket_note">Aplikasyon mTicket</string>
+    <string name="resources_link_trip_planner">Zouti pou planifye vwayaj</string>
+    <string name="setting_toggle_hide_maps">Kache Kat yo</string>
+    <string name="settings_link">Paramèt</string>
+    <string name="shuttle">Navèt</string>
+    <string name="stop_closed">Arè Fèmen</string>
+    <string name="suspension">Sispansyon</string>
+</resources>

--- a/androidApp/src/main/res/values-b+pt+BR/strings.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">versão %1$s</string>
+    <string name="arriving_abbr">CHE</string>
+    <string name="boarding_abbr">TRA</string>
+    <string name="cancelled">Cancelado</string>
+    <string name="detour">Desvio</string>
+    <string name="directionTo">%1$s para</string>
+    <string name="feedback_link_form">Enviar comentário no aplicativo</string>
+    <string name="filterShowAll">Tudo</string>
+    <string name="more_link">Mais</string>
+    <string name="more_page_footer">Feito com ♥ pelo T</string>
+    <string name="more_section_feature_flags">Exibir sinalizações</string>
+    <string name="more_section_resources">Recursos</string>
+    <string name="more_section_settings">Configurações</string>
+    <string name="more_section_support">Informações Gerais e Suporte da MBTA</string>
+    <string name="more_section_support_note">De segunda a sexta: 6:30 AM - 8 PM</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">Próximo</string>
+    <string name="no_service">Sem serviço</string>
+    <string name="no_stops_nearby">Você está fora da área de serviço da MBTA.</string>
+    <string name="no_stops_nearby_title">Nenhuma parada próxima</string>
+    <string name="now">Agora</string>
+    <string name="other_link_privacy_policy">Política de Privacidade</string>
+    <string name="other_link_source_code">Exibir origem no GitHub</string>
+    <string name="other_link_tos">Termos de Uso</string>
+    <string name="resources_link_fare_info">Informações sobre tarifas</string>
+    <string name="resources_link_mticket">Bilhetes de transporte diário por trem e balsa</string>
+    <string name="resources_link_mticket_note">Aplicativo mTicket</string>
+    <string name="resources_link_trip_planner">Planejador de trajetos</string>
+    <string name="setting_toggle_hide_maps">Ocultar mapas</string>
+    <string name="settings_link">Configurações</string>
+    <string name="shuttle">Ônibus vai-e-vem</string>
+    <string name="stop_closed">Parada fechada</string>
+    <string name="suspension">Suspensão</string>
+</resources>

--- a/androidApp/src/main/res/values-b+vi/strings.xml
+++ b/androidApp/src/main/res/values-b+vi/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">phiên bản %1$s</string>
+    <string name="arriving_abbr">ARR</string>
+    <string name="boarding_abbr">BRD</string>
+    <string name="cancelled">Đã hủy</string>
+    <string name="detour">Đường vòng</string>
+    <string name="directionTo">%1$s đến</string>
+    <string name="feedback_link_form">Gửi ý phản hồi về ứng dụng</string>
+    <string name="filterShowAll">Tất cả</string>
+    <string name="more_link">Thêm</string>
+    <string name="more_page_footer">Được tạo ra với ♥ bởi T</string>
+    <string name="more_section_feature_flags">Cờ tính năng</string>
+    <string name="more_section_resources">Nguồn</string>
+    <string name="more_section_settings">Cài đặt</string>
+    <string name="more_section_support">Thông tin &amp; Hỗ trợ chung của MBTA</string>
+    <string name="more_section_support_note">Từ thứ Hai đến thứ Sáu: 6:30 sáng - 8:00 tối</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">Ở gần</string>
+    <string name="no_service">Không có dịch vụ</string>
+    <string name="no_stops_nearby">Bạn đang ở ngoài khu vực dịch vụ của MBTA.</string>
+    <string name="no_stops_nearby_title">Không có điểm dừng gần đó</string>
+    <string name="now">Hiện nay</string>
+    <string name="other_link_privacy_policy">Chính sách bảo mật</string>
+    <string name="other_link_source_code">Xem nguồn trên GitHub</string>
+    <string name="other_link_tos">Điều khoản sử dụng</string>
+    <string name="resources_link_fare_info">Thông tin giá vé</string>
+    <string name="resources_link_mticket">Vé phà vé đường sắt ngoại ô (Commuter Rail)</string>
+    <string name="resources_link_mticket_note">Ứng dụng mTicket</string>
+    <string name="resources_link_trip_planner">Lập kế hoạch chuyến đi</string>
+    <string name="setting_toggle_hide_maps">Ẩn bản đồ</string>
+    <string name="settings_link">Cài đặt</string>
+    <string name="shuttle">Xe đưa đón</string>
+    <string name="stop_closed">Điểm dừng bị đóng</string>
+    <string name="suspension">Đình chỉ</string>
+</resources>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">版本%1$s</string>
+    <string name="arriving_abbr">到站</string>
+    <string name="boarding_abbr">上客</string>
+    <string name="cancelled">已取消</string>
+    <string name="detour">交通改道</string>
+    <string name="directionTo">%1$s至</string>
+    <string name="feedback_link_form">发送应用程序反馈</string>
+    <string name="filterShowAll">全部</string>
+    <string name="more_link">更多</string>
+    <string name="more_page_footer">Made with ♥ by the T</string>
+    <string name="more_section_feature_flags">功能标记</string>
+    <string name="more_section_resources">资源</string>
+    <string name="more_section_settings">设置</string>
+    <string name="more_section_support">MBTA通用信息与支持</string>
+    <string name="more_section_support_note">周一至周五：上午6:30至晚上8:00</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">附近</string>
+    <string name="no_service">无服务</string>
+    <string name="no_stops_nearby">您位于 MBTA 服务区之外。</string>
+    <string name="no_stops_nearby_title">附近无站点</string>
+    <string name="now">现在</string>
+    <string name="other_link_privacy_policy">隐私政策</string>
+    <string name="other_link_source_code">在GitHub上查看源代码</string>
+    <string name="other_link_tos">使用条款</string>
+    <string name="resources_link_fare_info">票价信息</string>
+    <string name="resources_link_mticket">通勤列车和轮渡票</string>
+    <string name="resources_link_mticket_note">mTicket应用程序</string>
+    <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="setting_toggle_hide_maps">隐藏地图</string>
+    <string name="settings_link">设置</string>
+    <string name="shuttle">摆渡巴士</string>
+    <string name="stop_closed">站点已关闭</string>
+    <string name="suspension">暂停</string>
+</resources>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_version_number">版本 %1$s</string>
+    <string name="arriving_abbr">到站</string>
+    <string name="boarding_abbr">上客</string>
+    <string name="cancelled">已取消</string>
+    <string name="detour">交通改道</string>
+    <string name="directionTo">%1$s至</string>
+    <string name="feedback_link_form">傳送應用程式回饋</string>
+    <string name="filterShowAll">全部</string>
+    <string name="more_link">更多</string>
+    <string name="more_page_footer">Made with ♥ by the T</string>
+    <string name="more_section_feature_flags">功能標記</string>
+    <string name="more_section_resources">資源</string>
+    <string name="more_section_settings">設定</string>
+    <string name="more_section_support">MBTA通用資訊與支援</string>
+    <string name="more_section_support_note">週一至週五：上午6:30至晚上8:00</string>
+    <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit_link">附近</string>
+    <string name="no_service">無服務</string>
+    <string name="no_stops_nearby">您位於 MBTA 服務區域之外。</string>
+    <string name="no_stops_nearby_title">附近沒有停靠站</string>
+    <string name="now">現在</string>
+    <string name="other_link_privacy_policy">隱私政策</string>
+    <string name="other_link_source_code">在GitHub上查看原始程式碼</string>
+    <string name="other_link_tos">使用條款</string>
+    <string name="resources_link_fare_info">票價資訊</string>
+    <string name="resources_link_mticket">通勤列車和輪渡票</string>
+    <string name="resources_link_mticket_note">mTicket應用程式</string>
+    <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="setting_toggle_hide_maps">隱藏地圖</string>
+    <string name="settings_link">設定</string>
+    <string name="shuttle">擺渡巴士</string>
+    <string name="stop_closed">網站已關閉</string>
+    <string name="suspension">暫停</string>
+</resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_version_number">version %1$s</string>
-    <string name="approaching_abbr">1 min</string>
     <string name="arriving_abbr">ARR</string>
     <string name="boarding_abbr">BRD</string>
     <string name="cancelled">Cancelled</string>
@@ -9,9 +8,8 @@
     <string name="directionTo">%1$s to</string>
     <string name="feedback_link_form">Send app feedback</string>
     <string name="filterShowAll">All</string>
-    <string name="hello_platform">Hello, %1$s!</string>
-    <string name="icon_description_external_link">External Link</string>
-    <string name="minutes_abbr">%1$s min</string>
+    <string name="icon_description_external_link" tools:ignore="MissingTranslation">External Link</string>
+    <string name="minutes_abbr" tools:ignore="MissingTranslation">%1$s min</string>
     <string name="more_link">More</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">Feature Flags</string>
@@ -22,8 +20,8 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit_link">Nearby</string>
     <string name="no_service">No Service</string>
-    <string name="no_stops_nearby">Your current location is outside of our search area.</string>
-    <string name="no_stops_nearby_title">No nearby MBTA stops</string>
+    <string name="no_stops_nearby">You’re outside the MBTA service area.</string>
+    <string name="no_stops_nearby_title">No nearby stops</string>
     <string name="now">Now</string>
     <string name="other_link_privacy_policy">Privacy Policy</string>
     <string name="other_link_source_code">View source on GitHub</string>

--- a/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
+++ b/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
@@ -1,0 +1,142 @@
+package com.mbta.tid.mbta_app.gradle
+
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.RegularFile
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class ConvertIosLocalizationTask : DefaultTask() {
+    @get:InputFile abstract var xcstrings: RegularFile
+    @get:OutputDirectory abstract var resources: Directory
+
+    @TaskAction
+    fun run() {
+        val iosStrings = readIosStrings()
+        val languageTags = iosStrings.values.map { it.keys }.reduce(Set<String>::plus) - "en"
+        val androidEnglishStringsById = parseAndroidStrings(resources.file("values/strings.xml"))
+        val androidIdsByEnglishString =
+            androidEnglishStringsById.entries.groupBy({ it.value }, { it.key })
+
+        for (languageTag in languageTags) {
+            val iosStringsByEnglishString = iosStrings.mapValues { it.value[languageTag] }
+            val translatedStringsById =
+                iosStringsByEnglishString
+                    .flatMap { (englishString, translations) ->
+                        val androidIds = androidIdsByEnglishString[englishString]
+                        if (androidIds == null || translations == null) return@flatMap emptyList()
+                        androidIds.map { Pair(it, translations) }
+                    }
+                    .toMap()
+            writeAndroidStrings(languageTag, translatedStringsById)
+        }
+    }
+
+    /** Returns (English text => (BCP 47 tag => translated text)) for non-plural strings. */
+    private fun readIosStrings(): Map<String, Map<String, String>> {
+        val inputData = xcstrings.asFile.readText()
+        val strings = Json.decodeFromString<XcStrings>(inputData)
+        return strings.staticStringsByEnglishText()
+    }
+
+    @Serializable
+    private data class XcStrings(
+        val sourceLanguage: String,
+        val strings: Map<String, XcStringInfo>,
+        val version: String,
+    ) {
+        fun staticStringsByEnglishText(): Map<String, Map<String, String>> {
+            return strings
+                .mapNotNull {
+                    val translations = it.value.invariantLocalizations() ?: return@mapNotNull null
+                    val englishText = translations["en"] ?: convertIosTemplate(it.key)
+                    Pair(englishText, translations)
+                }
+                .toMap()
+        }
+    }
+
+    @Serializable
+    private data class XcStringInfo(
+        val comment: String? = null,
+        val extractionState: String? = null,
+        val localizations: Map<String, Localization>? = null,
+    ) {
+
+        fun invariantLocalizations() =
+            localizations
+                ?.mapNotNull {
+                    Pair(
+                        convertIosTemplate(it.key),
+                        convertIosTemplate(it.value.stringUnit?.value ?: return@mapNotNull null)
+                    )
+                }
+                ?.toMap()
+    }
+
+    @Serializable
+    private data class Localization(
+        val stringUnit: StringUnit? = null,
+        val variations: Variations? = null,
+    )
+
+    @Serializable private data class StringUnit(val state: String, val value: String)
+
+    @Serializable private data class Variations(val plural: Map<String, Localization>)
+
+    /** @return A map from IDs to text content. */
+    private fun parseAndroidStrings(stringsFile: RegularFile): Map<String, String> {
+        val parser = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+        val xmlDocument = parser.parse(stringsFile.asFile)
+        val stringElements = xmlDocument.getElementsByTagName("string")
+        val result = mutableMapOf<String, String>()
+        for (i in 0 until stringElements.length) {
+            val stringElement = stringElements.item(i)
+            val id = stringElement.attributes.getNamedItem("name").textContent
+            val value = stringElement.textContent
+            result[id] = value
+        }
+        return result
+    }
+
+    private fun writeAndroidStrings(languageTag: String, stringsById: Map<String, String>) {
+        val outputDir = resources.dir("values-b+${languageTag.replace("-", "+")}")
+        outputDir.asFile.mkdirs()
+        val overrideFile = outputDir.file("strings.xml")
+        val overrideStrings = parseAndroidStrings(overrideFile)
+        val entriesToWrite =
+            stringsById.filterNot { it.key in overrideStrings.keys }.entries.sortedBy { it.key }
+        val outputFile = outputDir.file("strings_ios_converted.xml")
+        val result = buildString {
+            appendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+            appendLine("<resources>")
+            for ((id, value) in entriesToWrite) {
+                val escapedValue = value.replace("&", "&amp;").replace("<", "&lt;")
+                appendLine("    <string name=\"$id\">$escapedValue</string>")
+            }
+            appendLine("</resources>")
+        }
+        outputFile.asFile.writeText(result)
+    }
+
+    companion object {
+        private val template = Regex("""%(?:(?<index>\d+)\$)?l?(?<format>[\w@])""")
+
+        private fun replaceTemplate(match: MatchResult, getDefaultIndex: () -> Int): String {
+            val index = match.groups["index"]?.value ?: getDefaultIndex().toString()
+            val format = match.groups["format"]?.value.takeUnless { it == "@" } ?: "s"
+            return "%$index$$format"
+        }
+
+        private fun convertIosTemplate(iosTemplate: String): String {
+            var unspecifiedIndex = 1
+            return iosTemplate.replace(template) {
+                replaceTemplate(it) { unspecifiedIndex.also { unspecifiedIndex += 1 } }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Determine localization approach](https://app.asana.com/0/1205425564113216/1208790341716788/f)

I couldn't find any obviously useful automated tools for converting between iOS Localizable.xcstrings and Android string resources, but it turns out it's fairly straightforward to staple something basic together myself.

Tradeoffs:
- I'm using the iOS format as the source of truth here, because there's nothing in Android that can explicitly represent the "Needs Review" state that our workflow relies on.
- Instead of generating Android IDs for new iOS strings eagerly, this will only copy translations for strings which are already defined on Android in English. This is both easier and more useful, since it lets us pick manually what ID makes the most sense.
- The iOS string templating system and the Android string templating system aren't all that far apart, so it's not difficult to translate the easy cases over automatically.
  - I suspect but am not confident that multi-argument templates will also Just Work™.
- There are several options for inline text formatting on Android, some of which might even be easy to handle here, but we are currently not doing any of them and doing string manipulation after the fact instead, so this needs to be a separate ticket.
- Android plurals are [a separate kind of resource entirely](https://developer.android.com/guide/topics/resources/string-resource#Plurals) from Android strings; conveniently, we aren't using that subsystem at all yet, so I'm keeping things simple and ignoring that entirely for now.

Notes:
- I've set things up so we can manually define localized strings separate from the automatically converted translations; if we define a key in the `strings.xml` it will be removed from `strings_ios_converted.xml` to avoid confusion.
- I've flipped the switch to allow Android [app-specific language preferences](https://developer.android.com/guide/topics/resources/app-languages) at the OS level, but if we want that functionality to be usable on Android 9-12 and not just 13+ we need our own UI for it, and I'm not going to preemptively do anything for that.
- In the distant future we may benefit from linting on strings that are present in iOS but absent in Android, but right now we still have a ton of functionality that is simply not present in Android, so that would be incorrect to build now.
  - I've re-enabled the default lint for strings which have not been translated into all supported languages, though, which winds up being a lint on strings that are present in Android but absent in iOS.

### Testing

Manually validated that the imported translations work for the languages I can check. (Neither my emulator nor my physical Android phone support Haitian Creole at all.)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
