### PR TITLE
feat: set up logic for new feature promotion

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -1,10 +1,12 @@
 package com.mbta.tid.mbta_app.android
 
 import androidx.lifecycle.ViewModel
+import com.mbta.tid.mbta_app.model.FeaturePromo
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,17 +14,22 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class ContentViewModel(
+    private val featurePromoUseCase: FeaturePromoUseCase,
     private val onboardingRepository: IOnboardingRepository,
     private val settingsRepository: ISettingsRepository
 ) : ViewModel() {
     private val _hideMaps: MutableStateFlow<Boolean> = MutableStateFlow(false)
     val hideMaps: StateFlow<Boolean> = _hideMaps
+    private val _pendingFeaturePromos: MutableStateFlow<List<FeaturePromo>?> =
+        MutableStateFlow(null)
+    val pendingFeaturePromos: StateFlow<List<FeaturePromo>?> = _pendingFeaturePromos
     private val _pendingOnboarding: MutableStateFlow<List<OnboardingScreen>?> =
         MutableStateFlow(null)
     val pendingOnboarding: StateFlow<List<OnboardingScreen>?> = _pendingOnboarding
 
     init {
         loadHideMaps()
+        loadPendingFeaturePromos()
         loadPendingOnboarding()
     }
 
@@ -30,6 +37,13 @@ class ContentViewModel(
         CoroutineScope(Dispatchers.IO).launch {
             val data = settingsRepository.getSettings()
             _hideMaps.value = data[Settings.HideMaps] ?: false
+        }
+    }
+
+    fun loadPendingFeaturePromos() {
+        CoroutineScope(Dispatchers.IO).launch {
+            val data = featurePromoUseCase.getFeaturePromos()
+            _pendingFeaturePromos.value = data
         }
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.android.util.decodeMessage
 import com.mbta.tid.mbta_app.dependencyInjection.makeNativeModule
 import com.mbta.tid.mbta_app.initKoin
 import com.mbta.tid.mbta_app.repositories.AccessibilityStatusRepository
+import com.mbta.tid.mbta_app.repositories.CurrentAppVersionRepository
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 import org.phoenixframework.Socket
@@ -21,7 +22,11 @@ class MainApplication : Application() {
         super.onCreate()
         initKoin(
             appVariant,
-            makeNativeModule(AccessibilityStatusRepository(applicationContext), socket.wrapped()),
+            makeNativeModule(
+                AccessibilityStatusRepository(applicationContext),
+                CurrentAppVersionRepository(BuildConfig.VERSION_NAME),
+                socket.wrapped()
+            ),
             koinViewModelModule,
             this
         )

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		8CA485B82BDC679A00E84E1F /* VehicleExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA485B72BDC679A00E84E1F /* VehicleExtension.swift */; };
 		8CA606A92CC02FBC0019C448 /* ViewInspectorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA606A82CC02FBC0019C448 /* ViewInspectorExtensions.swift */; };
 		8CA7CDA02D359357008EE7D2 /* DestinationRowAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA7CD9F2D359353008EE7D2 /* DestinationRowAnalytics.swift */; };
+		8CA7CDAC2D3722C8008EE7D2 /* CurrentAppVersionRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CA7CDAB2D3722C3008EE7D2 /* CurrentAppVersionRepository.swift */; };
 		8CB28DB92C2CC5AD0036258E /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB28DB82C2CC5AD0036258E /* MapViewModel.swift */; };
 		8CB823D62BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D52BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift */; };
 		8CB823D92BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB823D82BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift */; };
@@ -398,6 +399,7 @@
 		8CA485B72BDC679A00E84E1F /* VehicleExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VehicleExtension.swift; sourceTree = "<group>"; };
 		8CA606A82CC02FBC0019C448 /* ViewInspectorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewInspectorExtensions.swift; sourceTree = "<group>"; };
 		8CA7CD9F2D359353008EE7D2 /* DestinationRowAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestinationRowAnalytics.swift; sourceTree = "<group>"; };
+		8CA7CDAB2D3722C3008EE7D2 /* CurrentAppVersionRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentAppVersionRepository.swift; sourceTree = "<group>"; };
 		8CB28DB82C2CC5AD0036258E /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		8CB823D52BC5E85C002C87E0 /* SheetNavigationStackEntryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetNavigationStackEntryTests.swift; sourceTree = "<group>"; };
 		8CB823D82BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsRouteViewTests.swift; sourceTree = "<group>"; };
@@ -1096,6 +1098,7 @@
 				9A3BAB732BEABADF00DAFDE2 /* ColorAssetExtension.swift */,
 				9AC10BD92B80067400EA4605 /* ColorHexExtension.swift */,
 				9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */,
+				8CA7CDAB2D3722C3008EE7D2 /* CurrentAppVersionRepository.swift */,
 				9AB44A122B911E6400E8FFB3 /* DateExtension.swift */,
 				9A03F3652BA9E68500DA40DC /* Debouncer.swift */,
 				8C05C57E2CD5688D000381E8 /* DependencyExtension.swift */,
@@ -1585,6 +1588,7 @@
 				9AF28F0D2D2854C200EC1C12 /* StopDetailsNoTripCard.swift in Sources */,
 				8CD79F112C46F6E200AFF17D /* MapboxBridge.swift in Sources */,
 				EDC768C72BCF6FD6008BAE58 /* RouteCard.swift in Sources */,
+				8CA7CDAC2D3722C8008EE7D2 /* CurrentAppVersionRepository.swift in Sources */,
 				9AB44A132B911E6400E8FFB3 /* DateExtension.swift in Sources */,
 				9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */,
 				8CA485B82BDC679A00E84E1F /* VehicleExtension.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .onAppear {
+            Task { await contentVM.loadFeaturePromos() }
             Task { await contentVM.loadOnboardingScreens() }
             Task { await nearbyVM.loadDebugSetting() }
         }

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -90,6 +90,7 @@ struct ProductionAppView: View {
     private static func initKoin(socket: PhoenixSocket) {
         let nativeModule: Koin_coreModule = MakeNativeModuleKt.makeNativeModule(
             accessibilityStatus: AccessibilityStatusRepository(),
+            currentAppVersion: CurrentAppVersionRepository(),
             socket: socket
         )
         HelpersKt.doInitKoin(appVariant: appVariant, nativeModule: nativeModule)

--- a/iosApp/iosApp/Utils/CurrentAppVersionRepository.swift
+++ b/iosApp/iosApp/Utils/CurrentAppVersionRepository.swift
@@ -1,0 +1,17 @@
+//
+//  CurrentAppVersionRepository.swift
+//  iosApp
+//
+//  Created by Horn, Melody on 2025-01-14.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Foundation
+import shared
+
+class CurrentAppVersionRepository: ICurrentAppVersionRepository {
+    func getCurrentAppVersion() -> AppVersion? {
+        guard let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return nil }
+        return AppVersion.companion.parse(version: version)
+    }
+}

--- a/iosApp/iosApp/ViewModels/ContentViewModel.swift
+++ b/iosApp/iosApp/ViewModels/ContentViewModel.swift
@@ -13,20 +13,26 @@ import shared
 class ContentViewModel: ObservableObject {
     @Published var configResponse: ApiResult<ConfigResponse>?
     @Published var hideMaps: Bool
+    @Published var featurePromosPending: [FeaturePromo]?
     @Published var onboardingScreensPending: [OnboardingScreen]?
 
     var configUseCase: ConfigUseCase
+    var featurePromoUseCase: FeaturePromoUseCase
     var onboardingRepository: IOnboardingRepository
     var settingsRepository: ISettingsRepository
 
     init(configUseCase: ConfigUseCase = UsecaseDI().configUsecase,
          configResponse: ApiResult<ConfigResponse>? = nil,
+         featurePromoUseCase: FeaturePromoUseCase = UsecaseDI().featurePromoUsecase,
+         featurePromosPending: [FeaturePromo]? = nil,
          onboardingRepository: IOnboardingRepository = RepositoryDI().onboarding,
          onboardingScreensPending: [OnboardingScreen]? = nil,
          settingsRepository: ISettingsRepository = RepositoryDI().settings,
          hideMaps: Bool = false) {
         self.configUseCase = configUseCase
         self.configResponse = configResponse
+        self.featurePromoUseCase = featurePromoUseCase
+        self.featurePromosPending = featurePromosPending
         self.onboardingRepository = onboardingRepository
         self.onboardingScreensPending = onboardingScreensPending
         self.settingsRepository = settingsRepository
@@ -43,6 +49,10 @@ class ContentViewModel: ObservableObject {
         } catch {
             configResponse = ApiResultError(code: nil, message: "\(error.localizedDescription)")
         }
+    }
+
+    @MainActor func loadFeaturePromos() async {
+        featurePromosPending = await (try? featurePromoUseCase.getFeaturePromos()) ?? []
     }
 
     @MainActor func loadHideMaps() async {

--- a/iosApp/iosAppTests/Views/ContentViewModelTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewModelTests.swift
@@ -25,6 +25,17 @@ final class ContentViewModelTests: XCTestCase {
         XCTAssertEqual(contentVM.configResponse, expectedResult)
     }
 
+    func testLoadFeaturePromoSetsFeaturePromo() async {
+        let contentVM = ContentViewModel(
+            featurePromoUseCase: FeaturePromoUseCase(
+                currentAppVersionRepository: MockCurrentAppVersionRepository(currentAppVersion: nil),
+                lastLaunchedAppVersionRepository: MockLastLaunchedAppVersionRepository(lastLaunchedAppVersion: nil)
+            )
+        )
+        await contentVM.loadFeaturePromos()
+        XCTAssertEqual(contentVM.featurePromosPending, [])
+    }
+
     func testLoadOnboardingSetsOnboarding() async {
         let contentVM = ContentViewModel(
             onboardingRepository: MockOnboardingRepository(pendingOnboarding: [.location, .feedback])

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.android.kt
@@ -1,0 +1,4 @@
+package com.mbta.tid.mbta_app.model
+
+actual val FeaturePromo.addedInVersion: AppVersion
+    get() = addedInAndroidVersion

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.android.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.repositories
+
+import com.mbta.tid.mbta_app.model.AppVersion
+
+class CurrentAppVersionRepository(versionName: String) : ICurrentAppVersionRepository {
+    private val appVersion = AppVersion.parse(versionName)
+
+    override fun getCurrentAppVersion() = appVersion
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -6,8 +6,10 @@ import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
+import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.ILastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -24,6 +26,7 @@ import com.mbta.tid.mbta_app.repositories.IVehicleRepository
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
 import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import okio.FileSystem
@@ -45,6 +48,7 @@ fun repositoriesModule(repositories: IRepositories): Module {
         single<IConfigRepository> { repositories.config }
         single<IErrorBannerStateRepository> { repositories.errorBanner }
         single<IGlobalRepository> { repositories.global }
+        single<ILastLaunchedAppVersionRepository> { repositories.lastLaunchedAppVersion }
         single<INearbyRepository> { repositories.nearby }
         single<IOnboardingRepository> { repositories.onboarding }
         single<IPinnedRoutesRepository> { repositories.pinnedRoutes }
@@ -56,6 +60,9 @@ fun repositoriesModule(repositories: IRepositories): Module {
         single<IStopRepository> { repositories.stop }
         single<ITripRepository> { repositories.trip }
         repositories.alerts?.let { alertsRepo -> factory<IAlertsRepository> { alertsRepo } }
+        repositories.currentAppVersion?.let { currentAppVersionRepo ->
+            factory<ICurrentAppVersionRepository> { currentAppVersionRepo }
+        }
         repositories.predictions?.let { predictionsRepo ->
             factory<IPredictionsRepository> { predictionsRepo }
         }
@@ -66,6 +73,7 @@ fun repositoriesModule(repositories: IRepositories): Module {
         repositories.vehicles?.let { vehiclesRepo -> factory<IVehiclesRepository> { vehiclesRepo } }
         single<IVisitHistoryRepository> { repositories.visitHistory }
         single { ConfigUseCase(get(), get()) }
+        single { FeaturePromoUseCase(get(), get()) }
         single { TogglePinnedRouteUsecase(get()) }
         single { VisitHistoryUsecase(get()) }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -1,12 +1,15 @@
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.AppVersion
 import com.mbta.tid.mbta_app.repositories.ConfigRepository
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.GlobalRepository
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
+import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.ILastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -29,10 +32,13 @@ import com.mbta.tid.mbta_app.repositories.IdleScheduleRepository
 import com.mbta.tid.mbta_app.repositories.IdleSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.IdleStopRepository
 import com.mbta.tid.mbta_app.repositories.IdleTripRepository
+import com.mbta.tid.mbta_app.repositories.LastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
+import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -58,8 +64,10 @@ interface IRepositories {
     val accessibilityStatus: IAccessibilityStatusRepository?
     val alerts: IAlertsRepository?
     val config: IConfigRepository
+    val currentAppVersion: ICurrentAppVersionRepository?
     val errorBanner: IErrorBannerStateRepository
     val global: IGlobalRepository
+    val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository
     val nearby: INearbyRepository
     val onboarding: IOnboardingRepository
     val pinnedRoutes: IPinnedRoutesRepository
@@ -81,8 +89,10 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val accessibilityStatus: IAccessibilityStatusRepository by inject()
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
+    override val currentAppVersion: ICurrentAppVersionRepository by inject()
     override val errorBanner: IErrorBannerStateRepository by inject()
     override val global: IGlobalRepository by inject()
+    override val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository by inject()
     override val nearby: INearbyRepository by inject()
     override val onboarding: IOnboardingRepository by inject()
     override val pinnedRoutes: IPinnedRoutesRepository by inject()
@@ -107,8 +117,10 @@ class RealRepositories : IRepositories {
     override val accessibilityStatus = null
     override val alerts = null
     override val config = ConfigRepository()
+    override val currentAppVersion = null
     override val errorBanner = ErrorBannerStateRepository()
     override val global = GlobalRepository()
+    override val lastLaunchedAppVersion = LastLaunchedAppVersionRepository()
     override val nearby = NearbyRepository()
     override val onboarding = OnboardingRepository()
     override val pinnedRoutes = PinnedRoutesRepository()
@@ -130,8 +142,10 @@ class MockRepositories(
     override val accessibilityStatus: IAccessibilityStatusRepository,
     override val alerts: IAlertsRepository,
     override val config: IConfigRepository,
+    override val currentAppVersion: ICurrentAppVersionRepository,
     override val errorBanner: IErrorBannerStateRepository,
     override val global: IGlobalRepository,
+    override val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository,
     override val nearby: INearbyRepository,
     override val onboarding: IOnboardingRepository,
     override val pinnedRoutes: IPinnedRoutesRepository,
@@ -162,8 +176,10 @@ class MockRepositories(
                     MockAccessibilityStatusRepository(isScreenReaderEnabled = false),
                 alerts = MockAlertsRepository(),
                 config = MockConfigRepository(),
+                currentAppVersion = MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u)),
                 errorBanner = errorBanner,
                 global = global,
+                lastLaunchedAppVersion = MockLastLaunchedAppVersionRepository(null),
                 nearby = IdleNearbyRepository(),
                 onboarding = MockOnboardingRepository(),
                 pinnedRoutes = PinnedRoutesRepository(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.dependencyInjection
 
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import org.koin.core.component.KoinComponent
@@ -8,6 +9,7 @@ import org.koin.core.component.inject
 
 class UsecaseDI : KoinComponent {
     val configUsecase: ConfigUseCase by inject()
+    val featurePromoUsecase: FeaturePromoUseCase by inject()
     val toggledPinnedRouteUsecase: TogglePinnedRouteUsecase by inject()
     val visitHistoryUsecase: VisitHistoryUsecase by inject()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
@@ -4,6 +4,7 @@ import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.repositories.AlertsRepository
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
+import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
@@ -17,10 +18,12 @@ import org.koin.dsl.module
 
 fun makeNativeModule(
     accessibilityStatus: IAccessibilityStatusRepository,
+    currentAppVersion: ICurrentAppVersionRepository,
     socket: PhoenixSocket
 ): Module {
     return module {
         single<IAccessibilityStatusRepository> { accessibilityStatus }
+        single<ICurrentAppVersionRepository> { currentAppVersion }
         single<PhoenixSocket> { socket }
         factory<IAlertsRepository> { AlertsRepository(get()) }
         factory<IPredictionsRepository> { PredictionsRepository(get()) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.endToEnd
 
+import com.mbta.tid.mbta_app.model.AppVersion
 import com.mbta.tid.mbta_app.model.NearbyStaticData
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -20,8 +21,10 @@ import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
+import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.ILastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
@@ -41,7 +44,9 @@ import com.mbta.tid.mbta_app.repositories.IdleRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
+import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -49,6 +54,7 @@ import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
@@ -99,6 +105,9 @@ fun endToEndModule(): Module {
         }
         single<IAlertsRepository> { MockAlertsRepository(AlertsStreamDataResponse(objects)) }
         single<IConfigRepository> { MockConfigRepository() }
+        single<ICurrentAppVersionRepository> {
+            MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u))
+        }
         single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
         single<IGlobalRepository> {
             object : IGlobalRepository {
@@ -114,6 +123,7 @@ fun endToEndModule(): Module {
                     ApiResult.Ok(state.value)
             }
         }
+        single<ILastLaunchedAppVersionRepository> { MockLastLaunchedAppVersionRepository(null) }
         single<INearbyRepository> {
             object : INearbyRepository {
                 override suspend fun getNearby(
@@ -237,6 +247,7 @@ fun endToEndModule(): Module {
         single<IVehiclesRepository> { MockVehiclesRepository() }
         single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
         single { ConfigUseCase(get(), get()) }
+        single { FeaturePromoUseCase(get(), get()) }
         single { TogglePinnedRouteUsecase(get()) }
         single { VisitHistoryUsecase(get()) }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AppVersion.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AppVersion.kt
@@ -1,0 +1,18 @@
+package com.mbta.tid.mbta_app.model
+
+data class AppVersion(val major: UInt, val minor: UInt, val patch: UInt) {
+    operator fun compareTo(otherVersion: AppVersion): Int {
+        return major.compareTo(otherVersion.major).takeUnless { it == 0 }
+            ?: minor.compareTo(otherVersion.minor).takeUnless { it == 0 }
+                ?: patch.compareTo(otherVersion.patch)
+    }
+
+    override fun toString() = "$major.$minor.$patch"
+
+    companion object {
+        fun parse(version: String): AppVersion {
+            val numbers = version.split('.', limit = 3).map(String::toUInt)
+            return AppVersion(numbers[0], numbers[1], numbers[2])
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
@@ -1,8 +1,10 @@
 package com.mbta.tid.mbta_app.model
 
-enum class FeaturePromo(val addedInVersion: AppVersion) {
+enum class FeaturePromo(val addedInAndroidVersion: AppVersion, val addedInIosVersion: AppVersion) {
     // ktfmt does not like empty enums as of the version we get with spotless
     Nothing(AppVersion(0u, 0u, 0u));
+
+    constructor(addedInVersion: AppVersion) : this(addedInVersion, addedInVersion)
 
     companion object {
         fun featuresBetween(
@@ -15,3 +17,5 @@ enum class FeaturePromo(val addedInVersion: AppVersion) {
         }
     }
 }
+
+expect val FeaturePromo.addedInVersion: AppVersion

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
@@ -1,0 +1,17 @@
+package com.mbta.tid.mbta_app.model
+
+enum class FeaturePromo(val addedInVersion: AppVersion) {
+    // ktfmt does not like empty enums as of the version we get with spotless
+    Nothing(AppVersion(0u, 0u, 0u));
+
+    companion object {
+        fun featuresBetween(
+            lastLaunchedVersion: AppVersion,
+            currentVersion: AppVersion
+        ): List<FeaturePromo> {
+            return entries.filter {
+                lastLaunchedVersion < it.addedInVersion && it.addedInVersion <= currentVersion
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.kt
@@ -1,0 +1,16 @@
+package com.mbta.tid.mbta_app.repositories
+
+import com.mbta.tid.mbta_app.model.AppVersion
+
+/**
+ * The app version is defined at compile time in Android, but the shared library can't see it there,
+ * so a simple `expect`/`actual` won't cut it.
+ */
+fun interface ICurrentAppVersionRepository {
+    fun getCurrentAppVersion(): AppVersion?
+}
+
+class MockCurrentAppVersionRepository(private val currentAppVersion: AppVersion?) :
+    ICurrentAppVersionRepository {
+    override fun getCurrentAppVersion() = currentAppVersion
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/LastLaunchedAppVersionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/LastLaunchedAppVersionRepository.kt
@@ -1,0 +1,48 @@
+package com.mbta.tid.mbta_app.repositories
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.AppVersion
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface ILastLaunchedAppVersionRepository {
+    suspend fun getLastLaunchedAppVersion(): AppVersion?
+
+    suspend fun setLastLaunchedAppVersion(version: AppVersion)
+}
+
+class LastLaunchedAppVersionRepository : ILastLaunchedAppVersionRepository, KoinComponent {
+    private val dataStore: DataStore<Preferences> by inject()
+
+    private val lastLaunchedAppVersionKey = stringPreferencesKey("last_launched_app_version")
+
+    override suspend fun getLastLaunchedAppVersion(): AppVersion? {
+        return dataStore.data
+            .map { it[lastLaunchedAppVersionKey] }
+            .first()
+            ?.let { AppVersion.parse(it) }
+    }
+
+    override suspend fun setLastLaunchedAppVersion(version: AppVersion) {
+        dataStore.edit { it[lastLaunchedAppVersionKey] = version.toString() }
+    }
+}
+
+class MockLastLaunchedAppVersionRepository
+@DefaultArgumentInterop.Enabled
+constructor(
+    private var lastLaunchedAppVersion: AppVersion?,
+    private var onSet: (AppVersion) -> Unit = {}
+) : ILastLaunchedAppVersionRepository {
+    override suspend fun getLastLaunchedAppVersion() = lastLaunchedAppVersion
+
+    override suspend fun setLastLaunchedAppVersion(version: AppVersion) {
+        onSet(version)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUseCase.kt
@@ -1,0 +1,28 @@
+package com.mbta.tid.mbta_app.usecases
+
+import com.mbta.tid.mbta_app.model.FeaturePromo
+import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.ILastLaunchedAppVersionRepository
+import org.koin.core.component.KoinComponent
+
+class FeaturePromoUseCase(
+    private val currentAppVersionRepository: ICurrentAppVersionRepository,
+    private val lastLaunchedAppVersionRepository: ILastLaunchedAppVersionRepository
+) : KoinComponent {
+    suspend fun getFeaturePromos(): List<FeaturePromo> {
+        val currentVersion =
+            currentAppVersionRepository.getCurrentAppVersion() ?: return emptyList()
+        val lastLaunchedVersion = lastLaunchedAppVersionRepository.getLastLaunchedAppVersion()
+        if (lastLaunchedVersion == currentVersion) return emptyList()
+        lastLaunchedAppVersionRepository.setLastLaunchedAppVersion(currentVersion)
+        if (lastLaunchedVersion == null) return emptyList()
+        val newFeatures = FeaturePromo.featuresBetween(lastLaunchedVersion, currentVersion)
+        if (newFeatures.size > MAX_PROMOS) return emptyList()
+        return newFeatures
+    }
+
+    companion object {
+        // https://www.xkcd.com/2615/
+        const val MAX_PROMOS = 2
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AppVersionTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AppVersionTest.kt
@@ -1,0 +1,33 @@
+package com.mbta.tid.mbta_app.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertTrue
+
+class AppVersionTest {
+    @Test
+    fun `comparison works`() {
+        assertEquals(AppVersion(1u, 2u, 3u), AppVersion(1u, 2u, 3u))
+        assertTrue(AppVersion(1u, 2u, 3u) < AppVersion(1u, 2u, 4u))
+        assertTrue(AppVersion(1u, 2u, 3u) < AppVersion(1u, 3u, 0u))
+        assertTrue(AppVersion(1u, 2u, 3u) < AppVersion(2u, 0u, 0u))
+    }
+
+    @Test
+    fun `toString works`() {
+        assertEquals("10.9.87", AppVersion(10u, 9u, 87u).toString())
+        assertEquals("3.0.0", AppVersion(3u, 0u, 0u).toString())
+    }
+
+    @Test
+    fun `parse works`() {
+        assertEquals(AppVersion(0u, 0u, 0u), AppVersion.parse("0.0.0"))
+        assertEquals(AppVersion(1u, 2u, 3u), AppVersion.parse("1.2.3"))
+        assertEquals(AppVersion(12u, 345u, 6789u), AppVersion.parse("12.345.6789"))
+        assertFails { AppVersion.parse("1.2.-3") }
+        assertFails { AppVersion.parse("1.0") }
+        assertFails { AppVersion.parse("1.2.3-beta9") }
+        assertFails { AppVersion.parse("Ceci n'est pas une version") }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
@@ -2,9 +2,9 @@ package com.mbta.tid.mbta_app.usecases
 
 import com.mbta.tid.mbta_app.model.AppVersion
 import com.mbta.tid.mbta_app.model.FeaturePromo
+import com.mbta.tid.mbta_app.model.addedInVersion
 import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
@@ -43,7 +43,6 @@ class FeaturePromoUsecaseTest {
     }
 
     @Test
-    @Ignore
     fun `skips promos when too many`() = runBlocking {
         // instead of an @Ignore we may forget, skip the test if there aren't enough features
         if (FeaturePromo.entries.size <= FeaturePromoUseCase.MAX_PROMOS) return@runBlocking

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
@@ -1,0 +1,56 @@
+package com.mbta.tid.mbta_app.usecases
+
+import com.mbta.tid.mbta_app.model.AppVersion
+import com.mbta.tid.mbta_app.model.FeaturePromo
+import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+import kotlinx.coroutines.runBlocking
+
+class FeaturePromoUsecaseTest {
+    @Test
+    fun `empty when no current version`() = runBlocking {
+        val useCase = FeaturePromoUseCase(
+            MockCurrentAppVersionRepository(null),
+            MockLastLaunchedAppVersionRepository(AppVersion(0u, 1u, 0u), onSet = { fail() })
+        )
+        assertEquals(emptyList(), useCase.getFeaturePromos())
+    }
+
+    @Test
+    fun `writes current and returns empty when no last launched version`() = runBlocking {
+        var savedVersion: AppVersion? = null
+        val useCase = FeaturePromoUseCase(
+            MockCurrentAppVersionRepository(AppVersion(0u, 1u, 0u)),
+            MockLastLaunchedAppVersionRepository(null, onSet = { savedVersion = it })
+        )
+        assertEquals(emptyList(), useCase.getFeaturePromos())
+        assertEquals(AppVersion(0u, 1u, 0u), savedVersion)
+    }
+
+    @Test
+    fun `returns new features when version bumped`() = runBlocking {
+        // instead of an @Ignore we may forget, skip the test if there are no features
+        if (FeaturePromo.entries.all { it.addedInVersion == AppVersion(0u, 0u, 0u) }) return@runBlocking
+        val useCase = FeaturePromoUseCase(
+            MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
+            MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
+        )
+        assertEquals(listOf(), useCase.getFeaturePromos())
+    }
+
+    @Test
+    @Ignore
+    fun `skips promos when too many`() = runBlocking {
+        // instead of an @Ignore we may forget, skip the test if there aren't enough features
+        if (FeaturePromo.entries.size <= FeaturePromoUseCase.MAX_PROMOS) return@runBlocking
+        val useCase = FeaturePromoUseCase(
+            MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
+            MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
+        )
+        assertEquals(emptyList(), useCase.getFeaturePromos())
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.ios.kt
@@ -1,0 +1,4 @@
+package com.mbta.tid.mbta_app.model
+
+actual val FeaturePromo.addedInVersion
+    get() = addedInIosVersion


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up logic for new feature promo](https://app.asana.com/0/1205732265579288/1209120993502865/f)

I am happy with this structure, which means I may have overengineered it.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Added some unit tests. Manually verified that the versions are being stored on both Android and iOS and therefore if we ship this in 1.1.5 we should be able to use it in 1.2.0.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
