### PR TITLE
refactor: Put no trip statuses into separate class

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
@@ -91,7 +91,10 @@ class HeadsignRowViewTest {
 
     @Test
     fun showsNoPredictions() {
-        init("Somewhere", RealtimePatterns.Format.None(secondaryAlert = null))
+        init(
+            "Somewhere",
+            RealtimePatterns.Format.NoTrips(RealtimePatterns.NoTripsFormat.PredictionsUnavailable)
+        )
 
         composeTestRule.onNodeWithText("Somewhere").assertIsDisplayed()
         composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
@@ -101,7 +104,8 @@ class HeadsignRowViewTest {
     fun showsNoPredictionsWithSecondaryAlert() {
         init(
             "Somewhere",
-            RealtimePatterns.Format.None(
+            RealtimePatterns.Format.NoTrips(
+                noTripsFormat = RealtimePatterns.NoTripsFormat.PredictionsUnavailable,
                 secondaryAlert = RealtimePatterns.Format.SecondaryAlert("alert-large-bus-issue")
             )
         )
@@ -113,7 +117,10 @@ class HeadsignRowViewTest {
 
     @Test
     fun showsAlert() {
-        init("Headsign", RealtimePatterns.Format.NoService(alert { effect = Alert.Effect.Shuttle }))
+        init(
+            "Headsign",
+            RealtimePatterns.Format.Disruption(alert { effect = Alert.Effect.Shuttle })
+        )
 
         composeTestRule.onNodeWithText("Shuttle", ignoreCase = true).assertIsDisplayed()
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
@@ -74,7 +74,10 @@ private fun DirectionRowViewPreview() {
             )
             DirectionRowView(
                 direction = Direction(name = "North", destination = "None", id = 0),
-                predictions = RealtimePatterns.Format.None(secondaryAlert = null)
+                predictions =
+                    RealtimePatterns.Format.NoTrips(
+                        RealtimePatterns.NoTripsFormat.PredictionsUnavailable
+                    )
             )
             DirectionRowView(
                 direction = Direction(name = "South", destination = "Loading", id = 1),
@@ -83,7 +86,7 @@ private fun DirectionRowViewPreview() {
             DirectionRowView(
                 direction = Direction(name = "East", destination = "No Service", id = 1),
                 predictions =
-                    RealtimePatterns.Format.NoService(
+                    RealtimePatterns.Format.Disruption(
                         alert =
                             ObjectCollectionBuilder.Single.alert {
                                 effect = Alert.Effect.Suspension

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
@@ -76,16 +76,23 @@ fun HeadsignRowViewPreview() {
                     secondaryAlert = RealtimePatterns.Format.SecondaryAlert("alert-large-bus-issue")
                 )
             )
-            HeadsignRowView("None", RealtimePatterns.Format.None(secondaryAlert = null))
+            HeadsignRowView(
+                "None",
+                RealtimePatterns.Format.NoTrips(
+                    RealtimePatterns.NoTripsFormat.PredictionsUnavailable
+                )
+            )
             HeadsignRowView(
                 "None with Alert",
-                RealtimePatterns.Format.None(
+                RealtimePatterns.Format.NoTrips(
+                    RealtimePatterns.NoTripsFormat.PredictionsUnavailable,
                     secondaryAlert = RealtimePatterns.Format.SecondaryAlert("alert-large-bus-issue")
                 )
             )
             HeadsignRowView(
                 "Decorated None with Alert",
-                RealtimePatterns.Format.None(
+                RealtimePatterns.Format.NoTrips(
+                    RealtimePatterns.NoTripsFormat.PredictionsUnavailable,
                     secondaryAlert =
                         RealtimePatterns.Format.SecondaryAlert("alert-large-green-issue")
                 ),
@@ -104,7 +111,7 @@ fun HeadsignRowViewPreview() {
             HeadsignRowView("Loading", RealtimePatterns.Format.Loading)
             HeadsignRowView(
                 "No Service",
-                RealtimePatterns.Format.NoService(alert { effect = Alert.Effect.Suspension })
+                RealtimePatterns.Format.Disruption(alert { effect = Alert.Effect.Suspension })
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -88,13 +88,10 @@ fun PredictionRowView(
                                 }
                             }
                         }
-                    is RealtimePatterns.Format.NoService ->
-                        UpcomingTripView(UpcomingTripViewState.NoService(predictions.alert.effect))
-                    is RealtimePatterns.Format.None -> UpcomingTripView(UpcomingTripViewState.None)
-                    is RealtimePatterns.Format.ServiceEndedToday ->
-                        UpcomingTripView(UpcomingTripViewState.ServiceEndedToday)
-                    is RealtimePatterns.Format.NoSchedulesToday ->
-                        UpcomingTripView(UpcomingTripViewState.NoSchedulesToday)
+                    is RealtimePatterns.Format.Disruption ->
+                        UpcomingTripView(UpcomingTripViewState.Disruption(predictions.alert.effect))
+                    is RealtimePatterns.Format.NoTrips ->
+                        UpcomingTripView((UpcomingTripViewState.NoTrips(predictions.noTripsFormat)))
                     is RealtimePatterns.Format.Loading ->
                         UpcomingTripView(UpcomingTripViewState.Loading)
                 }

--- a/iosApp/iosApp/ComponentViews/DirectionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionRowView.swift
@@ -48,29 +48,39 @@ struct DirectionRowView_Previews: PreviewProvider {
                 prediction.departureTime = now.addingTimeInterval(12 * 60).toKotlinInstant()
             }
             List {
-                DirectionRowView(direction: Direction(name: "West", destination: "Some", id: 0),
-                                 predictions: RealtimePatterns.FormatSome(trips: [
-                                     .init(
-                                         trip: .init(trip: trip1, prediction: prediction1),
-                                         routeType: RouteType.heavyRail,
-                                         now: now.toKotlinInstant(), context: .nearbyTransit
-                                     ),
-                                     .init(
-                                         trip: .init(trip: trip2, prediction: prediction2),
-                                         routeType: RouteType.heavyRail,
-                                         now: now.toKotlinInstant(), context: .nearbyTransit
-                                     ),
-                                 ], secondaryAlert: nil))
-                DirectionRowView(direction: Direction(name: "North", destination: "None", id: 0),
-                                 predictions: RealtimePatterns.FormatNone(secondaryAlert: nil))
-                DirectionRowView(direction: Direction(name: "South", destination: "Loading", id: 1),
-                                 predictions: RealtimePatterns.FormatLoading.shared)
-                DirectionRowView(direction: Direction(name: "East", destination: "No Service", id: 1),
-                                 predictions: RealtimePatterns.FormatNoService(
-                                     alert: ObjectCollectionBuilder.Single.shared.alert { alert in
-                                         alert.effect = .suspension
-                                     }
-                                 ))
+                DirectionRowView(
+                    direction: Direction(name: "West", destination: "Some", id: 0),
+                    predictions: RealtimePatterns.FormatSome(trips: [
+                        .init(
+                            trip: .init(trip: trip1, prediction: prediction1),
+                            routeType: RouteType.heavyRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                        .init(
+                            trip: .init(trip: trip2, prediction: prediction2),
+                            routeType: RouteType.heavyRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                    ], secondaryAlert: nil)
+                )
+                DirectionRowView(
+                    direction: Direction(name: "North", destination: "None", id: 0),
+                    predictions: RealtimePatterns.FormatNoTrips(
+                        noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable()
+                    )
+                )
+                DirectionRowView(
+                    direction: Direction(name: "South", destination: "Loading", id: 1),
+                    predictions: RealtimePatterns.FormatLoading.shared
+                )
+                DirectionRowView(
+                    direction: Direction(name: "East", destination: "No Service", id: 1),
+                    predictions: RealtimePatterns.FormatDisruption(
+                        alert: ObjectCollectionBuilder.Single.shared.alert { alert in
+                            alert.effect = .suspension
+                        }
+                    )
+                )
             }
         }.font(Typography.body)
     }

--- a/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
+++ b/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
@@ -65,49 +65,69 @@ struct HeadsignRowView_Previews: PreviewProvider {
             }
 
             List {
-                HeadsignRowView(headsign: "Some",
-                                predictions: RealtimePatterns.FormatSome(trips: [
-                                    .init(
-                                        trip: .init(trip: trip1, prediction: prediction1),
-                                        routeType: RouteType.lightRail,
-                                        now: now.toKotlinInstant(), context: .nearbyTransit
-                                    ),
-                                    .init(
-                                        trip: .init(trip: trip2, prediction: prediction2),
-                                        routeType: .heavyRail,
-                                        now: now.toKotlinInstant(), context: .nearbyTransit
-                                    ),
-                                ], secondaryAlert: nil))
-                HeadsignRowView(headsign: "Some with Alert",
-                                predictions: RealtimePatterns.FormatSome(trips: [
-                                    .init(
-                                        trip: .init(trip: trip1, prediction: prediction1),
-                                        routeType: RouteType.lightRail,
-                                        now: now.toKotlinInstant(), context: .nearbyTransit
-                                    ),
-                                    .init(
-                                        trip: .init(trip: trip2, prediction: prediction2),
-                                        routeType: .heavyRail,
-                                        now: now.toKotlinInstant(), context: .nearbyTransit
-                                    ),
-                                ], secondaryAlert: secondaryAlert))
-                HeadsignRowView(headsign: "None",
-                                predictions: RealtimePatterns.FormatNone(secondaryAlert: nil))
-                HeadsignRowView(headsign: "None with Alert",
-                                predictions: RealtimePatterns
-                                    .FormatNone(secondaryAlert: secondaryAlert))
-                HeadsignRowView(headsign: "Decorated None with Alert",
-                                predictions: RealtimePatterns
-                                    .FormatNone(secondaryAlert: greenLineEAlert),
-                                pillDecoration: .onRow(route: greenLineERoute))
-                HeadsignRowView(headsign: "Loading",
-                                predictions: RealtimePatterns.FormatLoading.shared)
-                HeadsignRowView(headsign: "No Service",
-                                predictions: RealtimePatterns.FormatNoService(
-                                    alert: ObjectCollectionBuilder.Single.shared.alert { alert in
-                                        alert.effect = .suspension
-                                    }
-                                ))
+                HeadsignRowView(
+                    headsign: "Some",
+                    predictions: RealtimePatterns.FormatSome(trips: [
+                        .init(
+                            trip: .init(trip: trip1, prediction: prediction1),
+                            routeType: RouteType.lightRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                        .init(
+                            trip: .init(trip: trip2, prediction: prediction2),
+                            routeType: .heavyRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                    ], secondaryAlert: nil)
+                )
+                HeadsignRowView(
+                    headsign: "Some with Alert",
+                    predictions: RealtimePatterns.FormatSome(trips: [
+                        .init(
+                            trip: .init(trip: trip1, prediction: prediction1),
+                            routeType: RouteType.lightRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                        .init(
+                            trip: .init(trip: trip2, prediction: prediction2),
+                            routeType: .heavyRail,
+                            now: now.toKotlinInstant(), context: .nearbyTransit
+                        ),
+                    ], secondaryAlert: secondaryAlert)
+                )
+                HeadsignRowView(
+                    headsign: "None",
+                    predictions: RealtimePatterns.FormatNoTrips(
+                        noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable()
+                    )
+                )
+                HeadsignRowView(
+                    headsign: "None with Alert",
+                    predictions: RealtimePatterns.FormatNoTrips(
+                        noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable(),
+                        secondaryAlert: secondaryAlert
+                    )
+                )
+                HeadsignRowView(
+                    headsign: "Decorated None with Alert",
+                    predictions: RealtimePatterns.FormatNoTrips(
+                        noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable(),
+                        secondaryAlert: greenLineEAlert
+                    ),
+                    pillDecoration: .onRow(route: greenLineERoute)
+                )
+                HeadsignRowView(
+                    headsign: "Loading",
+                    predictions: RealtimePatterns.FormatLoading.shared
+                )
+                HeadsignRowView(
+                    headsign: "No Service",
+                    predictions: RealtimePatterns.FormatDisruption(
+                        alert: ObjectCollectionBuilder.Single.shared.alert { alert in
+                            alert.effect = .suspension
+                        }
+                    )
+                )
             }
         }.font(Typography.body)
     }

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -66,18 +66,17 @@ struct PredictionRowView: View {
                 }
             }
             .padding(.vertical, 4)
-        case let .noService(alert):
+
+        case let .disruption(alert):
             UpcomingTripView(
-                prediction: .noService(alert.alert.effect),
+                prediction: .disruption(alert.alert.effect),
                 isFirst: true,
                 isOnly: true
             )
-        case .none:
-            UpcomingTripView(prediction: .none, isFirst: true, isOnly: true)
-        case .noSchedulesToday:
-            UpcomingTripView(prediction: .noSchedulesToday, isFirst: true, isOnly: true)
-        case .serviceEndedToday:
-            UpcomingTripView(prediction: .serviceEndedToday, isFirst: true, isOnly: true)
+
+        case let .noTrips(format):
+            UpcomingTripView(prediction: .noTrips(format.noTripsFormat), isFirst: true, isOnly: true)
+
         case .loading:
             UpcomingTripView(prediction: .loading, isFirst: true, isOnly: true)
         }

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -31,10 +31,8 @@ struct UpcomingTripView: View {
 
     enum State: Equatable {
         case loading
-        case none
-        case noSchedulesToday
-        case serviceEndedToday
-        case noService(shared.Alert.Effect)
+        case noTrips(RealtimePatterns.NoTripsFormat)
+        case disruption(shared.Alert.Effect)
         case some(TripInstantDisplay)
     }
 
@@ -137,23 +135,26 @@ struct UpcomingTripView: View {
                     )
                     : accessibilityFormatters.cancelledOther(date: format.scheduledTime.toNSDate()))
             }
-        case let .noService(alertEffect):
-            NoServiceView(effect: .from(alertEffect: alertEffect))
-        case .none:
-            Text(
-                "Predictions unavailable",
-                comment: "The status label when no predictions exist for a route and direction"
-            ).font(Typography.footnote)
-        case .serviceEndedToday:
-            Text(
-                "Service ended",
-                comment: "The status label for a route and direction when service was running earlier, but no more trips are running today"
-            ).font(Typography.footnote)
-        case .noSchedulesToday:
-            Text(
-                "No service today",
-                comment: "The status label for a route when no service is running for the entire service day"
-            ).font(Typography.footnote)
+        case let .disruption(alertEffect):
+            DisruptionView(effect: .from(alertEffect: alertEffect))
+        case let .noTrips(format):
+            switch onEnum(of: format) {
+            case .predictionsUnavailable:
+                Text(
+                    "Predictions unavailable",
+                    comment: "The status label when no predictions exist for a route and direction"
+                ).font(Typography.footnote)
+            case .serviceEndedToday:
+                Text(
+                    "Service ended",
+                    comment: "The status label for a route and direction when service was running earlier, but no more trips are running today"
+                ).font(Typography.footnote)
+            case .noSchedulesToday:
+                Text(
+                    "No service today",
+                    comment: "The status label for a route when no service is running for the entire service day"
+                ).font(Typography.footnote)
+            }
         case .loading:
             ProgressView()
         }
@@ -167,7 +168,7 @@ func makeTimeFormatter() -> DateFormatter {
     return formatter
 }
 
-struct NoServiceView: View {
+struct DisruptionView: View {
     let effect: Effect
 
     @ScaledMetric private var iconSize: CGFloat = 20
@@ -250,11 +251,11 @@ struct NoServiceView: View {
 struct UpcomingTripView_Previews: PreviewProvider {
     static var previews: some View {
         VStack(alignment: .trailing) {
-            UpcomingTripView(prediction: .noService(.suspension), routeType: .heavyRail)
-            UpcomingTripView(prediction: .noService(.shuttle), routeType: .heavyRail)
-            UpcomingTripView(prediction: .noService(.stopClosure), routeType: .heavyRail)
-            UpcomingTripView(prediction: .noService(.detour), routeType: .heavyRail)
-            UpcomingTripView(prediction: .noService(.detour), routeType: .heavyRail)
+            UpcomingTripView(prediction: .disruption(.suspension), routeType: .heavyRail)
+            UpcomingTripView(prediction: .disruption(.shuttle), routeType: .heavyRail)
+            UpcomingTripView(prediction: .disruption(.stopClosure), routeType: .heavyRail)
+            UpcomingTripView(prediction: .disruption(.detour), routeType: .heavyRail)
+            UpcomingTripView(prediction: .disruption(.detour), routeType: .heavyRail)
         }
         .padding(8)
         .frame(maxWidth: 150)

--- a/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
@@ -48,7 +48,9 @@ struct StopDetailsFilteredRouteView: View {
             ) {
                 RealtimePatterns.FormatSome(trips: [formattedUpcomingTrip], secondaryAlert: nil)
             } else {
-                RealtimePatterns.FormatNone(secondaryAlert: nil)
+                RealtimePatterns.FormatNoTrips(
+                    noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable()
+                )
             }
 
             if !(formatted is RealtimePatterns.FormatSome) {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -17,7 +17,7 @@ struct StopDetailsFilteredDepartureDetails: View {
     var setTripFilter: (TripDetailsFilter?) -> Void
 
     var tiles: [TileData]
-    var noPredictionsStatus: RealtimePatterns.Format?
+    var noPredictionsStatus: RealtimePatterns.NoTripsFormat?
     var alerts: [shared.Alert]
     var patternsByStop: PatternsByStop
     var pinned: Bool
@@ -103,10 +103,10 @@ struct StopDetailsFilteredDepartureDetails: View {
         .ignoresSafeArea(.all)
     }
 
-    func handleViewportForStatus(_ status: RealtimePatterns.Format?) {
+    func handleViewportForStatus(_ status: RealtimePatterns.NoTripsFormat?) {
         if let stop, let status {
             switch onEnum(of: status) {
-            case .none: viewportProvider.animateTo(
+            case .predictionsUnavailable: viewportProvider.animateTo(
                     coordinates: stop.coordinate,
                     zoom: MapDefaults.shared.midZoomThreshold
                 )

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -32,7 +32,7 @@ struct StopDetailsFilteredView: View {
     var analytics: StopDetailsAnalytics = AnalyticsProvider.shared
 
     var tiles: [TileData] = []
-    var noPredictionsStatus: RealtimePatterns.Format?
+    var noPredictionsStatus: RealtimePatterns.NoTripsFormat?
 
     var stop: Stop? { stopDetailsVM.global?.stops[stopId] }
     var nowInstant: Instant { now.toKotlinInstant() }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
@@ -10,7 +10,7 @@ import shared
 import SwiftUI
 
 struct StopDetailsNoTripCard: View {
-    var status: RealtimePatterns.Format
+    var status: RealtimePatterns.NoTripsFormat
     var headerColor: Color
     var routeType: RouteType
 
@@ -35,7 +35,7 @@ struct StopDetailsNoTripCard: View {
 
     var detailString: String? {
         switch onEnum(of: status) {
-        case .none: String(format: NSLocalizedString(
+        case .predictionsUnavailable: String(format: NSLocalizedString(
                 "Service is running, but predicted arrival times aren’t available. The map shows where %@ on this route currently are.",
                 comment: """
                 Explanation under the 'Predictions unavailable' header in stop details.
@@ -51,24 +51,22 @@ struct StopDetailsNoTripCard: View {
         // Text needed to be copied from UpcomingTripView because that sets the font style,
         // which means we're unable to override to use a larger font if we use that view directly
         switch onEnum(of: status) {
-        case .none:
+        case .predictionsUnavailable:
             Text("Predictions unavailable")
         case .noSchedulesToday:
             Text("No service today")
         case .serviceEndedToday:
             Text("Service ended")
-        default: EmptyView()
         }
     }
 
     @ViewBuilder
     var headerImage: some View {
         switch onEnum(of: status) {
-        case .none: Image(.liveDataSlash)
+        case .predictionsUnavailable: Image(.liveDataSlash)
             .resizable().scaledToFit().frame(width: 35, height: 35)
         case .noSchedulesToday, .serviceEndedToday: modeSlashImage
             .resizable().scaledToFit().frame(width: 35, height: 35)
-        default: EmptyView()
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/TileData.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TileData.swift
@@ -38,7 +38,9 @@ struct TileData: Identifiable {
         ) {
             RealtimePatterns.FormatSome(trips: [formattedUpcomingTrip], secondaryAlert: nil)
         } else {
-            RealtimePatterns.FormatNone(secondaryAlert: nil)
+            RealtimePatterns.FormatNoTrips(
+                noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable()
+            )
         }
 
         if !(formatted is RealtimePatterns.FormatSome) {

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -262,7 +262,7 @@ struct TripHeaderCard: View {
         }
         guard let entry else { return nil }
         if let alert = entry.alert {
-            return .noService(alert.effect)
+            return .disruption(alert.effect)
         } else {
             let formatted = entry.format(now: now.toKotlinInstant(), routeType: routeAccents.type)
             return switch onEnum(of: formatted) {

--- a/iosApp/iosApp/Pages/StopDetails/TripStatus.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStatus.swift
@@ -22,14 +22,10 @@ struct TripStatus: View {
             } else {
                 EmptyView()
             }
-        case let .noService(alert):
-            UpcomingTripView(prediction: .noService(alert.alert.effect))
-        case .none:
-            UpcomingTripView(prediction: .none)
-        case .noSchedulesToday:
-            UpcomingTripView(prediction: .noSchedulesToday)
-        case .serviceEndedToday:
-            UpcomingTripView(prediction: .serviceEndedToday)
+        case let .disruption(alert):
+            UpcomingTripView(prediction: .disruption(alert.alert.effect))
+        case let .noTrips(format):
+            UpcomingTripView(prediction: .noTrips(format.noTripsFormat))
         case .loading:
             UpcomingTripView(prediction: .loading)
         }

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -137,7 +137,7 @@ struct TripStopRow: View {
 
     var upcomingTripViewState: UpcomingTripView.State {
         if let alert = stop.alert {
-            .noService(alert.effect)
+            .disruption(alert.effect)
         } else {
             .some(stop.format(now: now, routeType: routeAccents.type))
         }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -77,7 +77,7 @@ struct TripDetailsStopView: View {
 
     var upcomingTripViewState: UpcomingTripView.State {
         if let alert = stop.alert {
-            .noService(alert.effect)
+            .disruption(alert.effect)
         } else {
             .some(stop.format(now: now, routeType: routeType))
         }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -253,7 +253,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             tiles: [],
-            noPredictionsStatus: RealtimePatterns.FormatServiceEndedToday(secondaryAlert: nil),
+            noPredictionsStatus: RealtimePatterns.NoTripsFormatServiceEndedToday(),
             alerts: [],
             patternsByStop: .init(routes: [route], line: line, stop: stop, patterns: [], directions: []),
             pinned: false,

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
@@ -19,7 +19,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
 
     func testPredictionsUnavailable() throws {
         let sut = StopDetailsNoTripCard(
-            status: RealtimePatterns.FormatNone(secondaryAlert: nil),
+            status: RealtimePatterns.NoTripsFormatPredictionsUnavailable(),
             headerColor: Color.text,
             routeType: .bus
         )
@@ -36,7 +36,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
 
     func testServiceEnded() throws {
         let sut = StopDetailsNoTripCard(
-            status: RealtimePatterns.FormatServiceEndedToday(secondaryAlert: nil),
+            status: RealtimePatterns.NoTripsFormatServiceEndedToday(),
             headerColor: Color.text,
             routeType: .ferry
         )
@@ -49,7 +49,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
 
     func testNoSchedulesToday() throws {
         let sut = StopDetailsNoTripCard(
-            status: RealtimePatterns.FormatNoSchedulesToday(secondaryAlert: nil),
+            status: RealtimePatterns.NoTripsFormatNoSchedulesToday(),
             headerColor: Color.text,
             routeType: .commuterRail
         )

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -272,7 +272,10 @@ final class NearbyTransitViewTests: XCTestCase {
             XCTAssertEqual(try upcomingPrediction.find(ViewType.Image.self).actualImage().name(), "live-data")
 
             XCTAssertEqual(try patterns[2].actualView().headsign, "Watertown Yard")
-            XCTAssertEqual(try patterns[2].find(UpcomingTripView.self).actualView().prediction, .serviceEndedToday)
+            XCTAssertEqual(
+                try patterns[2].find(UpcomingTripView.self).actualView().prediction,
+                .noTrips(RealtimePatterns.NoTripsFormatServiceEndedToday())
+            )
         }
         ViewHosting.host(view: sut)
         wait(for: [exp], timeout: 1)

--- a/iosApp/iosAppTests/Views/PredictionRowViewTests.swift
+++ b/iosApp/iosAppTests/Views/PredictionRowViewTests.swift
@@ -15,9 +15,10 @@ import XCTest
 final class PredictionRowViewTests: XCTestCase {
     func testSecondaryAlert() throws {
         let sut = PredictionRowView(
-            predictions: RealtimePatterns.FormatNone(secondaryAlert: .init(
-                iconName: "alert-large-bus-issue"
-            )),
+            predictions: RealtimePatterns.FormatNoTrips(
+                noTripsFormat: RealtimePatterns.NoTripsFormatPredictionsUnavailable(),
+                secondaryAlert: .init(iconName: "alert-large-bus-issue")
+            ),
             pillDecoration: .none,
             destination: { EmptyView() }
         )

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -125,7 +125,7 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testShuttleAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .noService(.shuttle), isFirst: false)
+        let sut = UpcomingTripView(prediction: .disruption(.shuttle), isFirst: false)
         XCTAssertEqual(
             "Shuttle buses replace service",
             try sut.inspect().find(text: "Shuttle")
@@ -134,7 +134,7 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testSuspensionAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .noService(.suspension), isFirst: false)
+        let sut = UpcomingTripView(prediction: .disruption(.suspension), isFirst: false)
         XCTAssertEqual(
             "Service suspended",
             try sut.inspect().find(text: "Suspension")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -34,7 +34,7 @@ class RealtimePatternsTest {
         val alert = objects.alert { effect = Alert.Effect.Suspension }
 
         assertEquals(
-            RealtimePatterns.Format.NoService(alert),
+            RealtimePatterns.Format.Disruption(alert),
             RealtimePatterns.ByHeadsign(route, "", null, emptyList(), emptyList(), listOf(alert))
                 .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
@@ -66,7 +66,8 @@ class RealtimePatternsTest {
 
         for ((route, icon) in cases) {
             assertEquals(
-                RealtimePatterns.Format.ServiceEndedToday(
+                RealtimePatterns.Format.NoTrips(
+                    RealtimePatterns.NoTripsFormat.ServiceEndedToday,
                     RealtimePatterns.Format.SecondaryAlert(icon)
                 ),
                 RealtimePatterns.ByHeadsign(
@@ -101,7 +102,7 @@ class RealtimePatternsTest {
         val alert = objects.alert { effect = Alert.Effect.Suspension }
 
         assertEquals(
-            RealtimePatterns.Format.NoService(alert),
+            RealtimePatterns.Format.Disruption(alert),
             RealtimePatterns.ByHeadsign(
                     route,
                     "",
@@ -203,7 +204,7 @@ class RealtimePatternsTest {
         val route = objects.route()
 
         assertEquals(
-            RealtimePatterns.Format.ServiceEndedToday(null),
+            RealtimePatterns.Format.NoTrips(RealtimePatterns.NoTripsFormat.ServiceEndedToday),
             RealtimePatterns.ByHeadsign(
                     route,
                     "",
@@ -230,7 +231,7 @@ class RealtimePatternsTest {
                 departureTime = now + 2.minutes
             }
         assertEquals(
-            RealtimePatterns.Format.None(null),
+            RealtimePatterns.Format.NoTrips(RealtimePatterns.NoTripsFormat.PredictionsUnavailable),
             RealtimePatterns.ByHeadsign(
                     route,
                     "",
@@ -391,7 +392,7 @@ class RealtimePatternsTest {
         val route = objects.route { type = RouteType.BUS }
 
         assertEquals(
-            RealtimePatterns.Format.NoSchedulesToday(null),
+            RealtimePatterns.Format.NoTrips(RealtimePatterns.NoTripsFormat.NoSchedulesToday),
             RealtimePatterns.ByHeadsign(
                     route,
                     "",

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -1582,7 +1582,7 @@ class StopDetailsDeparturesTest {
             )
         )
         assertEquals(
-            RealtimePatterns.Format.ServiceEndedToday(null),
+            RealtimePatterns.NoTripsFormat.ServiceEndedToday,
             StopDetailsDepartures.getNoPredictionsStatus(realtimePatterns, now)
         )
     }
@@ -1623,7 +1623,7 @@ class StopDetailsDeparturesTest {
             )
         )
         assertEquals(
-            RealtimePatterns.Format.NoSchedulesToday(null),
+            RealtimePatterns.NoTripsFormat.NoSchedulesToday,
             StopDetailsDepartures.getNoPredictionsStatus(realtimePatterns, now)
         )
     }
@@ -1663,7 +1663,7 @@ class StopDetailsDeparturesTest {
             )
         )
         assertEquals(
-            RealtimePatterns.Format.ServiceEndedToday(null),
+            RealtimePatterns.NoTripsFormat.ServiceEndedToday,
             StopDetailsDepartures.getNoPredictionsStatus(realtimePatterns, now)
         )
     }
@@ -1722,7 +1722,7 @@ class StopDetailsDeparturesTest {
             )
         )
         assertEquals(
-            RealtimePatterns.Format.None(null),
+            RealtimePatterns.NoTripsFormat.PredictionsUnavailable,
             StopDetailsDepartures.getNoPredictionsStatus(realtimePatterns, now)
         )
     }
@@ -1823,7 +1823,7 @@ class StopDetailsDeparturesTest {
             )
         )
         assertEquals(
-            RealtimePatterns.Format.ServiceEndedToday(null),
+            RealtimePatterns.NoTripsFormat.ServiceEndedToday,
             StopDetailsDepartures.getNoPredictionsStatus(realtimePatterns, now)
         )
     }


### PR DESCRIPTION
### Summary

_Ticket:_ Preparation for [Combined Stop + Trip Details: Handle cancelled trip](https://app.asana.com/0/1205732265579288/1209010745257743/f)

These changes were [suggested](https://github.com/mbta/mobile_app/pull/620#discussion_r1904376848) by Kayla in #620, I made roughly those changes, moving all the no trips states into a separate sealed class, and having a singular `RealtimePatterns.Format.NoTrips` class that contains all of them. I also renamed the `NoService` format to `Disruption`, since that more accurately captures what it is, and the similarity between it and `NoTrips` was confusing.

Split out into a separate PR from the cancellation handling because this touches android UI.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Updated existing tests, they all pass