### PR TITLE
feat: Add elevator accessibility feature toggle

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -86,6 +86,11 @@ class MoreViewModel(
                             value = settings[Settings.DevDebugMode] ?: false
                         ),
                         MoreItem.Toggle(
+                            label = context.getString(R.string.setting_elevator_accessibility),
+                            settings = Settings.ElevatorAccessibility,
+                            value = settings[Settings.ElevatorAccessibility] ?: false
+                        ),
+                        MoreItem.Toggle(
                             label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults,
                             value = settings[Settings.SearchRouteResults] ?: false

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Planificador de viaje</string>
     <string name="search_by_stop">Buscar por parada</string>
     <string name="service_ended">Servicio finalizado</string>
+    <string name="setting_elevator_accessibility">Mostrar accesibilidad del ascensor</string>
     <string name="setting_toggle_hide_maps">Ocultar Mapas</string>
     <string name="settings_link">Configuración</string>
     <string name="shuttle">Autobús de enlace</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Zouti pou planifye vwayaj</string>
     <string name="search_by_stop">Chèche pa kanpe</string>
     <string name="service_ended">Sèvis ki fini</string>
+    <string name="setting_elevator_accessibility">Montre aksè nan asansè</string>
     <string name="setting_toggle_hide_maps">Kache Kat yo</string>
     <string name="settings_link">Paramèt</string>
     <string name="shuttle">Navèt</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Planejador de trajetos</string>
     <string name="search_by_stop">Pesquisar por parada</string>
     <string name="service_ended">Serviço encerrado</string>
+    <string name="setting_elevator_accessibility">Mostrar acessibilidade do elevador</string>
     <string name="setting_toggle_hide_maps">Ocultar mapas</string>
     <string name="settings_link">Configurações</string>
     <string name="shuttle">Ônibus vai-e-vem</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Lập kế hoạch chuyến đi</string>
     <string name="search_by_stop">Tìm kiếm theo điểm dừng</string>
     <string name="service_ended">Dịch vụ đã kết thúc</string>
+    <string name="setting_elevator_accessibility">Hiển thị khả năng tiếp cận thang máy</string>
     <string name="setting_toggle_hide_maps">Ẩn bản đồ</string>
     <string name="settings_link">Cài đặt</string>
     <string name="shuttle">Xe đưa đón</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Trip Planner</string>
     <string name="search_by_stop">按站点搜索</string>
     <string name="service_ended">服务已结束</string>
+    <string name="setting_elevator_accessibility">显示电梯可达性</string>
     <string name="setting_toggle_hide_maps">隐藏地图</string>
     <string name="settings_link">设置</string>
     <string name="shuttle">摆渡巴士</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -73,6 +73,7 @@
     <string name="resources_link_trip_planner">Trip Planner</string>
     <string name="search_by_stop">按站點搜尋</string>
     <string name="service_ended">服務已結束</string>
+    <string name="setting_elevator_accessibility">顯示電梯可及性</string>
     <string name="setting_toggle_hide_maps">隱藏地圖</string>
     <string name="settings_link">設定</string>
     <string name="shuttle">擺渡巴士</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="resources_link_trip_planner">Trip Planner</string>
     <string name="search_by_stop">Search by stop</string>
     <string name="service_ended">Service ended</string>
+    <string name="setting_elevator_accessibility">Show elevator accessibility</string>
     <string name="setting_toggle_hide_maps">Hide Maps</string>
     <string name="settings_link">Settings</string>
     <string name="shuttle">Shuttle</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7165,6 +7165,47 @@
         }
       }
     },
+    "Show elevator accessibility" : {
+      "comment" : "A setting on the More page to display elevator accessibility",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar accesibilidad del ascensor"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Montre aksè nan asansè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mostrar acessibilidade do elevador"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hiển thị khả năng tiếp cận thang máy"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "显示电梯可达性"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "顯示電梯可及性"
+          }
+        }
+      }
+    },
     "Show maps" : {
       "comment" : "Onboarding button text for setting maps to shown",
       "localizations" : {

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -96,6 +96,14 @@ class SettingsViewModel: ObservableObject {
                     ),
                     .toggle(
                         label: NSLocalizedString(
+                            "Show elevator accessibility",
+                            comment: "A setting on the More page to display elevator accessibility"
+                        ),
+                        setting: .elevatorAccessibility,
+                        value: settings[.elevatorAccessibility] ?? false
+                    ),
+                    .toggle(
+                        label: NSLocalizedString(
                             "Route Search",
                             comment: "A setting on the More page to display routes in search (only visible for developers)"
                         ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -40,6 +40,7 @@ enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
     TripHeadsigns(booleanPreferencesKey("tripHeadsigns_featureFlag")),
+    ElevatorAccessibility(booleanPreferencesKey("elevator_accessibility")),
     HideMaps(booleanPreferencesKey("hide_maps")),
 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -41,6 +41,7 @@ class SettingsRepositoryTest : KoinTest {
                 Settings.DevDebugMode to true,
                 Settings.SearchRouteResults to false,
                 Settings.TripHeadsigns to false,
+                Settings.ElevatorAccessibility to false,
                 Settings.HideMaps to false,
             ),
             repo.getSettings()


### PR DESCRIPTION
### Summary

_Ticket:_ [Elevator Status | Feature flag](https://app.asana.com/0/1205732265579288/1209143579111803/f)

Adds a new feature toggle for elevator status (to be later moved into settings).

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

N/A