### PR TITLE
fix(Android): make flakiest tests more robust

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -33,6 +33,7 @@ class MoreViewModelTests {
         composeTestRule.awaitIdle()
         vm!!.toggleSetting(Settings.HideMaps)
         composeTestRule.awaitIdle()
+        composeTestRule.waitUntil { toggledHideMaps }
 
         assertTrue { toggledHideMaps }
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.pages
 
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -56,10 +57,12 @@ class MorePageTests : KoinTest {
         composeTestRule.onNodeWithText("Hide Maps").performClick()
 
         composeTestRule.awaitIdle()
+        composeTestRule.waitUntil { hideMapToggleCalled }
 
         assertTrue { hideMapToggleCalled }
     }
 
+    @OptIn(ExperimentalTestApi::class)
     @Test
     fun testLinksExist() {
         val koinApplication = koinApplication {
@@ -73,11 +76,15 @@ class MorePageTests : KoinTest {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }
 
+        composeTestRule.waitUntilExactlyOneExists(hasText("Send app feedback"))
         composeTestRule.onNodeWithText("Send app feedback").assertIsDisplayed()
         composeTestRule.onNodeWithText("Trip Planner").assertIsDisplayed()
         composeTestRule.onNodeWithText("Fare Information").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Commuter Rail and Ferry tickets").performScrollTo()
         composeTestRule.onNodeWithText("Commuter Rail and Ferry tickets").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Terms of Use").performScrollTo()
         composeTestRule.onNodeWithText("Terms of Use").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Privacy Policy").performScrollTo()
         composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
         composeTestRule.onNode(hasText("View source on GitHub")).performScrollTo()
         composeTestRule.onNodeWithText("View source on GitHub").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
@@ -46,6 +46,7 @@ class GetGlobalDataTest {
 
         requestSync.send(Unit)
         composeTestRule.awaitIdle()
+        composeTestRule.waitUntil { globalData == actualData }
         assertEquals(globalData, actualData)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
@@ -57,6 +57,7 @@ class GetRailRouteShapesTest {
         }
 
         composeTestRule.awaitIdle()
+        composeTestRule.waitUntil { mapFriendlyRouteResponse == actualRailRouteShapes }
         assertEquals(mapFriendlyRouteResponse, actualRailRouteShapes)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
@@ -32,6 +32,7 @@ class GetStopMapDataTest {
         }
 
         composeTestRule.awaitIdle()
+        composeTestRule.waitUntil { stopMapResponse == actualStopMapResponse }
         assertEquals(stopMapResponse, actualStopMapResponse)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
@@ -35,6 +35,7 @@ class SubscribeToAlertsTest {
         var actualData: AlertsStreamDataResponse? = null
         composeRule.setContent { actualData = subscribeToAlerts(alertsRepo) }
         composeRule.waitUntil { connectCount == 1 }
+        composeRule.waitUntil { alertsStreamDataResponse == actualData }
         assertEquals(alertsStreamDataResponse, actualData)
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -95,6 +95,7 @@ class SubscribeToVehiclesTest {
         runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
         waitUntil { disconnectCount == 3 }
+        waitUntil { connectCount == 2 }
         assertEquals(2, connectCount)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix flaky android emulator tests](https://app.asana.com/0/1205732265579288/1208937603891770/f)

I went through the 25 most recent CI failures, ignored the ones where other CI steps failed or the failing emulator tests looked related to the changes made in the PR, and added a `waitUntil` to give the non-Compose mocked network requests a little more time to settle. (I also added some scrolling on the one test here that was failing in Compose assertions, on the assumption that it's a scrolling issue again.)

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Ran the tests locally and checked that they all pass, although that only guarantees that I didn't break any of these tests, not that they'll pass more often in CI now.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
