### PR TITLE
feat(Android): animate new page sliding up

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -1,5 +1,8 @@
 package com.mbta.tid.mbta_app.android.pages
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -144,7 +147,13 @@ fun NearbyTransitPage(
                             modifier =
                                 Modifier.height(sheetHeight)
                                     .padding(outerSheetPadding)
-                                    .background(MaterialTheme.colorScheme.surface)
+                                    .background(MaterialTheme.colorScheme.surface),
+                            enterTransition = {
+                                slideIntoContainer(
+                                    AnimatedContentTransitionScope.SlideDirection.Up,
+                                    animationSpec = tween(easing = EaseInOut)
+                                )
+                            }
                         ) {
                             composable<SheetRoutes.StopDetails> { backStackEntry ->
                                 val navRoute: SheetRoutes.StopDetails = backStackEntry.toRoute()


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Nearby | Sheet / navigation](https://app.asana.com/0/1205732265579288/1208852051039919/f)

Apparently the Android stock navigation subsystem is just this flexible.

I haven't been able to see this animation play back smoothly at its default speed because we drop frames pretty badly on the page transition, but if I slow it way down then I do briefly see smooth motion. I don't think that frame loss is in-scope for this PR, but I may look into it separately.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"
android
- [x] All user-facing strings added to strings resource

### Testing

Manually validated that the animation should theoretically play.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
