### PR TITLE
feat(Android): hide maps

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -279,6 +279,7 @@ class NearbyTransitPageTest : KoinTest {
                         NearbyTransit(
                             alertData = AlertsStreamDataResponse(builder.alerts),
                             globalResponse = globalResponse,
+                            hideMaps = false,
                             lastNearbyTransitLocationState =
                                 remember { mutableStateOf(Position(0.0, 0.0)) },
                             nearbyTransitSelectingLocationState =
@@ -296,6 +297,7 @@ class NearbyTransitPageTest : KoinTest {
             }
         }
 
+        composeTestRule.onNodeWithContentDescription("Mapbox Logo").assertIsDisplayed()
         composeTestRule.waitUntilDoesNotExist(hasText("Loading..."))
         composeTestRule
             .onNodeWithContentDescription("Drag handle")
@@ -366,6 +368,7 @@ class NearbyTransitPageTest : KoinTest {
                         NearbyTransit(
                             alertData = AlertsStreamDataResponse(builder.alerts),
                             globalResponse = globalResponse,
+                            hideMaps = false,
                             lastNearbyTransitLocationState =
                                 remember { mutableStateOf(Position(0.0, 0.0)) },
                             nearbyTransitSelectingLocationState =
@@ -390,5 +393,39 @@ class NearbyTransitPageTest : KoinTest {
         mockMapVM.mutableLastErrorTimestamp.value = Clock.System.now()
 
         composeTestRule.waitUntil { mockMapVM.loadConfigCalledCount == 2 }
+    }
+
+    @Test
+    fun testHidesMap() {
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                CompositionLocalProvider(
+                    LocalActivity provides (LocalContext.current as Activity),
+                    LocalLocationClient provides MockFusedLocationProviderClient()
+                ) {
+                    NearbyTransitPage(
+                        Modifier,
+                        NearbyTransit(
+                            alertData = AlertsStreamDataResponse(builder.alerts),
+                            globalResponse = globalResponse,
+                            hideMaps = true,
+                            lastNearbyTransitLocationState =
+                                remember { mutableStateOf(Position(0.0, 0.0)) },
+                            nearbyTransitSelectingLocationState =
+                                remember { mutableStateOf(false) },
+                            scaffoldState = rememberBottomSheetScaffoldState(),
+                            locationDataManager = MockLocationDataManager(Location("mock")),
+                            viewportProvider = ViewportProvider(rememberMapViewportState()),
+                        ),
+                        false,
+                        {},
+                        {},
+                        bottomBar = {}
+                    )
+                }
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Mapbox Logo").assertDoesNotExist()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsViewTest.kt
@@ -13,7 +13,9 @@ class NoNearbyStopsViewTest {
 
     @Test
     fun displaysText() {
-        composeTestRule.setContent { NoNearbyStopsView({}, {}) }
+        composeTestRule.setContent {
+            NoNearbyStopsView(hideMaps = false, onOpenSearch = {}, onPanToDefaultCenter = {})
+        }
 
         composeTestRule.onNodeWithText("No nearby stops").assertIsDisplayed()
         composeTestRule.onNodeWithText("You’re outside the MBTA service area.").assertIsDisplayed()
@@ -27,6 +29,7 @@ class NoNearbyStopsViewTest {
         var pannedToDefaultCenter = false
         composeTestRule.setContent {
             NoNearbyStopsView(
+                hideMaps = false,
                 onOpenSearch = { openedSearch = true },
                 onPanToDefaultCenter = { pannedToDefaultCenter = true }
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,6 +45,7 @@ fun ContentView(
     val navController = rememberNavController()
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()
     val globalResponse = getGlobalData()
+    val hideMaps by viewModel.hideMaps.collectAsState()
     val pendingOnboarding = viewModel.pendingOnboarding.collectAsState().value
     val locationDataManager = rememberLocationDataManager()
     val mapViewportState = rememberMapViewportState {
@@ -80,11 +82,14 @@ fun ContentView(
     val sheetModifier = Modifier.fillMaxSize().background(colorResource(id = R.color.fill1))
     NavHost(navController = navController, startDestination = Routes.NearbyTransit) {
         composable<Routes.NearbyTransit> {
+            LaunchedEffect(null) { viewModel.loadHideMaps() }
+
             NearbyTransitPage(
                 modifier = sheetModifier,
                 NearbyTransit(
                     alertData = alertData,
                     globalResponse = globalResponse,
+                    hideMaps = hideMaps,
                     lastNearbyTransitLocationState = lastNearbyTransitLocationState,
                     nearbyTransitSelectingLocationState = nearbyTransitSelectingLocationState,
                     scaffoldState = scaffoldState,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -3,19 +3,34 @@ package com.mbta.tid.mbta_app.android
 import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class ContentViewModel(private val onboardingRepository: IOnboardingRepository) : ViewModel() {
+class ContentViewModel(
+    private val onboardingRepository: IOnboardingRepository,
+    private val settingsRepository: ISettingsRepository
+) : ViewModel() {
+    private val _hideMaps: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    val hideMaps: StateFlow<Boolean> = _hideMaps
     private val _pendingOnboarding: MutableStateFlow<List<OnboardingScreen>?> =
         MutableStateFlow(null)
     val pendingOnboarding: StateFlow<List<OnboardingScreen>?> = _pendingOnboarding
 
     init {
+        loadHideMaps()
         loadPendingOnboarding()
+    }
+
+    fun loadHideMaps() {
+        CoroutineScope(Dispatchers.IO).launch {
+            val data = settingsRepository.getSettings()
+            _hideMaps.value = data[Settings.HideMaps] ?: false
+        }
     }
 
     fun loadPendingOnboarding() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.location
 
+import android.location.Location
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -92,6 +93,20 @@ constructor(var viewport: MapViewportState, isManuallyCentering: Boolean = false
         animation: MapAnimationOptions = MapAnimationDefaults.options
     ) {
         this.viewport.easeTo(options, animation)
+    }
+
+    fun updateCameraState(location: Location?) {
+        val latitude = location?.latitude ?: return
+        val longitude = location.longitude
+        updateCameraState(
+            CameraState(
+                Point.fromLngLat(longitude, latitude),
+                EdgeInsets(0.0, 0.0, 0.0, 0.0),
+                Defaults.zoom,
+                0.0,
+                0.0
+            )
+        )
     }
 
     fun updateCameraState(state: CameraState) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsView.kt
@@ -29,7 +29,11 @@ import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 
 @Composable
-fun NoNearbyStopsView(onOpenSearch: () -> Unit, onPanToDefaultCenter: () -> Unit) {
+fun NoNearbyStopsView(
+    hideMaps: Boolean,
+    onOpenSearch: () -> Unit,
+    onPanToDefaultCenter: () -> Unit
+) {
     Column(
         modifier =
             Modifier.clip(RoundedCornerShape(8.dp))
@@ -75,26 +79,29 @@ fun NoNearbyStopsView(onOpenSearch: () -> Unit, onPanToDefaultCenter: () -> Unit
                 )
             }
         }
-        OutlinedButton(
-            onClick = onPanToDefaultCenter,
-            modifier = Modifier.requiredHeightIn(min = 48.dp),
-            shape = RoundedCornerShape(8.dp),
-            border = BorderStroke(1.dp, colorResource(R.color.key))
-        ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
-                verticalAlignment = Alignment.CenterVertically
+        if (!hideMaps) {
+            OutlinedButton(
+                onClick = onPanToDefaultCenter,
+                modifier = Modifier.requiredHeightIn(min = 48.dp),
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(1.dp, colorResource(R.color.key))
             ) {
-                Text(
-                    stringResource(R.string.no_stops_nearby_pan),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Icon(
-                    painterResource(R.drawable.fa_map),
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp)
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement =
+                        Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        stringResource(R.string.no_stops_nearby_pan),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Icon(
+                        painterResource(R.drawable.fa_map),
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
             }
         }
     }
@@ -103,5 +110,5 @@ fun NoNearbyStopsView(onOpenSearch: () -> Unit, onPanToDefaultCenter: () -> Unit
 @Preview
 @Composable
 private fun NoNearbyStopsViewPreview() {
-    MyApplicationTheme { NoNearbyStopsView({}, {}) }
+    MyApplicationTheme { NoNearbyStopsView(hideMaps = false, {}, {}) }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Map | Hide maps functionality](https://app.asana.com/0/1201654106676769/1208851802887624/f)

Stacked on #618 since the acceptance criteria specify that the location services button is in-scope for this ticket.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually validated that everything looks correct with hide maps turned on, except for the stop details page, which looks wrong and needs to be fixed before this PR is actually ready for review. Added a unit test to check that maps are correctly hidden and shown.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
