### PR TITLE
feat(android.StopDetailsFilterPills): optimized screen reader text

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/StopDetailsFilterPillsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/StopDetailsFilterPillsTest.kt
@@ -2,7 +2,14 @@ package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertContentDescriptionEquals
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -65,13 +72,30 @@ class StopDetailsFilterPillsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("RL", ignoreCase = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText("M", ignoreCase = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("RL", ignoreCase = true)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals("Red Line train")
+            .assertIsSelected()
+            .assert(onClickLabelContains("Remove"))
+
+        composeTestRule
+            .onNodeWithText("M", ignoreCase = true)
+            .assertIsDisplayed()
+            .assertIsNotSelected()
         composeTestRule
             .onNodeWithText(route3.shortName)
+            .assert(onClickLabelContains("Apply"))
+            .assertIsNotSelected()
             .onParent()
             .performScrollToNode(hasText(route3.shortName))
-        composeTestRule.onNodeWithText(route3.shortName).assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(route3.shortName)
+            .assertIsDisplayed()
+            .assertContentDescriptionEquals("55 bus")
+            .assertIsNotSelected()
+            .assert(onClickLabelContains("Apply"))
 
         composeTestRule.onNodeWithText("M", ignoreCase = true).performClick()
         assertTrue(filter.value?.routeId == route2.id)
@@ -80,7 +104,15 @@ class StopDetailsFilterPillsTest {
         assertTrue(filter.value == null)
         composeTestRule.onNodeWithText("All").assertDoesNotExist()
 
-        composeTestRule.onNodeWithText(route3.shortName).performClick()
+        composeTestRule
+            .onNodeWithText(route3.shortName)
+            .assert(onClickLabelContains("Apply"))
+            .performClick()
         assertTrue(filter.value?.routeId == route3.id)
     }
+
+    fun onClickLabelContains(text: String) =
+        SemanticsMatcher("hint matches") { node ->
+            node.config.getOrNull(SemanticsActions.OnClick)?.label?.contains(text) ?: false
+        }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -2,6 +2,9 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.model.Coordinate
@@ -232,7 +235,8 @@ class StopDetailsViewTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Sample Stop").assertExists()
+        composeTestRule.onNode(hasText("Sample Stop") and isHeading()).assertIsDisplayed()
+
         composeTestRule.onNodeWithText("Sample Route").assertExists()
         composeTestRule.onNodeWithText("Sample Headsign").assertExists()
         composeTestRule.onNodeWithText("1 min").assertExists()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -9,6 +9,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,7 +30,7 @@ fun SheetHeader(onClose: (() -> Unit)? = null, title: String? = null) {
         if (title != null) {
             Text(
                 title,
-                modifier = Modifier.padding(top = 1.dp),
+                modifier = Modifier.padding(top = 1.dp).semantics { heading() },
                 fontSize = 20.sp,
                 fontWeight = FontWeight.SemiBold
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilterPills.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilterPills.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -10,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -23,6 +23,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
@@ -53,6 +57,17 @@ fun StopDetailsFilterPills(
     onTapRoutePill: (PillFilter) -> Unit,
     onClearFilter: () -> Unit
 ) {
+
+    @Composable
+    fun pillHint(appliedFilter: StopDetailsFilter?, pillFilter: PillFilter): String {
+        val filteredToPill = appliedFilter?.routeId == pillFilter.id
+        return if (filteredToPill) {
+            stringResource(R.string.stop_filter_pills_remove_hint)
+        } else {
+            stringResource(R.string.stop_filter_pills_filter_hint)
+        }
+    }
+
     Box(Modifier.fillMaxWidth().padding(end = 16.dp)) {
         val scrollState = rememberScrollState()
 
@@ -68,7 +83,15 @@ fun StopDetailsFilterPills(
                     Modifier.padding(end = 8.dp)
                         .minimumInteractiveComponentSize()
                         .bringIntoViewRequester(requester)
-                        .toggleable(isActive) { onTapRoutePill(filterBy) }
+                        .clickable(
+                            onClickLabel = pillHint(filter, filterBy),
+                            onClick = { onTapRoutePill(filterBy) },
+                        )
+                        .semantics {
+                            role = Role.Button
+                            selected = isActive
+                        }
+
                 when (filterBy) {
                     is PillFilter.ByRoute -> {
                         RoutePill(

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">Marcar ruta favorita</string>
     <string name="star_route_hint">Fijar ruta al principio de la lista</string>
     <string name="stop_closed">Parada cerrada</string>
+    <string name="stop_filter_pills_filter_hint">Aplicar un filtro para que sólo se muestren las llegadas de esta ruta</string>
+    <string name="stop_filter_pills_remove_hint">Eliminar el filtro y mostrar todas las rutas</string>
     <string name="suspension">Suspensión</string>
     <string name="train">tren</string>
     <string name="trains">trenes</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">Mete wout nan favori</string>
     <string name="star_route_hint">mete wout nan tèt lis la</string>
     <string name="stop_closed">Arè Fèmen</string>
+    <string name="stop_filter_pills_filter_hint">Aplike yon filtè pou ke sèlman arive soti nan wout sa a yo parèt</string>
+    <string name="stop_filter_pills_remove_hint">Retire filtè a epi montre tout wout yo</string>
     <string name="suspension">Sispansyon</string>
     <string name="train">tren</string>
     <string name="trains">tren yo</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">Marcar rota como favorita</string>
     <string name="star_route_hint">fixar rota no topo da lista</string>
     <string name="stop_closed">Parada fechada</string>
+    <string name="stop_filter_pills_filter_hint">Aplique um filtro para que apenas as chegadas desta rota sejam exibidas</string>
+    <string name="stop_filter_pills_remove_hint">Remova o filtro e exiba todas as rotas</string>
     <string name="suspension">Suspensão</string>
     <string name="train">trem</string>
     <string name="trains">trens</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">Tuyến đường sao</string>
     <string name="star_route_hint">ghim đường dẫn đến đầu danh sách</string>
     <string name="stop_closed">Điểm dừng bị đóng</string>
+    <string name="stop_filter_pills_filter_hint">Áp dụng bộ lọc để chỉ hiển thị các chuyến đến từ tuyến đường này</string>
+    <string name="stop_filter_pills_remove_hint">Xóa bộ lọc và hiển thị tất cả các tuyến đường</string>
     <string name="suspension">Đình chỉ</string>
     <string name="train">tàu</string>
     <string name="trains">tàu</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">为线路添加星号</string>
     <string name="star_route_hint">将路线固定到列表顶部</string>
     <string name="stop_closed">站点已关闭</string>
+    <string name="stop_filter_pills_filter_hint">应用过滤器，以便仅显示来自该路线的到达</string>
+    <string name="stop_filter_pills_remove_hint">删除过滤器并显示所有路线</string>
     <string name="suspension">暂停</string>
     <string name="train">列车</string>
     <string name="trains">列车</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -70,6 +70,8 @@
     <string name="star_route">為線路添加星號</string>
     <string name="star_route_hint">將路線固定到清單頂部</string>
     <string name="stop_closed">網站已關閉</string>
+    <string name="stop_filter_pills_filter_hint">應用過濾器，以便僅顯示來自該路線的到達</string>
+    <string name="stop_filter_pills_remove_hint">刪除過濾器並顯示所有路由</string>
     <string name="suspension">暫停</string>
     <string name="train">列車</string>
     <string name="trains">列車</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -91,4 +91,7 @@
     <string name="vehicle_schedule_time_first">%1$s arriving at %2$s scheduled</string>
     <string name="vehicle_schedule_time_other">and at %1$s scheduled</string>
     <string name="westbound">Westbound</string>
+    <string name="stop_filter_pills_filter_hint">Apply a filter so that only arrivals from this route are displayed</string>
+    <string name="stop_filter_pills_remove_hint">Remove the filter and display all routes</string>
+
 </resources>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1781,6 +1781,47 @@
         }
       }
     },
+    "Apply a filter so that only arrivals from this route are displayed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aplicar un filtro para que sólo se muestren las llegadas de esta ruta"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aplike yon filtè pou ke sèlman arive soti nan wout sa a yo parèt"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aplique um filtro para que apenas as chegadas desta rota sejam exibidas"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Áp dụng bộ lọc để chỉ hiển thị các chuyến đến từ tuyến đường này"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "应用过滤器，以便仅显示来自该路线的到达"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "應用過濾器，以便僅顯示來自該路線的到達"
+          }
+        }
+      }
+    },
     "Approaching" : {
       "comment" : "Label for a vehicle's next stop. For example: Approaching Alewife",
       "localizations" : {
@@ -6294,6 +6335,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重新載入資料"
+          }
+        }
+      }
+    },
+    "Remove the filter and display all routes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eliminar el filtro y mostrar todas las rutas"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Retire filtè a epi montre tout wout yo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Remova o filtro e exiba todas as rotas"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Xóa bộ lọc và hiển thị tất cả các tuyến đường"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "删除过滤器并显示所有路线"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "刪除過濾器並顯示所有路由"
           }
         }
       }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Unfiltered Stop Details | Screen reader text](https://app.asana.com/0/1205732265579288/1208851006555185/f)

What is this PR for?
* Adds screen reader optimizations for unfiltered stop details - mainly the filter buttons.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [X] Add temporary machine translations, marked "Needs Review"

android
- [X] All user-facing strings added to strings resource
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ran locally with talk back on
* Added some unit tests

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
