### PR TITLE
fix(Android): Prevent squashed onboarding images

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -155,8 +155,8 @@ fun OnboardingScreenView(
                             }
                         ),
                         contentDescription = null,
-                        contentScale = ContentScale.FillBounds,
-                        modifier = Modifier.fillMaxWidth().align(Alignment.Center)
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize().align(Alignment.Center)
                     )
                     Image(
                         painterResource(
@@ -220,7 +220,7 @@ fun OnboardingScreenView(
                                             }
                                     ),
                                 alignment = Alignment.Center,
-                                contentScale = ContentScale.FillBounds
+                                contentScale = ContentScale.Crop
                             ),
                 ) {
                     Spacer(modifier = Modifier.weight(1f))
@@ -303,7 +303,7 @@ fun OnboardingScreenView(
                                             }
                                     ),
                                 alignment = Alignment.Center,
-                                contentScale = ContentScale.FillBounds
+                                contentScale = ContentScale.Crop
                             ),
                 ) {
                     Image(
@@ -317,8 +317,8 @@ fun OnboardingScreenView(
                                     }
                             ),
                         contentDescription = null,
-                        contentScale = ContentScale.FillBounds,
-                        modifier = Modifier.align(Alignment.Center).fillMaxWidth()
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.align(Alignment.Center).fillMaxSize()
                     )
                     Image(
                         painter =


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, reported [on slack](https://mbta.slack.com/archives/C07HCGLKZPY/p1737734821511149)

Switches onboarding image scaling to crop rather than stretch to fill bounds, and fill max size rather than max width.

android
~- [ ] All user-facing strings added to strings resource~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

N/A
