### PR TITLE
fix(Android): respond to TalkBack P0 QA

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -299,7 +299,7 @@ class NearbyTransitPageTest : KoinTest {
             }
         }
 
-        composeTestRule.onNodeWithContentDescription("Mapbox Logo").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Mapbox Attribution").assertIsDisplayed()
         composeTestRule.waitUntilDoesNotExist(hasContentDescription("Loading..."))
         composeTestRule
             .onNodeWithContentDescription("Drag handle")

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import com.mapbox.geojson.Point
@@ -255,6 +256,7 @@ fun HomeMapView(
                 },
             compass = {},
             scaleBar = {},
+            logo = { Logo(Modifier.clearAndSetSemantics {}) },
             mapViewportState = viewportProvider.viewport,
             style = {
                 MapStyle(


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | respond to first batch of QA feedback](https://app.asana.com/0/1205732265579288/1209263422629657/f)

[Per Slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1738247231226519?thread_ts=1738190984.789789&cid=C05QMG9GS9M), not including the focus order and route pin button tweaks.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually verified that the Mapbox logo is no longer present in accessibility traversal but the Mapbox attribution button still is.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
