### PR TITLE
feat(Android): Downstream disruptions/service changes

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -1,0 +1,108 @@
+package com.mbta.tid.mbta_app.android.stopDetails
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class AlertCardTests {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val color = Color.fromHex("ED8B00")
+    private val textColor = Color.fromHex("FFFFFF")
+
+    @Test
+    fun testDownstreamAlertCard() {
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                header = "Alert header"
+                effect = Alert.Effect.Detour
+            }
+        var onViewDetailsClicked = false
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                AlertCardSpec.Downstream,
+                color,
+                textColor,
+                { onViewDetailsClicked = true }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Detour ahead").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
+        assertTrue { onViewDetailsClicked }
+    }
+
+    @Test
+    fun testMajorAlertCard() {
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                header = "Alert header"
+                effect = Alert.Effect.Suspension
+            }
+        var onViewDetailsClicked = false
+        composeTestRule.setContent {
+            AlertCard(alert, AlertCardSpec.Major, color, textColor, { onViewDetailsClicked = true })
+        }
+
+        composeTestRule.onNodeWithText("Suspension").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Alert header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("View details").performClick()
+        assertTrue { onViewDetailsClicked }
+    }
+
+    @Test
+    fun testSecondaryAlertCard() {
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                header = "Alert header"
+                effect = Alert.Effect.Detour
+            }
+        var onViewDetailsClicked = false
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                AlertCardSpec.Secondary,
+                color,
+                textColor,
+                { onViewDetailsClicked = true }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Detour").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
+        assertTrue { onViewDetailsClicked }
+    }
+
+    @Test
+    fun testElevatorAlertCard() {
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                header = "Alert header"
+                effect = Alert.Effect.ElevatorClosure
+            }
+        var onViewDetailsClicked = false
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                AlertCardSpec.Elevator,
+                color,
+                textColor,
+                { onViewDetailsClicked = true }
+            )
+        }
+
+        composeTestRule.onNodeWithText("Alert header").assertIsDisplayed().performClick()
+        assertTrue { onViewDetailsClicked }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
@@ -116,28 +115,6 @@ fun StopDetailsFilteredDeparturesView(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 DirectionPicker(patternsByStop, stopFilter, updateStopFilter)
-
-                if (showElevatorAccessibility && elevatorAlerts.isNotEmpty()) {
-                    elevatorAlerts.map {
-                        Column(
-                            Modifier.background(
-                                    colorResource(R.color.fill3),
-                                    RoundedCornerShape(8.dp)
-                                )
-                                .clip(RoundedCornerShape(8.dp))
-                                .border(0.dp, Color.Unspecified, shape = RoundedCornerShape(8.dp))
-                                .clickable(
-                                    onClickLabel = stringResource(R.string.displays_more_info)
-                                ) {
-                                    openAlertDetails(
-                                        ModalRoutes.AlertDetails(it.id, null, null, stopId)
-                                    )
-                                }
-                        ) {
-                            StopDetailsAlertHeader(it, Color.Unspecified, showInfoIcon = true)
-                        }
-                    }
-                }
 
                 Column(
                     Modifier.background(colorResource(R.color.fill3), RoundedCornerShape(8.dp))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/AlertEffectExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/AlertEffectExtension.kt
@@ -1,0 +1,23 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.Alert
+
+@Composable
+fun Alert.effectDescription(): String {
+    val effectAhead = R.string.effect_ahead
+    return when (effect) {
+        Alert.Effect.Detour -> stringResource(effectAhead, stringResource(R.string.detour))
+        Alert.Effect.ServiceChange ->
+            stringResource(effectAhead, stringResource(R.string.service_change))
+        Alert.Effect.Shuttle -> stringResource(effectAhead, stringResource(R.string.shuttle_buses))
+        Alert.Effect.SnowRoute -> stringResource(effectAhead, stringResource(R.string.snow_route))
+        Alert.Effect.StopClosure ->
+            stringResource(effectAhead, stringResource(R.string.stop_closure))
+        Alert.Effect.Suspension ->
+            stringResource(effectAhead, stringResource(R.string.service_suspended))
+        else -> stringResource(effectAhead, stringResource(R.string.alert))
+    }
+}

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -38,6 +38,7 @@
     <string name="dock_closure">Cierre del muelle</string>
     <string name="drawbridge_being_raised">Puente levadizo en elevación</string>
     <string name="eastbound">En dirección este</string>
+    <string name="effect_ahead">%1$s adelante</string>
     <string name="electrical_work">Trabajo eléctrico</string>
     <plurals name="elevator_closure_count">
         <item quantity="one">%1$d ascensor cerrado</item>
@@ -151,14 +152,17 @@
     <string name="selected_stop_first_stop">%1$s, parada seleccionada, primera parada</string>
     <string name="service_change">Cambio de servicio</string>
     <string name="service_ended">Servicio finalizado</string>
+    <string name="service_suspended">Servicio suspendido</string>
     <string name="setting_elevator_accessibility">Mostrar accesibilidad del ascensor</string>
     <string name="setting_toggle_hide_maps">Ocultar Mapas</string>
     <string name="settings_link">Configuración</string>
     <string name="severe_weather">Clima severo</string>
     <string name="shuttle">Autobús de enlace</string>
+    <string name="shuttle_buses">Autobuses de enlace</string>
     <string name="signal_problem">Problema de señal</string>
     <string name="slippery_rail">Riel resbaloso</string>
     <string name="snow">Nieve</string>
+    <string name="snow_route">Ruta de nieve</string>
     <string name="southbound">En dirección sur</string>
     <string name="special_event">Evento especial</string>
     <string name="speed_restriction">Restricción de velocidad</string>
@@ -213,6 +217,7 @@
     <string name="vehicle_schedule_minutes_other">y en %1$d min programado</string>
     <string name="vehicle_schedule_time_first">%1$s llegará a la(s) %2$s como se programó</string>
     <string name="vehicle_schedule_time_other">y a la(s) %1$s como se programó</string>
+    <string name="view_details">Ver detalles</string>
     <string name="waiting_to_depart">Esperando para partir</string>
     <string name="weather">Clima</string>
     <string name="westbound">En dirección oeste</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -41,6 +41,7 @@
     <string name="dock_closure">Waf la Fèmen</string>
     <string name="drawbridge_being_raised">Y ap Leve Pon ki ka Bouje a</string>
     <string name="eastbound">Pran direksyon lès</string>
+    <string name="effect_ahead">%1$s devan</string>
     <string name="electrical_work">Travay Elektrik</string>
     <plurals name="elevator_closure_count">
         <item quantity="one">%1$d asansè fèmen</item>
@@ -156,14 +157,17 @@
     <string name="selected_stop_first_stop">%1$s, chwazi kanpe, premye kanpe</string>
     <string name="service_change">Chanjman Sèvis</string>
     <string name="service_ended">Sèvis ki fini</string>
+    <string name="service_suspended">Sèvis ki kanpe</string>
     <string name="setting_elevator_accessibility">Montre aksè nan asansè</string>
     <string name="setting_toggle_hide_maps">Kache Kat yo</string>
     <string name="settings_link">Paramèt</string>
     <string name="severe_weather">Move Tan</string>
     <string name="shuttle">Navèt</string>
+    <string name="shuttle_buses">Otobis navèt</string>
     <string name="signal_problem">Pwoblèm Siyal</string>
     <string name="slippery_rail">Ray ki Glise</string>
     <string name="snow">Nèj</string>
+    <string name="snow_route">Wout nèj</string>
     <string name="southbound">Nan direksyon sid</string>
     <string name="special_event">Evènman Espesyal</string>
     <string name="speed_restriction">Limit Vitès</string>
@@ -224,6 +228,7 @@
     <string name="vehicle_schedule_minutes_other">epi nan %1$d min pwograme</string>
     <string name="vehicle_schedule_time_first">%1$s ap rive a %2$s pwograme</string>
     <string name="vehicle_schedule_time_other">epi a %1$s pwograme</string>
+    <string name="view_details">Gade detay</string>
     <string name="waiting_to_depart">Ap tann pou yo pati</string>
     <string name="weather">Tan</string>
     <string name="westbound">Pran direksyon lwès</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -38,6 +38,7 @@
     <string name="dock_closure">Fechamento de doca</string>
     <string name="drawbridge_being_raised">Ponte móvel em elevação</string>
     <string name="eastbound">Sentido leste</string>
+    <string name="effect_ahead">%1$s à frente</string>
     <string name="electrical_work">Obra elétrica</string>
     <plurals name="elevator_closure_count">
         <item quantity="one">%1$d elevador fechado</item>
@@ -151,14 +152,17 @@
     <string name="selected_stop_first_stop">%1$s, parada selecionada, primeira parada</string>
     <string name="service_change">Troca de serviço</string>
     <string name="service_ended">Serviço encerrado</string>
+    <string name="service_suspended">Serviço suspenso</string>
     <string name="setting_elevator_accessibility">Mostrar acessibilidade do elevador</string>
     <string name="setting_toggle_hide_maps">Ocultar mapas</string>
     <string name="settings_link">Configurações</string>
     <string name="severe_weather">Tempo ruim</string>
     <string name="shuttle">Ônibus vai-e-vem</string>
+    <string name="shuttle_buses">Ônibus de transferência</string>
     <string name="signal_problem">Problema de sinal</string>
     <string name="slippery_rail">Trilho escorregadio</string>
     <string name="snow">Neve</string>
+    <string name="snow_route">Rota da neve</string>
     <string name="southbound">Sentido sul</string>
     <string name="special_event">Evento especial</string>
     <string name="speed_restriction">Restrição de velocidade</string>
@@ -213,6 +217,7 @@
     <string name="vehicle_schedule_minutes_other">e em %1$d min programado</string>
     <string name="vehicle_schedule_time_first">%1$s chegando às %2$s programado</string>
     <string name="vehicle_schedule_time_other">e às %1$s programado</string>
+    <string name="view_details">Ver detalhes</string>
     <string name="waiting_to_depart">Esperando para partir</string>
     <string name="weather">Clima</string>
     <string name="westbound">Sentido oeste</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -36,6 +36,7 @@
     <string name="dock_closure">Đóng bến tàu</string>
     <string name="drawbridge_being_raised">Cầu rút đang nâng</string>
     <string name="eastbound">Về hướng đông</string>
+    <string name="effect_ahead">%1$s phía trước</string>
     <string name="electrical_work">Thi công điện</string>
     <plurals name="elevator_closure_count">
         <item quantity="other">%1$d thang máy đóng cửa</item>
@@ -147,14 +148,17 @@
     <string name="selected_stop_first_stop">%1$s, điểm dừng đã chọn, điểm dừng đầu tiên</string>
     <string name="service_change">Thay đổi dịch vụ</string>
     <string name="service_ended">Dịch vụ đã kết thúc</string>
+    <string name="service_suspended">Dịch vụ bị đình chỉ</string>
     <string name="setting_elevator_accessibility">Hiển thị khả năng tiếp cận thang máy</string>
     <string name="setting_toggle_hide_maps">Ẩn bản đồ</string>
     <string name="settings_link">Cài đặt</string>
     <string name="severe_weather">Thời tiết khắc nghiệt</string>
     <string name="shuttle">Xe đưa đón</string>
+    <string name="shuttle_buses">Xe đưa đón</string>
     <string name="signal_problem">Vấn đề đèn tín hiệu</string>
     <string name="slippery_rail">Đường ray trơn trượt</string>
     <string name="snow">Tuyết</string>
+    <string name="snow_route">Tuyến đường tuyết</string>
     <string name="southbound">Về hướng nam</string>
     <string name="special_event">Sự kiện đặc biệt</string>
     <string name="speed_restriction">Giới hạn tốc độ</string>
@@ -205,6 +209,7 @@
     <string name="vehicle_schedule_minutes_other">và sau %1$d phút nữa theo lịch trình</string>
     <string name="vehicle_schedule_time_first">%1$s sẽ đến lúc %2$s theo lịch trình</string>
     <string name="vehicle_schedule_time_other">và lúc %1$s theo lịch trình</string>
+    <string name="view_details">Xem chi tiết</string>
     <string name="waiting_to_depart">Đang chờ khởi hành</string>
     <string name="weather">Thời tiết</string>
     <string name="westbound">Về hướng tây</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -36,6 +36,7 @@
     <string name="dock_closure">码头关闭</string>
     <string name="drawbridge_being_raised">吊桥升起</string>
     <string name="eastbound">东行</string>
+    <string name="effect_ahead">%1$s 前面</string>
     <string name="electrical_work">电力作业</string>
     <plurals name="elevator_closure_count">
         <item quantity="other">%1$d部电梯关闭</item>
@@ -147,14 +148,17 @@
     <string name="selected_stop_first_stop">%1$s，选定站点，第一站</string>
     <string name="service_change">服务变更</string>
     <string name="service_ended">服务已结束</string>
+    <string name="service_suspended">服务暂停</string>
     <string name="setting_elevator_accessibility">显示电梯可达性</string>
     <string name="setting_toggle_hide_maps">隐藏地图</string>
     <string name="settings_link">设置</string>
     <string name="severe_weather">恶劣天气</string>
     <string name="shuttle">摆渡巴士</string>
+    <string name="shuttle_buses">穿梭巴士</string>
     <string name="signal_problem">信号故障</string>
     <string name="slippery_rail">轨道湿滑</string>
     <string name="snow">降雪</string>
+    <string name="snow_route">雪道</string>
     <string name="southbound">南行</string>
     <string name="special_event">特殊事件</string>
     <string name="speed_restriction">速度限制</string>
@@ -205,6 +209,7 @@
     <string name="vehicle_schedule_minutes_other">下一趟车预定将在%1$d分钟内抵达</string>
     <string name="vehicle_schedule_time_first">%1$s预定于%2$s到站</string>
     <string name="vehicle_schedule_time_other">下一趟车预定将于%1$s到站</string>
+    <string name="view_details">查看详细信息</string>
     <string name="waiting_to_depart">等待出发</string>
     <string name="weather">天气</string>
     <string name="westbound">西行</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -36,6 +36,7 @@
     <string name="dock_closure">碼頭關閉</string>
     <string name="drawbridge_being_raised">吊橋升起</string>
     <string name="eastbound">東行</string>
+    <string name="effect_ahead">%1$s 前面</string>
     <string name="electrical_work">電力作業</string>
     <plurals name="elevator_closure_count">
         <item quantity="other">%1$d部電梯關閉</item>
@@ -147,14 +148,17 @@
     <string name="selected_stop_first_stop">%1$s，選定站點，第一站</string>
     <string name="service_change">服務變更</string>
     <string name="service_ended">服務已結束</string>
+    <string name="service_suspended">服務暫停</string>
     <string name="setting_elevator_accessibility">顯示電梯可及性</string>
     <string name="setting_toggle_hide_maps">隱藏地圖</string>
     <string name="settings_link">設定</string>
     <string name="severe_weather">惡劣天氣</string>
     <string name="shuttle">擺渡巴士</string>
+    <string name="shuttle_buses">穿梭巴士</string>
     <string name="signal_problem">信號故障</string>
     <string name="slippery_rail">軌道濕滑</string>
     <string name="snow">降雪</string>
+    <string name="snow_route">雪道</string>
     <string name="southbound">南行</string>
     <string name="special_event">特殊事件</string>
     <string name="speed_restriction">速度限制</string>
@@ -205,6 +209,7 @@
     <string name="vehicle_schedule_minutes_other">下一趟車預定將在%1$d分鐘內抵達</string>
     <string name="vehicle_schedule_time_first">%1$s預定於%2$s到站</string>
     <string name="vehicle_schedule_time_other">下一趟車預定將於%1$s到站</string>
+    <string name="view_details">查看詳細信息</string>
     <string name="waiting_to_depart">等待離開</string>
     <string name="weather">天氣</string>
     <string name="westbound">西行</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="drag_handle" tools:ignore="MissingTranslation">Drag handle</string>
     <string name="drawbridge_being_raised">Drawbridge Being Raised</string>
     <string name="eastbound">Eastbound</string>
+    <string name="effect_ahead">%1$s ahead</string>
     <string name="electrical_work">Electrical Work</string>
     <plurals name="elevator_closure_count">
         <item quantity="one">%1$d elevator closed</item>
@@ -153,14 +154,17 @@
     <string name="selected_stop_first_stop">%1$s, selected stop, first stop</string>
     <string name="service_change">Service Change</string>
     <string name="service_ended">Service ended</string>
+    <string name="service_suspended">Service suspended</string>
     <string name="setting_elevator_accessibility">Show elevator accessibility</string>
     <string name="setting_toggle_hide_maps">Hide Maps</string>
     <string name="settings_link">Settings</string>
     <string name="severe_weather">Severe Weather</string>
     <string name="shuttle">Shuttle</string>
+    <string name="shuttle_buses">Shuttle buses</string>
     <string name="signal_problem">Signal Problem</string>
     <string name="slippery_rail">Slippery Rail</string>
     <string name="snow">Snow</string>
+    <string name="snow_route">Snow route</string>
     <string name="southbound">Southbound</string>
     <string name="special_event">Special Event</string>
     <string name="speed_restriction">Speed Restriction</string>
@@ -214,8 +218,8 @@
     <string name="vehicle_schedule_minutes_other">and in %1$d min scheduled</string>
     <string name="vehicle_schedule_time_first">%1$s arriving at %2$s scheduled</string>
     <string name="vehicle_schedule_time_other">and at %1$s scheduled</string>
+    <string name="view_details">View details</string>
     <string name="waiting_to_depart">Waiting to depart</string>
     <string name="weather">Weather</string>
     <string name="westbound">Westbound</string>
-
 </resources>


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Stop + Trip Details | Show disruption downstream & handle service changes + unspecified stops](https://app.asana.com/0/1205732265579288/1209204160447281/f)

Add mini MVP card for downstream disruptions, service changes, and unspecified stops. 

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Added tests for the various states.
