### PR TITLE
fix: tweak direction picker on both iOS and Android

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
@@ -2,9 +2,11 @@ package com.mbta.tid.mbta_app.android.component
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
@@ -27,7 +29,11 @@ private fun directionNameFormatted(direction: Direction) =
     localizedDirectionNames[direction.name] ?: R.string.heading
 
 @Composable
-fun DirectionLabel(direction: Direction, modifier: Modifier = Modifier) {
+fun DirectionLabel(
+    direction: Direction,
+    modifier: Modifier = Modifier,
+    textColor: Color = LocalContentColor.current
+) {
     val destination = direction.destination
     Column(modifier = modifier) {
         if (destination != null) {
@@ -36,11 +42,13 @@ fun DirectionLabel(direction: Direction, modifier: Modifier = Modifier) {
                     R.string.directionTo,
                     stringResource(directionNameFormatted(direction))
                 ),
+                color = textColor,
                 fontSize = 13.sp,
                 modifier = Modifier.placeholderIfLoading()
             )
             Text(
                 destination,
+                color = textColor,
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.placeholderIfLoading()
@@ -48,6 +56,7 @@ fun DirectionLabel(direction: Direction, modifier: Modifier = Modifier) {
         } else {
             Text(
                 stringResource(directionNameFormatted(direction)),
+                color = textColor,
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.placeholderIfLoading()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
@@ -5,11 +5,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -18,11 +19,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionLabel
 import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.PatternsByStop
+import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -51,7 +56,7 @@ fun DirectionPicker(
                 .fillMaxWidth()
                 .height(IntrinsicSize.Max),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.spacedBy(2.dp)
         ) {
             for (direction in availableDirections) {
                 val isSelected = filter?.directionId == direction
@@ -73,14 +78,60 @@ fun DirectionPicker(
                             contentColor =
                                 if (isSelected) Color.fromHex(route.textColor)
                                 else colorResource(R.color.deselected_toggle_text)
-                        )
+                        ),
+                    contentPadding = PaddingValues(8.dp)
                 ) {
-                    DirectionLabel(
-                        direction = directions[(direction)],
-                        modifier = Modifier.padding(8.dp)
-                    )
+                    DirectionLabel(direction = directions[(direction)])
+                    Spacer(Modifier.weight(1f))
                 }
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun DirectionPickerPreview() {
+    val objects = ObjectCollectionBuilder()
+    val stop = objects.stop()
+    val route =
+        objects.route {
+            color = "FFC72C"
+            textColor = "000000"
+        }
+    val patternOutbound = objects.routePattern(route) { directionId = 0 }
+    val patternInbound = objects.routePattern(route) { directionId = 1 }
+    DirectionPicker(
+        patternsByStop =
+            PatternsByStop(
+                routes = listOf(route),
+                line = null,
+                stop,
+                patterns =
+                    listOf(
+                        RealtimePatterns.ByHeadsign(
+                            route = route,
+                            headsign = "Out",
+                            line = null,
+                            patterns = listOf(patternOutbound),
+                            upcomingTrips = emptyList()
+                        ),
+                        RealtimePatterns.ByHeadsign(
+                            route = route,
+                            headsign = "In",
+                            line = null,
+                            patterns = listOf(patternInbound),
+                            upcomingTrips = emptyList()
+                        ),
+                    ),
+                directions =
+                    listOf(
+                        Direction(name = "Outbound", destination = "Out", id = 0),
+                        Direction(name = "Inbound", destination = "In", id = 1),
+                    ),
+                elevatorAlerts = emptyList()
+            ),
+        filter = StopDetailsFilter(routeId = route.id, directionId = 0),
+        updateStopFilter = {}
+    )
 }

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -32,7 +32,7 @@ struct DirectionPicker: View {
     var body: some View {
         if availableDirections.count > 1 {
             let deselectedBackroundColor = deselectedBackgroundColor(route)
-            HStack(alignment: .center) {
+            HStack(alignment: .center, spacing: 2) {
                 ForEach(availableDirections, id: \.hashValue) { direction in
                     let isSelected = filter?.directionId == direction
                     let action = { setFilter(.init(routeId: line?.id ?? route.id, directionId: direction)) }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Direction picker unselected side looks wrong](https://app.asana.com/0/1205732265579288/1209226816339258/f)

Just made this task while waiting on other work to get unblocked.

Before:
<img width="847" alt="Screenshot 2025-01-23 at 10 39 06 AM" src="https://github.com/user-attachments/assets/170a9200-78f5-41ea-bc7a-51d37b6af5a4" />
After:
<img width="847" alt="Screenshot 2025-01-23 at 10 31 37 AM" src="https://github.com/user-attachments/assets/22b6f3b5-6e5a-4068-a166-dd763b8eb8e9" />

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manually verified that this looks better than it used to.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
