### PR TITLE
fix(Android): reset nearby transit state on pan/recenter

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.state
 
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,7 +53,7 @@ class SubscribeToPredictionsTest {
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }
-            predictions =
+            val predictionsVM =
                 subscribeToPredictions(
                     stopIds,
                     predictionsRepo,
@@ -62,6 +63,7 @@ class SubscribeToPredictionsTest {
                         MockSettingsRepository()
                     )
                 )
+            predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
         composeTestRule.waitUntil { connectProps == listOf("place-a") }
@@ -102,7 +104,7 @@ class SubscribeToPredictionsTest {
         composeTestRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 var stopIds by remember { stopIds }
-                predictions =
+                val predictionsVM =
                     subscribeToPredictions(
                         stopIds,
                         predictionsRepo,
@@ -112,6 +114,7 @@ class SubscribeToPredictionsTest {
                             MockSettingsRepository()
                         )
                     )
+                predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
             }
         }
 
@@ -145,7 +148,7 @@ class SubscribeToPredictionsTest {
         var predictions: PredictionsStreamDataResponse? = null
 
         composeTestRule.setContent {
-            predictions =
+            val predictionsVM =
                 subscribeToPredictions(
                     emptyList(),
                     predictionsRepo,
@@ -155,6 +158,7 @@ class SubscribeToPredictionsTest {
                         MockSettingsRepository()
                     )
                 )
+            predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
         composeTestRule.waitUntil { predictions != null }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -13,7 +13,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -67,7 +69,13 @@ fun NearbyTransitView(
     val now = timer(updateInterval = 5.seconds)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
     val schedules = getSchedule(stopIds)
-    val predictions = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)
+    val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)
+    val predictions by predictionsVM.predictionsFlow.collectAsState(initial = null)
+    LaunchedEffect(targetLocation == null) {
+        if (targetLocation == null) {
+            predictionsVM.reset()
+        }
+    }
 
     val (pinnedRoutes, togglePinnedRoute) = managePinnedRoutes()
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -46,6 +46,7 @@ import com.mbta.tid.mbta_app.android.map.IMapViewModel
 import com.mbta.tid.mbta_app.android.map.MapViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitTabViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitView
+import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NoNearbyStopsView
 import com.mbta.tid.mbta_app.android.search.SearchBarOverlay
 import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
@@ -64,6 +65,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
+import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -216,6 +218,8 @@ fun NearbyTransitPage(
                 }
             }
             composable<SheetRoutes.NearbyTransit> {
+                // for ViewModel reasons, must be within the `composable` to be the same instance
+                val nearbyViewModel: NearbyTransitViewModel = koinViewModel()
                 LaunchedEffect(true) {
                     if (!navBarVisible) {
                         showNavBar()
@@ -234,13 +238,13 @@ fun NearbyTransitPage(
                 }
                 LaunchedEffect(nearbyTransit.viewportProvider.isManuallyCentering) {
                     if (nearbyTransit.viewportProvider.isManuallyCentering) {
-                        // TODO reset view model
+                        nearbyViewModel.reset()
                         targetLocation = null
                     }
                 }
                 LaunchedEffect(nearbyTransit.viewportProvider.isFollowingPuck) {
                     if (nearbyTransit.viewportProvider.isFollowingPuck) {
-                        // TODO reset view model
+                        nearbyViewModel.reset()
                         targetLocation = null
                     }
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -3,6 +3,8 @@ package com.mbta.tid.mbta_app.android.pages
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.mapbox.maps.MapboxExperimental
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
@@ -36,11 +38,12 @@ fun StopDetailsPage(
 ) {
     val globalResponse = getGlobalData()
 
-    val predictionsResponse =
+    val predictionsVM =
         subscribeToPredictions(
             stopIds = listOf(stop.id),
             errorBannerViewModel = errorBannerViewModel
         )
+    val predictionsResponse by predictionsVM.predictionsFlow.collectAsState(initial = null)
 
     val now = timer(updateInterval = 5.seconds)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
@@ -20,7 +20,9 @@ value class PhoenixSocketWrapper(private val socket: Socket) : PhoenixSocket {
 
     fun attachLogging() {
         socket.onMessage { message -> Log.i("Socket", message.toString()) }
-        socket.onError { throwable, response -> Log.e("Socket", response.toString(), throwable) }
+        socket.onError { throwable, response ->
+            Log.e("Socket", response?.toString() ?: throwable.toString(), throwable)
+        }
     }
 }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -45,6 +45,9 @@ class PredictionsViewModel(
         currentStopIds = stopIds
         if (stopIds != null) {
             predictionsRepository.connectV2(stopIds, ::handleJoinMessage, ::handlePushMessage)
+        } else {
+            // reset predictions if nearby stop list has been reset
+            _predictions.value = null
         }
     }
 
@@ -88,7 +91,6 @@ class PredictionsViewModel(
 
     fun disconnect() {
         predictionsRepository.disconnect()
-        _predictions.value = null
         errorBannerViewModel.loadingWhenPredictionsStale = true
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -88,6 +88,7 @@ class PredictionsViewModel(
 
     fun disconnect() {
         predictionsRepository.disconnect()
+        _predictions.value = null
         errorBannerViewModel.loadingWhenPredictionsStale = true
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Nearby | Reset state when panning or recentering](https://app.asana.com/0/1205732265579288/1208915825996354/f)

I thought this would be easy, and if I knew one more thing about ViewModels it would've been easy, but I did not, so this was really difficult.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manually verified that the ViewModel gets reset and the stale data does not flash in for a frame or two.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
