### PR TITLE
fix: accept null vehicle direction id

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		8C2F26962CDD709700386D4F /* NoNearbyStopsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2F26952CDD709700386D4F /* NoNearbyStopsView.swift */; };
 		8C2F26982CDE7B3600386D4F /* NoNearbyStopsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2F26972CDE7B3600386D4F /* NoNearbyStopsViewTests.swift */; };
 		8C3D64102BE19DBA0026DD53 /* MorePage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3D640F2BE19DBA0026DD53 /* MorePage.swift */; };
+		8C4E22672D2F04DE00616C42 /* KotlinIntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4E22662D2F04DE00616C42 /* KotlinIntExtension.swift */; };
 		8C5054582BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5054572BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift */; };
 		8C5054A02CA47C3C00137CFE /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C50549F2CA47C3C00137CFE /* ErrorBanner.swift */; };
 		8C5F47662C40842200FB71DA /* TripDetailsStopViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5F47652C40842200FB71DA /* TripDetailsStopViewTests.swift */; };
@@ -378,6 +379,7 @@
 		8C349BB72B754F2600AC7FFB /* 10 Park Plaza.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "10 Park Plaza.gpx"; sourceTree = "<group>"; };
 		8C3D640F2BE19DBA0026DD53 /* MorePage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorePage.swift; sourceTree = "<group>"; };
 		8C42F06F2B890BC800F9A77B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8C4E22662D2F04DE00616C42 /* KotlinIntExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KotlinIntExtension.swift; sourceTree = "<group>"; };
 		8C5054572BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyStopDetailsPage.swift; sourceTree = "<group>"; };
 		8C50549F2CA47C3C00137CFE /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		8C5F47652C40842200FB71DA /* TripDetailsStopViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailsStopViewTests.swift; sourceTree = "<group>"; };
@@ -1101,6 +1103,7 @@
 				9A6DDF902B976FDF004D141A /* EmptyWhenModifier.swift */,
 				8CE36C8E2CAB231500D77F22 /* FetchApi.swift */,
 				9ADB849C2BAD05BC006581CE /* Inspection.swift */,
+				8C4E22662D2F04DE00616C42 /* KotlinIntExtension.swift */,
 				8CE1D6752CC9690400E3BDB1 /* LoadingPlaceholderModifier.swift */,
 				8CD79F102C46F6E200AFF17D /* MapboxBridge.swift */,
 				9A3B09352B967CEC00691427 /* NonNilModifier.swift */,
@@ -1574,6 +1577,7 @@
 				6EE7457E2B965ADE0052227E /* Socket.swift in Sources */,
 				9A5B27582BB22BF9009A6FC6 /* MapLayerManager.swift in Sources */,
 				9A03F3662BA9E68500DA40DC /* Debouncer.swift in Sources */,
+				8C4E22672D2F04DE00616C42 /* KotlinIntExtension.swift in Sources */,
 				8CE014102BBDB8DC00918FAE /* StopDetailsRoutesView.swift in Sources */,
 				ED93D6042CB6C0B4003B1C12 /* StopResultsView.swift in Sources */,
 				6EA231712C21BF8900789173 /* RoundedBorderModifier.swift in Sources */,

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -296,6 +296,10 @@ extension HomeMapView {
             // TODO: figure out something to do if this is nil
             return
         }
+        guard let directionId = vehicle.directionId?.int32Value ?? trip?.trip.directionId else {
+            // TODO: figure out something to do if this is nil
+            return
+        }
 
         // If we're missing the stop ID or stop sequence, we can still navigate to the trip details
         // page, but we won't be able to tell what the target stop was.
@@ -307,7 +311,7 @@ extension HomeMapView {
                 stopSequence: stopSequence
             ) : nil,
             routeId: routeId,
-            directionId: vehicle.directionId
+            directionId: directionId
         ), mapSelection: true)
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -94,7 +94,7 @@ struct TripDetailsView: View {
                let global = stopDetailsVM.global,
                let stops = TripDetailsStopList.companion.fromPieces(
                    tripId: tripFilter.tripId,
-                   directionId: tripData.trip.directionId,
+                   directionId: KotlinInt(int: tripData.trip.directionId),
                    tripSchedules: tripData.tripSchedules,
                    tripPredictions: tripData.tripPredictions,
                    vehicle: vehicle,

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -83,7 +83,7 @@ struct TripDetailsPage: View {
             if tripPredictionsLoaded, let globalResponse, let vehicle = vehicleResponse?.vehicle,
                let stops = TripDetailsStopList.companion.fromPieces(
                    tripId: tripId,
-                   directionId: trip?.directionId ?? vehicle.directionId,
+                   directionId: KotlinInt(int: trip?.directionId) ?? vehicle.directionId,
                    tripSchedules: tripSchedulesResponse,
                    tripPredictions: tripPredictions,
                    vehicle: vehicle,

--- a/iosApp/iosApp/Utils/KotlinIntExtension.swift
+++ b/iosApp/iosApp/Utils/KotlinIntExtension.swift
@@ -1,0 +1,16 @@
+//
+//  KotlinIntExtension.swift
+//  iosApp
+//
+//  Created by Horn, Melody on 2025-01-08.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import shared
+
+extension KotlinInt {
+    convenience init?(int: Int32?) {
+        guard let int else { return nil }
+        self.init(int: int)
+    }
+}

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -551,7 +551,7 @@ final class HomeMapViewTests: XCTestCase {
 
         let initialNav: SheetNavigationStackEntry = .legacyStopDetails(
             stop,
-            .init(routeId: vehicle.routeId!, directionId: vehicle.directionId)
+            .init(routeId: vehicle.routeId!, directionId: vehicle.directionId!.int32Value)
         )
         nearbyVM.navigationStack = [initialNav]
         let locationDataManager: LocationDataManager = .init(locationFetcher: MockLocationFetcher())
@@ -656,7 +656,7 @@ final class HomeMapViewTests: XCTestCase {
 
         let initialNav: SheetNavigationStackEntry = .legacyStopDetails(
             stop,
-            .init(routeId: vehicle1.routeId!, directionId: vehicle1.directionId)
+            .init(routeId: vehicle1.routeId!, directionId: vehicle1.directionId!.int32Value)
         )
         let mapVM: MapViewModel = .init(
             allRailSourceData: MapTestDataHelper.shared.routeResponse.routesWithSegmentedShapes,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -143,7 +143,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
 
         fun fromPieces(
             tripId: String,
-            directionId: Int,
+            directionId: Int?,
             tripSchedules: TripSchedulesResponse?,
             tripPredictions: PredictionsStreamDataResponse?,
             vehicle: Vehicle?,
@@ -396,7 +396,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             alertsData: AlertsStreamDataResponse?,
             globalData: GlobalResponse,
             tripId: String,
-            directionId: Int
+            directionId: Int?
         ): Alert? {
             val entryTime = entry.prediction?.predictionTime ?: entry.schedule?.scheduleTime
             val entryRoute = entry.prediction?.routeId ?: entry.schedule?.routeId

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -11,7 +11,7 @@ data class Vehicle(
     val bearing: Double?,
     @SerialName("current_status") val currentStatus: CurrentStatus,
     @SerialName("current_stop_sequence") val currentStopSequence: Int?,
-    @SerialName("direction_id") val directionId: Int,
+    @SerialName("direction_id") val directionId: Int?,
     val latitude: Double,
     val longitude: Double,
     @SerialName("updated_at") val updatedAt: Instant,


### PR DESCRIPTION
### Summary

_Ticket:_ none

Saw this on a bus this morning while testing an unrelated change.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Checked that both iOS and Android tests still compile and pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
