### PR TITLE
feat(Android): allow small sheet size

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 import android.app.Activity
 import android.location.Location
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
@@ -19,6 +18,7 @@ import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -9,13 +9,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.printToLog
 import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
@@ -306,6 +309,9 @@ class NearbyTransitPageTest : KoinTest {
         composeTestRule.onNodeWithText("Green Line Head Sign").assertExists()
         composeTestRule.onNodeWithText("5 min").assertExists()
 
+        composeTestRule
+            .onNodeWithContentDescription("Drag handle")
+            .performSemanticsAction(SemanticsActions.Expand)
         try {
             composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
         } catch (ex: ComposeTimeoutException) {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.printToLog
 import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
@@ -309,7 +309,8 @@ class NearbyTransitPageTest : KoinTest {
         try {
             composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
         } catch (ex: ComposeTimeoutException) {
-            composeTestRule.onRoot().printToLog("ci-keep")
+            // by some mechanism there are two roots
+            composeTestRule.onAllNodes(isRoot()).printToLog("ci-keep")
             throw ex
         }
         composeTestRule.onNodeWithText("Sample Route").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -310,7 +310,7 @@ class NearbyTransitPageTest : KoinTest {
             composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
         } catch (ex: ComposeTimeoutException) {
             // by some mechanism there are two roots
-            composeTestRule.onAllNodes(isRoot()).printToLog("ci-keep")
+            composeTestRule.onAllNodes(isRoot()).printToLog("ci-keep", maxDepth = Int.MAX_VALUE)
             throw ex
         }
         composeTestRule.onNodeWithText("Sample Route").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -9,11 +9,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.printToLog
 import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
@@ -303,7 +306,12 @@ class NearbyTransitPageTest : KoinTest {
         composeTestRule.onNodeWithText("Green Line Head Sign").assertExists()
         composeTestRule.onNodeWithText("5 min").assertExists()
 
-        composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
+        try {
+            composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
+        } catch (ex: ComposeTimeoutException) {
+            composeTestRule.onRoot().printToLog("ci-keep")
+            throw ex
+        }
         composeTestRule.onNodeWithText("Sample Route").assertExists()
         composeTestRule.onNodeWithText("Sample Stop").assertExists()
         composeTestRule.onNodeWithText("Sample Headsign").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -303,6 +303,7 @@ class NearbyTransitPageTest : KoinTest {
         composeTestRule.onNodeWithText("Green Line Head Sign").assertExists()
         composeTestRule.onNodeWithText("5 min").assertExists()
 
+        composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
         composeTestRule.onNodeWithText("Sample Route").assertExists()
         composeTestRule.onNodeWithText("Sample Stop").assertExists()
         composeTestRule.onNodeWithText("Sample Headsign").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -10,16 +10,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performSemanticsAction
-import androidx.compose.ui.test.printToLog
 import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
@@ -300,6 +297,9 @@ class NearbyTransitPageTest : KoinTest {
         }
 
         composeTestRule.waitUntilDoesNotExist(hasText("Loading..."))
+        composeTestRule
+            .onNodeWithContentDescription("Drag handle")
+            .performSemanticsAction(SemanticsActions.Expand)
 
         composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
         composeTestRule.onNodeWithText("Search by stop").assertIsDisplayed()
@@ -309,16 +309,6 @@ class NearbyTransitPageTest : KoinTest {
         composeTestRule.onNodeWithText("Green Line Head Sign").assertExists()
         composeTestRule.onNodeWithText("5 min").assertExists()
 
-        composeTestRule
-            .onNodeWithContentDescription("Drag handle")
-            .performSemanticsAction(SemanticsActions.Expand)
-        try {
-            composeTestRule.waitUntilExactlyOneExists(hasText("Sample Route"))
-        } catch (ex: ComposeTimeoutException) {
-            // by some mechanism there are two roots
-            composeTestRule.onAllNodes(isRoot()).printToLog("ci-keep", maxDepth = Int.MAX_VALUE)
-            throw ex
-        }
         composeTestRule.onNodeWithText("Sample Route").assertExists()
         composeTestRule.onNodeWithText("Sample Stop").assertExists()
         composeTestRule.onNodeWithText("Sample Headsign").assertExists()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -3,8 +3,6 @@ package com.mbta.tid.mbta_app.android
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.rememberBottomSheetScaffoldState
-import androidx.compose.material3.rememberStandardBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -20,6 +18,8 @@ import androidx.navigation.compose.rememberNavController
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mbta.tid.mbta_app.android.component.BottomNavBar
+import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.component.sheet.rememberStandardBottomSheetState
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.location.rememberLocationDataManager
 import com.mbta.tid.mbta_app.android.pages.MorePage

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/AnchoredDraggable.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/AnchoredDraggable.kt
@@ -1,0 +1,133 @@
+/**
+ * Derived from
+ * https://android.googlesource.com/platform/frameworks/support/+/065f8f4c9800a64e5344e69e1a0aef65fa981370/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/internal/AnchoredDraggable.kt,
+ * which is
+ *
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.mbta.tid.mbta_app.android.component.sheet
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import kotlin.math.roundToInt
+
+/**
+ * This is how the [androidx.compose.material3.StandardBottomSheet] sets its anchors in response to
+ * the available size, and initial attempts to rewrite it to more direct
+ * [AnchoredDraggableState.updateAnchors] calls were unsuccessful.
+ *
+ * @see androidx.compose.material3.internal.draggableAnchors
+ */
+@OptIn(ExperimentalFoundationApi::class)
+internal fun <T> Modifier.draggableAnchors(
+    state: AnchoredDraggableState<T>,
+    orientation: Orientation,
+    anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+) = this then DraggableAnchorsElement(state, anchors, orientation)
+
+/** @see androidx.compose.material3.internal.DraggableAnchorsElement */
+@OptIn(ExperimentalFoundationApi::class)
+private class DraggableAnchorsElement<T>(
+    private val state: AnchoredDraggableState<T>,
+    private val anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+    private val orientation: Orientation
+) : ModifierNodeElement<DraggableAnchorsNode<T>>() {
+    override fun create() = DraggableAnchorsNode(state, anchors, orientation)
+
+    override fun update(node: DraggableAnchorsNode<T>) {
+        node.state = state
+        node.anchors = anchors
+        node.orientation = orientation
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+
+        if (other !is DraggableAnchorsElement<*>) return false
+
+        if (state != other.state) return false
+        if (anchors !== other.anchors) return false
+        if (orientation != other.orientation) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + anchors.hashCode()
+        result = 31 * result + orientation.hashCode()
+        return result
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        debugInspectorInfo {
+            properties["state"] = state
+            properties["anchors"] = anchors
+            properties["orientation"] = orientation
+        }
+    }
+}
+
+/** @see androidx.compose.material3.internal.DraggableAnchorsNode */
+@OptIn(ExperimentalFoundationApi::class)
+private class DraggableAnchorsNode<T>(
+    var state: AnchoredDraggableState<T>,
+    var anchors: (size: IntSize, constraints: Constraints) -> Pair<DraggableAnchors<T>, T>,
+    var orientation: Orientation
+) : Modifier.Node(), LayoutModifierNode {
+    private var didLookahead: Boolean = false
+
+    override fun onDetach() {
+        didLookahead = false
+    }
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        // If we are in a lookahead pass, we only want to update the anchors here and not in
+        // post-lookahead. If there is no lookahead happening (!isLookingAhead && !didLookahead),
+        // update the anchors in the main pass.
+        if (!isLookingAhead || !didLookahead) {
+            val size = IntSize(placeable.width, placeable.height)
+            val newAnchorResult = anchors(size, constraints)
+            state.updateAnchors(newAnchorResult.first, newAnchorResult.second)
+        }
+        didLookahead = isLookingAhead || didLookahead
+        return layout(placeable.width, placeable.height) {
+            // In a lookahead pass, we use the position of the current target as this is where any
+            // ongoing animations would move. If the component is in a settled state, lookahead
+            // and post-lookahead will converge.
+            val offset =
+                if (isLookingAhead) {
+                    state.anchors.positionOf(state.targetValue)
+                } else state.requireOffset()
+            val xOffset = if (orientation == Orientation.Horizontal) offset else 0f
+            val yOffset = if (orientation == Orientation.Vertical) offset else 0f
+            placeable.place(xOffset.roundToInt(), yOffset.roundToInt())
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
@@ -1,0 +1,352 @@
+/**
+ * Derived from
+ * https://android.googlesource.com/platform/frameworks/support/+/065f8f4c9800a64e5344e69e1a0aef65fa981370/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/BottomSheetScaffold.kt,
+ * which is
+ *
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.mbta.tid.mbta_app.android.component.sheet
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.DraggableAnchors
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.requiredHeightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.R as MaterialR
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.collapse
+import androidx.compose.ui.semantics.expand
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.coerceIn
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrNull
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
+
+/** @see androidx.compose.material3.BottomSheetScaffold */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+@ExperimentalMaterial3Api
+fun BottomSheetScaffold(
+    sheetContent: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    scaffoldState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(),
+    sheetSmallHeight: Dp = 200.dp,
+    sheetMaxWidth: Dp = BottomSheetDefaults.SheetMaxWidth,
+    sheetShape: Shape = BottomSheetDefaults.ExpandedShape,
+    sheetContainerColor: Color = BottomSheetDefaults.ContainerColor,
+    sheetContentColor: Color = contentColorFor(sheetContainerColor),
+    sheetTonalElevation: Dp = 0.dp,
+    sheetShadowElevation: Dp = BottomSheetDefaults.Elevation,
+    sheetDragHandle: @Composable (() -> Unit)? = { BottomSheetDefaults.DragHandle() },
+    sheetSwipeEnabled: Boolean = true,
+    topBar: @Composable (() -> Unit)? = null,
+    snackbarHost: @Composable (SnackbarHostState) -> Unit = { SnackbarHost(it) },
+    containerColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = contentColorFor(containerColor),
+    content: @Composable (PaddingValues) -> Unit
+) {
+    // padding the map to account for the sheet height is a bit of a mess, especially because
+    // padding with the full layout height crashes the app, so we need a max padding
+    var layoutHeight by remember { mutableFloatStateOf(0f) }
+    val density = LocalDensity.current
+    val actualSheetHeight =
+        with(density) {
+            scaffoldState.bottomSheetState.anchoredDraggableState.offset
+                .takeUnless { it.isNaN() }
+                ?.let { (layoutHeight - it).toDp() }
+        }
+    val maxPadding = with(density) { layoutHeight.toDp() - sheetSmallHeight }
+    BottomSheetScaffoldLayout(
+        modifier = modifier.onGloballyPositioned { layoutHeight = it.boundsInWindow().height },
+        topBar = topBar,
+        body = {
+            content(
+                PaddingValues(
+                    bottom =
+                        (actualSheetHeight ?: 0.dp).coerceIn(
+                            sheetSmallHeight,
+                            max(maxPadding, sheetSmallHeight)
+                        )
+                )
+            )
+        },
+        snackbarHost = { snackbarHost(scaffoldState.snackbarHostState) },
+        sheetOffset = { scaffoldState.bottomSheetState.requireOffset() },
+        sheetState = scaffoldState.bottomSheetState,
+        containerColor = containerColor,
+        contentColor = contentColor,
+        bottomSheet = {
+            StandardBottomSheet(
+                state = scaffoldState.bottomSheetState,
+                smallHeight = sheetSmallHeight,
+                sheetMaxWidth = sheetMaxWidth,
+                sheetSwipeEnabled = sheetSwipeEnabled,
+                shape = sheetShape,
+                containerColor = sheetContainerColor,
+                contentColor = sheetContentColor,
+                tonalElevation = sheetTonalElevation,
+                shadowElevation = sheetShadowElevation,
+                dragHandle = sheetDragHandle,
+                content = sheetContent
+            )
+        }
+    )
+}
+
+/** @see androidx.compose.material3.BottomSheetScaffoldState */
+@ExperimentalMaterial3Api
+@Stable
+class BottomSheetScaffoldState(
+    val bottomSheetState: SheetState,
+    val snackbarHostState: SnackbarHostState
+)
+
+/** @see androidx.compose.material3.rememberBottomSheetScaffoldState */
+@Composable
+@ExperimentalMaterial3Api
+fun rememberBottomSheetScaffoldState(
+    bottomSheetState: SheetState = rememberStandardBottomSheetState(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+): BottomSheetScaffoldState {
+    return remember(bottomSheetState, snackbarHostState) {
+        BottomSheetScaffoldState(
+            bottomSheetState = bottomSheetState,
+            snackbarHostState = snackbarHostState
+        )
+    }
+}
+
+/** @see androidx.compose.material3.rememberStandardBottomSheetState */
+@Composable
+fun rememberStandardBottomSheetState(
+    initialValue: SheetValue = SheetValue.Medium,
+    confirmValueChange: (SheetValue) -> Boolean = { true },
+    skipHiddenState: Boolean = true,
+) =
+    rememberSheetState(
+        confirmValueChange = confirmValueChange,
+        initialValue = initialValue,
+        skipHiddenState = skipHiddenState,
+    )
+
+/** @see androidx.compose.material3.StandardBottomSheet */
+@OptIn(ExperimentalFoundationApi::class)
+@SuppressLint("PrivateResource")
+@Composable
+private fun StandardBottomSheet(
+    state: SheetState,
+    smallHeight: Dp,
+    sheetMaxWidth: Dp,
+    sheetSwipeEnabled: Boolean,
+    shape: Shape,
+    containerColor: Color,
+    contentColor: Color,
+    tonalElevation: Dp,
+    shadowElevation: Dp,
+    dragHandle: @Composable (() -> Unit)?,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val orientation = Orientation.Vertical
+    val smallHeightPx = with(LocalDensity.current) { smallHeight.toPx() }
+    val nestedScroll =
+        if (sheetSwipeEnabled) {
+            Modifier.nestedScroll(
+                remember(state.anchoredDraggableState) {
+                    ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
+                        sheetState = state,
+                        orientation = orientation,
+                        onFling = { scope.launch { state.settle(it) } }
+                    )
+                }
+            )
+        } else {
+            Modifier
+        }
+    Surface(
+        modifier =
+            Modifier.widthIn(max = sheetMaxWidth)
+                .fillMaxWidth()
+                .requiredHeightIn(min = smallHeight)
+                .then(nestedScroll)
+                .draggableAnchors(state.anchoredDraggableState, orientation) { _, constraints ->
+                    val layoutHeight = constraints.maxHeight.toFloat()
+                    val newAnchors = DraggableAnchors {
+                        SheetValue.Small at layoutHeight - smallHeightPx
+                        SheetValue.Medium at layoutHeight / 2
+                        SheetValue.Large at 0f
+                    }
+                    val newTarget = state.anchoredDraggableState.targetValue
+                    return@draggableAnchors newAnchors to newTarget
+                }
+                .anchoredDraggable(
+                    state = state.anchoredDraggableState,
+                    orientation = orientation,
+                    enabled = sheetSwipeEnabled
+                ),
+        shape = shape,
+        color = containerColor,
+        contentColor = contentColor,
+        tonalElevation = tonalElevation,
+        shadowElevation = shadowElevation,
+    ) {
+        Column(Modifier.fillMaxWidth()) {
+            if (dragHandle != null) {
+                val collapseActionLabel =
+                    stringResource(MaterialR.string.m3c_bottom_sheet_collapse_description)
+                val expandActionLabel =
+                    stringResource(MaterialR.string.m3c_bottom_sheet_expand_description)
+                Box(
+                    Modifier.align(CenterHorizontally).semantics(mergeDescendants = true) {
+                        with(state) {
+                            // Provides semantics to interact with the bottomsheet if there is more
+                            // than one anchor to swipe to and swiping is enabled.
+                            if (anchoredDraggableState.anchors.size > 1 && sheetSwipeEnabled) {
+                                when (currentValue) {
+                                    SheetValue.Small -> {
+                                        expand(expandActionLabel) {
+                                            scope.launch { animateTo(SheetValue.Medium) }
+                                            true
+                                        }
+                                    }
+                                    SheetValue.Medium -> {
+                                        collapse(collapseActionLabel) {
+                                            scope.launch { animateTo(SheetValue.Small) }
+                                            true
+                                        }
+                                        expand(expandActionLabel) {
+                                            scope.launch { animateTo(SheetValue.Large) }
+                                            true
+                                        }
+                                    }
+                                    SheetValue.Large -> {
+                                        collapse(collapseActionLabel) {
+                                            scope.launch { animateTo(SheetValue.Medium) }
+                                            true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                ) {
+                    dragHandle()
+                }
+            }
+            content()
+        }
+    }
+}
+
+/** @see androidx.compose.material3.BottomSheetScaffoldLayout */
+@Composable
+private fun BottomSheetScaffoldLayout(
+    modifier: Modifier,
+    topBar: @Composable (() -> Unit)?,
+    body: @Composable () -> Unit,
+    bottomSheet: @Composable () -> Unit,
+    snackbarHost: @Composable () -> Unit,
+    sheetOffset: () -> Float,
+    sheetState: SheetState,
+    containerColor: Color,
+    contentColor: Color,
+) {
+    Layout(
+        contents =
+            listOf<@Composable () -> Unit>(
+                topBar ?: {},
+                {
+                    Surface(
+                        modifier = modifier,
+                        color = containerColor,
+                        contentColor = contentColor,
+                        content = body
+                    )
+                },
+                bottomSheet,
+                snackbarHost
+            )
+    ) {
+        (topBarMeasurables, bodyMeasurables, bottomSheetMeasurables, snackbarHostMeasurables),
+        constraints ->
+        val layoutWidth = constraints.maxWidth
+        val layoutHeight = constraints.maxHeight
+        val looseConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+
+        val sheetPlaceables = bottomSheetMeasurables.fastMap { it.measure(looseConstraints) }
+
+        val topBarPlaceables = topBarMeasurables.fastMap { it.measure(looseConstraints) }
+        val topBarHeight = topBarPlaceables.fastMaxOfOrNull { it.height } ?: 0
+
+        val bodyConstraints = looseConstraints.copy(maxHeight = layoutHeight - topBarHeight)
+        val bodyPlaceables = bodyMeasurables.fastMap { it.measure(bodyConstraints) }
+
+        val snackbarPlaceables = snackbarHostMeasurables.fastMap { it.measure(looseConstraints) }
+
+        layout(layoutWidth, layoutHeight) {
+            val sheetWidth = sheetPlaceables.fastMaxOfOrNull { it.width } ?: 0
+            val sheetOffsetX = Integer.max(0, (layoutWidth - sheetWidth) / 2)
+
+            val snackbarWidth = snackbarPlaceables.fastMaxOfOrNull { it.width } ?: 0
+            val snackbarHeight = snackbarPlaceables.fastMaxOfOrNull { it.height } ?: 0
+            val snackbarOffsetX = (layoutWidth - snackbarWidth) / 2
+            val snackbarOffsetY =
+                when (sheetState.currentValue) {
+                    SheetValue.Small,
+                    SheetValue.Medium -> sheetOffset().roundToInt() - snackbarHeight
+                    SheetValue.Large -> layoutHeight - snackbarHeight
+                }
+
+            // Placement order is important for elevation
+            bodyPlaceables.fastForEach { it.placeRelative(0, topBarHeight) }
+            topBarPlaceables.fastForEach { it.placeRelative(0, 0) }
+            sheetPlaceables.fastForEach { it.placeRelative(sheetOffsetX, 0) }
+            snackbarPlaceables.fastForEach { it.placeRelative(snackbarOffsetX, snackbarOffsetY) }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/SheetDefaults.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/SheetDefaults.kt
@@ -1,0 +1,184 @@
+/**
+ * Derived from
+ * https://android.googlesource.com/platform/frameworks/support/+/065f8f4c9800a64e5344e69e1a0aef65fa981370/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SheetDefaults.kt,
+ * which is
+ *
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.mbta.tid.mbta_app.android.component.sheet
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.FloatExponentialDecaySpec
+import androidx.compose.animation.core.generateDecayAnimationSpec
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.AnchoredDraggableState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.animateTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.unit.dp
+
+/** @see androidx.compose.material3.SheetState */
+@OptIn(ExperimentalFoundationApi::class)
+class SheetState(
+    density: Density,
+    initialValue: SheetValue = SheetValue.Medium,
+    confirmValueChange: (SheetValue) -> Boolean = { true },
+) {
+    val currentValue: SheetValue
+        get() = anchoredDraggableState.currentValue
+
+    fun requireOffset(): Float = anchoredDraggableState.requireOffset()
+
+    internal suspend fun animateTo(targetValue: SheetValue) {
+        anchoredDraggableState.animateTo(targetValue)
+    }
+
+    internal suspend fun settle(velocity: Float) {
+        anchoredDraggableState.settle(velocity)
+    }
+
+    internal var anchoredDraggableState =
+        AnchoredDraggableState(
+            initialValue = initialValue,
+            positionalThreshold = { with(density) { 56.dp.toPx() } },
+            velocityThreshold = { with(density) { 125.dp.toPx() } },
+            snapAnimationSpec = BottomSheetAnimationSpec,
+            decayAnimationSpec = FloatExponentialDecaySpec().generateDecayAnimationSpec(),
+            confirmValueChange = confirmValueChange,
+        )
+
+    companion object {
+        fun Saver(
+            confirmValueChange: (SheetValue) -> Boolean,
+            density: Density,
+        ) =
+            Saver<SheetState, SheetValue>(
+                save = { it.currentValue },
+                restore = { savedValue ->
+                    SheetState(
+                        density,
+                        savedValue,
+                        confirmValueChange,
+                    )
+                }
+            )
+    }
+}
+
+/** @see androidx.compose.material3.SheetValue */
+enum class SheetValue {
+    Large,
+    Medium,
+    Small,
+}
+
+/** @see androidx.compose.material3.ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection */
+@OptIn(ExperimentalFoundationApi::class)
+internal fun ConsumeSwipeWithinBottomSheetBoundsNestedScrollConnection(
+    sheetState: SheetState,
+    orientation: Orientation,
+    onFling: (velocity: Float) -> Unit
+): NestedScrollConnection =
+    object : NestedScrollConnection {
+        override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+            val delta = available.toFloat()
+            return if (delta < 0 && source == NestedScrollSource.UserInput) {
+                sheetState.anchoredDraggableState.dispatchRawDelta(delta).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override fun onPostScroll(
+            consumed: Offset,
+            available: Offset,
+            source: NestedScrollSource
+        ): Offset {
+            return if (source == NestedScrollSource.UserInput) {
+                sheetState.anchoredDraggableState.dispatchRawDelta(available.toFloat()).toOffset()
+            } else {
+                Offset.Zero
+            }
+        }
+
+        override suspend fun onPreFling(available: Velocity): Velocity {
+            val toFling = available.toFloat()
+            val currentOffset = sheetState.requireOffset()
+            val minAnchor = sheetState.anchoredDraggableState.anchors.minAnchor()
+            return if (toFling < 0 && currentOffset > minAnchor) {
+                onFling(toFling)
+                // since we go to the anchor with tween settling, consume all for the best UX
+                available
+            } else {
+                Velocity.Zero
+            }
+        }
+
+        override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+            onFling(available.toFloat())
+            return available
+        }
+
+        private fun Float.toOffset(): Offset =
+            Offset(
+                x = if (orientation == Orientation.Horizontal) this else 0f,
+                y = if (orientation == Orientation.Vertical) this else 0f
+            )
+
+        @JvmName("velocityToFloat")
+        private fun Velocity.toFloat() = if (orientation == Orientation.Horizontal) x else y
+
+        @JvmName("offsetToFloat")
+        private fun Offset.toFloat(): Float = if (orientation == Orientation.Horizontal) x else y
+    }
+
+/** @see androidx.compose.material3.rememberSheetState */
+@Composable
+internal fun rememberSheetState(
+    skipPartiallyExpanded: Boolean = false,
+    confirmValueChange: (SheetValue) -> Boolean = { true },
+    initialValue: SheetValue = SheetValue.Medium,
+    skipHiddenState: Boolean = false,
+): SheetState {
+    val density = LocalDensity.current
+    return rememberSaveable(
+        skipPartiallyExpanded,
+        confirmValueChange,
+        skipHiddenState,
+        saver =
+            SheetState.Saver(
+                confirmValueChange = confirmValueChange,
+                density = density,
+            )
+    ) {
+        SheetState(
+            density,
+            initialValue,
+            confirmValueChange,
+        )
+    }
+}
+
+/** @see androidx.compose.material3.BottomSheetAnimationSpec */
+private val BottomSheetAnimationSpec: AnimationSpec<Float> =
+    tween(durationMillis = 300, easing = FastOutSlowInEasing)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -34,6 +34,7 @@ import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DragHandle
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.component.sheet.SheetValue
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.HomeMapView
@@ -119,6 +120,10 @@ fun NearbyTransitPage(
 
     LaunchedEffect(nearbyTransit.globalResponse) {
         mapViewModel.setGlobalResponse(nearbyTransit.globalResponse)
+    }
+
+    LaunchedEffect(currentNavEntry) {
+        nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Medium)
     }
 
     SearchBarOverlay(::handleStopNavigation, currentNavEntry, searchFocusRequester) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.BottomSheetScaffold
-import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
@@ -34,6 +32,8 @@ import androidx.navigation.toRoute
 import com.mapbox.maps.MapboxExperimental
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DragHandle
+import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
+import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.HomeMapView
@@ -267,7 +267,6 @@ fun NearbyTransitPage(
                 },
                 sheetContainerColor = MaterialTheme.colorScheme.surface,
                 scaffoldState = nearbyTransit.scaffoldState,
-                sheetPeekHeight = 422.dp,
             ) { sheetPadding ->
                 HomeMapView(
                     Modifier.padding(sheetPadding),


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Nearby | Sheet / navigation](https://app.asana.com/0/1205732265579288/1208852051039919/f)

There is [a third-party library](https://github.com/skydoves/FlexibleBottomSheet) that we could consider instead, but it's got outstanding issues that haven't been so much as acknowledged for months, and it doesn't provide an equivalent to the full Scaffold component, so we'd need to copy in some of the Layout stuff anyway. (I also didn't check for this until after I had already done most of this work.)

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"
android
- [x] All user-facing strings added to strings resource

### Testing

Manually verified that the new sheet has all three sizes and that the Mapbox attribution footer is in the right place at the sizes where the map is visible.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
