### PR TITLE
feat(Android): error banner

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -1,0 +1,110 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.model.ErrorBannerState
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import org.junit.Rule
+import org.junit.Test
+
+class ErrorBannerTests {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testRespondsToState() {
+        val errorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
+        val viewModel = ErrorBannerViewModel(false, errorRepo, MockSettingsRepository())
+
+        composeTestRule.setContent {
+            LaunchedEffect(null) { viewModel.activate() }
+            ErrorBanner(viewModel)
+        }
+
+        composeTestRule.onNodeWithText("Unable to connect").assertExists()
+
+        errorRepo.mutableFlow.tryEmit(ErrorBannerState.DataError(emptySet(), {}))
+
+        composeTestRule.onNodeWithText("Error loading data").assertExists()
+
+        errorRepo.mutableFlow.tryEmit(
+            ErrorBannerState.StalePredictions(
+                lastUpdated = Clock.System.now().minus(2.minutes),
+                action = {}
+            )
+        )
+
+        composeTestRule.onNodeWithText("Updated 2 minutes ago").assertExists()
+    }
+
+    @Test
+    fun testNetworkError() {
+        val networkErrorRepo =
+            MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
+        val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo, MockSettingsRepository())
+
+        composeTestRule.setContent {
+            LaunchedEffect(null) { networkErrorVM.activate() }
+            ErrorBanner(networkErrorVM)
+        }
+
+        composeTestRule.onNodeWithText("Unable to connect").assertExists()
+    }
+
+    @Test
+    fun testDataError() {
+        val dataErrorRepo =
+            MockErrorBannerStateRepository(
+                state = ErrorBannerState.DataError(messages = emptySet(), action = {})
+            )
+        val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo, MockSettingsRepository())
+        composeTestRule.setContent {
+            LaunchedEffect(null) { dataErrorVM.activate() }
+            ErrorBanner(dataErrorVM)
+        }
+
+        composeTestRule.onNodeWithText("Error loading data").assertExists()
+    }
+
+    @Test
+    fun testPredictionsStale() {
+        val staleRepo =
+            MockErrorBannerStateRepository(
+                state =
+                    ErrorBannerState.StalePredictions(
+                        lastUpdated = Clock.System.now().minus(2.minutes),
+                        action = {}
+                    )
+            )
+        val staleVM = ErrorBannerViewModel(false, staleRepo, MockSettingsRepository())
+        composeTestRule.setContent {
+            LaunchedEffect(null) { staleVM.activate() }
+            ErrorBanner(staleVM)
+        }
+
+        composeTestRule.onNodeWithText("Updated 2 minutes ago").assertExists()
+    }
+
+    @Test
+    fun testLoadingWhenPredictionsStale() {
+        val staleRepo =
+            MockErrorBannerStateRepository(
+                state =
+                    ErrorBannerState.StalePredictions(
+                        lastUpdated = Clock.System.now().minus(2.minutes),
+                        action = {}
+                    )
+            )
+        val staleVM = ErrorBannerViewModel(true, staleRepo, MockSettingsRepository())
+        composeTestRule.setContent {
+            LaunchedEffect(null) { staleVM.activate() }
+            ErrorBanner(staleVM)
+        }
+
+        composeTestRule.onNodeWithText("Updated 2 minutes ago").assertDoesNotExist()
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -45,16 +45,20 @@ import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import io.github.dellisd.spatialk.geojson.Position
@@ -201,6 +205,8 @@ class NearbyTransitPageTest : KoinTest {
     val koinApplication = koinApplication {
         modules(
             module {
+                single<ISettingsRepository> { MockSettingsRepository() }
+                single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                 single<ISchedulesRepository> { MockScheduleRepository() }
                 single<IPredictionsRepository> {
                     object : IPredictionsRepository {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -18,11 +18,13 @@ import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
@@ -178,6 +180,8 @@ class NearbyTransitViewTest : KoinTest {
     val koinApplication = koinApplication {
         modules(
             module {
+                single<ISettingsRepository> { MockSettingsRepository() }
+                single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                 single<ISchedulesRepository> { MockScheduleRepository() }
                 single<IPredictionsRepository> {
                     object : IPredictionsRepository {
@@ -279,6 +283,8 @@ class NearbyTransitViewTest : KoinTest {
         val emptyNearbyKoinApplication = koinApplication {
             modules(
                 module {
+                    single<ISettingsRepository> { MockSettingsRepository() }
+                    single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                     single<INearbyRepository> { MockNearbyRepository() }
                     single<ISchedulesRepository> { MockScheduleRepository() }
                     single<IPredictionsRepository> {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -22,10 +23,12 @@ import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
@@ -247,7 +250,13 @@ class NearbyTransitViewTest : KoinTest {
                     setLastLocation = {},
                     setSelectingLocation = {},
                     onOpenStopDetails = { _, _ -> },
-                    noNearbyStopsView = {}
+                    noNearbyStopsView = {},
+                    errorBannerViewModel =
+                        ErrorBannerViewModel(
+                            false,
+                            MockErrorBannerStateRepository(),
+                            MockSettingsRepository()
+                        )
                 )
             }
         }
@@ -301,7 +310,13 @@ class NearbyTransitViewTest : KoinTest {
                     setLastLocation = {},
                     setSelectingLocation = {},
                     onOpenStopDetails = { _, _ -> },
-                    noNearbyStopsView = { Text("This would be the no nearby stops view") }
+                    noNearbyStopsView = { Text("This would be the no nearby stops view") },
+                    errorBannerViewModel =
+                        ErrorBannerViewModel(
+                            false,
+                            MockErrorBannerStateRepository(),
+                            MockSettingsRepository()
+                        )
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -17,8 +17,10 @@ import com.mbta.tid.mbta_app.model.SearchResults
 import com.mbta.tid.mbta_app.model.StopResult
 import com.mbta.tid.mbta_app.model.StopResultRoute
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -34,6 +36,7 @@ class SearchBarOverlayTest : KoinTest {
     val koinApplication = koinApplication {
         modules(
             module {
+                single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                 single<IGlobalRepository> { MockGlobalRepository() }
                 single<ISearchResultRepository> {
                     object : ISearchResultRepository {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -10,10 +10,13 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -49,7 +52,16 @@ class SubscribeToPredictionsTest {
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }
-            predictions = subscribeToPredictions(stopIds, predictionsRepo)
+            predictions =
+                subscribeToPredictions(
+                    stopIds,
+                    predictionsRepo,
+                    ErrorBannerViewModel(
+                        false,
+                        MockErrorBannerStateRepository(),
+                        MockSettingsRepository()
+                    )
+                )
         }
 
         composeTestRule.waitUntil { connectProps == listOf("place-a") }
@@ -90,7 +102,16 @@ class SubscribeToPredictionsTest {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 var stopIds by remember { stopIds }
-                predictions = subscribeToPredictions(stopIds, predictionsRepo)
+                predictions =
+                    subscribeToPredictions(
+                        stopIds,
+                        predictionsRepo,
+                        ErrorBannerViewModel(
+                            false,
+                            MockErrorBannerStateRepository(),
+                            MockSettingsRepository()
+                        )
+                    )
             }
         }
 
@@ -124,7 +145,16 @@ class SubscribeToPredictionsTest {
         var predictions: PredictionsStreamDataResponse? = null
 
         composeTestRule.setContent {
-            predictions = subscribeToPredictions(emptyList(), predictionsRepo)
+            predictions =
+                subscribeToPredictions(
+                    emptyList(),
+                    predictionsRepo,
+                    ErrorBannerViewModel(
+                        false,
+                        MockErrorBannerStateRepository(),
+                        MockSettingsRepository()
+                    )
+                )
         }
 
         composeTestRule.waitUntil { predictions != null }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -28,9 +29,11 @@ import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
@@ -230,7 +233,13 @@ class StopDetailsViewTest {
                     togglePinnedRoute = {},
                     onClose = {},
                     filter = filterState.value,
-                    updateStopFilter = filterState::value::set
+                    updateStopFilter = filterState::value::set,
+                    errorBannerViewModel =
+                        ErrorBannerViewModel(
+                            false,
+                            MockErrorBannerStateRepository(),
+                            MockSettingsRepository()
+                        )
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -23,6 +23,7 @@ import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -121,6 +122,7 @@ class StopDetailsViewTest {
     val koinApplication = koinApplication {
         modules(
             module {
+                single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                 single<ISchedulesRepository> { MockScheduleRepository() }
                 single<IPredictionsRepository> {
                     object : IPredictionsRepository {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -53,11 +53,7 @@ fun ErrorBanner(vm: ErrorBannerViewModel) {
             ErrorCard(
                 details = {
                     Row(verticalAlignment = Alignment.CenterVertically) {
-                        Icon(
-                            Icons.Rounded.Clear,
-                            contentDescription =
-                                "Displayed when the phone is not connected to the network"
-                        )
+                        Icon(Icons.Rounded.Clear, contentDescription = "")
                         Text(
                             stringResource(R.string.unable_to_connect),
                             modifier = Modifier.padding(start = 8.dp)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -1,0 +1,168 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Clear
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.ErrorBannerState
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+
+@Composable
+fun ErrorBanner(vm: ErrorBannerViewModel) {
+    val state by vm.errorState.collectAsState()
+    when (state) {
+        is ErrorBannerState.DataError -> {
+            ErrorCard(
+                details = { Text(stringResource(R.string.error_loading_data)) },
+                button = {
+                    RefreshButton(label = stringResource(R.string.reload_data)) {
+                        (state as ErrorBannerState.DataError).action()
+                        vm.clearState()
+                    }
+                }
+            )
+        }
+        is ErrorBannerState.NetworkError -> {
+            ErrorCard(
+                details = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Rounded.Clear,
+                            contentDescription =
+                                "Displayed when the phone is not connected to the network"
+                        )
+                        Text(
+                            stringResource(R.string.unable_to_connect),
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                        Spacer(Modifier.weight(1f))
+                    }
+                }
+            )
+        }
+        is ErrorBannerState.StalePredictions -> {
+            if (vm.loadingWhenPredictionsStale) {
+                Row(
+                    modifier = Modifier.heightIn(60.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    IndeterminateLoadingIndicator()
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            } else {
+                ErrorCard(
+                    details = {
+                        val minutes = (state as ErrorBannerState.StalePredictions).minutesAgo()
+                        Text(stringResource(R.string.updated_mins_ago, minutes))
+                    },
+                    button = {
+                        RefreshButton(label = stringResource(R.string.refresh_predictions)) {
+                            (state as ErrorBannerState.StalePredictions).action()
+                            vm.clearState()
+                        }
+                    }
+                )
+            }
+        }
+        null -> return
+    }
+}
+
+@Composable
+private fun ErrorCard(details: @Composable () -> Unit, button: (@Composable () -> Unit)? = null) {
+    Row(
+        modifier =
+            Modifier.padding(16.dp)
+                .heightIn(60.dp)
+                .background(Color.Gray.copy(alpha = 0.1f))
+                .clip(RoundedCornerShape(15.dp)),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.padding(horizontal = 8.dp)) { details() }
+        Spacer(Modifier.weight(1f))
+        if (button != null) {
+            Box(modifier = Modifier.padding(horizontal = 8.dp)) { button() }
+        }
+    }
+}
+
+@Composable
+private fun RefreshButton(
+    loading: Boolean = false,
+    label: String = stringResource(R.string.refresh),
+    action: () -> Unit
+) {
+    Button(onClick = action) {
+        Box {
+            if (loading) {
+                IndeterminateLoadingIndicator()
+            } else {
+                Icon(
+                    Icons.Rounded.Refresh,
+                    contentDescription = label,
+                    modifier = Modifier.width(20.dp)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ErrorBannerPreviews() {
+    val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
+    val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo, MockSettingsRepository())
+    val dataErrorRepo =
+        MockErrorBannerStateRepository(
+            state = ErrorBannerState.DataError(messages = emptySet(), action = {})
+        )
+    val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo, MockSettingsRepository())
+    val staleRepo =
+        MockErrorBannerStateRepository(
+            state =
+                ErrorBannerState.StalePredictions(
+                    lastUpdated = Clock.System.now().minus(2.minutes),
+                    action = {}
+                )
+        )
+    val staleVM = ErrorBannerViewModel(false, staleRepo, MockSettingsRepository())
+    val staleLoadingVM = ErrorBannerViewModel(true, staleRepo, MockSettingsRepository())
+    LaunchedEffect(null) { networkErrorVM.activate() }
+    LaunchedEffect(null) { dataErrorVM.activate() }
+    LaunchedEffect(null) { staleVM.activate() }
+    LaunchedEffect(null) { staleLoadingVM.activate() }
+    Column(verticalArrangement = Arrangement.SpaceEvenly) {
+        ErrorBanner(networkErrorVM)
+        ErrorBanner(dataErrorVM)
+        ErrorBanner(staleVM)
+        ErrorBanner(staleLoadingVM)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBannerViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBannerViewModel.kt
@@ -1,0 +1,51 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.mbta.tid.mbta_app.model.ErrorBannerState
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+
+class ErrorBannerViewModel(
+    var loadingWhenPredictionsStale: Boolean = false,
+    val errorRepository: IErrorBannerStateRepository,
+    val settingsRepository: ISettingsRepository
+) : ViewModel() {
+
+    private val _errorState = MutableStateFlow<ErrorBannerState?>(null)
+    val errorState: StateFlow<ErrorBannerState?> = _errorState.asStateFlow()
+
+    var showDebugMessages: Boolean = false
+
+    suspend fun activate() {
+        errorRepository.subscribeToNetworkStatusChanges()
+        showDebugMessages = settingsRepository.getSettings()[Settings.DevDebugMode] ?: false
+
+        errorRepository.state.onEach { _errorState.emit(it) }.collect()
+    }
+
+    fun clearState() {
+        errorRepository.clearState()
+    }
+
+    class Factory(
+        var loadingWhenPredictionsStale: Boolean = false,
+        val errorRepository: IErrorBannerStateRepository,
+        val settingsRepository: ISettingsRepository
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ErrorBannerViewModel(
+                loadingWhenPredictionsStale,
+                errorRepository,
+                settingsRepository
+            )
+                as T
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/IndeterminateLoadingIndicator.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/IndeterminateLoadingIndicator.kt
@@ -1,0 +1,17 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun IndeterminateLoadingIndicator(modifier: Modifier = Modifier.width(20.dp)) {
+    CircularProgressIndicator(
+        modifier = modifier,
+        color = MaterialTheme.colorScheme.secondary,
+        trackColor = MaterialTheme.colorScheme.surfaceVariant,
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.ErrorBanner
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
@@ -45,6 +47,7 @@ fun NearbyTransitView(
     onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
     noNearbyStopsView: @Composable () -> Unit,
     nearbyVM: NearbyTransitViewModel = koinViewModel(),
+    errorBannerViewModel: ErrorBannerViewModel
 ) {
     LaunchedEffect(targetLocation, globalResponse) {
         if (globalResponse != null && targetLocation != null) {
@@ -59,7 +62,7 @@ fun NearbyTransitView(
     val now = timer(updateInterval = 5.seconds)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
     val schedules = getSchedule(stopIds)
-    val predictions = subscribeToPredictions(stopIds)
+    val predictions = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)
 
     val (pinnedRoutes, togglePinnedRoute) = managePinnedRoutes()
 
@@ -100,7 +103,7 @@ fun NearbyTransitView(
                     .padding(bottom = 12.dp, start = 16.dp, end = 16.dp),
             style = MaterialTheme.typography.titleLarge
         )
-
+        ErrorBanner(errorBannerViewModel)
         if (nearbyWithRealtimeInfo == null) {
             Text(text = stringResource(R.string.loading))
         } else if (nearbyWithRealtimeInfo.isEmpty()) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
@@ -4,43 +4,55 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.android.util.isRoughlyEqualTo
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import io.github.dellisd.spatialk.geojson.Position
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class NearbyTransitViewModel(val nearbyRepository: INearbyRepository) : ViewModel() {
+class NearbyTransitViewModel(val nearbyRepository: INearbyRepository) : KoinComponent, ViewModel() {
     var loadedLocation by mutableStateOf<Position?>(null)
     var loading by mutableStateOf(false)
     var nearby by mutableStateOf<NearbyStaticData?>(null)
 
     private var fetchNearbyTask: Job? = null
 
-    suspend fun getNearby(
+    private val errorBannerRepository: IErrorBannerStateRepository by inject()
+
+    fun getNearby(
         globalResponse: GlobalResponse,
         location: Position,
         setLastLocation: (Position) -> Unit,
         setSelectingLocation: (Boolean) -> Unit
     ) {
-        withContext(Dispatchers.IO) {
+        CoroutineScope(Dispatchers.IO).launch {
             if (loadedLocation?.isRoughlyEqualTo(location) == true) {
-                return@withContext
+                return@launch
             }
             if (loading) {
                 fetchNearbyTask?.cancel()
             }
             fetchNearbyTask = launch {
                 loading = true
-                when (val data = nearbyRepository.getNearby(globalResponse, location)) {
-                    is ApiResult.Ok -> nearby = data.data
-                    is ApiResult.Error -> TODO("handle errors")
-                }
+                fetchApi(
+                    errorBannerRepo = errorBannerRepository,
+                    errorKey = "NearbyViewModel.getNearby",
+                    getData = { nearbyRepository.getNearby(globalResponse, location) },
+                    onSuccess = { nearby = it },
+                    onRefreshAfterError = {
+                        getNearby(globalResponse, location, setLastLocation, setSelectingLocation)
+                    }
+                )
                 loading = false
                 setLastLocation(location)
                 setSelectingLocation(false)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.android.util.isRoughlyEqualTo
 import com.mbta.tid.mbta_app.model.NearbyStaticData
-import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
@@ -16,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -37,8 +37,8 @@ import androidx.navigation.toRoute
 import com.mapbox.maps.MapboxExperimental
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DragHandle
-import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.component.sheet.SheetValue

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -38,6 +38,7 @@ import com.mapbox.maps.MapboxExperimental
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DragHandle
 import com.mbta.tid.mbta_app.android.component.LocationAuthButton
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.component.sheet.SheetValue
@@ -61,6 +62,7 @@ import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
+import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
 data class NearbyTransit(
@@ -86,8 +88,17 @@ fun NearbyTransitPage(
     showNavBar: () -> Unit,
     hideNavBar: () -> Unit,
     bottomBar: @Composable () -> Unit,
-    mapViewModel: IMapViewModel = viewModel(factory = MapViewModel.Factory())
+    mapViewModel: IMapViewModel = viewModel(factory = MapViewModel.Factory()),
+    errorBannerViewModel: ErrorBannerViewModel =
+        viewModel(
+            factory =
+                ErrorBannerViewModel.Factory(
+                    errorRepository = koinInject(),
+                    settingsRepository = koinInject()
+                )
+        )
 ) {
+    LaunchedEffect(Unit) { errorBannerViewModel.activate() }
     val navController = rememberNavController()
     val currentNavEntry: NavBackStackEntry? by
         navController.currentBackStackEntryFlow.collectAsStateWithLifecycle(initialValue = null)
@@ -189,7 +200,8 @@ fun NearbyTransitPage(
                         nearbyTransit.alertData,
                         onClose = { navController.popBackStack() },
                         updateStopFilter = ::updateStopFilter,
-                        updateDepartures = ::updateStopDepartures
+                        updateDepartures = ::updateStopDepartures,
+                        errorBannerViewModel = errorBannerViewModel
                     )
                 }
             }
@@ -264,7 +276,8 @@ fun NearbyTransitPage(
                                 ::openSearch,
                                 ::panToDefaultCenter
                             )
-                        }
+                        },
+                        errorBannerViewModel = errorBannerViewModel
                     )
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import com.mapbox.maps.MapboxExperimental
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
@@ -31,10 +32,15 @@ fun StopDetailsPage(
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,
     updateDepartures: (StopDetailsDepartures?) -> Unit,
+    errorBannerViewModel: ErrorBannerViewModel
 ) {
     val globalResponse = getGlobalData()
 
-    val predictionsResponse = subscribeToPredictions(stopIds = listOf(stop.id))
+    val predictionsResponse =
+        subscribeToPredictions(
+            stopIds = listOf(stop.id),
+            errorBannerViewModel = errorBannerViewModel
+        )
 
     val now = timer(updateInterval = 5.seconds)
 
@@ -79,5 +85,6 @@ fun StopDetailsPage(
         togglePinnedRoute,
         onClose,
         updateStopFilter,
+        errorBannerViewModel
     )
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.ErrorBanner
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.timer
@@ -30,6 +32,7 @@ fun StopDetailsView(
     togglePinnedRoute: (String) -> Unit,
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,
+    errorBannerViewModel: ErrorBannerViewModel
 ) {
     val globalResponse = getGlobalData()
 
@@ -86,6 +89,8 @@ fun StopDetailsView(
                     .border(2.dp, colorResource(R.color.halo))
             )
         }
+
+        ErrorBanner(errorBannerViewModel)
 
         if (departures != null) {
             StopDetailsRoutesView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
@@ -1,0 +1,33 @@
+package com.mbta.tid.mbta_app.android.util
+
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+
+/**
+ * If `getData` returns an `ApiResultOk`, clears any preexisting data error in `errorKey` in
+ * `errorBannerRepo` and calls `onSuccess`. If `getData` returns an `ApiResultError` or throws, sets
+ * an error in `errorKey` in `errorBannerRepo` with the given `onRefreshAfterError`.
+ */
+suspend fun <T : Any> fetchApi(
+    errorBannerRepo: IErrorBannerStateRepository,
+    errorKey: String,
+    getData: suspend () -> ApiResult<T>,
+    onSuccess: suspend (T) -> Unit = {},
+    onRefreshAfterError: () -> Unit
+) {
+    val result: ApiResult<T> =
+        try {
+            getData()
+        } catch (e: Exception) {
+            ApiResult.Error(code = null, message = e.message ?: "No error message")
+        }
+    when (result) {
+        is ApiResult.Error -> {
+            errorBannerRepo.setDataError(key = errorKey, action = onRefreshAfterError)
+        }
+        is ApiResult.Ok -> {
+            errorBannerRepo.clearDataError(key = errorKey)
+            onSuccess(result.data)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
@@ -19,7 +19,7 @@ suspend fun <T : Any> fetchApi(
         try {
             getData()
         } catch (e: Exception) {
-            ApiResult.Error(code = null, message = e.message ?: "No error message")
+            ApiResult.Error(code = null, message = e.message ?: "")
         }
     when (result) {
         is ApiResult.Error -> {

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">Desvío</string>
     <string name="directionTo">%1$s a</string>
     <string name="eastbound">En dirección este</string>
+    <string name="error_loading_data">Error al cargar datos</string>
     <string name="feature_flag_debug_mode">Modo de Depuración</string>
     <string name="feature_flag_route_search">Buscador de rutas</string>
     <string name="feedback_link_form">Enviar comentarios sobre la aplicación</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">Ver código fuente en GitHub</string>
     <string name="other_link_tos">Términos de uso</string>
     <string name="outbound">Saliente</string>
+    <string name="refresh">Refrescar</string>
+    <string name="refresh_predictions">Refrescar predicciones</string>
+    <string name="reload_data">Recargar datos</string>
     <string name="resources_link_fare_info">Información de tarifas</string>
     <string name="resources_link_mticket">Boletos de tren de cercanías y ferri</string>
     <string name="resources_link_mticket_note">mTicket App</string>
@@ -80,6 +84,7 @@
     <string name="suspension">Suspensión</string>
     <string name="train">tren</string>
     <string name="trains">trenes</string>
+    <string name="unable_to_connect">No se puede conectar</string>
     <string name="unstar_route_hint">desanclar ruta de la parte superior de la lista</string>
     <string name="vehicle_arriving_first">%1$s está llegando ahora</string>
     <string name="vehicle_arriving_other">y llegando ahora</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">Detou</string>
     <string name="directionTo">%1$s pou</string>
     <string name="eastbound">Pran direksyon lès</string>
+    <string name="error_loading_data">Erè nan chajman done</string>
     <string name="feature_flag_debug_mode">Mòd Debug</string>
     <string name="feature_flag_route_search">Rechèch Wout</string>
     <string name="feedback_link_form">Voye kòmantè sou aplikasyon</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">Gade sous sou GitHub</string>
     <string name="other_link_tos">Kondisyon itilizasyon</string>
     <string name="outbound">Soti</string>
+    <string name="refresh">Rafrechi</string>
+    <string name="refresh_predictions">Rafrechi prediksyon</string>
+    <string name="reload_data">Rechaje done</string>
     <string name="resources_link_fare_info">Enfòmasyon Tarif</string>
     <string name="resources_link_mticket">Tikè Tren Vil la ak Bato</string>
     <string name="resources_link_mticket_note">Aplikasyon mTicket</string>
@@ -80,6 +84,7 @@
     <string name="suspension">Sispansyon</string>
     <string name="train">tren</string>
     <string name="trains">tren yo</string>
+    <string name="unable_to_connect">Pa ka konekte</string>
     <string name="unstar_route_hint">retire wout ki soti anlè lis la</string>
     <string name="vehicle_arriving_first">%1$s ap rive kounye a</string>
     <string name="vehicle_arriving_other">ap rive kounye a</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">Desvio</string>
     <string name="directionTo">%1$s para</string>
     <string name="eastbound">Sentido leste</string>
+    <string name="error_loading_data">Erro ao carregar dados</string>
     <string name="feature_flag_debug_mode">Modo de depuração</string>
     <string name="feature_flag_route_search">Pesquisa de rotas</string>
     <string name="feedback_link_form">Enviar comentário no aplicativo</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">Exibir origem no GitHub</string>
     <string name="other_link_tos">Termos de Uso</string>
     <string name="outbound">Saída</string>
+    <string name="refresh">Atualizar</string>
+    <string name="refresh_predictions">Atualizar previsões</string>
+    <string name="reload_data">Recarregar dados</string>
     <string name="resources_link_fare_info">Informações sobre tarifas</string>
     <string name="resources_link_mticket">Bilhetes de transporte diário por trem e balsa</string>
     <string name="resources_link_mticket_note">Aplicativo mTicket</string>
@@ -80,6 +84,7 @@
     <string name="suspension">Suspensão</string>
     <string name="train">trem</string>
     <string name="trains">trens</string>
+    <string name="unable_to_connect">Impossível conectar</string>
     <string name="unstar_route_hint">desafixar a rota do topo da lista</string>
     <string name="vehicle_arriving_first">%1$s chegando agora</string>
     <string name="vehicle_arriving_other">e chegando agora</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">Đường vòng</string>
     <string name="directionTo">%1$s đến</string>
     <string name="eastbound">Về hướng đông</string>
+    <string name="error_loading_data">Lỗi khi tải dữ liệu</string>
     <string name="feature_flag_debug_mode">Chế độ gỡ lỗi</string>
     <string name="feature_flag_route_search">Tìm kiếm tuyến đường</string>
     <string name="feedback_link_form">Gửi ý phản hồi về ứng dụng</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">Xem nguồn trên GitHub</string>
     <string name="other_link_tos">Điều khoản sử dụng</string>
     <string name="outbound">Đi</string>
+    <string name="refresh">Làm mới</string>
+    <string name="refresh_predictions">Làm mới dự đoán</string>
+    <string name="reload_data">Tải lại dữ liệu</string>
     <string name="resources_link_fare_info">Thông tin giá vé</string>
     <string name="resources_link_mticket">Vé phà vé đường sắt ngoại ô (Commuter Rail)</string>
     <string name="resources_link_mticket_note">Ứng dụng mTicket</string>
@@ -80,6 +84,7 @@
     <string name="suspension">Đình chỉ</string>
     <string name="train">tàu</string>
     <string name="trains">tàu</string>
+    <string name="unable_to_connect">Không thể kết nối</string>
     <string name="unstar_route_hint">bỏ ghim tuyến đường khỏi đầu danh sách</string>
     <string name="vehicle_arriving_first">%1$s đang đến</string>
     <string name="vehicle_arriving_other">và đang đến</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">交通改道</string>
     <string name="directionTo">%1$s至</string>
     <string name="eastbound">东行</string>
+    <string name="error_loading_data">加载数据时出错</string>
     <string name="feature_flag_debug_mode">调试模式</string>
     <string name="feature_flag_route_search">线路搜索</string>
     <string name="feedback_link_form">发送应用程序反馈</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">在GitHub上查看源代码</string>
     <string name="other_link_tos">使用条款</string>
     <string name="outbound">出站</string>
+    <string name="refresh">刷新</string>
+    <string name="refresh_predictions">刷新预测</string>
+    <string name="reload_data">重新加载数据</string>
     <string name="resources_link_fare_info">票价信息</string>
     <string name="resources_link_mticket">通勤列车和轮渡票</string>
     <string name="resources_link_mticket_note">mTicket应用程序</string>
@@ -80,6 +84,7 @@
     <string name="suspension">暂停</string>
     <string name="train">列车</string>
     <string name="trains">列车</string>
+    <string name="unable_to_connect">无法连接</string>
     <string name="unstar_route_hint">从列表顶部取消固定路线</string>
     <string name="vehicle_arriving_first">%1$s现已到站</string>
     <string name="vehicle_arriving_other">下一趟车现已到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -12,6 +12,7 @@
     <string name="detour">交通改道</string>
     <string name="directionTo">%1$s至</string>
     <string name="eastbound">東行</string>
+    <string name="error_loading_data">載入資料時發生錯誤</string>
     <string name="feature_flag_debug_mode">調試模式</string>
     <string name="feature_flag_route_search">線路搜尋</string>
     <string name="feedback_link_form">傳送應用程式回饋</string>
@@ -62,6 +63,9 @@
     <string name="other_link_source_code">在GitHub上查看原始程式碼</string>
     <string name="other_link_tos">使用條款</string>
     <string name="outbound">出站</string>
+    <string name="refresh">重新整理</string>
+    <string name="refresh_predictions">重新整理預測</string>
+    <string name="reload_data">重新載入資料</string>
     <string name="resources_link_fare_info">票價資訊</string>
     <string name="resources_link_mticket">通勤列車和輪渡票</string>
     <string name="resources_link_mticket_note">mTicket應用程式</string>
@@ -80,6 +84,7 @@
     <string name="suspension">暫停</string>
     <string name="train">列車</string>
     <string name="trains">列車</string>
+    <string name="unable_to_connect">無法連接</string>
     <string name="unstar_route_hint">從清單頂部取消固定路線</string>
     <string name="vehicle_arriving_first">%1$s現已到站</string>
     <string name="vehicle_arriving_other">下一趟車現已到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -98,5 +98,10 @@
     <string name="westbound">Westbound</string>
     <string name="stop_filter_pills_filter_hint">Apply a filter so that only arrivals from this route are displayed</string>
     <string name="stop_filter_pills_remove_hint">Remove the filter and display all routes</string>
-
+    <string name="refresh">Refresh</string>
+    <string name="refresh_predictions">Refresh predictions</string>
+    <string name="updated_mins_ago">Updated %1$d minutes ago</string>
+    <string name="unable_to_connect">Unable to connect</string>
+    <string name="reload_data">Reload data</string>
+    <string name="error_loading_data">Error loading data</string>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -100,7 +100,7 @@
     <string name="stop_filter_pills_remove_hint">Remove the filter and display all routes</string>
     <string name="refresh">Refresh</string>
     <string name="refresh_predictions">Refresh predictions</string>
-    <string name="updated_mins_ago">Updated %1$d minutes ago</string>
+    <string name="updated_mins_ago" tools:ignore="MissingTranslation">Updated %1$d minutes ago</string>
     <string name="unable_to_connect">Unable to connect</string>
     <string name="reload_data">Reload data</string>
     <string name="error_loading_data">Error loading data</string>


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Nearby | Display error banners](https://app.asana.com/0/1205732265579288/1208968297244757/f)

What is this PR for?

Adding the error banner on Android for nearby transit.

![Screenshot_20250108_081216](https://github.com/user-attachments/assets/e5b06bcc-21fe-478e-a38d-59ec73633e25)

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Added previews and automated tests for various error banner states.
