### PR TITLE
fix(StopDetailsFilteredRouteView): Remove temporary selected trip border

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredRouteView.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -123,16 +122,6 @@ fun StopDetailsFilteredRouteView(
                             row.upcoming.trip.headsign,
                             RealtimePatterns.Format.Some(listOf(row.formatted), null),
                             Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
-                                .border(
-                                    BorderStroke(
-                                        if (row.upcoming.trip.id == tripFilter?.tripId) {
-                                            10.dp
-                                        } else {
-                                            0.dp
-                                        },
-                                        colorResource(R.color.key)
-                                    )
-                                )
                                 .clickable(
                                     onClickLabel = null,
                                     onClick = {


### PR DESCRIPTION
### Summary

No ticket

What is this PR for?
Removes debugging border around the selected trip

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
