### PR TITLE
fix(Android): skip hide maps onboarding for non-accessibility accessibility services

### DIFF
--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.android.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.repositories
 
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
+import android.os.Build
 import android.view.accessibility.AccessibilityManager
 
 class AccessibilityStatusRepository(context: Context) : IAccessibilityStatusRepository {
@@ -11,9 +12,17 @@ class AccessibilityStatusRepository(context: Context) : IAccessibilityStatusRepo
     // https://stackoverflow.com/a/59950182
     override fun isScreenReaderEnabled(): Boolean {
         if (accessibility == null) return false
-        return accessibility.isEnabled &&
+        if (!accessibility.isEnabled) return false
+        val services =
             accessibility
                 .getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
-                .isNotEmpty()
+                .filter {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        it.isAccessibilityTool
+                    } else {
+                        it.feedbackType != AccessibilityServiceInfo.FEEDBACK_GENERIC
+                    }
+                }
+        return services.isNotEmpty()
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack message](https://mbta.slack.com/archives/C05QMG9GS9M/p1738003892339439?thread_ts=1738001493.639229&cid=C05QMG9GS9M)

On Android, a lot of non-accessibility-related apps run as accessibility services to get access to info like which app is running. If I have two of those running, I should not see the hide maps onboarding screen.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Verified that on my personal phone neither [Tasker](https://tasker.joaoapps.com/) nor [ScreenZen](https://www.screenzen.co/) causes the onboarding screen to show but TalkBack still does.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
