### PR TITLE
feat: Update stop details navigation to match spec

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -181,7 +181,7 @@ struct StopDetailsFilteredView: View {
                 stop: stop,
                 pinned: pinned,
                 onPin: toggledPinnedRoute,
-                onClose: { nearbyVM.navigationStack.removeAll() }
+                onClose: { nearbyVM.goBack() }
             )
             if nearbyVM.showDebugMessages {
                 DebugView {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -66,7 +66,6 @@ struct StopDetailsUnfilteredView: View {
                 VStack(spacing: 16) {
                     SheetHeader(
                         title: stop?.name ?? "Invalid Stop",
-                        onBack: nearbyVM.navigationStack.count > 1 ? { nearbyVM.goBack() } : nil,
                         onClose: { nearbyVM.navigationStack.removeAll() }
                     )
                     if nearbyVM.showDebugMessages {

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -101,8 +101,10 @@ extension [SheetNavigationStackEntry] {
             if case let .legacyStopDetails(stop, _) = self.last {
                 _ = self.popLast()
                 self.append(.legacyStopDetails(stop, newValue))
-            } else if case let .stopDetails(stopId: stopId, stopFilter: _, tripFilter: _) = self.last {
-                _ = self.popLast()
+            } else if case let .stopDetails(stopId: stopId, stopFilter: currentStopFilter, tripFilter: _) = self.last {
+                if currentStopFilter != nil {
+                    _ = self.popLast()
+                }
                 self.append(.stopDetails(stopId: stopId, stopFilter: newValue, tripFilter: nil))
             }
         }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -121,7 +121,12 @@ class NearbyViewModel: ObservableObject {
             _ = navigationStack.popLast()
             navigationStack.append(entry)
         } else if case let .stopDetails(stopId: targetStop, stopFilter: _, tripFilter: _) = entry,
-                  case let .stopDetails(stopId: currentStop, stopFilter: _, tripFilter: _) = navigationStack.last,
+                  case let .stopDetails(
+                      stopId: currentStop,
+                      stopFilter: currentStopFilter,
+                      tripFilter: _
+                  ) = navigationStack.last,
+                  currentStopFilter != nil,
                   targetStop == currentStop {
             _ = navigationStack.popLast()
             navigationStack.append(entry)

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -131,25 +131,12 @@ class NearbyViewModel: ObservableObject {
                 stopFilter: lastFilter,
                 tripFilter: _
             ) = navigationStack.last,
-            lastFilter != nil,
             targetStop == lastStop {
             // When the stop filter changes, we want a new entry to be added (i.e. no pop) only when
             // you're on the unfiltered (lastFilter == nil) page, but if there is already a filter,
             // the entry with the old filter should be popped and replaced with the new value.
-            _ = navigationStack.popLast()
-
-            // If the new filter is nil and there is already a nil filter in the stack for the same stop ID,
-            // we don't want a duplicate unfiltered entry, so skip appending a new one
-            if newFilter == nil,
-               case let .stopDetails(
-                   stopId: penultimateStop,
-                   stopFilter: penultimateFilter,
-                   tripFilter: _
-               ) = navigationStack.last,
-               penultimateStop == targetStop,
-               penultimateFilter == nil {
-                return
-            }
+            if lastFilter != nil { _ = navigationStack.popLast() }
+            if navigationStack.shouldSkipStopFilterUpdate(newStop: targetStop, newFilter: newFilter) { return }
             navigationStack.append(entry)
         } else {
             navigationStack.append(entry)

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -115,51 +115,6 @@ final class StopDetailsPageTests: XCTestCase {
         wait(for: [exp], timeout: 30)
     }
 
-    func testBackButton() throws {
-        let objects = ObjectCollectionBuilder()
-        let stop = objects.stop { _ in }
-
-        class FakeNearbyVM: NearbyViewModel {
-            let backExp: XCTestExpectation
-            init(_ backExp: XCTestExpectation) {
-                self.backExp = backExp
-                super.init(combinedStopAndTrip: true)
-            }
-
-            override func goBack() {
-                backExp.fulfill()
-            }
-        }
-
-        let backExp = XCTestExpectation(description: "goBack called")
-        let nearbyVM = FakeNearbyVM(backExp)
-        nearbyVM.navigationStack = [
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-        ]
-
-        let stopDetailsVM = StopDetailsViewModel(
-            predictionsRepository: MockPredictionsRepository(),
-            schedulesRepository: MockScheduleRepository()
-        )
-
-        let sut = StopDetailsPage(
-            stopId: stop.id,
-            stopFilter: nil,
-            tripFilter: nil,
-            errorBannerVM: .init(),
-            nearbyVM: nearbyVM,
-            mapVM: .init(),
-            stopDetailsVM: stopDetailsVM,
-            viewportProvider: .init()
-        )
-
-        try sut.inspect().find(viewWithAccessibilityLabel: "Back").button().tap()
-
-        wait(for: [backExp], timeout: 2)
-    }
-
     func testCloseButton() throws {
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -145,60 +145,6 @@ final class StopDetailsViewTests: XCTestCase {
         XCTAssert(nearbyVM.navigationStack.isEmpty)
     }
 
-    func testBackButtonGoesBack() throws {
-        let objects = ObjectCollectionBuilder()
-        let stop = objects.stop { _ in }
-
-        let initialNavStack: [SheetNavigationStackEntry] = [
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-            .tripDetails(tripId: "", vehicleId: "", target: nil, routeId: "", directionId: 0),
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-        ]
-        let nearbyVM: NearbyViewModel = .init(navigationStack: initialNavStack)
-        let sut = StopDetailsView(
-            stopId: stop.id,
-            stopFilter: nil,
-            tripFilter: nil,
-            setStopFilter: { _ in },
-            setTripFilter: { _ in },
-            departures: nil,
-            now: Date.now,
-            errorBannerVM: .init(),
-            nearbyVM: nearbyVM,
-            mapVM: .init(),
-            stopDetailsVM: .init()
-        )
-
-        ViewHosting.host(view: sut)
-        try? sut.inspect().find(viewWithAccessibilityLabel: "Back").button().tap()
-        XCTAssertEqual(initialNavStack.dropLast(), nearbyVM.navigationStack)
-    }
-
-    func testBackButtonHiddenWhenNearbyIsBack() throws {
-        let objects = ObjectCollectionBuilder()
-        let stop = objects.stop { _ in }
-
-        let nearbyVM: NearbyViewModel = .init(navigationStack: [
-            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
-        ])
-        let sut = StopDetailsView(
-            stopId: stop.id,
-            stopFilter: nil,
-            tripFilter: nil,
-            setStopFilter: { _ in },
-            setTripFilter: { _ in },
-            departures: nil,
-            now: Date.now,
-            errorBannerVM: .init(),
-            nearbyVM: nearbyVM,
-            mapVM: .init(),
-            stopDetailsVM: .init()
-        )
-
-        ViewHosting.host(view: sut)
-        XCTAssertNil(try? sut.inspect().find(viewWithAccessibilityLabel: "Back"))
-    }
-
     func testDebugModeNotShownByDefault() throws {
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in

--- a/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
+++ b/iosApp/iosAppTests/Utils/SheetNavigationStackEntryTests.swift
@@ -21,7 +21,7 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         XCTAssertEqual(stack, [])
     }
 
-    func testLastFilterShallow() throws {
+    func testLastFilterShallowLegacy() throws {
         let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         var stack: [SheetNavigationStackEntry] = [.legacyStopDetails(stop, nil)]
 
@@ -38,7 +38,7 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         XCTAssertEqual(stack.lastStopDetailsFilter, nil)
     }
 
-    func testLastFilterDeep() throws {
+    func testLastFilterDeepLegacy() throws {
         let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         let otherStop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         let previousEntries: [SheetNavigationStackEntry] = [
@@ -67,7 +67,7 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         XCTAssertEqual(stack.lastStopDetailsFilter, nil)
     }
 
-    func testLastFilterNotTop() throws {
+    func testLastFilterNotTopLegacy() throws {
         let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         var stack: [SheetNavigationStackEntry] = [
             .legacyStopDetails(stop, .init(routeId: "A", directionId: 1)),
@@ -108,7 +108,7 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         XCTAssertEqual(alertEntry.coverItemIdentifiable()!.id, "0")
     }
 
-    func testNavStackLastStop() throws {
+    func testNavStackLastStopLegacy() throws {
         let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
         let stopEntry: SheetNavigationStackEntry = .legacyStopDetails(stop, .init(routeId: "A", directionId: 1))
         let tripEntry: SheetNavigationStackEntry = .tripDetails(
@@ -165,5 +165,38 @@ final class SheetNavigationStackEntryTests: XCTestCase {
         stack.remove(at: stack.count - 1)
         stack.append(tripEntry)
         XCTAssertEqual(stop.id, stack.lastStopId)
+    }
+
+    func testLastFilterSet() throws {
+        let stop = ObjectCollectionBuilder.Single.shared.stop { _ in }
+        var stack: [SheetNavigationStackEntry] = [.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)]
+
+        let filter1 = StopDetailsFilter(routeId: "A", directionId: 1)
+        stack.lastStopDetailsFilter = filter1
+
+        XCTAssertEqual([
+            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
+            .stopDetails(stopId: stop.id, stopFilter: filter1, tripFilter: nil),
+        ], stack)
+        XCTAssertEqual(filter1, stack.lastStopDetailsFilter)
+
+        let filter2 = StopDetailsFilter(routeId: "A", directionId: 0)
+        stack.lastStopDetailsFilter = filter2
+
+        XCTAssertEqual([
+            .stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil),
+            .stopDetails(stopId: stop.id, stopFilter: filter2, tripFilter: nil),
+        ], stack)
+        XCTAssertEqual(filter2, stack.lastStopDetailsFilter)
+
+        stack.lastStopDetailsFilter = nil
+
+        XCTAssertEqual([.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)], stack)
+        XCTAssertEqual(nil, stack.lastStopDetailsFilter)
+
+        stack.lastStopDetailsFilter = nil
+
+        XCTAssertEqual([.stopDetails(stopId: stop.id, stopFilter: nil, tripFilter: nil)], stack)
+        XCTAssertEqual(nil, stack.lastStopDetailsFilter)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Combined Stop + Trip Details: nav changes](https://app.asana.com/0/1205732265579288/1208725410378683/f)

This updates the combined stop/trip navigation to match the desired behavior. Back buttons are removed from the filtered and unflitered stop pages, and the X button on filtered stop details will bring you back to the place you came from, either the unfiltered stop or nearby transit. Because this doesn't involve changing the actual entry type, but just the stop filter on the entry, there's some slightly convoluted logic to ensure that filter entries are appended rather than replacing the unfiltered entry, and that when the filtered entries are removed, that they don't add duplicate unfiltered entries. This logic also unfortunately needs to exist in two places, since a new entry can be pushed in its entirety to the nearby VM, or the filter value can be modified independently through `lastStopDetailsFilter`.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
~- [ ] Add temporary machine translations, marked "Needs Review"~
android
~- [ ] All user-facing strings added to strings resource~

### Testing

Added tests for new behavior
