### PR TITLE
fix(StopDetailsPage): Distinct errorKeys from API requests on NearbyTransitPage

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -44,7 +44,7 @@ fun ContentView(
 ) {
     val navController = rememberNavController()
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()
-    val globalResponse = getGlobalData()
+    val globalResponse = getGlobalData("ContentView.getGlobalData")
     val hideMaps by viewModel.hideMaps.collectAsState()
     val pendingOnboarding = viewModel.pendingOnboarding.collectAsState().value
     val locationDataManager = rememberLocationDataManager()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -66,15 +66,15 @@ fun NearbyTransitView(
     }
     val now = timer(updateInterval = 5.seconds)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
-    val schedules = getSchedule(stopIds)
+    val schedules = getSchedule(stopIds, "NearbyTransitView.getSchedule")
     val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)
     val predictions by predictionsVM.predictionsFlow.collectAsState(initial = null)
+
     LaunchedEffect(targetLocation == null) {
         if (targetLocation == null) {
             predictionsVM.reset()
         }
     }
-
     val (pinnedRoutes, togglePinnedRoute) = managePinnedRoutes()
 
     val nearbyWithRealtimeInfo =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -36,7 +36,7 @@ fun StopDetailsPage(
     updateDepartures: (StopDetailsDepartures?) -> Unit,
     errorBannerViewModel: ErrorBannerViewModel
 ) {
-    val globalResponse = getGlobalData()
+    val globalResponse = getGlobalData("StopDetailsPage.getGlobalData")
 
     val predictionsVM =
         subscribeToPredictions(
@@ -47,7 +47,7 @@ fun StopDetailsPage(
 
     val now = timer(updateInterval = 5.seconds)
 
-    val schedulesResponse = getSchedule(stopIds = listOf(stop.id))
+    val schedulesResponse = getSchedule(stopIds = listOf(stop.id), "StopDetailsPage.getSchedule")
 
     val (pinnedRoutes, togglePinnedRoute) = managePinnedRoutes()
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -59,7 +59,7 @@ fun SearchBarOverlay(
         }
     var expanded by rememberSaveable { mutableStateOf(false) }
     var searchInputState by rememberSaveable { mutableStateOf("") }
-    val globalResponse = getGlobalData()
+    val globalResponse = getGlobalData("SearchBar.getGlobalData")
     val searchResultsVm = getSearchResultsVm(globalResponse = globalResponse)
     val searchResults = searchResultsVm.searchResults.collectAsState(initial = null).value
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
@@ -24,14 +24,14 @@ class GlobalDataViewModel(
     private val _globalResponse = MutableStateFlow<GlobalResponse?>(null)
     var globalResponse: StateFlow<GlobalResponse?> = _globalResponse
 
-    fun getGlobalData() {
+    fun getGlobalData(errorKey: String) {
         CoroutineScope(Dispatchers.IO).launch {
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
-                errorKey = "GlobalDataViewModel.getGlobalData",
+                errorKey = errorKey,
                 getData = { globalRepository.getGlobalData() },
                 onSuccess = { _globalResponse.emit(it) },
-                onRefreshAfterError = { getGlobalData() }
+                onRefreshAfterError = { getGlobalData(errorKey) }
             )
         }
     }
@@ -48,12 +48,13 @@ class GlobalDataViewModel(
 
 @Composable
 fun getGlobalData(
+    errorKey: String,
     globalRepository: IGlobalRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject()
 ): GlobalResponse? {
     val viewModel: GlobalDataViewModel =
         viewModel(factory = GlobalDataViewModel.Factory(globalRepository, errorBannerRepository))
 
-    LaunchedEffect(key1 = null) { viewModel.getGlobalData() }
+    LaunchedEffect(key1 = null) { viewModel.getGlobalData(errorKey) }
     return viewModel.globalResponse.collectAsState(initial = null).value
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSchedule.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSchedule.kt
@@ -25,15 +25,15 @@ class ScheduleViewModel(
     private val _schedule = MutableStateFlow<ScheduleResponse?>(null)
     val schedule: StateFlow<ScheduleResponse?> = _schedule
 
-    fun getSchedule(stopIds: List<String>) {
+    fun getSchedule(stopIds: List<String>, errorKey: String) {
         if (stopIds.isNotEmpty()) {
             CoroutineScope(Dispatchers.IO).launch {
                 fetchApi(
                     errorBannerRepo = errorBannerRepository,
-                    errorKey = "ScheduleViewModel.getSchedule",
+                    errorKey = errorKey,
                     getData = { schedulesRepository.getSchedule(stopIds, Clock.System.now()) },
                     onSuccess = { _schedule.value = it },
-                    onRefreshAfterError = { getSchedule(stopIds) }
+                    onRefreshAfterError = { getSchedule(stopIds, errorKey) }
                 )
             }
         } else {
@@ -54,13 +54,14 @@ class ScheduleViewModel(
 @Composable
 fun getSchedule(
     stopIds: List<String>?,
+    errorKey: String,
     schedulesRepository: ISchedulesRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
 ): ScheduleResponse? {
     var viewModel: ScheduleViewModel =
         viewModel(factory = ScheduleViewModel.Factory(schedulesRepository, errorBannerRepository))
 
-    LaunchedEffect(key1 = stopIds) { viewModel.getSchedule(stopIds ?: emptyList()) }
+    LaunchedEffect(key1 = stopIds) { viewModel.getSchedule(stopIds ?: emptyList(), errorKey) }
 
     return viewModel?.schedule?.collectAsState(initial = null)?.value
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.state
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -145,7 +144,7 @@ fun subscribeToPredictions(
         onPauseOrDispose { viewModel.disconnect() }
     }
 
-        LaunchedEffect(key1 = timer) { viewModel.checkPredictionsStale() }
+    LaunchedEffect(key1 = timer) { viewModel.checkPredictionsStale() }
 
-        return viewModel
+    return viewModel
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -2,15 +2,19 @@ package com.mbta.tid.mbta_app.android.state
 
 import android.util.Log
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -94,15 +98,17 @@ class PredictionsViewModel(
     }
 
     fun checkPredictionsStale() {
-        predictionsRepository.lastUpdated?.let { lastPredictions ->
-            errorBannerViewModel.errorRepository.checkPredictionsStale(
-                predictionsLastUpdated = lastPredictions,
-                predictionQuantity = predictions.value?.predictionQuantity() ?: 0,
-                action = {
-                    disconnect()
-                    connect(currentStopIds)
-                }
-            )
+        CoroutineScope(Dispatchers.IO).launch {
+            predictionsRepository.lastUpdated?.let { lastPredictions ->
+                errorBannerViewModel.errorRepository.checkPredictionsStale(
+                    predictionsLastUpdated = lastPredictions,
+                    predictionQuantity = predictions.value?.predictionQuantity() ?: 0,
+                    action = {
+                        disconnect()
+                        connect(currentStopIds)
+                    }
+                )
+            }
         }
     }
 
@@ -120,12 +126,15 @@ class PredictionsViewModel(
 fun subscribeToPredictions(
     stopIds: List<String>?,
     predictionsRepository: IPredictionsRepository = koinInject(),
-    errorBannerViewModel: ErrorBannerViewModel
+    errorBannerViewModel: ErrorBannerViewModel,
+    checkPredictionsStaleInterval: Duration = 5.seconds
 ): PredictionsViewModel {
     val viewModel: PredictionsViewModel =
         viewModel(
             factory = PredictionsViewModel.Factory(predictionsRepository, errorBannerViewModel)
         )
+
+    val timer = timer(checkPredictionsStaleInterval)
 
     LifecycleResumeEffect(key1 = stopIds) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -135,5 +144,8 @@ fun subscribeToPredictions(
 
         onPauseOrDispose { viewModel.disconnect() }
     }
-    return viewModel
+
+        LaunchedEffect(key1 = timer) { viewModel.checkPredictionsStale() }
+
+        return viewModel
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -33,7 +33,7 @@ fun StopDetailsView(
     updateStopFilter: (StopDetailsFilter?) -> Unit,
     errorBannerViewModel: ErrorBannerViewModel
 ) {
-    val globalResponse = getGlobalData()
+    val globalResponse = getGlobalData("SopDetailsView.getGlobalData")
 
     val now = timer(updateInterval = 5.seconds)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import kotlin.time.Duration.Companion.minutes
@@ -90,7 +91,9 @@ abstract class IErrorBannerStateRepository(initialState: ErrorBannerState? = nul
 
 class ErrorBannerStateRepository : IErrorBannerStateRepository(), KoinComponent
 
-class MockErrorBannerStateRepository(
+class MockErrorBannerStateRepository
+@DefaultArgumentInterop.Enabled
+constructor(
     state: ErrorBannerState? = null,
     onSubscribeToNetworkChanges: (() -> Unit)? = null,
     onCheckPredictionsStale: (() -> Unit)? = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -52,7 +52,7 @@ abstract class IErrorBannerStateRepository(initialState: ErrorBannerState? = nul
             }
     }
 
-    fun checkPredictionsStale(
+    open fun checkPredictionsStale(
         predictionsLastUpdated: Instant,
         predictionQuantity: Int,
         action: () -> Unit
@@ -93,12 +93,23 @@ class ErrorBannerStateRepository : IErrorBannerStateRepository(), KoinComponent
 class MockErrorBannerStateRepository(
     state: ErrorBannerState? = null,
     onSubscribeToNetworkChanges: (() -> Unit)? = null,
+    onCheckPredictionsStale: (() -> Unit)? = null
 ) : IErrorBannerStateRepository(state) {
     private val onSubscribeToNetworkChanges = onSubscribeToNetworkChanges
+    private val onCheckPredictionsStale = onCheckPredictionsStale
+
     val mutableFlow
         get() = flow
 
     override fun subscribeToNetworkStatusChanges() {
         onSubscribeToNetworkChanges?.invoke()
+    }
+
+    override fun checkPredictionsStale(
+        predictionsLastUpdated: Instant,
+        predictionQuantity: Int,
+        action: () -> Unit
+    ) {
+        onCheckPredictionsStale?.invoke()
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -41,6 +41,7 @@ class MockGlobalRepository
 @DefaultArgumentInterop.Enabled
 constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) : IGlobalRepository {
 
+    @DefaultArgumentInterop.Enabled
     constructor(
         response: GlobalResponse =
             GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -39,16 +39,25 @@ class GlobalRepository(
 
 class MockGlobalRepository
 @DefaultArgumentInterop.Enabled
-constructor(
-    val response: GlobalResponse =
-        GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),
-    val onGet: () -> Unit = {}
-) : IGlobalRepository {
-    override val state = MutableStateFlow(response)
+constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) : IGlobalRepository {
+
+    constructor(
+        response: GlobalResponse =
+            GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),
+        onGet: () -> Unit = {}
+    ) : this(ApiResult.Ok(response), onGet)
+
+    override val state =
+        MutableStateFlow(
+            when (result) {
+                is ApiResult.Error -> null
+                is ApiResult.Ok -> result.data
+            }
+        )
 
     override suspend fun getGlobalData(): ApiResult<GlobalResponse> {
         onGet()
-        return ApiResult.Ok(response)
+        return result
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
@@ -43,9 +44,16 @@ class SchedulesRepository : ISchedulesRepository, KoinComponent {
 }
 
 class MockScheduleRepository(
-    private val scheduleResponse: ScheduleResponse = ScheduleResponse(listOf(), mapOf()),
+    private val response: ApiResult<ScheduleResponse>,
     private val callback: (stopIds: List<String>) -> Unit = {}
 ) : ISchedulesRepository {
+
+    @DefaultArgumentInterop.Enabled
+    constructor(
+        scheduleResponse: ScheduleResponse = ScheduleResponse(listOf(), mapOf()),
+        callback: (stopIds: List<String>) -> Unit = {}
+    ) : this(ApiResult.Ok(scheduleResponse), callback)
+
     constructor() :
         this(
             scheduleResponse = ScheduleResponse(schedules = listOf(), trips = mapOf()),
@@ -57,12 +65,12 @@ class MockScheduleRepository(
         now: Instant
     ): ApiResult<ScheduleResponse> {
         callback(stopIds)
-        return ApiResult.Ok(scheduleResponse)
+        return response
     }
 
     override suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse> {
         callback(stopIds)
-        return ApiResult.Ok(scheduleResponse)
+        return response
     }
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Unfiltered Stop Details | Display error banners](https://app.asana.com/0/1205732265579288/1208968297244759/f)

What is this PR for?

Solves part 2 of https://github.com/mbta/mobile_app/pull/638. 

`getSchedule` was always using the same errorKey, so a race condition where the nearby transit `getSchedule` request finishes after the `stopDetails` request resulted the stopDetails error banner disappearing.

Now, getSchedule and getGlobalData take an errorKey param so the error can be recorded in a context-dependent way.

Additionally, while debugging I noticed that checkPredictionsStale was not being called periodically. This adds that functionality.

_Note:_
I created a[ separate ticket](https://app.asana.com/0/1208621177839510/1209118361132271/f) to appropriately clear the error banner when navigating between nearby transit & stop details. This is an issue on iOS as well, and is therefore out of scope of this android parity task.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Added unit tests
* Ran locally with hardcoded error for `getSchedule` for `place-pktrm`. Confirmed error banner displayed as expected
* Added logs for `checkPredictionStale`, confirmed it was called multiple times. Not exactly every 5 seconds, so something may be going on there that warrants further investigation, but it was being called on at least some interval.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
