### PR TITLE
fix: parcel crash, move data/functions to VM

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -311,11 +311,12 @@ class NearbyTransitPageTest : KoinTest {
         open class MockMapVM : IMapViewModel {
             var mutableLastErrorTimestamp = MutableStateFlow<Instant?>(null)
             override var lastMapboxErrorTimestamp: Flow<Instant?> = mutableLastErrorTimestamp
-            override var railRouteLineData: List<RouteLineData>? = null
-            override var stopSourceData: FeatureCollection? = null
-            override var globalResponse: GlobalResponse? = null
-            override var alertsData: AlertsStreamDataResponse? = null
-            override var railRouteShapes: MapFriendlyRouteResponse? = null
+            override var railRouteLineData: Flow<List<RouteLineData>?> =
+                MutableStateFlow(value = null)
+            override var stopSourceData: Flow<FeatureCollection?> = MutableStateFlow(value = null)
+            override var globalResponse: Flow<GlobalResponse?> = MutableStateFlow(value = null)
+            override var railRouteShapes: Flow<MapFriendlyRouteResponse?> =
+                MutableStateFlow(value = null)
 
             var loadConfigCalledCount = 0
 
@@ -327,9 +328,13 @@ class NearbyTransitPageTest : KoinTest {
                 return null
             }
 
-            override fun refreshRouteLineData(now: Instant) {}
+            override suspend fun refreshRouteLineData(now: Instant) {}
 
-            override fun refreshStopFeatures(now: Instant, selectedStop: Stop?) {}
+            override suspend fun refreshStopFeatures(now: Instant, selectedStop: Stop?) {}
+
+            override suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?) {}
+
+            override suspend fun setGlobalResponse(globalResponse: GlobalResponse?) {}
         }
 
         val mockMapVM = MockMapVM()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.rule.GrantPermissionRule
+import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
@@ -25,14 +26,18 @@ import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
 import com.mbta.tid.mbta_app.android.util.LocalActivity
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
+import com.mbta.tid.mbta_app.map.RouteLineData
 import com.mbta.tid.mbta_app.model.Coordinate
+import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
@@ -306,12 +311,25 @@ class NearbyTransitPageTest : KoinTest {
         open class MockMapVM : IMapViewModel {
             var mutableLastErrorTimestamp = MutableStateFlow<Instant?>(null)
             override var lastMapboxErrorTimestamp: Flow<Instant?> = mutableLastErrorTimestamp
+            override var railRouteLineData: List<RouteLineData>? = null
+            override var stopSourceData: FeatureCollection? = null
+            override var globalResponse: GlobalResponse? = null
+            override var alertsData: AlertsStreamDataResponse? = null
+            override var railRouteShapes: MapFriendlyRouteResponse? = null
 
             var loadConfigCalledCount = 0
 
             override suspend fun loadConfig() {
                 loadConfigCalledCount += 1
             }
+
+            override fun globalMapData(now: Instant): GlobalMapData? {
+                return null
+            }
+
+            override fun refreshRouteLineData(now: Instant) {}
+
+            override fun refreshStopFeatures(now: Instant, selectedStop: Stop?) {}
         }
 
         val mockMapVM = MockMapVM()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -131,7 +131,7 @@ fun HomeMapView(
     fun updateDisplayedRoutesBasedOnStop() {
         val globalResponse = globalResponse ?: return
         val railRouteShapes = railRouteShapes ?: return
-        if (stopMapData == null) return
+        val stopMapData = stopMapData ?: return
 
         val filteredRoutes =
             if (stopDetailsFilter != null) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +21,6 @@ import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.navigation.NavBackStackEntry
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
-import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.Point
 import com.mapbox.maps.MapView
 import com.mapbox.maps.MapboxExperimental
@@ -49,7 +47,6 @@ import com.mapbox.maps.viewannotation.viewAnnotationOptions
 import com.mbta.tid.mbta_app.android.appVariant
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
-import com.mbta.tid.mbta_app.android.state.getRailRouteShapes
 import com.mbta.tid.mbta_app.android.state.getStopMapData
 import com.mbta.tid.mbta_app.android.util.LazyObjectQueue
 import com.mbta.tid.mbta_app.android.util.rememberPrevious
@@ -57,17 +54,11 @@ import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.android.util.toPoint
 import com.mbta.tid.mbta_app.map.ColorPalette
 import com.mbta.tid.mbta_app.map.RouteFeaturesBuilder
-import com.mbta.tid.mbta_app.map.RouteLineData
-import com.mbta.tid.mbta_app.map.StopFeaturesBuilder
 import com.mbta.tid.mbta_app.map.StopLayerGenerator
-import com.mbta.tid.mbta_app.map.StopSourceData
-import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
-import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
@@ -77,8 +68,6 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun HomeMapView(
     modifier: Modifier = Modifier,
-    globalResponse: GlobalResponse?,
-    alertsData: AlertsStreamDataResponse?,
     lastNearbyTransitLocation: Position?,
     nearbyTransitSelectingLocationState: MutableState<Boolean>,
     locationDataManager: LocationDataManager,
@@ -87,7 +76,8 @@ fun HomeMapView(
     handleStopNavigation: (String) -> Unit,
     vehiclesData: List<Vehicle>,
     stopDetailsDepartures: StopDetailsDepartures?,
-    stopDetailsFilter: StopDetailsFilter?
+    stopDetailsFilter: StopDetailsFilter?,
+    viewModel: IMapViewModel
 ) {
     var nearbyTransitSelectingLocation by nearbyTransitSelectingLocationState
     val previousNavEntry: NavBackStackEntry? = rememberPrevious(current = currentNavEntry)
@@ -95,22 +85,12 @@ fun HomeMapView(
     val layerManager = remember { LazyObjectQueue<MapLayerManager>() }
     var selectedStop by remember { mutableStateOf<Stop?>(null) }
 
-    val railRouteShapes = getRailRouteShapes()
-    var railRouteLineData: List<RouteLineData>? by rememberSaveable { mutableStateOf(null) }
-    var stopSourceData: FeatureCollection? by rememberSaveable { mutableStateOf(null) }
-
+    val railRouteShapes = viewModel.railRouteShapes.collectAsState(initial = null).value
+    val stopSourceData = viewModel.stopSourceData.collectAsState(initial = null).value
+    val globalResponse = viewModel.globalResponse.collectAsState(initial = null).value
+    val railRouteLineData = viewModel.railRouteLineData.collectAsState(initial = null).value
     val now = timer(updateInterval = 10.seconds)
-    val globalMapData =
-        remember(globalResponse, alertsData, now) {
-            if (globalResponse != null) {
-                GlobalMapData(
-                    globalResponse,
-                    GlobalMapData.getAlertsByStop(globalResponse, alertsData, now)
-                )
-            } else {
-                null
-            }
-        }
+    val globalMapData = remember(now) { viewModel.globalMapData(now) }
 
     val isDarkMode = isSystemInDarkTheme()
     val stopMapData: StopMapResponse? = selectedStop?.let { getStopMapData(stopId = it.id) }
@@ -149,7 +129,9 @@ fun HomeMapView(
     }
 
     fun updateDisplayedRoutesBasedOnStop() {
-        if (railRouteShapes == null || globalResponse == null || stopMapData == null) return
+        val globalResponse = globalResponse ?: return
+        val railRouteShapes = railRouteShapes ?: return
+        if (stopMapData == null) return
 
         val filteredRoutes =
             if (stopDetailsFilter != null) {
@@ -177,33 +159,11 @@ fun HomeMapView(
         }
     }
 
-    fun refreshRouteLineData() {
-        if (railRouteShapes == null || globalResponse == null) return
-        railRouteLineData =
-            RouteFeaturesBuilder.generateRouteLines(
-                railRouteShapes.routesWithSegmentedShapes,
-                globalResponse.routes,
-                globalResponse.stops,
-                globalMapData?.alertsByStop
-            )
-    }
-
     fun refreshRouteLineSource() {
         val routeData = railRouteLineData ?: return
         layerManager.run {
             updateRouteSourceData(RouteFeaturesBuilder.buildCollection(routeData).toMapbox())
         }
-    }
-
-    fun refreshStopFeatures() {
-        val routeLineData = railRouteLineData ?: return
-        stopSourceData =
-            StopFeaturesBuilder.buildCollection(
-                    StopSourceData(selectedStopId = selectedStop?.id),
-                    globalMapData?.mapStops.orEmpty(),
-                    routeLineData
-                )
-                .toMapbox()
     }
 
     fun refreshStopSource() {
@@ -279,15 +239,15 @@ fun HomeMapView(
         ) {
             LaunchedEffect(currentNavEntry) { handleNavChange() }
             LaunchedEffect(railRouteShapes, globalResponse, globalMapData) {
-                refreshRouteLineData()
+                viewModel.refreshRouteLineData(now)
             }
             LaunchedEffect(railRouteLineData) {
                 refreshRouteLineSource()
-                refreshStopFeatures()
+                viewModel.refreshStopFeatures(now, selectedStop)
             }
             LaunchedEffect(selectedStop) {
                 positionViewportToStop()
-                refreshStopFeatures()
+                viewModel.refreshStopFeatures(now, selectedStop)
             }
             LaunchedEffect(stopSourceData) { refreshStopSource() }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -2,24 +2,56 @@ package com.mbta.tid.mbta_app.android.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.mapbox.common.HttpServiceFactory
 import com.mapbox.common.MapboxOptions
+import com.mapbox.geojson.FeatureCollection
 import com.mbta.tid.mbta_app.dependencyInjection.UsecaseDI
+import com.mbta.tid.mbta_app.map.RouteFeaturesBuilder
+import com.mbta.tid.mbta_app.map.RouteLineData
+import com.mbta.tid.mbta_app.map.StopFeaturesBuilder
+import com.mbta.tid.mbta_app.map.StopSourceData
+import com.mbta.tid.mbta_app.model.GlobalMapData
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
+import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 interface IMapViewModel {
     var lastMapboxErrorTimestamp: Flow<Instant?>
+    var railRouteLineData: Flow<List<RouteLineData>?>
+    var stopSourceData: Flow<FeatureCollection?>
+    var globalResponse: Flow<GlobalResponse?>
+    var railRouteShapes: Flow<MapFriendlyRouteResponse?>
 
     suspend fun loadConfig()
+
+    fun globalMapData(now: Instant): GlobalMapData?
+
+    suspend fun refreshRouteLineData(now: Instant)
+
+    suspend fun refreshStopFeatures(now: Instant, selectedStop: Stop?)
+
+    suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?)
+
+    suspend fun setGlobalResponse(globalResponse: GlobalResponse?)
 }
 
 open class MapViewModel(
@@ -28,14 +60,26 @@ open class MapViewModel(
     setHttpInterceptor: (MapHttpInterceptor?) -> Unit = { interceptor ->
         HttpServiceFactory.setHttpServiceInterceptor(interceptor)
     }
-) : ViewModel(), IMapViewModel {
+) : ViewModel(), IMapViewModel, KoinComponent {
     private val _config = MutableStateFlow<ApiResult<ConfigResponse>?>(null)
     var config: StateFlow<ApiResult<ConfigResponse>?> = _config
     private val _lastMapboxErrorTimestamp = MutableStateFlow<Instant?>(null)
     override var lastMapboxErrorTimestamp = _lastMapboxErrorTimestamp.debounce(1.seconds)
+    private val _railRouteLineData = MutableStateFlow<List<RouteLineData>?>(null)
+    override var railRouteLineData: Flow<List<RouteLineData>?> = _railRouteLineData
+    private val _stopSourceData = MutableStateFlow<FeatureCollection?>(null)
+    override var stopSourceData: Flow<FeatureCollection?> = _stopSourceData
+    private val _globalResponse = MutableStateFlow<GlobalResponse?>(null)
+    override var globalResponse: Flow<GlobalResponse?> = _globalResponse
+    private val _railRouteShapes = MutableStateFlow<MapFriendlyRouteResponse?>(null)
+    override var railRouteShapes: Flow<MapFriendlyRouteResponse?> = _railRouteShapes
+
+    private var alertsData: AlertsStreamDataResponse? = null
+    private val railRouteShapeRepository: IRailRouteShapeRepository by inject()
 
     init {
         setHttpInterceptor(MapHttpInterceptor { updateLastErrorTimestamp() })
+        viewModelScope.launch { _railRouteShapes.value = fetchRailRouteShapes() }
     }
 
     private fun updateLastErrorTimestamp() {
@@ -48,6 +92,51 @@ open class MapViewModel(
             configureMapboxToken(latestConfig.data.mapboxPublicToken)
         }
         _config.value = latestConfig
+    }
+
+    override fun globalMapData(now: Instant): GlobalMapData? =
+        runBlocking(Dispatchers.IO) {
+            globalResponse.first()?.let {
+                GlobalMapData(it, GlobalMapData.getAlertsByStop(it, alertsData, now))
+            }
+        }
+
+    override suspend fun refreshRouteLineData(now: Instant) {
+        val globalResponse = globalResponse.first() ?: return
+        val railRouteShapes = railRouteShapes.first() ?: return
+        _railRouteLineData.value =
+            RouteFeaturesBuilder.generateRouteLines(
+                railRouteShapes.routesWithSegmentedShapes,
+                globalResponse.routes,
+                globalResponse.stops,
+                globalMapData(now)?.alertsByStop
+            )
+    }
+
+    override suspend fun refreshStopFeatures(now: Instant, selectedStop: Stop?) {
+        val routeLineData = railRouteLineData.first() ?: return
+        _stopSourceData.value =
+            StopFeaturesBuilder.buildCollection(
+                    StopSourceData(selectedStopId = selectedStop?.id),
+                    globalMapData(now)?.mapStops.orEmpty(),
+                    routeLineData
+                )
+                .toMapbox()
+    }
+
+    override suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?) {
+        this.alertsData = alertsData
+    }
+
+    override suspend fun setGlobalResponse(globalResponse: GlobalResponse?) {
+        _globalResponse.value = globalResponse
+    }
+
+    private suspend fun fetchRailRouteShapes(): MapFriendlyRouteResponse? {
+        return when (val data = railRouteShapeRepository.getRailRouteShapes()) {
+            is ApiResult.Ok -> data.data
+            is ApiResult.Error -> null
+        }
     }
 
     class Factory : ViewModelProvider.Factory {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -126,6 +126,12 @@ fun NearbyTransitPage(
         mapViewModel.loadConfig()
     }
 
+    LaunchedEffect(nearbyTransit.alertData) { mapViewModel.setAlertsData(nearbyTransit.alertData) }
+
+    LaunchedEffect(nearbyTransit.globalResponse) {
+        mapViewModel.setGlobalResponse(nearbyTransit.globalResponse)
+    }
+
     Scaffold(bottomBar = bottomBar) { outerSheetPadding ->
         BottomSheetScaffold(
             sheetDragHandle = { DragHandle() },
@@ -260,8 +266,6 @@ fun NearbyTransitPage(
         ) { sheetPadding ->
             HomeMapView(
                 Modifier.padding(sheetPadding),
-                globalResponse = nearbyTransit.globalResponse,
-                alertsData = nearbyTransit.alertData,
                 lastNearbyTransitLocation = nearbyTransit.lastNearbyTransitLocation,
                 nearbyTransitSelectingLocationState =
                     nearbyTransit.nearbyTransitSelectingLocationState,
@@ -271,7 +275,8 @@ fun NearbyTransitPage(
                 handleStopNavigation = ::handleStopNavigation,
                 vehiclesData = vehiclesData,
                 stopDetailsDepartures = stopDetailsDepartures,
-                stopDetailsFilter = stopDetailsFilter
+                stopDetailsFilter = stopDetailsFilter,
+                viewModel = mapViewModel
             )
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Data parsing crash on backgrounding](https://app.asana.com/0/1205732265579288/1208885747081174/f)

What is this PR for?

Resolves the crashes that occur when backgrounding the app.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"
android
- [x] All user-facing strings added to strings resource

### Testing

What testing have you done?

No logic changes, just shuffling data around into a view model. Not sure if there's a way to automate lifecycle testing.
