### PR TITLE
feat(iOS): UI for secondary and downstream alerts in combined stop details

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		9A2BCBDE2CED365200FB2913 /* StopDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */; };
 		9A2BCBE02CED366300FB2913 /* StopDetailsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */; };
 		9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */; };
+		9A3739942D3AD67200BBE127 /* InfoIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3739932D3AD67200BBE127 /* InfoIcon.swift */; };
 		9A37F3052BACCC40001714FE /* DoubleRoundedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */; };
 		9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */; };
 		9A392C972CC0497C00DE1FBE /* ErrorBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */; };
@@ -431,6 +432,7 @@
 		9A2BCBDD2CED365200FB2913 /* StopDetailsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsPageTests.swift; sourceTree = "<group>"; };
 		9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsViewTests.swift; sourceTree = "<group>"; };
 		9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripAccessibilityFormatters.swift; sourceTree = "<group>"; };
+		9A3739932D3AD67200BBE127 /* InfoIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoIcon.swift; sourceTree = "<group>"; };
 		9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRoundedExtension.swift; sourceTree = "<group>"; };
 		9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateExtension.swift; sourceTree = "<group>"; };
 		9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerViewModel.swift; sourceTree = "<group>"; };
@@ -1005,6 +1007,7 @@
 				9AB44A102B8FC43E00E8FFB3 /* ErrorCard.swift */,
 				9A4092E62D0248120026EB01 /* HaloSeparator.swift */,
 				9A2005C82B97B65900F562E1 /* HeadsignRowView.swift */,
+				9A3739932D3AD67200BBE127 /* InfoIcon.swift */,
 				9A9E7DD62C220812000DA1FD /* LineCard.swift */,
 				9A9E7DCE2C2200C9000DA1FD /* LineHeader.swift */,
 				6EA2316E2C21BEB100789173 /* LoadingCard.swift */,
@@ -1547,6 +1550,7 @@
 				6E99CBB72B9892C80047E78D /* SocketProvider.swift in Sources */,
 				ED5C93F42C496FB90086D017 /* TripDetailsHeader.swift in Sources */,
 				8C1587042C76524600AB5036 /* AppVariantExtension.swift in Sources */,
+				9A3739942D3AD67200BBE127 /* InfoIcon.swift in Sources */,
 				8C255B992D388299003C4E3F /* AlertCard.swift in Sources */,
 				8CE36C8F2CAB231500D77F22 /* FetchApi.swift in Sources */,
 				9A4DB77A2CA47E6D00E8755B /* SearchField.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		9A2BCBE02CED366300FB2913 /* StopDetailsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */; };
 		9A320F962CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */; };
 		9A3739942D3AD67200BBE127 /* InfoIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3739932D3AD67200BBE127 /* InfoIcon.swift */; };
+		9A3739962D3AEC4500BBE127 /* AlertCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3739952D3AEC4500BBE127 /* AlertCardTests.swift */; };
 		9A37F3052BACCC40001714FE /* DoubleRoundedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */; };
 		9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */; };
 		9A392C972CC0497C00DE1FBE /* ErrorBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */; };
@@ -433,6 +434,7 @@
 		9A2BCBDF2CED366300FB2913 /* StopDetailsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsViewTests.swift; sourceTree = "<group>"; };
 		9A320F952CD3E4CF0096D7B1 /* UpcomingTripAccessibilityFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpcomingTripAccessibilityFormatters.swift; sourceTree = "<group>"; };
 		9A3739932D3AD67200BBE127 /* InfoIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoIcon.swift; sourceTree = "<group>"; };
+		9A3739952D3AEC4500BBE127 /* AlertCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertCardTests.swift; sourceTree = "<group>"; };
 		9A37F3042BACCC40001714FE /* DoubleRoundedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleRoundedExtension.swift; sourceTree = "<group>"; };
 		9A37F3062BACCCA5001714FE /* CoordinateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinateExtension.swift; sourceTree = "<group>"; };
 		9A392C962CC0497C00DE1FBE /* ErrorBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBannerViewModel.swift; sourceTree = "<group>"; };
@@ -666,6 +668,7 @@
 			isa = PBXGroup;
 			children = (
 				6E973DA82C178BF500CBF341 /* ActionButtonTests.swift */,
+				9A3739952D3AEC4500BBE127 /* AlertCardTests.swift */,
 				6E4C375D2C4BDC9F00EA67CF /* ContentViewModelTests.swift */,
 				6EED5EAA2B3E1B550052A1B8 /* ContentViewTests.swift */,
 				9AAA26A62C2DC06600A7745A /* DirectionLabelTests.swift */,
@@ -1497,6 +1500,7 @@
 				6EED5EAB2B3E1B550052A1B8 /* ContentViewTests.swift in Sources */,
 				ED5C93F62C4A1AD70086D017 /* TripDetailsHeaderTests.swift in Sources */,
 				9A9BA0002D03565800BCB2BD /* TripDetailsViewTests.swift in Sources */,
+				9A3739962D3AEC4500BBE127 /* AlertCardTests.swift in Sources */,
 				9A60E8E72B8501BD008A8D5C /* RoutePillTests.swift in Sources */,
 				9A8375EE2D0A14DD00E3694F /* TripHeaderCardTests.swift in Sources */,
 				6E35D4D32B72CD3900A2BF95 /* HomeMapViewTests.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/InfoIcon.swift
+++ b/iosApp/iosApp/ComponentViews/InfoIcon.swift
@@ -1,0 +1,21 @@
+//
+//  InfoIcon.swift
+//  iosApp
+//
+//  Created by esimon on 1/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct InfoIcon: View {
+    var size: Double = 16
+
+    var body: some View {
+        Image(.faCircleInfo)
+            .resizable()
+            .frame(width: size, height: size)
+            .foregroundStyle(Color.text.opacity(0.6))
+            .accessibilityHidden(true)
+    }
+}

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -426,6 +426,7 @@
       }
     },
     "%@ ahead" : {
+      "comment" : "Label for an alert that exists on a future stop along the selected route,\nthe interpolated value can be any alert effect,\nex. \"[Detour] ahead\", \"[Shuttle buses] ahead\"",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsAlertHeader.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsAlertHeader.swift
@@ -25,12 +25,9 @@ struct StopDetailsAlertHeader: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.vertical, 3)
-            Image(.faCircleInfo)
-                .resizable()
-                .frame(width: iconSize, height: iconSize)
+            InfoIcon(size: iconSize)
                 .padding(4)
                 .frame(maxHeight: .infinity, alignment: .center)
-                .foregroundStyle(Color.deemphasized)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 12)

--- a/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsDownstreamAlert.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsDownstreamAlert.swift
@@ -24,12 +24,7 @@ struct StopDetailsDownstreamAlert: View {
             Text("\(alert.effectDescription()) ahead")
                 .font(.callout)
                 .frame(maxWidth: .infinity, alignment: .leading)
-
-            Image(.faCircleInfo)
-                .resizable()
-                .frame(width: iconSize, height: iconSize, alignment: .center)
-                .padding(4)
-                .foregroundStyle(Color.deemphasized)
+            InfoIcon(size: iconSize).padding(4)
         }
         .padding(.horizontal, 8).padding(.vertical, 10)
         .background(Color.fill2)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -21,6 +21,7 @@ struct StopDetailsFilteredView: View {
     var now: Date
 
     var alerts: [shared.Alert]
+    var downstreamAlerts: [shared.Alert]
     var patternsByStop: PatternsByStop?
     var servedRoutes: [StopDetailsFilterPills.FilterBy] = []
 
@@ -68,8 +69,10 @@ struct StopDetailsFilteredView: View {
         if let departures, let patternsByStop {
             if let global = stopDetailsVM.global {
                 alerts = patternsByStop.alertsHereFor(directionId: stopFilter.directionId, global: global)
+                downstreamAlerts = patternsByStop.alertsDownstream(directionId: stopFilter.directionId)
             } else {
                 alerts = []
+                downstreamAlerts = []
             }
 
             tiles = departures.stopDetailsFormattedTrips(
@@ -99,6 +102,7 @@ struct StopDetailsFilteredView: View {
 
         } else {
             alerts = []
+            downstreamAlerts = []
             noPredictionsStatus = nil
             tiles = []
         }
@@ -136,6 +140,7 @@ struct StopDetailsFilteredView: View {
                     tiles: tiles,
                     noPredictionsStatus: noPredictionsStatus,
                     alerts: alerts,
+                    downstreamAlerts: downstreamAlerts,
                     patternsByStop: patternsByStop,
                     pinned: pinned,
                     now: now,
@@ -197,6 +202,7 @@ struct StopDetailsFilteredView: View {
             tiles: tiles,
             noPredictionsStatus: nil,
             alerts: alerts,
+            downstreamAlerts: downstreamAlerts,
             patternsByStop: loadingPatterns,
             pinned: pinned,
             now: now,

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -91,7 +91,7 @@ struct TripHeaderCard: View {
             VStack(alignment: .leading, spacing: 2) {
                 HStack {
                     Text("Scheduled to depart").font(Typography.footnote)
-                    if onTap != nil { infoIcon }
+                    if onTap != nil { InfoIcon() }
                 }
                 Text(stopEntry.stop.name)
                     .font(Typography.headlineBold)
@@ -247,7 +247,7 @@ struct TripHeaderCard: View {
     @ViewBuilder private var tripIndicator: some View {
         VStack {
             switch spec {
-            case .finishingAnotherTrip, .noVehicle: if onTap != nil { infoIcon }
+            case .finishingAnotherTrip, .noVehicle: if onTap != nil { InfoIcon() }
             case .vehicle: liveIndicator
             case .scheduled: EmptyView()
             }
@@ -260,14 +260,6 @@ struct TripHeaderCard: View {
                 ).foregroundStyle(Color.text).opacity(0.6)
             }
         }
-    }
-
-    @ViewBuilder private var infoIcon: some View {
-        Image(.faCircleInfo)
-            .resizable()
-            .frame(width: 16, height: 16)
-            .foregroundStyle(Color.text.opacity(0.5))
-            .accessibilityHidden(true)
     }
 
     @ViewBuilder private var liveIndicator: some View {

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -1,0 +1,101 @@
+//
+//  AlertCardTests.swift
+//  iosAppTests
+//
+//  Created by esimon on 1/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class AlertCardTests: XCTestCase {
+    override func setUp() {
+        executionTimeAllowance = 60
+    }
+
+    func testMajorAlertCard() throws {
+        let objects = ObjectCollectionBuilder()
+        let alert = objects.alert { alert in
+            alert.effect = .stationClosure
+            alert.header = "Test header"
+        }
+
+        let exp = XCTestExpectation(description: "Detail button pressed")
+        let sut = AlertCard(
+            alert: alert,
+            spec: .major,
+            color: Color.pink,
+            textColor: Color.orange,
+            onViewDetails: {
+                exp.fulfill()
+            }
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Station Closure"))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "alert-borderless-suspension"
+        }))
+        XCTAssertThrowsError(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-circle-info"
+        }))
+        try sut.inspect().find(button: "View details").tap()
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testSecondaryAlertCard() throws {
+        let objects = ObjectCollectionBuilder()
+        let alert = objects.alert { alert in
+            alert.effect = .detour
+        }
+
+        let exp = XCTestExpectation(description: "Card pressed")
+        let sut = AlertCard(
+            alert: alert,
+            spec: .secondary,
+            color: Color.pink,
+            textColor: Color.orange,
+            onViewDetails: {
+                exp.fulfill()
+            }
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Detour"))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "alert-borderless-issue"
+        }))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-circle-info"
+        }))
+        try sut.inspect().button().tap()
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testDownstreamAlertCard() throws {
+        let objects = ObjectCollectionBuilder()
+        let alert = objects.alert { alert in
+            alert.effect = .serviceChange
+        }
+
+        let exp = XCTestExpectation(description: "Card pressed")
+        let sut = AlertCard(
+            alert: alert,
+            spec: .downstream,
+            color: Color.pink,
+            textColor: Color.orange,
+            onViewDetails: {
+                exp.fulfill()
+            }
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Service Change ahead"))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "alert-borderless-issue"
+        }))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-circle-info"
+        }))
+        try sut.inspect().button().tap()
+        wait(for: [exp], timeout: 1)
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Stop + Trip Details | Show disruption downstream](https://app.asana.com/0/1209140624048233/1209154953848789/f) + [ | Stop + Trip Details | Handle Service changes + unspecified stops](https://app.asana.com/0/1209140624048233/1209154953848791/f)

Combined the downstream and secondary alert tickets because it ended up being easier to just do them both at once.

Adds a spec to the AlertCard which can be `major`, `secondary`, or `downstream`.

![Simulator Screenshot - iPhone 15 - 2025-01-17 at 15 32 51](https://github.com/user-attachments/assets/b3126980-d053-4973-aca2-740f9d677355) ![Simulator Screenshot - iPhone 15 - 2025-01-17 at 15 33 47](https://github.com/user-attachments/assets/f7702703-4928-4558-863e-ab617b140bd0)



iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Added unit tests for new behavior