### PR TITLE
test(StopDetailsViewModel): Address remaining flakiness

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -68,7 +68,8 @@ class StopDetailsViewModel(
             schedulesRepo: ISchedulesRepository = MockScheduleRepository(),
             tripPredictionsRepo: ITripPredictionsRepository = MockTripPredictionsRepository(),
             tripRepo: ITripRepository = MockTripRepository(),
-            vehicleRepo: IVehicleRepository = MockVehicleRepository()
+            vehicleRepo: IVehicleRepository = MockVehicleRepository(),
+            coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default
         ): StopDetailsViewModel {
             return StopDetailsViewModel(
                 errorBannerRepo,
@@ -76,7 +77,8 @@ class StopDetailsViewModel(
                 schedulesRepo,
                 tripPredictionsRepo,
                 tripRepo,
-                vehicleRepo
+                vehicleRepo,
+                coroutineDispatcher
             )
         }
     }


### PR DESCRIPTION
### Summary

Follow up to https://github.com/mbta/mobile_app/pull/675, which introduced some tests that are still flaky.

What is this PR for?

An attempt to resolve flakiness in the `stopDetailsManagedVM` tests. I expaned the use of the StandardTestDispatcher recommended [here](https://developer.android.com/kotlin/coroutines/test#standardtestdispatcher) to the view model in each managedVM test. These tests passed running repeatedly locally, except for `testManagerHandlesTripFilterChange` which consistently failed until I also added `composeTestRule.awaitIdle()` I'm not entirely sure why that test in particular was failing. 

If these continue to flake after these changes, then we should take @EmmaSimon's suggestion of skipping them for now and make a ticket to follow up on them.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
