### PR TITLE
Revert "build(deps): bump org.cyclonedx:cyclonedx-core-java from 9.0.5 to 10.1.0"

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.cyclonedx:cyclonedx-core-java:10.1.0")
+    implementation("org.cyclonedx:cyclonedx-core-java:9.0.5")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 }
 


### PR DESCRIPTION
Reverts mbta/mobile_app#624

This started breaking iOS builds, this file wasn't set to run the iOS workflows, so there wasn't an indication in the PR that anything was wrong.