### PR TITLE
Jvc android search recent stops

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -46,6 +46,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
@@ -56,6 +57,7 @@ import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
 import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
@@ -210,6 +212,9 @@ class NearbyTransitPageTest : KoinTest {
             module {
                 single<ISettingsRepository> { MockSettingsRepository() }
                 single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
+                single<IGlobalRepository> {
+                    MockGlobalRepository(response = GlobalResponse(builder))
+                }
                 single<ISchedulesRepository> { MockScheduleRepository() }
                 single<IPredictionsRepository> {
                     object : IPredictionsRepository {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -54,13 +54,16 @@ import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.Flow
@@ -263,6 +266,8 @@ class NearbyTransitPageTest : KoinTest {
                 single<IVehiclesRepository> { MockVehiclesRepository() }
                 single<ISearchResultRepository> { MockSearchResultRepository() }
                 viewModelOf(::NearbyTransitViewModel)
+                single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
+                single<VisitHistoryUsecase> { VisitHistoryUsecase(get()) }
             }
         )
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -25,13 +25,16 @@ import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
@@ -236,6 +239,8 @@ class NearbyTransitViewTest : KoinTest {
                 single<IRailRouteShapeRepository> { MockRailRouteShapeRepository() }
                 single<TogglePinnedRouteUsecase> { TogglePinnedRouteUsecase(get()) }
                 viewModelOf(::NearbyTransitViewModel)
+                single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
+                single<VisitHistoryUsecase> { VisitHistoryUsecase(get()) }
             }
         )
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -29,7 +29,7 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -111,7 +111,7 @@ class SearchBarOverlayTest : KoinTest {
             }
         }
 
-        backgroundScope.launch {
+        runBlocking {
             mockVisitHistoryRepository.setVisitHistory(
                 VisitHistory().apply { add(Visit.StopVisit(visitedStop.id)) }
             )
@@ -121,7 +121,7 @@ class SearchBarOverlayTest : KoinTest {
         searchNode.assertExists()
         searchNode.requestFocus()
         composeTestRule.awaitIdle()
-
+        composeTestRule.onNodeWithText("Recently Visited").assertExists()
         composeTestRule.onNodeWithText(visitedStop.name).assertExists()
 
         searchNode.performTextInput("sto")

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -121,7 +121,7 @@ class SearchBarOverlayTest : KoinTest {
         searchNode.assertExists()
         searchNode.requestFocus()
         composeTestRule.awaitIdle()
-        composeTestRule.onNodeWithText("Recently Visited").assertExists()
+        composeTestRule.onNodeWithText("Recently Viewed").assertExists()
         composeTestRule.waitUntilAtLeastOneExists(hasText(visitedStop.name))
         composeTestRule.onNodeWithText(visitedStop.name).assertExists()
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -122,6 +122,7 @@ class SearchBarOverlayTest : KoinTest {
         searchNode.requestFocus()
         composeTestRule.awaitIdle()
         composeTestRule.onNodeWithText("Recently Visited").assertExists()
+        composeTestRule.waitUntilAtLeastOneExists(hasText(visitedStop.name))
         composeTestRule.onNodeWithText(visitedStop.name).assertExists()
 
         searchNode.performTextInput("sto")

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
@@ -1,17 +1,31 @@
 package com.mbta.tid.mbta_app.android.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.history.Visit
+import com.mbta.tid.mbta_app.history.VisitHistory
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.SearchResults
 import com.mbta.tid.mbta_app.model.StopResult
 import com.mbta.tid.mbta_app.model.StopResultRoute
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
 class GetSearchResultTest {
+    val builder = ObjectCollectionBuilder()
+    val visitedStop =
+        builder.stop {
+            id = "visitedStopId"
+            name = "visitedStopName"
+        }
+
     val searchResults =
         SearchResults(
             routes = emptyList(),
@@ -39,26 +53,42 @@ class GetSearchResultTest {
     @Test
     fun testSearchResults() = runTest {
         var actualSearchResultsViewModel: SearchResultsViewModel? = null
+        val mockVisitHistoryRepository = MockVisitHistoryRepository()
+        val visitHistory = VisitHistory()
+
+        backgroundScope.launch {
+            visitHistory.add(Visit.StopVisit(visitedStop.id))
+            mockVisitHistoryRepository.setVisitHistory(visitHistory)
+        }
 
         composeTestRule.setContent {
             actualSearchResultsViewModel =
                 getSearchResultsVm(
+                    GlobalResponse(builder),
                     object : ISearchResultRepository {
                         override suspend fun getSearchResults(
                             query: String
                         ): ApiResult<SearchResults>? {
                             return ApiResult.Ok(searchResults)
                         }
-                    }
+                    },
+                    VisitHistoryUsecase(mockVisitHistoryRepository)
                 )
         }
 
         composeTestRule.waitUntil { actualSearchResultsViewModel != null }
+        composeTestRule.awaitIdle()
+
+        actualSearchResultsViewModel?.getSearchResults("")
+        composeTestRule.waitUntil { actualSearchResultsViewModel?.searchResults?.value != null }
+        assert(
+            actualSearchResultsViewModel?.searchResults?.value?.stops?.first()?.id == visitedStop.id
+        )
 
         actualSearchResultsViewModel?.getSearchResults("query")
-
-        composeTestRule.waitUntil { actualSearchResultsViewModel?.searchResults?.value != null }
-
+        composeTestRule.waitUntil {
+            actualSearchResultsViewModel?.searchResults?.value == searchResults
+        }
         assert(actualSearchResultsViewModel?.searchResults?.value == searchResults)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
@@ -13,7 +13,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -56,7 +56,7 @@ class GetSearchResultTest {
         val mockVisitHistoryRepository = MockVisitHistoryRepository()
         val visitHistory = VisitHistory()
 
-        backgroundScope.launch {
+        runBlocking {
             visitHistory.add(Visit.StopVisit(visitedStop.id))
             mockVisitHistoryRepository.setVisitHistory(visitHistory)
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -101,13 +101,25 @@ fun ContentView(
                 hideNavBar = { navBarVisible = false },
                 bottomBar = {
                     if (navBarVisible) {
-                        BottomNavBar(navController = navController)
+                        BottomNavBar(
+                            currentDestination = navController.currentBackStackEntry?.destination,
+                            navigateToNearby = { navController.navigate(Routes.NearbyTransit) },
+                            navigateToMore = { navController.navigate(Routes.More) }
+                        )
                     }
                 }
             )
         }
         composable<Routes.More> {
-            MorePage(bottomBar = { BottomNavBar(navController = navController) })
+            MorePage(
+                bottomBar = {
+                    BottomNavBar(
+                        currentDestination = navController.currentBackStackEntry?.destination,
+                        navigateToNearby = { navController.navigate(Routes.NearbyTransit) },
+                        navigateToMore = { navController.navigate(Routes.More) }
+                    )
+                }
+            )
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/Routes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/Routes.kt
@@ -2,8 +2,8 @@ package com.mbta.tid.mbta_app.android
 
 import kotlinx.serialization.Serializable
 
-object Routes {
-    @Serializable object NearbyTransit
+sealed class Routes {
+    @Serializable object NearbyTransit : Routes()
 
-    @Serializable object More
+    @Serializable object More : Routes()
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
@@ -8,22 +8,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
+import androidx.navigation.NavDestination
 import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.android.Routes
 
 @Composable
-fun BottomNavBar(navController: NavHostController) {
-
-    val currentDestination = navController.currentBackStackEntry?.destination
-
+fun BottomNavBar(
+    currentDestination: NavDestination?,
+    navigateToNearby: () -> Unit,
+    navigateToMore: () -> Unit
+) {
     BottomAppBar(
         modifier = Modifier.height(83.dp),
         containerColor = MaterialTheme.colorScheme.surfaceVariant,
         actions = {
             BottomNavIconButton(
                 modifier = Modifier.fillMaxSize().weight(1f),
-                onClick = { navController.navigate(Routes.NearbyTransit) },
+                onClick = navigateToNearby,
                 icon = R.drawable.map_pin,
                 label = stringResource(R.string.nearby_transit_link),
                 // currentDestination?.hiearchy?.any { it.hasRoute(Routes.NearbyTransit::class)
@@ -34,7 +34,7 @@ fun BottomNavBar(navController: NavHostController) {
 
             BottomNavIconButton(
                 modifier = Modifier.fillMaxSize().weight(1f),
-                onClick = { navController.navigate(Routes.More) },
+                onClick = navigateToMore,
                 icon = R.drawable.more,
                 label = stringResource(R.string.more_link),
                 active = currentDestination?.route?.contains("More") ?: true

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.layout.boundsInWindow
@@ -38,7 +36,6 @@ import com.mapbox.maps.MapboxExperimental
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DragHandle
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
-import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.component.sheet.SheetValue
@@ -53,15 +50,20 @@ import com.mbta.tid.mbta_app.android.nearbyTransit.NoNearbyStopsView
 import com.mbta.tid.mbta_app.android.search.SearchBarOverlay
 import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
 import com.mbta.tid.mbta_app.android.util.toPosition
+import com.mbta.tid.mbta_app.history.Visit
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -96,7 +98,8 @@ fun NearbyTransitPage(
                     errorRepository = koinInject(),
                     settingsRepository = koinInject()
                 )
-        )
+        ),
+    visitHistoryUsecase: VisitHistoryUsecase = koinInject()
 ) {
     LaunchedEffect(Unit) { errorBannerViewModel.activate() }
     val navController = rememberNavController()
@@ -110,7 +113,14 @@ fun NearbyTransitPage(
 
     val searchFocusRequester = remember { FocusRequester() }
 
+    fun updateVisitHistory(stopId: String) {
+        CoroutineScope(Dispatchers.IO).launch {
+            visitHistoryUsecase.addVisit(Visit.StopVisit(stopId))
+        }
+    }
+
     fun handleStopNavigation(stopId: String) {
+        updateVisitHistory(stopId)
         navController.navigate(SheetRoutes.StopDetails(stopId, null, null)) {
             popUpTo(SheetRoutes.NearbyTransit)
         }
@@ -235,51 +245,27 @@ fun NearbyTransitPage(
                     }
                 }
 
-                LaunchedEffect(nearbyTransit.hideMaps) {
-                    if (nearbyTransit.hideMaps) {
-                        nearbyTransit.locationDataManager.currentLocation.collect { location ->
-                            if (location != null) {
-                                nearbyTransit.viewportProvider.updateCameraState(location)
-                            }
-                        }
-                    }
-                }
-
-                Column {
-                    if (nearbyTransit.hideMaps) {
-                        LocationAuthButton(
-                            nearbyTransit.locationDataManager,
-                            Modifier.align(Alignment.CenterHorizontally)
+                NearbyTransitView(
+                    alertData = nearbyTransit.alertData,
+                    globalResponse = nearbyTransit.globalResponse,
+                    targetLocation = targetLocation,
+                    setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
+                    setSelectingLocation = { nearbyTransit.nearbyTransitSelectingLocation = it },
+                    onOpenStopDetails = { stopId, filter ->
+                        updateVisitHistory(stopId)
+                        navController.navigate(
+                            SheetRoutes.StopDetails(stopId, filter?.routeId, filter?.directionId)
                         )
-                    }
-
-                    NearbyTransitView(
-                        alertData = nearbyTransit.alertData,
-                        globalResponse = nearbyTransit.globalResponse,
-                        targetLocation = targetLocation,
-                        setLastLocation = { nearbyTransit.lastNearbyTransitLocation = it },
-                        setSelectingLocation = {
-                            nearbyTransit.nearbyTransitSelectingLocation = it
-                        },
-                        onOpenStopDetails = { stopId, filter ->
-                            navController.navigate(
-                                SheetRoutes.StopDetails(
-                                    stopId,
-                                    filter?.routeId,
-                                    filter?.directionId
-                                )
-                            )
-                        },
-                        noNearbyStopsView = {
-                            NoNearbyStopsView(
-                                hideMaps = nearbyTransit.hideMaps,
-                                ::openSearch,
-                                ::panToDefaultCenter
-                            )
-                        },
-                        errorBannerViewModel = errorBannerViewModel
-                    )
-                }
+                    },
+                    noNearbyStopsView = {
+                        NoNearbyStopsView(
+                            nearbyTransit.hideMaps,
+                            ::openSearch,
+                            ::panToDefaultCenter
+                        )
+                    },
+                    errorBannerViewModel = errorBannerViewModel
+                )
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -114,7 +114,7 @@ fun NearbyTransitPage(
     val searchFocusRequester = remember { FocusRequester() }
 
     fun updateVisitHistory(stopId: String) {
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(Dispatchers.Default).launch {
             visitHistoryUsecase.addVisit(Visit.StopVisit(stopId))
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -70,9 +70,7 @@ fun SearchBarOverlay(
             contentColor = colorResource(R.color.deemphasized),
             disabledContentColor = colorResource(R.color.deemphasized),
         )
-    LaunchedEffect(searchInputState, expanded) {
-        searchResultsVm.getSearchResults(searchInputState)
-    }
+    LaunchedEffect(searchInputState, visible) { searchResultsVm.getSearchResults(searchInputState) }
 
     Box(contentAlignment = Alignment.TopCenter) {
         Box(
@@ -145,7 +143,7 @@ fun SearchBarOverlay(
                             item {
                                 Text(
                                     modifier = Modifier.padding(bottom = 10.dp),
-                                    text = stringResource(R.string.recently_visited),
+                                    text = stringResource(R.string.recently_viewed),
                                     style = MaterialTheme.typography.headlineSmall,
                                     fontWeight = FontWeight.Bold
                                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -1,9 +1,13 @@
 package com.mbta.tid.mbta_app.android.search
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -12,6 +16,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
@@ -30,12 +35,14 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.navigation.NavBackStackEntry
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.search.results.StopResultsView
+import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.getSearchResultsVm
 
 @ExperimentalMaterial3Api
@@ -52,7 +59,8 @@ fun SearchBarOverlay(
         }
     var expanded by rememberSaveable { mutableStateOf(false) }
     var searchInputState by rememberSaveable { mutableStateOf("") }
-    val searchResultsVm = getSearchResultsVm()
+    val globalResponse = getGlobalData()
+    val searchResultsVm = getSearchResultsVm(globalResponse = globalResponse)
     val searchResults = searchResultsVm.searchResults.collectAsState(initial = null).value
 
     val buttonColors =
@@ -62,7 +70,9 @@ fun SearchBarOverlay(
             contentColor = colorResource(R.color.deemphasized),
             disabledContentColor = colorResource(R.color.deemphasized),
         )
-    LaunchedEffect(searchInputState) { searchResultsVm.getSearchResults(searchInputState) }
+    LaunchedEffect(searchInputState, expanded) {
+        searchResultsVm.getSearchResults(searchInputState)
+    }
 
     Box(contentAlignment = Alignment.TopCenter) {
         Box(
@@ -127,9 +137,30 @@ fun SearchBarOverlay(
                     expanded = expanded,
                     onExpandedChange = {},
                 ) {
-                    LazyColumn {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().background(colorResource(R.color.fill2)),
+                        contentPadding = PaddingValues(16.dp)
+                    ) {
+                        if (searchInputState.isEmpty()) {
+                            item {
+                                Text(
+                                    modifier = Modifier.padding(bottom = 10.dp),
+                                    text = "Recently Visited",
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
                         items(searchResults?.stops ?: emptyList()) { stop ->
-                            StopResultsView(stop, onStopNavigation)
+                            val shape =
+                                if (searchResults?.stops?.first() == stop) {
+                                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
+                                } else if (searchResults?.stops?.last() == stop) {
+                                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
+                                } else {
+                                    RoundedCornerShape(0.dp)
+                                }
+                            StopResultsView(shape, stop, globalResponse, onStopNavigation)
                         }
                     }
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -153,7 +153,9 @@ fun SearchBarOverlay(
                         }
                         items(searchResults?.stops ?: emptyList()) { stop ->
                             val shape =
-                                if (searchResults?.stops?.first() == stop) {
+                                if (searchResults?.stops?.size == 1) {
+                                    RoundedCornerShape(10.dp)
+                                } else if (searchResults?.stops?.first() == stop) {
                                     RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
                                 } else if (searchResults?.stops?.last() == stop) {
                                     RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -114,7 +114,7 @@ fun SearchBarOverlay(
                             leadingIcon = {
                                 Icon(
                                     painterResource(R.drawable.magnifying_glass),
-                                    "Search",
+                                    null,
                                     tint = colorResource(R.color.deemphasized)
                                 )
                             },
@@ -126,7 +126,7 @@ fun SearchBarOverlay(
                                     ) {
                                         Icon(
                                             painterResource(R.drawable.fa_xmark),
-                                            "Voice Search",
+                                            stringResource(R.string.close_button_label),
                                             tint = colorResource(R.color.deemphasized)
                                         )
                                     }
@@ -145,7 +145,7 @@ fun SearchBarOverlay(
                             item {
                                 Text(
                                     modifier = Modifier.padding(bottom = 10.dp),
-                                    text = "Recently Visited",
+                                    text = stringResource(R.string.recently_visited),
                                     style = MaterialTheme.typography.headlineSmall,
                                     fontWeight = FontWeight.Bold
                                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
@@ -43,6 +43,7 @@ fun StopResultsView(
     val scrollState = rememberScrollState()
 
     val routes = globalResponse?.getTypicalRoutesFor(stop.id) ?: emptyList()
+    val isLast = shape.bottomStart.toPx(Size.VisibilityThreshold, Density(1f)) == 0f
 
     Column {
         Row(
@@ -91,7 +92,7 @@ fun StopResultsView(
                 }
             }
         }
-        if (shape.bottomStart.toPx(Size.VisibilityThreshold, Density(1f)) == 0f) {
+        if (!isLast) {
             HorizontalDivider(
                 modifier = Modifier.fillMaxWidth().height(1.dp),
                 color = colorResource(id = R.color.fill1)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.search.results
 
+import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -18,20 +20,26 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
-import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.model.RoutePillSpec
 import com.mbta.tid.mbta_app.model.StopResult
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
 
 @Composable
-fun StopResultsView(stop: StopResult, handleSearch: (String) -> Unit) {
-    val globalResponse = getGlobalData()
+fun StopResultsView(
+    shape: RoundedCornerShape,
+    stop: StopResult,
+    globalResponse: GlobalResponse?,
+    handleSearch: (String) -> Unit
+) {
     val scrollState = rememberScrollState()
 
     val routes = globalResponse?.getTypicalRoutesFor(stop.id) ?: emptyList()
@@ -40,7 +48,7 @@ fun StopResultsView(stop: StopResult, handleSearch: (String) -> Unit) {
         Row(
             modifier =
                 Modifier.clickable { handleSearch(stop.id) }
-                    .background(colorResource(id = R.color.fill3))
+                    .background(colorResource(id = R.color.fill3), shape = shape)
                     .padding(12.dp)
                     .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
@@ -83,9 +91,11 @@ fun StopResultsView(stop: StopResult, handleSearch: (String) -> Unit) {
                 }
             }
         }
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth().height(1.dp),
-            color = colorResource(id = R.color.fill1)
-        )
+        if (shape.bottomStart.toPx(Size.VisibilityThreshold, Density(1f)) == 0f) {
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth().height(1.dp),
+                color = colorResource(id = R.color.fill1)
+            )
+        }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
@@ -36,8 +36,8 @@ class SearchResultsViewModel(
         job?.cancel()
         job =
             CoroutineScope(Dispatchers.IO).launch {
-                delay(500)
                 if (query.isNotEmpty()) {
+                    delay(500)
                     when (val data = searchResultRepository.getSearchResults(query)) {
                         is ApiResult.Ok -> _searchResults.emit(data.data)
                         is ApiResult.Error -> _searchResults.emit(null)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
@@ -4,12 +4,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.mbta.tid.mbta_app.history.Visit
+import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.SearchResults
+import com.mbta.tid.mbta_app.model.StopResult
+import com.mbta.tid.mbta_app.model.StopResultRoute
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -17,43 +24,69 @@ import org.koin.compose.koinInject
 
 @OptIn(kotlinx.coroutines.FlowPreview::class)
 class SearchResultsViewModel(
+    private val globalResponse: GlobalResponse?,
     private val searchResultRepository: ISearchResultRepository,
+    private val visitHistoryUsecase: VisitHistoryUsecase,
 ) : ViewModel() {
     private var _searchResults: MutableStateFlow<SearchResults?> = MutableStateFlow(null)
-    private var lastClickTime: Long? = null
     private var job: Job? = null
     val searchResults: StateFlow<SearchResults?> = _searchResults
 
     fun getSearchResults(query: String) {
-        val currentTime = System.currentTimeMillis()
-        if (lastClickTime != null && currentTime - lastClickTime!! > 500) {
-            job?.cancel()
-            job =
-                CoroutineScope(Dispatchers.IO).launch {
+        job?.cancel()
+        job =
+            CoroutineScope(Dispatchers.IO).launch {
+                delay(500)
+                if (query.isNotEmpty()) {
                     when (val data = searchResultRepository.getSearchResults(query)) {
                         is ApiResult.Ok -> _searchResults.emit(data.data)
                         is ApiResult.Error -> _searchResults.emit(null)
                         null -> {}
                     }
+                } else {
+                    val latestVisits = visitHistoryUsecase.getLatestVisits()
+                    _searchResults.emit(
+                        SearchResults(
+                            stops = latestVisits.mapIndexedNotNull(::mapLatestVisitsToResult),
+                            routes = emptyList(),
+                        )
+                    )
                 }
-        } else if (lastClickTime == null) {
-            job =
-                CoroutineScope(Dispatchers.IO).launch {
-                    when (val data = searchResultRepository.getSearchResults(query)) {
-                        is ApiResult.Ok -> _searchResults.emit(data.data)
-                        is ApiResult.Error -> _searchResults.emit(null)
-                        null -> {}
-                    }
-                }
+            }
+    }
+
+    private fun mapLatestVisitsToResult(index: Int, visit: Visit): StopResult? {
+        if (visit is Visit.StopVisit && globalResponse != null) {
+            val stop = globalResponse.stops[visit.stopId]
+            if (stop == null) {
+                return null
+            }
+
+            val routes = globalResponse.getTypicalRoutesFor(stop.id)
+            val isStation = stop.locationType == LocationType.STATION
+            return StopResult(
+                id = stop.id,
+                name = stop.name,
+                isStation = isStation,
+                routes = routes.map { StopResultRoute(type = it.type, icon = "") },
+                rank = index,
+                zone = null,
+            )
+        } else {
+            return null
         }
-        lastClickTime = currentTime
     }
 }
 
 @Composable
 fun getSearchResultsVm(
-    searchResultRepository: ISearchResultRepository = koinInject()
+    globalResponse: GlobalResponse?,
+    searchResultRepository: ISearchResultRepository = koinInject(),
+    visitHistoryUsecase: VisitHistoryUsecase = koinInject()
 ): SearchResultsViewModel {
-    val viewModel = remember { SearchResultsViewModel(searchResultRepository) }
+    val viewModel =
+        remember(globalResponse) {
+            SearchResultsViewModel(globalResponse, searchResultRepository, visitHistoryUsecase)
+        }
     return viewModel
 }

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">Refrescar</string>
     <string name="refresh_predictions">Refrescar predicciones</string>
     <string name="reload_data">Recargar datos</string>
+    <string name="recently_viewed">Visto recientemente</string>
     <string name="resources_link_fare_info">Información de tarifas</string>
     <string name="resources_link_mticket">Boletos de tren de cercanías y ferri</string>
     <string name="resources_link_mticket_note">mTicket App</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">Rafrechi</string>
     <string name="refresh_predictions">Rafrechi prediksyon</string>
     <string name="reload_data">Rechaje done</string>
+    <string name="recently_viewed">Sa w fenk sot Wè</string>
     <string name="resources_link_fare_info">Enfòmasyon Tarif</string>
     <string name="resources_link_mticket">Tikè Tren Vil la ak Bato</string>
     <string name="resources_link_mticket_note">Aplikasyon mTicket</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">Atualizar</string>
     <string name="refresh_predictions">Atualizar previsões</string>
     <string name="reload_data">Recarregar dados</string>
+    <string name="recently_viewed">Visto(s) recentemente</string>
     <string name="resources_link_fare_info">Informações sobre tarifas</string>
     <string name="resources_link_mticket">Bilhetes de transporte diário por trem e balsa</string>
     <string name="resources_link_mticket_note">Aplicativo mTicket</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">Làm mới</string>
     <string name="refresh_predictions">Làm mới dự đoán</string>
     <string name="reload_data">Tải lại dữ liệu</string>
+    <string name="recently_viewed">Đã xem gần đây</string>
     <string name="resources_link_fare_info">Thông tin giá vé</string>
     <string name="resources_link_mticket">Vé phà vé đường sắt ngoại ô (Commuter Rail)</string>
     <string name="resources_link_mticket_note">Ứng dụng mTicket</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">刷新</string>
     <string name="refresh_predictions">刷新预测</string>
     <string name="reload_data">重新加载数据</string>
+    <string name="recently_viewed">近期查看过</string>
     <string name="resources_link_fare_info">票价信息</string>
     <string name="resources_link_mticket">通勤列车和轮渡票</string>
     <string name="resources_link_mticket_note">mTicket应用程序</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -66,6 +66,7 @@
     <string name="refresh">重新整理</string>
     <string name="refresh_predictions">重新整理預測</string>
     <string name="reload_data">重新載入資料</string>
+    <string name="recently_viewed">近期查看過</string>
     <string name="resources_link_fare_info">票價資訊</string>
     <string name="resources_link_mticket">通勤列車和輪渡票</string>
     <string name="resources_link_mticket_note">mTicket應用程式</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -64,7 +64,7 @@
     <string name="other_link_tos">Terms of Use</string>
     <string name="outbound">Outbound</string>
     <string name="recenter" tools:ignore="MissingTranslation">Recenter</string>
-    <string name="recently_visited" tools:ignore="MissingTranslation">Recently Visited</string>
+    <string name="recently_viewed">Recently Viewed</string>
     <string name="resources_link_fare_info">Fare Information</string>
     <string name="resources_link_mticket">Commuter Rail and Ferry tickets</string>
     <string name="resources_link_mticket_note">mTicket App</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <string name="other_link_tos">Terms of Use</string>
     <string name="outbound">Outbound</string>
     <string name="recenter" tools:ignore="MissingTranslation">Recenter</string>
+    <string name="recently_visited" tools:ignore="MissingTranslation">Recently Visited</string>
     <string name="resources_link_fare_info">Fare Information</string>
     <string name="resources_link_mticket">Commuter Rail and Ferry tickets</string>
     <string name="resources_link_mticket_note">mTicket App</string>


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Search | Search recently visited](https://app.asana.com/0/1205732265579288/1208839363050256/f)

What is this PR for?

When there is no query entered in the Search view, shows a list of recently visited stops.

![Screenshot_20250106_094147](https://github.com/user-attachments/assets/868737df-6511-4fa1-8b76-d8e07bb7e0d9)


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
Updated unit tests for affected views.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
