### PR TITLE
feat(iOS): Stop details cancelled trip card

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -220,6 +220,7 @@
 		9AF0937A2BD962FF001DF39F /* DirectionPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF093792BD962FF001DF39F /* DirectionPickerTests.swift */; };
 		9AF28F0D2D2854C200EC1C12 /* StopDetailsNoTripCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF28F0C2D2854C200EC1C12 /* StopDetailsNoTripCard.swift */; };
 		9AF28F0F2D287DFF00EC1C12 /* StopDetailsNoTripCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF28F0E2D287DFF00EC1C12 /* StopDetailsNoTripCardTests.swift */; };
+		9AF28F112D2D8D2A00EC1C12 /* StopDetailsIconCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF28F102D2D8D2900EC1C12 /* StopDetailsIconCard.swift */; };
 		9AF29DF62CF5431A005AA4A3 /* DepartureTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF29DF52CF54319005AA4A3 /* DepartureTile.swift */; };
 		9AF29DF82CF5454E005AA4A3 /* StopDetailsFilteredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF29DF72CF5454E005AA4A3 /* StopDetailsFilteredView.swift */; };
 		9AF29DFA2CF548E5005AA4A3 /* StopDetailsUnfilteredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF29DF92CF548E5005AA4A3 /* StopDetailsUnfilteredView.swift */; };
@@ -522,6 +523,7 @@
 		9AF0937C2BDC1FC5001DF39F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		9AF28F0C2D2854C200EC1C12 /* StopDetailsNoTripCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsNoTripCard.swift; sourceTree = "<group>"; };
 		9AF28F0E2D287DFF00EC1C12 /* StopDetailsNoTripCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsNoTripCardTests.swift; sourceTree = "<group>"; };
+		9AF28F102D2D8D2900EC1C12 /* StopDetailsIconCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsIconCard.swift; sourceTree = "<group>"; };
 		9AF29DF52CF54319005AA4A3 /* DepartureTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartureTile.swift; sourceTree = "<group>"; };
 		9AF29DF72CF5454E005AA4A3 /* StopDetailsFilteredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsFilteredView.swift; sourceTree = "<group>"; };
 		9AF29DF92CF548E5005AA4A3 /* StopDetailsUnfilteredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsUnfilteredView.swift; sourceTree = "<group>"; };
@@ -1138,6 +1140,7 @@
 				9AF29E052CFE2C4C005AA4A3 /* StopDetailsFilteredDepartureDetails.swift */,
 				9AF29DFF2CF63330005AA4A3 /* StopDetailsFilteredHeader.swift */,
 				9AF29DF72CF5454E005AA4A3 /* StopDetailsFilteredView.swift */,
+				9AF28F102D2D8D2900EC1C12 /* StopDetailsIconCard.swift */,
 				9AF28F0C2D2854C200EC1C12 /* StopDetailsNoTripCard.swift */,
 				9ACE4FCF2CE6707900FEB006 /* StopDetailsPage.swift */,
 				9AF29DF92CF548E5005AA4A3 /* StopDetailsUnfilteredView.swift */,
@@ -1684,6 +1687,7 @@
 				9ACE4FD22CE6709B00FEB006 /* StopDetailsView.swift in Sources */,
 				6E4C37582C4AEF3E00EA67CF /* ContentViewModel.swift in Sources */,
 				8C5054A02CA47C3C00137CFE /* ErrorBanner.swift in Sources */,
+				9AF28F112D2D8D2A00EC1C12 /* StopDetailsIconCard.swift in Sources */,
 				9A18DEAD2D07DDC800DA0A3B /* RouteExtension.swift in Sources */,
 				6E973DA52C17384C00CBF341 /* SheetHeader.swift in Sources */,
 				9A9E7DD32C2203BE000DA1FD /* TransitCard.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/HaloSeparator.swift
+++ b/iosApp/iosApp/ComponentViews/HaloSeparator.swift
@@ -10,6 +10,6 @@ import SwiftUI
 
 struct HaloSeparator: View {
     var body: some View {
-        Divider().frame(maxHeight: 1).foregroundStyle(Color.halo)
+        Divider().frame(height: 1).background(Color.halo)
     }
 }

--- a/iosApp/iosApp/ComponentViews/RouteIcon.swift
+++ b/iosApp/iosApp/ComponentViews/RouteIcon.swift
@@ -26,3 +26,20 @@ func routeIconResource(_ routeType: RouteType) -> ImageResource {
     default: .modeSubway
     }
 }
+
+func routeSlashIcon(_ route: Route) -> Image {
+    routeSlashIcon(route.type)
+}
+
+func routeSlashIcon(_ routeType: RouteType) -> Image {
+    Image(routeSlashIconResource(routeType))
+}
+
+func routeSlashIconResource(_ routeType: RouteType) -> ImageResource {
+    switch routeType {
+    case .bus: .modeBusSlash
+    case .commuterRail: .modeCrSlash
+    case .ferry: .modeFerrySlash
+    default: .modeSubwaySlash
+    }
+}

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -8345,6 +8345,47 @@
         }
       }
     },
+    "This trip has been cancelled. We’re sorry for the inconvenience." : {
+      "comment" : "Explanation for a cancelled trip on stop details",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este viaje ha sido cancelado. Lamentamos las molestias."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vwayaj sa a te anile. Nou regrèt deranjman an."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta viagem foi cancelada. Lamentamos o inconveniente."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chuyến đi này đã bị hủy. Chúng tôi xin lỗi vì sự bất tiện này."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此行程已取消。我们对此造成的不便深表歉意。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "這次旅行已取消。對於造成您的不便，我們深表歉意。"
+          }
+        }
+      }
+    },
     "This vehicle is completing another trip" : {
       "localizations" : {
         "es" : {
@@ -8668,6 +8709,47 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "列車"
+          }
+        }
+      }
+    },
+    "Trip cancelled" : {
+      "comment" : "Header for a cancelled trip card on stop details",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Viaje cancelado"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vwayaj anile"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Viagem cancelada"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chuyến đi bị hủy"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行程取消"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行程取消"
           }
         }
       }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -43,11 +43,6 @@ struct StopDetailsFilteredDepartureDetails: View {
 
     var routeColor: Color { Color(hex: patternsByStop.representativeRoute.color) }
     var routeType: RouteType { patternsByStop.representativeRoute.type }
-    var headerColor: Color {
-        // Regular bus color needs to be overridden for contrast, but SL should not be
-        let isSL = MapStopRoute.silver.matches(route: patternsByStop.representativeRoute)
-        return if routeType == .bus, !isSL { Color.text } else { routeColor }
-    }
 
     var selectedTripIsCancelled: Bool {
         if let tripFilter {
@@ -93,11 +88,12 @@ struct StopDetailsFilteredDepartureDetails: View {
                     if let noPredictionsStatus {
                         StopDetailsNoTripCard(
                             status: noPredictionsStatus,
-                            headerColor: headerColor,
+                            accentColor: routeColor,
                             routeType: routeType
                         )
                     } else if selectedTripIsCancelled {
                         StopDetailsIconCard(
+                            accentColor: routeColor,
                             details: Text(
                                 "This trip has been cancelled. We’re sorry for the inconvenience.",
                                 comment: "Explanation for a cancelled trip on stop details"
@@ -106,7 +102,6 @@ struct StopDetailsFilteredDepartureDetails: View {
                                 "Trip cancelled",
                                 comment: "Header for a cancelled trip card on stop details"
                             ),
-                            headerColor: headerColor,
                             icon: routeSlashIcon(routeType)
                         )
                     } else {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsIconCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsIconCard.swift
@@ -1,0 +1,40 @@
+//
+//  StopDetailsIconCard.swift
+//  iosApp
+//
+//  Created by esimon on 1/7/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import shared
+import SwiftUI
+
+struct StopDetailsIconCard<Header: View, Details: View>: View {
+    var details: Details?
+    var header: Header
+    var headerColor: Color
+    var icon: Image
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 16) {
+                icon
+                    .resizable().scaledToFit()
+                    .frame(width: 35, height: 35)
+                    .foregroundStyle(headerColor)
+                    .frame(width: 48, height: 48)
+                header.font(Typography.title2Bold).foregroundStyle(headerColor)
+            }.frame(maxWidth: .infinity, alignment: .leading)
+
+            if let details {
+                HaloSeparator()
+                details.font(Typography.callout)
+            }
+        }
+        .padding(16)
+        .background(Color.fill3)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 1))
+        .padding(.horizontal, 16)
+    }
+}

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsIconCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsIconCard.swift
@@ -10,9 +10,9 @@ import shared
 import SwiftUI
 
 struct StopDetailsIconCard<Header: View, Details: View>: View {
+    var accentColor: Color
     var details: Details?
     var header: Header
-    var headerColor: Color
     var icon: Image
 
     var body: some View {
@@ -21,13 +21,15 @@ struct StopDetailsIconCard<Header: View, Details: View>: View {
                 icon
                     .resizable().scaledToFit()
                     .frame(width: 35, height: 35)
-                    .foregroundStyle(headerColor)
                     .frame(width: 48, height: 48)
-                header.font(Typography.title2Bold).foregroundStyle(headerColor)
+                    .foregroundStyle(accentColor)
+                header
+                    .font(Typography.title2Bold)
+                    .foregroundStyle(Color.text)
             }.frame(maxWidth: .infinity, alignment: .leading)
 
             if let details {
-                HaloSeparator()
+                Divider().frame(height: 2).background(accentColor.opacity(0.25))
                 details.font(Typography.callout)
             }
         }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
@@ -15,33 +15,23 @@ struct StopDetailsNoTripCard: View {
     var routeType: RouteType
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack(spacing: 16) {
-                headerImage.foregroundStyle(headerColor).frame(width: 48, height: 48)
-                headerText.font(Typography.title2Bold).foregroundStyle(headerColor)
-            }.frame(maxWidth: .infinity, alignment: .leading)
-
-            if let details = detailString {
-                HaloSeparator()
-                Text(details).font(Typography.callout)
-            }
-        }
-        .padding(16)
-        .background(Color.fill3)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 1))
-        .padding(.horizontal, 16)
+        StopDetailsIconCard(
+            details: detailText,
+            header: headerText,
+            headerColor: headerColor,
+            icon: headerImage
+        )
     }
 
-    var detailString: String? {
+    var detailText: Text? {
         switch onEnum(of: status) {
-        case .predictionsUnavailable: String(format: NSLocalizedString(
+        case .predictionsUnavailable: Text(String(format: NSLocalizedString(
                 "Service is running, but predicted arrival times aren’t available. The map shows where %@ on this route currently are.",
                 comment: """
                 Explanation under the 'Predictions unavailable' header in stop details.
                 The interpolated value can be "buses" or "trains".
                 """
-            ), routeType.typeText(isOnly: false))
+            ), routeType.typeText(isOnly: false)))
         default: nil
         }
     }
@@ -60,22 +50,10 @@ struct StopDetailsNoTripCard: View {
         }
     }
 
-    @ViewBuilder
-    var headerImage: some View {
+    var headerImage: Image {
         switch onEnum(of: status) {
         case .predictionsUnavailable: Image(.liveDataSlash)
-            .resizable().scaledToFit().frame(width: 35, height: 35)
-        case .noSchedulesToday, .serviceEndedToday: modeSlashImage
-            .resizable().scaledToFit().frame(width: 35, height: 35)
-        }
-    }
-
-    var modeSlashImage: Image {
-        switch routeType {
-        case .bus: Image(.modeBusSlash)
-        case .commuterRail: Image(.modeCrSlash)
-        case .ferry: Image(.modeFerrySlash)
-        default: Image(.modeSubwaySlash)
+        case .noSchedulesToday, .serviceEndedToday: routeSlashIcon(routeType)
         }
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
@@ -11,14 +11,14 @@ import SwiftUI
 
 struct StopDetailsNoTripCard: View {
     var status: RealtimePatterns.NoTripsFormat
-    var headerColor: Color
+    var accentColor: Color
     var routeType: RouteType
 
     var body: some View {
         StopDetailsIconCard(
+            accentColor: accentColor,
             details: detailText,
             header: headerText,
-            headerColor: headerColor,
             icon: headerImage
         )
     }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -240,6 +240,90 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(TripDetailsView.self))
     }
 
+    func testShowsCancelledTripCard() throws {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let route = objects.route { route in
+            route.id = "66"
+            route.type = .bus
+        }
+        let pattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: pattern)
+        let schedule = objects.schedule { schedule in
+            schedule.trip = trip
+            schedule.departureTime = now.addingTimeInterval(10).toKotlinInstant()
+        }
+        let prediction = objects.prediction(schedule: schedule) { prediction in
+            prediction.trip = trip
+            prediction.scheduleRelationship = .cancelled
+        }
+
+        let tile1 = TileData(
+            route: route,
+            headsign: "Harvard",
+            formatted: RealtimePatterns.FormatSome(
+                trips: [.init(
+                    id: trip.id, routeType: .bus,
+                    format: .Cancelled(
+                        scheduledTime: schedule.departureTime!
+                    )
+                )],
+                secondaryAlert: nil
+            )
+        )
+        let tile2 = TileData(
+            route: route,
+            headsign: tile1.headsign,
+            formatted: RealtimePatterns.FormatSome(
+                trips: [.init(id: "other", routeType: .bus, format: .Minutes(minutes: 3))],
+                secondaryAlert: nil
+            )
+        )
+        let sut = StopDetailsFilteredDepartureDetails(
+            stopId: stop.id,
+            stopFilter: .init(routeId: route.id, directionId: 0),
+            tripFilter: .init(tripId: trip.id, vehicleId: nil, stopSequence: nil, selectionLock: false),
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            tiles: [tile1, tile2],
+            noPredictionsStatus: nil,
+            alerts: [],
+            patternsByStop: .init(
+                routes: [route],
+                line: nil,
+                stop: stop,
+                patterns: [
+                    RealtimePatterns.ByHeadsign(
+                        route: route,
+                        headsign: "Harvard",
+                        line: nil,
+                        patterns: [pattern],
+                        upcomingTrips: [
+                            .init(trip: trip, schedule: schedule, prediction: prediction),
+                        ]
+                    ),
+                ], directions: [
+                    .init(name: "", destination: "", id: 0),
+                    .init(name: "", destination: "", id: 1),
+                ]
+            ),
+            pinned: false,
+            now: Date.now,
+            errorBannerVM: .init(),
+            nearbyVM: .init(),
+            mapVM: .init(),
+            stopDetailsVM: .init(),
+            viewportProvider: .init()
+        ).environmentObject(ViewportProvider())
+        XCTAssertNotNil(try sut.inspect().find(text: "Trip cancelled"))
+        XCTAssertNotNil(try sut.inspect()
+            .find(text: "This trip has been cancelled. We’re sorry for the inconvenience."))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "mode-bus-slash"
+        }))
+    }
+
     func testShowsNoTripCard() throws {
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -87,11 +87,21 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             return currentTripFilter
         }
 
-        val firstTrip: UpcomingTrip = relevantTrips.firstOrNull() ?: return null
+        var filterTrip: UpcomingTrip = relevantTrips.firstOrNull() ?: return null
+        var cancelIndex = 1
+        while (filterTrip.isCancelled && relevantTrips.size > cancelIndex) {
+            // If the auto trip filter would select a cancelled trip,
+            // select the next uncancelled trip instead
+            val nextTrip = relevantTrips[cancelIndex]
+            if (!nextTrip.isCancelled) {
+                filterTrip = nextTrip
+            }
+            cancelIndex++
+        }
         return TripDetailsFilter(
-            tripId = firstTrip.trip.id,
-            vehicleId = firstTrip.vehicle?.id,
-            stopSequence = firstTrip.stopSequence
+            tripId = filterTrip.trip.id,
+            vehicleId = filterTrip.vehicle?.id,
+            stopSequence = filterTrip.stopSequence
         )
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Combined Stop + Trip Details: Handle cancelled trip](https://app.asana.com/0/1205732265579288/1209010745257743/f)

Makes it possible to select cancelled trips on the stop page, and when you do, shows an explainer card saying that the trip is cancelled. Also includes a change to the auto trip filter logic to skip any cancelled trips and automatically select the first predicted or scheduled trip when you open stop details, so that cancelled trips must be manually tapped to be selected (unless there are only cancelled trips, in which case the first is selected).

![Simulator Screenshot - iPhone 15 - 2025-01-07 at 16 26 24](https://github.com/user-attachments/assets/ea219ba6-0c04-4b1a-998e-4aa7ddde6bfc)

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
~- [ ] All user-facing strings added to strings resource~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Manually tested with cancelled trips, added unit tests for auto trip filter changes and for UI changes.