### PR TITLE
fix: replace Coordinate with Position in NearbyRepository

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -31,7 +31,6 @@ import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
 import com.mbta.tid.mbta_app.android.util.LocalActivity
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.map.RouteLineData
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
@@ -245,7 +244,7 @@ class NearbyTransitPageTest : KoinTest {
                     object : INearbyRepository {
                         override suspend fun getNearby(
                             global: GlobalResponse,
-                            location: Coordinate
+                            location: Position
                         ): ApiResult<NearbyStaticData> {
                             val data = NearbyStaticData(global, NearbyResponse(builder))
                             return ApiResult.Ok(data)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -219,7 +218,7 @@ class NearbyTransitViewTest : KoinTest {
                     object : INearbyRepository {
                         override suspend fun getNearby(
                             global: GlobalResponse,
-                            location: Coordinate
+                            location: Position
                         ): ApiResult<NearbyStaticData> {
                             val data = NearbyStaticData(global, NearbyResponse(builder))
                             return ApiResult.Ok(data)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetNearbyTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetNearbyTest.kt
@@ -4,13 +4,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
+import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -27,16 +27,16 @@ class GetNearbyTest {
 
         val builder2 = ObjectCollectionBuilder()
 
-        val coordinate1 = Coordinate(0.0, 0.0)
-        val coordinate2 = Coordinate(1.0, 1.0)
+        val position1 = Position(0.0, 0.0)
+        val position2 = Position(1.0, 1.0)
 
         val nearbyRepository =
             object : INearbyRepository {
                 override suspend fun getNearby(
                     globalResponse: GlobalResponse,
-                    location: Coordinate
+                    location: Position
                 ): ApiResult<NearbyStaticData> {
-                    if (location == coordinate1) {
+                    if (location == position1) {
                         return ApiResult.Ok(
                             NearbyStaticData(globalResponse, NearbyResponse(builder1))
                         )
@@ -48,14 +48,14 @@ class GetNearbyTest {
                 }
             }
 
-        var coordinate by mutableStateOf(coordinate1)
+        var position by mutableStateOf(position1)
         var actualNearby: NearbyStaticData? = null
 
         composeTestRule.setContent {
             actualNearby =
                 getNearby(
                     globalResponse = globalResponse,
-                    location = coordinate1,
+                    location = position1,
                     setLastLocation = { /* null-op */},
                     setSelectingLocation = {},
                     nearbyRepository = nearbyRepository
@@ -65,7 +65,7 @@ class GetNearbyTest {
         composeTestRule.awaitIdle()
         assertEquals(NearbyStaticData(globalResponse, NearbyResponse(builder1)), actualNearby)
 
-        coordinate = coordinate2
+        position = position2
         composeTestRule.awaitIdle()
         assertEquals(NearbyStaticData(globalResponse, NearbyResponse(builder2)), actualNearby)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -33,6 +32,7 @@ import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
+import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
 import org.junit.Rule
@@ -162,7 +162,7 @@ class StopDetailsViewTest {
                     object : INearbyRepository {
                         override suspend fun getNearby(
                             global: GlobalResponse,
-                            location: Coordinate
+                            location: Position
                         ): ApiResult<NearbyStaticData> {
                             val data = NearbyStaticData(global, NearbyResponse(builder))
                             return ApiResult.Ok(data)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -24,7 +24,6 @@ import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
 import com.mbta.tid.mbta_app.android.util.timer
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopsAssociated
@@ -49,7 +48,7 @@ fun NearbyTransitView(
     var nearby: NearbyStaticData? =
         getNearby(
             globalResponse,
-            targetLocation?.let { Coordinate(latitude = it.latitude, longitude = it.longitude) },
+            targetLocation,
             setLastLocation,
             setSelectingLocation,
         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getNearby.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getNearby.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -21,7 +20,7 @@ import org.koin.compose.koinInject
 class NearbyViewModel(
     private val nearbyRepository: INearbyRepository,
     private val globalResponse: GlobalResponse?,
-    private val location: Coordinate?,
+    private val location: Position?,
     setLastLocation: (Position) -> Unit,
     setSelectingLocation: (Boolean) -> Unit,
 ) : ViewModel() {
@@ -34,16 +33,14 @@ class NearbyViewModel(
             nearbyResponse.collect {
                 if (globalResponse != null && location != null) {
                     getNearby(globalResponse, location)
-                    setLastLocation(
-                        Position(latitude = location.latitude, longitude = location.longitude)
-                    )
+                    setLastLocation(location)
                     setSelectingLocation(false)
                 }
             }
         }
     }
 
-    suspend fun getNearby(globalResponse: GlobalResponse, location: Coordinate) {
+    suspend fun getNearby(globalResponse: GlobalResponse, location: Position) {
         when (val data = nearbyRepository.getNearby(globalResponse, location)) {
             is ApiResult.Ok -> _nearbyResponse.emit(data.data)
             is ApiResult.Error -> TODO("handle errors")
@@ -59,7 +56,7 @@ class NearbyViewModel(
 @Composable
 fun getNearby(
     globalResponse: GlobalResponse?,
-    location: Coordinate?,
+    location: Position?,
     setLastLocation: (Position) -> Unit,
     setSelectingLocation: (Boolean) -> Unit,
     nearbyRepository: INearbyRepository = koinInject()

--- a/iosApp/iosApp/Utils/CoordinateExtension.swift
+++ b/iosApp/iosApp/Utils/CoordinateExtension.swift
@@ -21,8 +21,8 @@ extension CLLocationCoordinate2D {
             && longitude.rounded(toPlaces: 6) == other.longitude.rounded(toPlaces: 6)
     }
 
-    /// Convenience conversion to Kotlin Coordinate class
-    var coordinateKt: Coordinate {
-        Coordinate(latitude: latitude, longitude: longitude)
+    /// Convenience conversion to Kotlin Position class
+    var positionKt: GeojsonPosition {
+        GeojsonPosition(longitude: longitude, latitude: latitude)
     }
 }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -185,7 +185,7 @@ class NearbyViewModel: ObservableObject {
             await fetchApi(
                 errorBannerRepository,
                 errorKey: "NearbyViewModel.getNearby",
-                getData: { try await self.nearbyRepository.getNearby(global: global, location: location.coordinateKt) },
+                getData: { try await self.nearbyRepository.getNearby(global: global, location: location.positionKt) },
                 onSuccess: {
                     self.nearbyState.nearbyByRouteAndStop = $0
                     self.nearbyState.loadedLocation = location

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.endToEnd
 
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -52,6 +51,7 @@ import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.datetime.Clock
@@ -118,7 +118,7 @@ fun endToEndModule(): Module {
             object : INearbyRepository {
                 override suspend fun getNearby(
                     global: GlobalResponse,
-                    location: Coordinate
+                    location: Position
                 ): ApiResult<NearbyStaticData> =
                     ApiResult.Ok(
                         NearbyStaticData(global, NearbyResponse(listOf(stopParkStreet.id)))

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Coordinate.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Coordinate.kt
@@ -1,3 +1,0 @@
-package com.mbta.tid.mbta_app.model
-
-data class Coordinate(val latitude: Double, val longitude: Double)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.repositories
 
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -11,11 +10,11 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 
 interface INearbyRepository {
-    suspend fun getNearby(global: GlobalResponse, location: Coordinate): ApiResult<NearbyStaticData>
+    suspend fun getNearby(global: GlobalResponse, location: Position): ApiResult<NearbyStaticData>
 }
 
 class NearbyRepository : KoinComponent, INearbyRepository {
-    override suspend fun getNearby(global: GlobalResponse, location: Coordinate) =
+    override suspend fun getNearby(global: GlobalResponse, location: Position) =
         ApiResult.runCatching {
             val searchPosition =
                 Position(latitude = location.latitude, longitude = location.longitude)
@@ -61,7 +60,7 @@ class NearbyRepository : KoinComponent, INearbyRepository {
 class MockNearbyRepository : INearbyRepository {
     override suspend fun getNearby(
         global: GlobalResponse,
-        location: Coordinate
+        location: Position
     ): ApiResult<NearbyStaticData> {
         return ApiResult.Ok(NearbyStaticData(data = emptyList()))
     }
@@ -70,7 +69,7 @@ class MockNearbyRepository : INearbyRepository {
 class IdleNearbyRepository : INearbyRepository {
     override suspend fun getNearby(
         global: GlobalResponse,
-        location: Coordinate
+        location: Position
     ): ApiResult<NearbyStaticData> {
         return suspendCancellableCoroutine {}
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.repositories
 
-import com.mbta.tid.mbta_app.model.Coordinate
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
@@ -71,7 +70,7 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val staticData = runBlocking {
-            repo.getNearby(globalData, Coordinate(searchPoint.latitude, searchPoint.longitude))
+            repo.getNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
         }
 
         assertEquals(
@@ -118,7 +117,7 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val staticData = runBlocking {
-            repo.getNearby(globalData, Coordinate(searchPoint.latitude, searchPoint.longitude))
+            repo.getNearby(globalData, Position(latitude = searchPoint.latitude, longitude =  searchPoint.longitude))
         }
 
         assertEquals(
@@ -156,7 +155,7 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val staticData = runBlocking {
-            repo.getNearby(globalData, Coordinate(searchPoint.latitude, searchPoint.longitude))
+            repo.getNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
         }
 
         assertEquals(ApiResult.Ok(NearbyStaticData(emptyList())), staticData)


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Nearby | Reset state when panning or recentering](https://app.asana.com/0/1205732265579288/1208915825996354/f), tangentially

We should probably have caught this a while back, but we're already using the Spatial K Position in enough other places in `shared` that it doesn't make sense to also have our own `Coordinate` for just this one use case.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Checked that all related unit tests pass on Android and iOS.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
