### PR TITLE
feat(android.StopDetailsViewModel): Trip & vehicle data

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -23,6 +23,7 @@ import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.MainApplication
 import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
@@ -30,9 +31,9 @@ import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.IMapViewModel
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
-import com.mbta.tid.mbta_app.android.stopDetails.StopDetailsViewModel
 import com.mbta.tid.mbta_app.android.util.LocalActivity
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
+import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.map.RouteLineData
 import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.LocationType
@@ -48,27 +49,11 @@ import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
-import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
-import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
-import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
-import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
-import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
-import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
-import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
-import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
-import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
-import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
-import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
-import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
-import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.Flow
@@ -214,14 +199,12 @@ class NearbyTransitPageTest : KoinTest {
 
     val koinApplication = koinApplication {
         modules(
+            repositoriesModule(MockRepositories.buildWithDefaults()),
             module {
                 single<Analytics> { analytics }
-                single<ISettingsRepository> { MockSettingsRepository() }
-                single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
                 single<IGlobalRepository> {
                     MockGlobalRepository(response = GlobalResponse(builder))
                 }
-                single<ISchedulesRepository> { MockScheduleRepository() }
                 single<IPredictionsRepository> {
                     object : IPredictionsRepository {
                         override fun connect(
@@ -272,15 +255,8 @@ class NearbyTransitPageTest : KoinTest {
                         }
                     }
                 }
-                single<IRailRouteShapeRepository> { MockRailRouteShapeRepository() }
-                single<TogglePinnedRouteUsecase> { TogglePinnedRouteUsecase(get()) }
-                single<IVehiclesRepository> { MockVehiclesRepository() }
-                single<ISearchResultRepository> { MockSearchResultRepository() }
-                viewModelOf(::NearbyTransitViewModel)
-                viewModelOf(::StopDetailsViewModel)
-                single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
-                single<VisitHistoryUsecase> { VisitHistoryUsecase(get()) }
-            }
+            },
+            MainApplication.koinViewModelModule,
         )
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
@@ -123,6 +123,7 @@ class StopDetailsFilteredRouteViewTest {
             }
 
             StopDetailsFilteredRouteView(
+                stopId = stop.id,
                 viewModel = viewModel,
                 global = globalResponse,
                 now = now,
@@ -167,6 +168,7 @@ class StopDetailsFilteredRouteViewTest {
             }
 
             StopDetailsFilteredRouteView(
+                stopId = stop.id,
                 viewModel = viewModel,
                 global = globalResponse,
                 now = now,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteViewTest.kt
@@ -14,9 +14,6 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
-import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
@@ -102,13 +99,7 @@ class StopDetailsFilteredRouteViewTest {
 
     @Test
     fun testStopDetailsRouteViewDisplaysCorrectly() {
-
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
         viewModel.setDepartures(
             checkNotNull(
                 StopDetailsDepartures.fromData(
@@ -152,12 +143,7 @@ class StopDetailsFilteredRouteViewTest {
     fun testTappingTripSetsFilter() {
         var tripFilter: TripDetailsFilter? = null
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
         viewModel.setDepartures(
             checkNotNull(
                 StopDetailsDepartures.fromData(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -18,6 +18,9 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripRepository
+import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -43,9 +46,12 @@ class StopDetailsPageTest : KoinTest {
     fun testCallsUpdateDepartures() = runTest {
         val viewModel =
             StopDetailsViewModel(
-                MockScheduleRepository(),
+                MockErrorBannerStateRepository(),
                 MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
+                MockScheduleRepository(),
+                MockTripPredictionsRepository(),
+                MockTripRepository(),
+                MockVehicleRepository()
             )
 
         val filters = mutableStateOf(StopDetailsPageFilters("stop", null, null))

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
@@ -13,9 +13,6 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
-import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
 import org.junit.Rule
@@ -101,12 +98,7 @@ class StopDetailsRoutesViewTest {
     @Test
     fun testStopDetailsRoutesViewDisplaysCorrectly() {
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setDepartures(
             checkNotNull(
@@ -148,12 +140,7 @@ class StopDetailsRoutesViewTest {
     @Test
     fun testLoadingStateFiltered() {
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         composeTestRule.setContent {
             val filterState = remember {
@@ -179,12 +166,7 @@ class StopDetailsRoutesViewTest {
 
     @Test
     fun testLoadingStateUnfiltered() {
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         composeTestRule.setContent {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesViewTest.kt
@@ -119,6 +119,7 @@ class StopDetailsRoutesViewTest {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
 
             StopDetailsRoutesView(
+                stopId = stop.id,
                 viewModel = viewModel,
                 global = globalResponse,
                 now = now,
@@ -148,6 +149,7 @@ class StopDetailsRoutesViewTest {
             }
 
             StopDetailsRoutesView(
+                stopId = stop.id,
                 viewModel = viewModel,
                 global = globalResponse,
                 now = now,
@@ -172,6 +174,7 @@ class StopDetailsRoutesViewTest {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
 
             StopDetailsRoutesView(
+                stopId = stop.id,
                 viewModel = viewModel,
                 global = globalResponse,
                 now = now,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -37,6 +37,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import org.junit.Rule
@@ -1049,6 +1051,8 @@ class StopDetailsViewModelTest {
 
     @Test
     fun testManagersAppliesStopFilterAutomaticallyOnDepartureChange() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
         val objects = ObjectCollectionBuilder()
 
         val now = Clock.System.now()
@@ -1097,7 +1101,8 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, filter -> newStopFilter = filter },
-                updateTripFilter = { _, _ -> }
+                updateTripFilter = { _, _ -> },
+                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {
@@ -1116,7 +1121,7 @@ class StopDetailsViewModelTest {
             }
         }
 
-        composeTestRule.awaitIdle()
+        advanceUntilIdle()
 
         composeTestRule.waitUntil {
             newStopFilter == StopDetailsFilter(route.id, routePattern.directionId)
@@ -1189,7 +1194,7 @@ class StopDetailsViewModelTest {
                 )
             }
         }
-        composeTestRule.awaitIdle()
+        advanceUntilIdle()
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
 
@@ -1268,7 +1273,7 @@ class StopDetailsViewModelTest {
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
 
-        composeTestRule.awaitIdle()
+        advanceUntilIdle()
 
         composeTestRule.waitUntil(2_000) { newTripFilter == expectedTripFilter }
         kotlin.test.assertEquals(expectedTripFilter, newTripFilter)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -23,9 +23,15 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.model.response.TripResponse
+import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
+import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripRepository
+import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
 import junit.framework.TestCase.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -58,7 +64,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewModel.loadStopDetails("stop") } }
 
@@ -90,7 +96,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewModel.loadStopDetails("stop") } }
 
@@ -127,7 +133,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewModel.loadStopDetails("stop") } }
 
@@ -169,7 +175,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewModel.loadStopDetails("stop") } }
 
@@ -194,7 +200,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         assertNull(viewModel.stopDepartures.value)
 
@@ -221,7 +227,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent {
             LaunchedEffect(Unit) {
@@ -237,6 +243,455 @@ class StopDetailsViewModelTest {
         assertEquals("stop2", viewModel.stopData.value?.stopId)
         assertNotNull(viewModel.stopData?.value?.predictionsByStop)
         assertNotNull(viewModel.stopData?.value?.schedules)
+    }
+
+    @Test
+    fun testLoadTripData() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip1 = objects.trip(pattern) { headsign = "0" }
+        val schedule =
+            objects.schedule {
+                trip = trip1
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle =
+            objects.vehicle {
+                tripId = trip1.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        var tripPredictionsConnectedCount = 0
+        var tripPredictionsDisconnectedCount = 0
+        var vehicleConnectedCount = 0
+        var vehicleDisconnectedCount = 0
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo =
+                    MockTripPredictionsRepository(
+                        { tripPredictionsConnectedCount += 1 },
+                        { tripPredictionsDisconnectedCount += 1 },
+                        tripPredictions
+                    ),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip1)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository(
+                        { vehicleConnectedCount += 1 },
+                        { vehicleDisconnectedCount += 1 },
+                        ApiResult.Ok(VehicleStreamDataResponse(vehicle))
+                    )
+            )
+
+        val tripFilter = TripDetailsFilter(trip1.id, vehicle.id, 0, false)
+        composeTestRule.setContent {
+            LaunchedEffect(Unit) { viewModel.handleTripFilterChange(tripFilter) }
+        }
+
+        composeTestRule.waitUntil { viewModel.tripData.value != null }
+        assertEquals(tripFilter, viewModel.tripData.value?.tripFilter)
+        assertEquals(trip1, viewModel.tripData.value?.trip)
+
+        composeTestRule.waitUntil { viewModel.tripData.value?.tripSchedules != null }
+        assertEquals(tripSchedules, viewModel.tripData.value?.tripSchedules)
+        composeTestRule.waitUntil { viewModel.tripData.value?.tripPredictions != null }
+        assertEquals(tripPredictions, viewModel.tripData.value?.tripPredictions)
+        composeTestRule.waitUntil { viewModel.tripData.value?.vehicle != null }
+        assertEquals(vehicle, viewModel.tripData.value?.vehicle)
+
+        assertEquals(true, viewModel.tripData.value?.tripPredictionsLoaded)
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        viewModel.clearTripDetails()
+
+        composeTestRule.waitUntil { viewModel.tripData.value == null }
+        assertNull(viewModel.tripData.value)
+
+        assertEquals(3, tripPredictionsDisconnectedCount)
+        assertEquals(3, vehicleDisconnectedCount)
+    }
+
+    @Test
+    fun testSkipLoadingTripData() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip1 = objects.trip(pattern) { headsign = "0" }
+        val schedule =
+            objects.schedule {
+                trip = trip1
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle =
+            objects.vehicle {
+                tripId = trip1.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        var tripPredictionsConnectedCount = 0
+        var tripPredictionsDisconnectedCount = 0
+        var vehicleConnectedCount = 0
+        var vehicleDisconnectedCount = 0
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo =
+                    MockTripPredictionsRepository(
+                        { tripPredictionsConnectedCount += 1 },
+                        { tripPredictionsDisconnectedCount += 1 },
+                        tripPredictions
+                    ),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip1)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository(
+                        { vehicleConnectedCount += 1 },
+                        { vehicleDisconnectedCount += 1 },
+                        ApiResult.Ok(VehicleStreamDataResponse(vehicle))
+                    )
+            )
+
+        val tripFilter = TripDetailsFilter(trip1.id, vehicle.id, 0, false)
+        composeTestRule.setContent {
+            LaunchedEffect(Unit) { viewModel.handleTripFilterChange(tripFilter) }
+        }
+
+        composeTestRule.waitUntil { viewModel.tripData.value != null }
+        assertEquals(tripFilter, viewModel.tripData.value?.tripFilter)
+        assertEquals(trip1, viewModel.tripData.value?.trip)
+
+        composeTestRule.waitUntil { viewModel.tripData.value?.tripSchedules != null }
+        assertEquals(tripSchedules, viewModel.tripData.value?.tripSchedules)
+        composeTestRule.waitUntil { viewModel.tripData.value?.tripPredictions != null }
+        assertEquals(tripPredictions, viewModel.tripData.value?.tripPredictions)
+        composeTestRule.waitUntil { viewModel.tripData.value?.vehicle != null }
+        assertEquals(vehicle, viewModel.tripData.value?.vehicle)
+
+        assertEquals(true, viewModel.tripData.value?.tripPredictionsLoaded)
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        // Call handle change again - connection / disconnect counts should stay the same
+
+        viewModel.handleTripFilterChange(tripFilter)
+
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        assertEquals(tripFilter, viewModel.tripData.value?.tripFilter)
+        assertEquals(trip1, viewModel.tripData.value?.trip)
+        assertEquals(tripSchedules, viewModel.tripData.value?.tripSchedules)
+        assertEquals(tripPredictions, viewModel.tripData.value?.tripPredictions)
+        assertEquals(vehicle, viewModel.tripData.value?.vehicle)
+    }
+
+    @Test
+    fun testSkipLoadingRedundantVehicleData() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip0 = objects.trip(pattern) { headsign = "0" }
+        val trip1 = objects.trip(pattern) { headsign = "0" }
+
+        val schedule =
+            objects.schedule {
+                trip = trip0
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle =
+            objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        var tripPredictionsConnectedCount = 0
+        var tripPredictionsDisconnectedCount = 0
+        var vehicleConnectedCount = 0
+        var vehicleDisconnectedCount = 0
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo =
+                    MockTripPredictionsRepository(
+                        { tripPredictionsConnectedCount += 1 },
+                        { tripPredictionsDisconnectedCount += 1 },
+                        tripPredictions
+                    ),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip1)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository(
+                        { vehicleConnectedCount += 1 },
+                        { vehicleDisconnectedCount += 1 },
+                        ApiResult.Ok(VehicleStreamDataResponse(vehicle))
+                    )
+            )
+
+        val tripFilter = TripDetailsFilter(trip0.id, vehicle.id, 0, false)
+        composeTestRule.setContent {
+            LaunchedEffect(Unit) { viewModel.handleTripFilterChange(tripFilter) }
+        }
+
+        composeTestRule.waitUntil {
+            viewModel.tripData.value?.tripSchedules != null &&
+                viewModel.tripData.value?.tripPredictions != null &&
+                viewModel.tripData.value?.vehicle != null
+        }
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        // Call handle change again - only the tripId changed
+        val newTripFilter = tripFilter.copy(tripId = trip1.id)
+
+        viewModel.handleTripFilterChange(newTripFilter)
+
+        composeTestRule.waitUntil {
+            tripPredictionsDisconnectedCount == 4 && tripPredictionsConnectedCount == 2
+        }
+
+        assertEquals(4, tripPredictionsDisconnectedCount)
+        assertEquals(2, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        assertEquals(newTripFilter, viewModel.tripData.value?.tripFilter)
+        assertEquals(trip1, viewModel.tripData.value?.trip)
+        assertEquals(tripSchedules, viewModel.tripData.value?.tripSchedules)
+        assertEquals(tripPredictions, viewModel.tripData.value?.tripPredictions)
+        assertEquals(vehicle, viewModel.tripData.value?.vehicle)
+    }
+
+    @Test
+    fun testSkipLoadingRedundantTripData() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip0 = objects.trip(pattern) { headsign = "0" }
+
+        val schedule =
+            objects.schedule {
+                trip = trip0
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle0 =
+            objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val vehicle1 =
+            objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        var tripPredictionsConnectedCount = 0
+        var tripPredictionsDisconnectedCount = 0
+        var vehicleConnectedCount = 0
+        var vehicleDisconnectedCount = 0
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo =
+                    MockTripPredictionsRepository(
+                        { tripPredictionsConnectedCount += 1 },
+                        { tripPredictionsDisconnectedCount += 1 },
+                        tripPredictions
+                    ),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip0)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository(
+                        { vehicleConnectedCount += 1 },
+                        { vehicleDisconnectedCount += 1 },
+                        ApiResult.Ok(VehicleStreamDataResponse(vehicle1))
+                    )
+            )
+
+        val tripFilter = TripDetailsFilter(trip0.id, vehicle0.id, 0, false)
+        composeTestRule.setContent {
+            LaunchedEffect(Unit) { viewModel.handleTripFilterChange(tripFilter) }
+        }
+
+        composeTestRule.waitUntil {
+            viewModel.tripData.value?.tripSchedules != null &&
+                viewModel.tripData.value?.tripPredictions != null &&
+                viewModel.tripData.value?.vehicle != null
+        }
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+        assertEquals(1, vehicleConnectedCount)
+
+        // Call handle change again - only the vehicleId changed
+        val newTripFilter = tripFilter.copy(vehicleId = vehicle1.id)
+
+        viewModel.handleTripFilterChange(newTripFilter)
+
+        composeTestRule.waitUntil { vehicleDisconnectedCount == 4 && vehicleConnectedCount == 2 }
+
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(1, tripPredictionsConnectedCount)
+        assertEquals(4, vehicleDisconnectedCount)
+        assertEquals(2, vehicleConnectedCount)
+
+        assertEquals(newTripFilter, viewModel.tripData.value?.tripFilter)
+        assertEquals(trip0, viewModel.tripData.value?.trip)
+        assertEquals(tripSchedules, viewModel.tripData.value?.tripSchedules)
+        assertEquals(tripPredictions, viewModel.tripData.value?.tripPredictions)
+        assertEquals(vehicle1, viewModel.tripData.value?.vehicle)
+    }
+
+    @Test
+    fun testNullTripFilter() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip1 = objects.trip(pattern) { headsign = "0" }
+        val schedule =
+            objects.schedule {
+                trip = trip1
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle =
+            objects.vehicle {
+                tripId = trip1.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        var tripPredictionsConnectedCount = 0
+        var tripPredictionsDisconnectedCount = 0
+        var vehicleConnectedCount = 0
+        var vehicleDisconnectedCount = 0
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo =
+                    MockTripPredictionsRepository(
+                        { tripPredictionsConnectedCount += 1 },
+                        { tripPredictionsDisconnectedCount += 1 },
+                        tripPredictions
+                    ),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip1)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository(
+                        { vehicleConnectedCount += 1 },
+                        { vehicleDisconnectedCount += 1 },
+                        ApiResult.Ok(VehicleStreamDataResponse(vehicle))
+                    )
+            )
+
+        val tripFilter = TripDetailsFilter(trip1.id, vehicle.id, 0, false)
+        composeTestRule.setContent {
+            LaunchedEffect(Unit) { viewModel.handleTripFilterChange(tripFilter) }
+        }
+
+        composeTestRule.waitUntil {
+            tripPredictionsConnectedCount == 1 && vehicleConnectedCount == 1
+        }
+        assertEquals(2, tripPredictionsDisconnectedCount)
+        assertEquals(2, vehicleDisconnectedCount)
+
+        assertNotNull(viewModel.tripData.value)
+
+        viewModel.handleTripFilterChange(null)
+
+        composeTestRule.waitUntil {
+            tripPredictionsDisconnectedCount == 3 && vehicleDisconnectedCount == 3
+        }
+        assertEquals(3, tripPredictionsDisconnectedCount)
+        assertEquals(3, vehicleDisconnectedCount)
+
+        assertNull(viewModel.tripData.value)
     }
 
     @Test
@@ -257,7 +712,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         val stopFilters =
             mutableStateOf<StopDetailsPageFilters?>(StopDetailsPageFilters("stop1", null, null))
@@ -295,26 +750,155 @@ class StopDetailsViewModelTest {
     }
 
     @Test
+    fun testManagerHandlesTripFilterChange() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
+
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip1 = objects.trip(pattern) { headsign = "0" }
+        val schedule =
+            objects.schedule {
+                trip = trip1
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle =
+            objects.vehicle {
+                tripId = trip1.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        val tripPredictions = PredictionsStreamDataResponse(objects)
+        val tripSchedules = TripSchedulesResponse.Schedules(listOf(schedule))
+
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                tripPredictionsRepo = MockTripPredictionsRepository({}, {}, tripPredictions),
+                tripRepo =
+                    MockTripRepository(
+                        tripSchedulesResponse = tripSchedules,
+                        tripResponse = TripResponse(trip1)
+                    ),
+                vehicleRepo =
+                    MockVehicleRepository({}, {}, ApiResult.Ok(VehicleStreamDataResponse(vehicle)))
+            )
+
+        val newTripFilter = TripDetailsFilter(trip1.id, vehicle.id, 0, false)
+
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.STARTED)
+
+        val stopFilters =
+            mutableStateOf<StopDetailsPageFilters?>(
+                StopDetailsPageFilters(stop.id, StopDetailsFilter(route.id, 0), null)
+            )
+
+        composeTestRule.setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
+                var stopFilters by remember { stopFilters }
+                stopDetailsManagedVM(
+                    stopFilters,
+                    viewModel = viewModel,
+                    globalResponse = null,
+                    alertData = null,
+                    pinnedRoutes = setOf(),
+                    updateStopFilter = { _, _ -> },
+                    updateTripFilter = { _, _ -> }
+                )
+            }
+        }
+
+        composeTestRule.waitUntil { viewModel.stopData.value != null }
+        assertNull(viewModel.tripData.value)
+
+        stopFilters.value = stopFilters.value?.copy(tripFilter = newTripFilter)
+        composeTestRule.waitUntil { viewModel.tripData.value != null }
+        assertNotNull(viewModel.tripData.value)
+    }
+
+    @Test
     fun testManagerHandlesBackgrounding() = runTest {
         val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route()
 
-        var connectCount = 0
-        var disconnectCount = 0
+        val pattern =
+            objects.routePattern(route) {
+                directionId = 0
+                representativeTrip { headsign = "0" }
+            }
+        val trip0 = objects.trip(pattern) { headsign = "0" }
+
+        val schedule =
+            objects.schedule {
+                trip = trip0
+                routeId = route.id
+                stopId = stop.id
+            }
+        val vehicle0 =
+            objects.vehicle {
+                tripId = trip0.id
+                currentStatus = Vehicle.CurrentStatus.InTransitTo
+                stopId = stop.id
+                currentStopSequence = 0
+            }
+
+        var stopPredictionsConnectCount = 0
+        var stopPredictionsDisconnectCount = 0
+
+        var tripPredictionsConnectCount = 0
+        var tripPredictionsDisconnectCount = 0
+
+        var vehicleConnectCount = 0
+        var vehicleDisconnectCount = 0
 
         val predictionsRepo =
             MockPredictionsRepository(
                 connectV2Outcome = ApiResult.Ok(PredictionsByStopJoinResponse(objects)),
-                onConnectV2 = { connectCount += 1 },
-                onDisconnect = { disconnectCount += 1 }
+                onConnectV2 = { stopPredictionsConnectCount += 1 },
+                onDisconnect = { stopPredictionsDisconnectCount += 1 }
+            )
+
+        val tripPredictionsRepo =
+            MockTripPredictionsRepository(
+                { tripPredictionsConnectCount += 1 },
+                { tripPredictionsDisconnectCount += 1 },
+                PredictionsStreamDataResponse(objects)
+            )
+        val vehicleRepo =
+            MockVehicleRepository(
+                { vehicleConnectCount += 1 },
+                { vehicleDisconnectCount += 1 },
+                ApiResult.Ok(VehicleStreamDataResponse(vehicle0))
             )
 
         val schedulesRepo = MockScheduleRepository(ScheduleResponse(objects))
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel =
+            StopDetailsViewModel.mocked(
+                errorBannerRepo,
+                predictionsRepo,
+                schedulesRepo,
+                tripPredictionsRepo,
+                vehicleRepo = vehicleRepo
+            )
 
-        val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
+        val stopFilters =
+            mutableStateOf(
+                StopDetailsPageFilters(
+                    "stop1",
+                    StopDetailsFilter("route", 0),
+                    TripDetailsFilter("tripId", "vehicleId", 0)
+                )
+            )
 
         val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
 
@@ -336,25 +920,48 @@ class StopDetailsViewModelTest {
         composeTestRule.waitUntil {
             // In resumed state, so joined 1 time for stop, 1 time for resume.
             // Need to start with lifecycle resumed in order to test pause
-            connectCount == 2
+            stopPredictionsConnectCount == 2
+
+            // Trip channels rejoin is no-op because tripData hasn't been set yet
+            && tripPredictionsConnectCount == 1 && vehicleConnectCount == 1
         }
 
-        assertEquals(2, connectCount)
-        assertEquals(1, disconnectCount)
+        assertEquals(2, stopPredictionsConnectCount)
+        assertEquals(1, stopPredictionsDisconnectCount)
+
+        assertEquals(1, tripPredictionsConnectCount)
+        assertEquals(2, tripPredictionsDisconnectCount)
+
+        assertEquals(1, vehicleConnectCount)
+        assertEquals(2, vehicleDisconnectCount)
+
         assertEquals("stop1", viewModel.stopData.value?.stopId)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
-        composeTestRule.waitUntil { disconnectCount == 2 }
+        composeTestRule.waitUntil {
+            stopPredictionsDisconnectCount == 2 &&
+                tripPredictionsDisconnectCount == 3 &&
+                vehicleDisconnectCount == 3
+        }
 
-        assertEquals(2, connectCount)
-        assertEquals(2, disconnectCount)
+        assertEquals(2, stopPredictionsConnectCount)
+        assertEquals(2, stopPredictionsDisconnectCount)
+        assertEquals(3, tripPredictionsDisconnectCount)
+        assertEquals(3, vehicleDisconnectCount)
+
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        composeTestRule.waitUntil { connectCount == 3 }
+        composeTestRule.waitUntil {
+            stopPredictionsConnectCount == 3 &&
+                tripPredictionsConnectCount == 2 &&
+                vehicleConnectCount == 2
+        }
 
-        assertEquals(3, connectCount)
-        assertEquals(2, disconnectCount)
+        assertEquals(3, stopPredictionsConnectCount)
+        assertEquals(2, stopPredictionsDisconnectCount)
+        assertEquals(2, tripPredictionsConnectCount)
+        assertEquals(2, vehicleConnectCount)
     }
 
     @Test
@@ -371,7 +978,7 @@ class StopDetailsViewModelTest {
 
         val errorBannerRepo = MockErrorBannerStateRepository()
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
 
@@ -415,7 +1022,7 @@ class StopDetailsViewModelTest {
                 onCheckPredictionsStale = { checkPredictionsStaleCount += 1 }
             )
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         composeTestRule.setContent {
             var stopFilters by remember { stopFilters }
@@ -472,7 +1079,7 @@ class StopDetailsViewModelTest {
 
         val stopFilters = mutableStateOf(StopDetailsPageFilters(stop.id, null, null))
 
-        val viewModel = StopDetailsViewModel(schedulesRepo, predictionsRepo, errorBannerRepo)
+        val viewModel = StopDetailsViewModel.mocked(errorBannerRepo, predictionsRepo, schedulesRepo)
 
         var newStopFilter: StopDetailsFilter? = null
 
@@ -543,12 +1150,7 @@ class StopDetailsViewModelTest {
 
         objects.prediction(schedule) { departureTime = now.plus(10.minutes) }
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         val stopFilters =
             mutableStateOf(StopDetailsPageFilters(stop.id, StopDetailsFilter(route.id, 0), null))
@@ -620,12 +1222,7 @@ class StopDetailsViewModelTest {
 
         objects.prediction(schedule) { departureTime = now.plus(10.minutes) }
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         // There are no trips in direction 1
         val stopFilters =

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -1132,6 +1132,8 @@ class StopDetailsViewModelTest {
 
     @Test
     fun testManagerAppliesTripFilterAutomaticallyOnDepartureChange() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
 
@@ -1176,7 +1178,8 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, _ -> },
-                updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter }
+                updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
+                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {
@@ -1204,6 +1207,7 @@ class StopDetailsViewModelTest {
 
     @Test
     fun testManagerAppliesTripFilterAutomaticallyOnFilterChange() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
 
@@ -1249,7 +1253,8 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, _ -> },
-                updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter }
+                updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
+                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -1193,7 +1193,7 @@ class StopDetailsViewModelTest {
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
 
-        composeTestRule.waitUntil { newTripFilter == expectedTripFilter }
+        composeTestRule.waitUntil(2000) { newTripFilter == expectedTripFilter }
         kotlin.test.assertEquals(expectedTripFilter, newTripFilter)
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -917,6 +917,8 @@ class StopDetailsViewModelTest {
             }
         }
 
+        composeTestRule.awaitIdle()
+
         composeTestRule.waitUntil {
             // In resumed state, so joined 1 time for stop, 1 time for resume.
             // Need to start with lifecycle resumed in order to test pause
@@ -938,6 +940,7 @@ class StopDetailsViewModelTest {
         assertEquals("stop1", viewModel.stopData.value?.stopId)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
+        composeTestRule.awaitIdle()
 
         composeTestRule.waitUntil {
             stopPredictionsDisconnectCount == 2 &&
@@ -952,6 +955,7 @@ class StopDetailsViewModelTest {
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
+        composeTestRule.awaitIdle()
         composeTestRule.waitUntil {
             stopPredictionsConnectCount == 3 &&
                 tripPredictionsConnectCount == 2 &&

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -36,7 +36,6 @@ import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
-import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
@@ -193,13 +192,7 @@ class StopDetailsViewTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testStopDetailsViewDisplaysCorrectly() {
-
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setDepartures(
             StopDetailsDepartures(
@@ -279,12 +272,8 @@ class StopDetailsViewTest {
                 header = "Elevator alert header"
             }
 
-        val viewModel =
-            StopDetailsViewModel(
-                MockScheduleRepository(),
-                MockPredictionsRepository(),
-                MockErrorBannerStateRepository()
-            )
+        val viewModel = StopDetailsViewModel.mocked()
+
         viewModel.setDepartures(
             StopDetailsDepartures(
                 listOf(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
@@ -50,7 +50,7 @@ class MainApplication : Application() {
         val koinViewModelModule = module {
             viewModelOf(::ContentViewModel)
             viewModelOf(::NearbyTransitViewModel)
-            viewModelOf(::StopDetailsViewModel)
+            viewModel { StopDetailsViewModel(get(), get(), get(), get(), get(), get()) }
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/LoadingStopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/LoadingStopDetailsView.kt
@@ -45,6 +45,7 @@ fun LoadingStopDetailsView(stopFilter: StopDetailsFilter?, tripFilter: TripDetai
                     }
                 } else {
                     StopDetailsFilteredRouteView(
+                        stopId = "",
                         viewModel = viewModel,
                         global = null,
                         now = Clock.System.now(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteView.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -34,6 +35,7 @@ import kotlinx.datetime.Instant
 
 @Composable
 fun StopDetailsFilteredRouteView(
+    stopId: String,
     viewModel: StopDetailsViewModel,
     global: GlobalResponse?,
     now: Instant,
@@ -121,6 +123,16 @@ fun StopDetailsFilteredRouteView(
                             row.upcoming.trip.headsign,
                             RealtimePatterns.Format.Some(listOf(row.formatted), null),
                             Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                                .border(
+                                    BorderStroke(
+                                        if (row.upcoming.trip.id == tripFilter?.tripId) {
+                                            10.dp
+                                        } else {
+                                            0.dp
+                                        },
+                                        colorResource(R.color.key)
+                                    )
+                                )
                                 .clickable(
                                     onClickLabel = null,
                                     onClick = {
@@ -140,6 +152,13 @@ fun StopDetailsFilteredRouteView(
                     }
                 }
             }
+
+            TripDetailsView(
+                tripFilter = tripFilter,
+                stopId = stopId,
+                stopDetailsVM = viewModel,
+                now = now
+            )
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
@@ -131,11 +131,11 @@ private fun StopDetailsRoutesViewPreview() {
 
     val viewModel =
         StopDetailsViewModel(
-            MockScheduleRepository(),
-            MockPredictionsRepository(),
             MockErrorBannerStateRepository(),
-            MockTripRepository(),
+            MockPredictionsRepository(),
+            MockScheduleRepository(),
             MockTripPredictionsRepository(),
+            MockTripRepository(),
             MockVehicleRepository()
         )
     viewModel.setDepartures(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
@@ -35,6 +35,7 @@ import kotlinx.datetime.Instant
 
 @Composable
 fun StopDetailsRoutesView(
+    stopId: String,
     viewModel: StopDetailsViewModel,
     global: GlobalResponse?,
     now: Instant,
@@ -53,6 +54,7 @@ fun StopDetailsRoutesView(
         LoadingStopDetailsView(stopFilter, tripFilter)
     } else if (stopFilter != null) {
         StopDetailsFilteredRouteView(
+            stopId,
             viewModel,
             global = global,
             now = now,
@@ -187,6 +189,7 @@ private fun StopDetailsRoutesViewPreview() {
 
     MyApplicationTheme {
         StopDetailsRoutesView(
+            stopId = stop.id,
             viewModel = viewModel,
             global = null,
             now = Clock.System.now(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsRoutesView.kt
@@ -26,6 +26,9 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
+import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripRepository
+import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -130,7 +133,10 @@ private fun StopDetailsRoutesViewPreview() {
         StopDetailsViewModel(
             MockScheduleRepository(),
             MockPredictionsRepository(),
-            MockErrorBannerStateRepository()
+            MockErrorBannerStateRepository(),
+            MockTripRepository(),
+            MockTripPredictionsRepository(),
+            MockVehicleRepository()
         )
     viewModel.setDepartures(
         StopDetailsDepartures(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -153,6 +153,7 @@ fun StopDetailsView(
                 }
             }
             StopDetailsRoutesView(
+                stopId,
                 viewModel,
                 globalResponse,
                 now,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -246,9 +246,12 @@ class StopDetailsViewModel(
     }
 
     private suspend fun loadTripDetails(tripFilter: TripDetailsFilter) {
-        val trip = CoroutineScope(Dispatchers.Default).async { loadTrip(tripFilter) }.await()
-        val schedules =
-            CoroutineScope(Dispatchers.Default).async { loadTripSchedules(tripFilter) }.await()
+        val tripResult = CoroutineScope(Dispatchers.Default).async { loadTrip(tripFilter) }
+        val schedulesResult =
+            CoroutineScope(Dispatchers.Default).async { loadTripSchedules(tripFilter) }
+
+        val trip = tripResult.await()
+        val schedules = schedulesResult.await()
         if (trip == null) {
             _tripData.value = null
         } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsHeader.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.runtime.Composable
+import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
 
-@Composable fun TripDetailsHeader() {}
+@Composable fun TripDetailsHeader(tripId: String, spec: TripHeaderSpec?) {}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -1,5 +1,17 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.runtime.Composable
+import com.mbta.tid.mbta_app.model.TripDetailsStopList
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import kotlinx.datetime.Instant
 
-@Composable fun TripStops() {}
+@Composable
+fun TripStops(
+    targetId: String,
+    stops: TripDetailsStopList,
+    stopSequence: Int?,
+    headerSpec: TripHeaderSpec?,
+    now: Instant,
+    global: GlobalResponse?
+) {}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
@@ -1,0 +1,18 @@
+package com.mbta.tid.mbta_app.model.stopDetailsPage
+
+import com.mbta.tid.mbta_app.model.Trip
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
+import com.mbta.tid.mbta_app.model.Vehicle
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TripData(
+    val tripFilter: TripDetailsFilter,
+    val trip: Trip,
+    val tripSchedules: TripSchedulesResponse?,
+    val tripPredictions: PredictionsStreamDataResponse?,
+    val tripPredictionsLoaded: Boolean = false,
+    val vehicle: Vehicle?
+)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripHeaderSpec.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripHeaderSpec.kt
@@ -1,0 +1,48 @@
+package com.mbta.tid.mbta_app.model.stopDetailsPage
+
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.TripDetailsStopList
+import com.mbta.tid.mbta_app.model.Vehicle
+
+sealed class TripHeaderSpec {
+    data object FinishingAnotherTrip : TripHeaderSpec()
+
+    data object NoVehicle : TripHeaderSpec()
+
+    data class Scheduled(val stop: Stop, val entry: TripDetailsStopList.Entry) : TripHeaderSpec()
+
+    data class VehicleOnTrip(
+        val vehicle: Vehicle,
+        val stop: Stop,
+        val entry: TripDetailsStopList.Entry?
+    ) : TripHeaderSpec()
+
+    companion object {
+        fun getSpec(
+            tripId: String,
+            stops: TripDetailsStopList,
+            terminalStop: Stop?,
+            vehicle: Vehicle?,
+            vehicleStop: Stop?
+        ): TripHeaderSpec? {
+            return if (vehicle != null && vehicleStop != null) {
+                val atTerminal =
+                    terminalStop != null &&
+                        terminalStop?.id == vehicleStop.id &&
+                        vehicle.currentStatus == Vehicle.CurrentStatus.StoppedAt
+                val terminalEntry = if (atTerminal) stops.startTerminalEntry else null
+                if (vehicle.tripId == tripId) {
+                    VehicleOnTrip(vehicle, vehicleStop, terminalEntry)
+                } else {
+                    FinishingAnotherTrip
+                }
+            } else if (stops.stops.any { it.prediction != null }) {
+                NoVehicle
+            } else if (terminalStop != null && stops.startTerminalEntry != null) {
+                Scheduled(terminalStop, stops.startTerminalEntry)
+            } else {
+                null
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | stop + trip details | barebones UX](https://app.asana.com/0/1205732265579288/1209118361132266/f)

What is this PR for?

This PR adds all functionality to the StopDetailsViewModel for fetching the relevant trip + vehicle data based on the trip filter.

Based entirely on [StopDetailsViewModel.swift](https://github.com/mbta/mobile_app/blob/main/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift). I considered pulling out some common helper classes, but for expediency opted not to at this point since this PR is blocking other work.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Added unit tests based on swift tests & updated existing tests
* Ran locally with logs & confirmed data loads as expected

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
