### PR TITLE
fix(Android): internationalize all hardcoded text

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -106,6 +106,7 @@ task<ConvertIosMapIconsTask>("convertIosIconsToAssets") {
 }
 
 task<ConvertIosLocalizationTask>("convertIosLocalization") {
+    androidEnglishStrings = layout.projectDirectory.file("src/main/res/values/strings.xml")
     xcstrings = layout.projectDirectory.file("../iosApp/iosApp/Localizable.xcstrings")
     resources = layout.projectDirectory.dir("src/main/res")
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
@@ -52,6 +52,6 @@ class ContentViewTests : KoinTest {
         composeTestRule.onNodeWithText("MBTA Go").assertIsDisplayed()
 
         composeTestRule.onNodeWithText("Nearby").performClick()
-        composeTestRule.onNodeWithText("Nearby transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
@@ -48,7 +48,7 @@ class DirectionPickerTest {
                 null,
                 stop,
                 patterns,
-                listOf(Direction("A", null, 0), Direction("B", null, 1))
+                listOf(Direction("North", null, 0), Direction("South", null, 1))
             )
         var filter: StopDetailsFilter? = StopDetailsFilter(routeId = route.id, directionId = 0)
         composeTestRule.setContent {
@@ -57,8 +57,8 @@ class DirectionPickerTest {
             }
         }
 
-        composeTestRule.onNodeWithText("A").assertIsDisplayed()
-        composeTestRule.onNodeWithText("B").performClick()
+        composeTestRule.onNodeWithText("Northbound").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound").performClick()
         assertTrue(filter?.routeId == route.id)
         assertTrue(filter?.directionId == 1)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
@@ -94,7 +94,7 @@ class HeadsignRowViewTest {
         init("Somewhere", RealtimePatterns.Format.None(secondaryAlert = null))
 
         composeTestRule.onNodeWithText("Somewhere").assertIsDisplayed()
-        composeTestRule.onNodeWithText("No Predictions").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
     }
 
     @Test
@@ -107,7 +107,7 @@ class HeadsignRowViewTest {
         )
 
         composeTestRule.onNodeWithText("Somewhere").assertIsDisplayed()
-        composeTestRule.onNodeWithText("No Predictions").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Alert").assertIsDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/PinButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/PinButtonTest.kt
@@ -18,7 +18,7 @@ class PinButtonTest {
             PinButton(pinned = false, color = Color.Unspecified) { wasTapped = true }
         }
 
-        composeTestRule.onNodeWithContentDescription("pin route").performClick()
+        composeTestRule.onNodeWithContentDescription("Star route").performClick()
         assertTrue(wasTapped)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RouteHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RouteHeaderTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
@@ -31,7 +30,6 @@ class RouteHeaderTest {
             )
         }
         composeTestRule.onNodeWithText("Short name").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Bus").assertIsDisplayed()
     }
 
     @Test
@@ -53,7 +51,6 @@ class RouteHeaderTest {
             )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Ferry").assertIsDisplayed()
     }
 
     @Test
@@ -75,7 +72,6 @@ class RouteHeaderTest {
             )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Commuter Rail").assertIsDisplayed()
     }
 
     @Test
@@ -97,6 +93,5 @@ class RouteHeaderTest {
             )
         }
         composeTestRule.onNodeWithText("Long name").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Subway").assertIsDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -286,7 +286,7 @@ class NearbyTransitPageTest : KoinTest {
 
         composeTestRule.waitUntilDoesNotExist(hasText("Loading..."))
 
-        composeTestRule.onNodeWithText("Nearby transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
 
         composeTestRule.onNodeWithText("Green Line Long Name").assertExists()
         composeTestRule.onNodeWithText("Green Line Stop").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -244,7 +244,7 @@ class NearbyTransitViewTest : KoinTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Nearby transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
         composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
         composeTestRule.onNodeWithText("1 min").assertIsDisplayed()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.component
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -11,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -18,11 +20,11 @@ import com.mbta.tid.mbta_app.android.R
 
 enum class ActionButtonKind(
     val iconSize: Dp,
-    val accessibilityLabel: String,
+    @StringRes val accessibilityLabel: Int,
     @DrawableRes val image: Int
 ) {
-    Back(14.dp, "Back", R.drawable.fa_chevron_left),
-    Close(10.dp, "Close", R.drawable.fa_xmark)
+    Back(14.dp, R.string.back_button_label, R.drawable.fa_chevron_left),
+    Close(10.dp, R.string.close_button_label, R.drawable.fa_xmark)
 }
 
 @Composable
@@ -38,7 +40,11 @@ fun ActionButton(kind: ActionButtonKind, action: () -> Unit) {
             ),
         contentPadding = PaddingValues(5.dp)
     ) {
-        Icon(painterResource(kind.image), kind.accessibilityLabel, Modifier.size(kind.iconSize))
+        Icon(
+            painterResource(kind.image),
+            stringResource(kind.accessibilityLabel),
+            Modifier.size(kind.iconSize)
+        )
     }
 }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/AlertIcon.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/AlertIcon.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.StopAlertState
 
@@ -21,7 +22,7 @@ fun AlertIcon(alertState: StopAlertState, color: Color?, modifier: Modifier = Mo
 
     Icon(
         painterResource(iconId),
-        contentDescription = alertState.name,
+        contentDescription = stringResource(R.string.alert),
         modifier,
         tint = color ?: colorResource(R.color.text)
     )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavIconButton.kt
@@ -43,11 +43,7 @@ fun BottomNavIconButton(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Icon(
-                painterResource(icon),
-                contentDescription = "@null",
-                modifier = Modifier.size(24.dp)
-            )
+            Icon(painterResource(icon), contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.height(4.dp))
             Text(label, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -10,25 +11,36 @@ import androidx.compose.ui.unit.sp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.Direction
 
-private val reformatDirectionNames = setOf("North", "South", "East", "West")
+private val localizedDirectionNames: Map<String, Int> =
+    mapOf(
+        "North" to R.string.northbound,
+        "South" to R.string.southbound,
+        "East" to R.string.eastbound,
+        "West" to R.string.westbound,
+        "Inbound" to R.string.inbound,
+        "Outbound" to R.string.outbound,
+    )
 
+@StringRes
 private fun directionNameFormatted(direction: Direction) =
-    if (reformatDirectionNames.contains(direction.name)) "${direction.name}bound"
-    else direction.name
+    localizedDirectionNames[direction.name] ?: R.string.heading
 
 @Composable
 fun DirectionLabel(direction: Direction, modifier: Modifier = Modifier) {
     val destination = direction.destination
-    Column {
+    Column(modifier = modifier) {
         if (destination != null) {
             Text(
-                stringResource(R.string.directionTo, directionNameFormatted(direction)),
+                stringResource(
+                    R.string.directionTo,
+                    stringResource(directionNameFormatted(direction))
+                ),
                 fontSize = 13.sp
             )
             Text(destination, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
         } else {
             Text(
-                directionNameFormatted(direction),
+                stringResource(directionNameFormatted(direction)),
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PinButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PinButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 
@@ -24,7 +25,7 @@ fun PinButton(pinned: Boolean, color: Color, action: () -> Unit) {
                         if (pinned) R.drawable.pinned_route_active
                         else R.drawable.pinned_route_inactive
                 ),
-            contentDescription = "pin route",
+            contentDescription = stringResource(R.string.pin_route),
             modifier = Modifier.size(20.dp),
             tint = color
         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.generated.drawableByName
@@ -45,7 +46,10 @@ fun PredictionRowView(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         predictions.secondaryAlert?.let { secondaryAlert ->
-            Image(painterResource(drawableByName(secondaryAlert.iconName)), "Alert")
+            Image(
+                painterResource(drawableByName(secondaryAlert.iconName)),
+                stringResource(R.string.alert)
+            )
         }
         if (pillDecoration is PillDecoration.OnRow) {
             RoutePill(pillDecoration.route, line = null, RoutePillType.Flex)
@@ -95,7 +99,7 @@ fun PredictionRowView(
             ) {
                 Icon(
                     painterResource(id = R.drawable.baseline_chevron_right_24),
-                    contentDescription = "Arrow Right",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.tertiary
                 )
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RouteIcon.kt
@@ -11,8 +11,8 @@ import com.mbta.tid.mbta_app.model.RouteType
 @Composable
 fun routeIcon(routeType: RouteType) =
     when (routeType) {
-        RouteType.BUS -> Pair(painterResource(id = R.drawable.mode_bus), "Bus")
-        RouteType.COMMUTER_RAIL -> Pair(painterResource(id = R.drawable.mode_cr), "Commuter Rail")
-        RouteType.FERRY -> Pair(painterResource(id = R.drawable.mode_ferry), "Ferry")
-        else -> Pair(painterResource(id = R.drawable.mode_subway), "Subway")
+        RouteType.BUS -> Pair(painterResource(id = R.drawable.mode_bus), null)
+        RouteType.COMMUTER_RAIL -> Pair(painterResource(id = R.drawable.mode_cr), null)
+        RouteType.FERRY -> Pair(painterResource(id = R.drawable.mode_ferry), null)
+        else -> Pair(painterResource(id = R.drawable.mode_subway), null)
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TransitHeader.kt
@@ -27,7 +27,7 @@ fun TransitHeader(
     backgroundColor: Color,
     textColor: Color,
     modeIcon: Painter,
-    modeDescription: String,
+    modeDescription: String?,
     rightContent: (@Composable (textColor: Color) -> Unit)? = null
 ) {
     Column(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -152,11 +152,12 @@ fun UpcomingTripView(state: UpcomingTripViewState) {
             }
         is UpcomingTripViewState.NoService ->
             NoServiceView(NoServiceViewEffect.from(state.effect), modifier)
-        is UpcomingTripViewState.None -> Text("No Predictions", modifier, fontSize = 13.sp)
+        is UpcomingTripViewState.None ->
+            Text(stringResource(R.string.no_predictions), modifier, fontSize = 13.sp)
         is UpcomingTripViewState.ServiceEndedToday ->
-            Text("Service ended", modifier, fontSize = 13.sp)
+            Text(stringResource(R.string.service_ended), modifier, fontSize = 13.sp)
         is UpcomingTripViewState.NoSchedulesToday ->
-            Text("No service today", modifier, fontSize = 13.sp)
+            Text(stringResource(R.string.no_service_today), modifier, fontSize = 13.sp)
         is UpcomingTripViewState.Loading -> CircularProgressIndicator(modifier)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
@@ -8,7 +8,9 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.mbta.tid.mbta_app.android.R
 
 @Composable
 fun RecenterButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
@@ -21,7 +23,7 @@ fun RecenterButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
                 contentColor = Color.White
             )
     ) {
-        Icon(Icons.Default.LocationOn, "Recenter")
+        Icon(Icons.Default.LocationOn, stringResource(R.string.recenter))
     }
 }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -81,12 +81,12 @@ class MoreViewModel(
                 items =
                     listOf(
                         MoreItem.Toggle(
-                            label = "Debug Mode",
+                            label = context.getString(R.string.feature_flag_debug_mode),
                             settings = Settings.DevDebugMode,
                             value = settings[Settings.DevDebugMode] ?: false
                         ),
                         MoreItem.Toggle(
-                            label = "Route Search",
+                            label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults,
                             value = settings[Settings.SearchRouteResults] ?: false
                         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -81,13 +81,13 @@ fun NearbyTransitView(
 
     Column(modifier) {
         Text(
-            text = "Nearby transit",
+            text = stringResource(R.string.nearby_transit),
             modifier = Modifier.padding(bottom = 12.dp, start = 16.dp, end = 16.dp),
             style = MaterialTheme.typography.titleLarge
         )
 
         if (nearbyWithRealtimeInfo == null) {
-            Text(text = "Loading...", modifier)
+            Text(text = stringResource(R.string.loading), modifier)
         } else if (nearbyWithRealtimeInfo.isEmpty()) {
             Column(Modifier.padding(8.dp).weight(1f), verticalArrangement = Arrangement.Center) {
                 Text(

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">Alerta</string>
     <string name="app_version_number">versión %1$s</string>
     <string name="arriving_abbr">LLEGAN.</string>
+    <string name="back_button_label">Atrás</string>
     <string name="boarding_abbr">ABORD.</string>
     <string name="cancelled">Cancelado</string>
+    <string name="close_button_label">Cerrar</string>
     <string name="detour">Desvío</string>
     <string name="directionTo">%1$s a</string>
+    <string name="eastbound">En dirección este</string>
+    <string name="feature_flag_debug_mode">Modo de Depuración</string>
+    <string name="feature_flag_route_search">Buscador de rutas</string>
     <string name="feedback_link_form">Enviar comentarios sobre la aplicación</string>
     <string name="filterShowAll">Todos</string>
+    <string name="heading">Rumbo</string>
+    <string name="inbound">Entrante</string>
+    <string name="loading">Cargando…</string>
     <string name="more_link">Más</string>
     <string name="more_page_footer">Hecho con ♥ por T</string>
     <string name="more_section_feature_flags">Banderas de características</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">Información general y soporte de MBTA</string>
     <string name="more_section_support_note">De lunes a viernes de 6:30 a. m. a 8:00 p. m.</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">Tránsito cercano</string>
     <string name="nearby_transit_link">Cerca</string>
+    <string name="no_predictions">Las predicciones no están disponibles</string>
     <string name="no_service">Sin servicio</string>
+    <string name="no_service_today">No hay servicio hoy</string>
     <string name="no_stops_nearby">Estás fuera del área de servicio de MBTA.</string>
     <string name="no_stops_nearby_title">No hay paradas cercanas</string>
+    <string name="northbound">En dirección norte</string>
     <string name="now">Ahora</string>
     <string name="other_link_privacy_policy">Política de privacidad</string>
     <string name="other_link_source_code">Ver código fuente en GitHub</string>
     <string name="other_link_tos">Términos de uso</string>
+    <string name="outbound">Saliente</string>
+    <string name="pin_route">Marcar ruta favorita</string>
     <string name="resources_link_fare_info">Información de tarifas</string>
     <string name="resources_link_mticket">Boletos de tren de cercanías y ferri</string>
     <string name="resources_link_mticket_note">mTicket App</string>
     <string name="resources_link_trip_planner">Planificador de viaje</string>
+    <string name="service_ended">Servicio finalizado</string>
     <string name="setting_toggle_hide_maps">Ocultar Mapas</string>
     <string name="settings_link">Configuración</string>
     <string name="shuttle">Autobús de enlace</string>
+    <string name="southbound">En dirección sur</string>
     <string name="stop_closed">Parada cerrada</string>
     <string name="suspension">Suspensión</string>
+    <string name="westbound">En dirección oeste</string>
 </resources>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">Alèt</string>
     <string name="app_version_number">vèsyon %1$s</string>
     <string name="arriving_abbr">ARR</string>
+    <string name="back_button_label">Retounen</string>
     <string name="boarding_abbr">BRD</string>
     <string name="cancelled">Anile</string>
+    <string name="close_button_label">Fèmen</string>
     <string name="detour">Detou</string>
     <string name="directionTo">%1$s pou</string>
+    <string name="eastbound">Pran direksyon lès</string>
+    <string name="feature_flag_debug_mode">Mòd Debug</string>
+    <string name="feature_flag_route_search">Rechèch Wout</string>
     <string name="feedback_link_form">Voye kòmantè sou aplikasyon</string>
     <string name="filterShowAll">Tout</string>
+    <string name="heading">Prale nan direksyon</string>
+    <string name="inbound">Antran</string>
+    <string name="loading">Chajman...</string>
     <string name="more_link">Plis</string>
     <string name="more_page_footer">Ki fèt ak ♥ pa T a</string>
     <string name="more_section_feature_flags">Drapo Opsyon</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">Enfòmasyon ak Sipò Jeneral MBTA</string>
     <string name="more_section_support_note">Lendi rive vandredi: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">Transpò piblik ki toupre</string>
     <string name="nearby_transit_link">Toupre</string>
+    <string name="no_predictions">Pa gen prediksyon disponib</string>
     <string name="no_service">Pa gen Sèvis</string>
+    <string name="no_service_today">Pa gen sèvis jodi a</string>
     <string name="no_stops_nearby">Ou andeyò zòn sèvis MBTA a.</string>
     <string name="no_stops_nearby_title">Pa gen arè ki tou pre</string>
+    <string name="northbound">Nan direksyon nò</string>
     <string name="now">Kounye a</string>
     <string name="other_link_privacy_policy">Règleman sou Vi Prive</string>
     <string name="other_link_source_code">Gade sous sou GitHub</string>
     <string name="other_link_tos">Kondisyon itilizasyon</string>
+    <string name="outbound">Soti</string>
+    <string name="pin_route">Mete wout nan favori</string>
     <string name="resources_link_fare_info">Enfòmasyon Tarif</string>
     <string name="resources_link_mticket">Tikè Tren Vil la ak Bato</string>
     <string name="resources_link_mticket_note">Aplikasyon mTicket</string>
     <string name="resources_link_trip_planner">Zouti pou planifye vwayaj</string>
+    <string name="service_ended">Sèvis ki fini</string>
     <string name="setting_toggle_hide_maps">Kache Kat yo</string>
     <string name="settings_link">Paramèt</string>
     <string name="shuttle">Navèt</string>
+    <string name="southbound">Nan direksyon sid</string>
     <string name="stop_closed">Arè Fèmen</string>
     <string name="suspension">Sispansyon</string>
+    <string name="westbound">Pran direksyon lwès</string>
 </resources>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">Alerta</string>
     <string name="app_version_number">versão %1$s</string>
     <string name="arriving_abbr">CHE</string>
+    <string name="back_button_label">Voltar</string>
     <string name="boarding_abbr">TRA</string>
     <string name="cancelled">Cancelado</string>
+    <string name="close_button_label">Fechar</string>
     <string name="detour">Desvio</string>
     <string name="directionTo">%1$s para</string>
+    <string name="eastbound">Sentido leste</string>
+    <string name="feature_flag_debug_mode">Modo de depuração</string>
+    <string name="feature_flag_route_search">Pesquisa de rotas</string>
     <string name="feedback_link_form">Enviar comentário no aplicativo</string>
     <string name="filterShowAll">Tudo</string>
+    <string name="heading">Rumo</string>
+    <string name="inbound">Entrada</string>
+    <string name="loading">Carregando...</string>
     <string name="more_link">Mais</string>
     <string name="more_page_footer">Feito com ♥ pelo T</string>
     <string name="more_section_feature_flags">Exibir sinalizações</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">Informações Gerais e Suporte da MBTA</string>
     <string name="more_section_support_note">De segunda a sexta: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">Trânsito próximo</string>
     <string name="nearby_transit_link">Próximo</string>
+    <string name="no_predictions">Previsões indisponíveis</string>
     <string name="no_service">Sem serviço</string>
+    <string name="no_service_today">Sem serviço hoje</string>
     <string name="no_stops_nearby">Você está fora da área de serviço da MBTA.</string>
     <string name="no_stops_nearby_title">Nenhuma parada próxima</string>
+    <string name="northbound">Sentido norte</string>
     <string name="now">Agora</string>
     <string name="other_link_privacy_policy">Política de Privacidade</string>
     <string name="other_link_source_code">Exibir origem no GitHub</string>
     <string name="other_link_tos">Termos de Uso</string>
+    <string name="outbound">Saída</string>
+    <string name="pin_route">Marcar rota como favorita</string>
     <string name="resources_link_fare_info">Informações sobre tarifas</string>
     <string name="resources_link_mticket">Bilhetes de transporte diário por trem e balsa</string>
     <string name="resources_link_mticket_note">Aplicativo mTicket</string>
     <string name="resources_link_trip_planner">Planejador de trajetos</string>
+    <string name="service_ended">Serviço encerrado</string>
     <string name="setting_toggle_hide_maps">Ocultar mapas</string>
     <string name="settings_link">Configurações</string>
     <string name="shuttle">Ônibus vai-e-vem</string>
+    <string name="southbound">Sentido sul</string>
     <string name="stop_closed">Parada fechada</string>
     <string name="suspension">Suspensão</string>
+    <string name="westbound">Sentido oeste</string>
 </resources>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">Báo động</string>
     <string name="app_version_number">phiên bản %1$s</string>
     <string name="arriving_abbr">ARR</string>
+    <string name="back_button_label">Mặt sau</string>
     <string name="boarding_abbr">BRD</string>
     <string name="cancelled">Đã hủy</string>
+    <string name="close_button_label">Đóng</string>
     <string name="detour">Đường vòng</string>
     <string name="directionTo">%1$s đến</string>
+    <string name="eastbound">Về hướng đông</string>
+    <string name="feature_flag_debug_mode">Chế độ gỡ lỗi</string>
+    <string name="feature_flag_route_search">Tìm kiếm tuyến đường</string>
     <string name="feedback_link_form">Gửi ý phản hồi về ứng dụng</string>
     <string name="filterShowAll">Tất cả</string>
+    <string name="heading">Tiêu đề</string>
+    <string name="inbound">Đến</string>
+    <string name="loading">Đang tải...</string>
     <string name="more_link">Thêm</string>
     <string name="more_page_footer">Được tạo ra với ♥ bởi T</string>
     <string name="more_section_feature_flags">Cờ tính năng</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">Thông tin &amp; Hỗ trợ chung của MBTA</string>
     <string name="more_section_support_note">Từ thứ Hai đến thứ Sáu: 6:30 sáng - 8:00 tối</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">Phương tiện công cộng ở gần</string>
     <string name="nearby_transit_link">Ở gần</string>
+    <string name="no_predictions">Dự đoán không có sẵn</string>
     <string name="no_service">Không có dịch vụ</string>
+    <string name="no_service_today">Hôm nay không có dịch vụ</string>
     <string name="no_stops_nearby">Bạn đang ở ngoài khu vực dịch vụ của MBTA.</string>
     <string name="no_stops_nearby_title">Không có điểm dừng gần đó</string>
+    <string name="northbound">Về hướng bắc</string>
     <string name="now">Hiện nay</string>
     <string name="other_link_privacy_policy">Chính sách bảo mật</string>
     <string name="other_link_source_code">Xem nguồn trên GitHub</string>
     <string name="other_link_tos">Điều khoản sử dụng</string>
+    <string name="outbound">Đi</string>
+    <string name="pin_route">Tuyến đường sao</string>
     <string name="resources_link_fare_info">Thông tin giá vé</string>
     <string name="resources_link_mticket">Vé phà vé đường sắt ngoại ô (Commuter Rail)</string>
     <string name="resources_link_mticket_note">Ứng dụng mTicket</string>
     <string name="resources_link_trip_planner">Lập kế hoạch chuyến đi</string>
+    <string name="service_ended">Dịch vụ đã kết thúc</string>
     <string name="setting_toggle_hide_maps">Ẩn bản đồ</string>
     <string name="settings_link">Cài đặt</string>
     <string name="shuttle">Xe đưa đón</string>
+    <string name="southbound">Về hướng nam</string>
     <string name="stop_closed">Điểm dừng bị đóng</string>
     <string name="suspension">Đình chỉ</string>
+    <string name="westbound">Về hướng tây</string>
 </resources>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">警报</string>
     <string name="app_version_number">版本%1$s</string>
     <string name="arriving_abbr">到站</string>
+    <string name="back_button_label">后退</string>
     <string name="boarding_abbr">上客</string>
     <string name="cancelled">已取消</string>
+    <string name="close_button_label">关闭</string>
     <string name="detour">交通改道</string>
     <string name="directionTo">%1$s至</string>
+    <string name="eastbound">东行</string>
+    <string name="feature_flag_debug_mode">调试模式</string>
+    <string name="feature_flag_route_search">线路搜索</string>
     <string name="feedback_link_form">发送应用程序反馈</string>
     <string name="filterShowAll">全部</string>
+    <string name="heading">方向</string>
+    <string name="inbound">进站</string>
+    <string name="loading">正在加载……</string>
     <string name="more_link">更多</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">功能标记</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">MBTA通用信息与支持</string>
     <string name="more_section_support_note">周一至周五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
+    <string name="no_predictions">预测不可用</string>
     <string name="no_service">无服务</string>
+    <string name="no_service_today">今日无服务</string>
     <string name="no_stops_nearby">您位于 MBTA 服务区之外。</string>
     <string name="no_stops_nearby_title">附近无站点</string>
+    <string name="northbound">北行</string>
     <string name="now">现在</string>
     <string name="other_link_privacy_policy">隐私政策</string>
     <string name="other_link_source_code">在GitHub上查看源代码</string>
     <string name="other_link_tos">使用条款</string>
+    <string name="outbound">出站</string>
+    <string name="pin_route">为线路添加星号</string>
     <string name="resources_link_fare_info">票价信息</string>
     <string name="resources_link_mticket">通勤列车和轮渡票</string>
     <string name="resources_link_mticket_note">mTicket应用程序</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="service_ended">服务已结束</string>
     <string name="setting_toggle_hide_maps">隐藏地图</string>
     <string name="settings_link">设置</string>
     <string name="shuttle">摆渡巴士</string>
+    <string name="southbound">南行</string>
     <string name="stop_closed">站点已关闭</string>
     <string name="suspension">暂停</string>
+    <string name="westbound">西行</string>
 </resources>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -1,13 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="alert">警報</string>
     <string name="app_version_number">版本 %1$s</string>
     <string name="arriving_abbr">到站</string>
+    <string name="back_button_label">後退</string>
     <string name="boarding_abbr">上客</string>
     <string name="cancelled">已取消</string>
+    <string name="close_button_label">關閉</string>
     <string name="detour">交通改道</string>
     <string name="directionTo">%1$s至</string>
+    <string name="eastbound">東行</string>
+    <string name="feature_flag_debug_mode">調試模式</string>
+    <string name="feature_flag_route_search">線路搜尋</string>
     <string name="feedback_link_form">傳送應用程式回饋</string>
     <string name="filterShowAll">全部</string>
+    <string name="heading">方向</string>
+    <string name="inbound">進站</string>
+    <string name="loading">正在載入……</string>
     <string name="more_link">更多</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">功能標記</string>
@@ -16,21 +25,30 @@
     <string name="more_section_support">MBTA通用資訊與支援</string>
     <string name="more_section_support_note">週一至週五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
+    <string name="no_predictions">預測不可用</string>
     <string name="no_service">無服務</string>
+    <string name="no_service_today">今日無服務</string>
     <string name="no_stops_nearby">您位於 MBTA 服務區域之外。</string>
     <string name="no_stops_nearby_title">附近沒有停靠站</string>
+    <string name="northbound">北行</string>
     <string name="now">現在</string>
     <string name="other_link_privacy_policy">隱私政策</string>
     <string name="other_link_source_code">在GitHub上查看原始程式碼</string>
     <string name="other_link_tos">使用條款</string>
+    <string name="outbound">出站</string>
+    <string name="pin_route">為線路添加星號</string>
     <string name="resources_link_fare_info">票價資訊</string>
     <string name="resources_link_mticket">通勤列車和輪渡票</string>
     <string name="resources_link_mticket_note">mTicket應用程式</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="service_ended">服務已結束</string>
     <string name="setting_toggle_hide_maps">隱藏地圖</string>
     <string name="settings_link">設定</string>
     <string name="shuttle">擺渡巴士</string>
+    <string name="southbound">南行</string>
     <string name="stop_closed">網站已關閉</string>
     <string name="suspension">暫停</string>
+    <string name="westbound">西行</string>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="alert">Alert</string>
     <string name="app_version_number">version %1$s</string>
     <string name="arriving_abbr">ARR</string>
+    <string name="back_button_label">Back</string>
     <string name="boarding_abbr">BRD</string>
     <string name="cancelled">Cancelled</string>
+    <string name="close_button_label">Close</string>
     <string name="detour">Detour</string>
     <string name="directionTo">%1$s to</string>
+    <string name="eastbound">Eastbound</string>
+    <string name="feature_flag_debug_mode">Debug Mode</string>
+    <string name="feature_flag_route_search">Route Search</string>
     <string name="feedback_link_form">Send app feedback</string>
     <string name="filterShowAll">All</string>
+    <string name="heading">Heading</string>
     <string name="icon_description_external_link" tools:ignore="MissingTranslation">External Link</string>
+    <string name="inbound">Inbound</string>
+    <string name="loading" tools:ignore="TypographyEllipsis">Loading...</string>
     <string name="minutes_abbr" tools:ignore="MissingTranslation">%1$s min</string>
     <string name="more_link">More</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
@@ -18,21 +27,31 @@
     <string name="more_section_support">General MBTA Information &amp; Support</string>
     <string name="more_section_support_note">Monday through Friday: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
+    <string name="nearby_transit">Nearby Transit</string>
     <string name="nearby_transit_link">Nearby</string>
+    <string name="no_predictions">Predictions unavailable</string>
     <string name="no_service">No Service</string>
+    <string name="no_service_today">No service today</string>
     <string name="no_stops_nearby">You’re outside the MBTA service area.</string>
     <string name="no_stops_nearby_title">No nearby stops</string>
+    <string name="northbound">Northbound</string>
     <string name="now">Now</string>
     <string name="other_link_privacy_policy">Privacy Policy</string>
     <string name="other_link_source_code">View source on GitHub</string>
     <string name="other_link_tos">Terms of Use</string>
+    <string name="outbound">Outbound</string>
+    <string name="pin_route">Star route</string>
+    <string name="recenter" tools:ignore="MissingTranslation">Recenter</string>
     <string name="resources_link_fare_info">Fare Information</string>
     <string name="resources_link_mticket">Commuter Rail and Ferry tickets</string>
     <string name="resources_link_mticket_note">mTicket App</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="service_ended">Service ended</string>
     <string name="setting_toggle_hide_maps">Hide Maps</string>
     <string name="settings_link">Settings</string>
     <string name="shuttle">Shuttle</string>
+    <string name="southbound">Southbound</string>
     <string name="stop_closed">Stop Closed</string>
     <string name="suspension">Suspension</string>
+    <string name="westbound">Westbound</string>
 </resources>

--- a/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
+++ b/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 abstract class ConvertIosLocalizationTask : DefaultTask() {
+    @get:InputFile abstract var androidEnglishStrings: RegularFile
     @get:InputFile abstract var xcstrings: RegularFile
     @get:OutputDirectory abstract var resources: Directory
 
@@ -18,7 +19,7 @@ abstract class ConvertIosLocalizationTask : DefaultTask() {
     fun run() {
         val iosStrings = readIosStrings()
         val languageTags = iosStrings.values.map { it.keys }.reduce(Set<String>::plus) - "en"
-        val androidEnglishStringsById = parseAndroidStrings(resources.file("values/strings.xml"))
+        val androidEnglishStringsById = parseAndroidStrings(androidEnglishStrings)
         val androidIdsByEnglishString =
             androidEnglishStringsById.entries.groupBy({ it.value }, { it.key })
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Localization catchup](https://app.asana.com/0/1205732265579288/1208936978928073/f)

Since we are using the iOS side as the source of truth after all, this task is easy.

android
- [x] All user-facing strings added to strings resource

### Testing

Verified that the new labels appear properly.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
