### PR TITLE
feat(android.TripDetails): Initial UI layout improvements

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -1,9 +1,15 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
 import com.mbta.tid.mbta_app.model.Stop
@@ -76,16 +82,22 @@ fun TripDetailsView(
         val headerSpec: TripHeaderSpec? =
             TripHeaderSpec.getSpec(tripId, stops, terminalStop, vehicle, vehicleStop)
 
-        TripHeaderCard(tripId, headerSpec, stopId, routeAccents, now)
-        TripStops(
-            stopId,
-            stops,
-            tripFilter.stopSequence,
-            headerSpec,
-            now,
-            globalResponse,
-            routeAccents
-        )
+        Column() {
+            Column(Modifier.zIndex(1F)) {
+                TripHeaderCard(tripId, headerSpec, stopId, routeAccents, now)
+            }
+            Column(Modifier.offset(y = (-6).dp).padding(horizontal = 4.dp)) {
+                TripStops(
+                    stopId,
+                    stops,
+                    tripFilter.stopSequence,
+                    headerSpec,
+                    now,
+                    globalResponse,
+                    routeAccents
+                )
+            }
+        }
     } else {
         // TODO: loading
         CircularProgressIndicator()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.stopDetails
 import android.content.Context
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,12 +13,14 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
@@ -59,7 +62,12 @@ fun TripHeaderCard(
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier.padding(vertical = 16.dp).background(colorResource(R.color.fill3)),
+        modifier
+            .padding(top = 16.dp)
+            .border(2.dp, colorResource(R.color.halo), shape = RoundedCornerShape(8.dp))
+            .padding(1.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(colorResource(R.color.fill3)),
     ) {
         Row(
             Modifier.padding(vertical = 16.dp)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -2,10 +2,12 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import android.content.Context
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -20,8 +22,8 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.RoutePill
@@ -47,30 +49,31 @@ fun TripStopRow(
     lastStop: Boolean = false
 ) {
     val context = LocalContext.current
-    Column(modifier) {
+    Column(modifier.defaultMinSize(minHeight = 48.dp)) {
         Box(contentAlignment = Alignment.BottomCenter) {
             if (!lastStop && !targeted) {
                 HaloSeparator()
             }
-            Column {
+            Column(Modifier.padding(vertical = 12.dp, horizontal = 8.dp)) {
                 Row(
                     Modifier.semantics(mergeDescendants = true) {
                         if (targeted) {
                             heading()
                         }
-                    }
+                    },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
                         stop.stop.name,
                         Modifier.semantics {
-                            contentDescription =
-                                stopAccessibilityLabel(stop, targeted, firstStop, context)
-                        },
+                                contentDescription =
+                                    stopAccessibilityLabel(stop, targeted, firstStop, context)
+                            }
+                            .weight(1F),
                         color = colorResource(R.color.text),
-                        textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.bodySmall
+                        style = MaterialTheme.typography.bodyLarge,
                     )
-                    Spacer(Modifier.weight(1f))
                     CompositionLocalProvider(
                         LocalContentColor provides colorResource(R.color.text)
                     ) {
@@ -105,7 +108,10 @@ private fun connectionLabel(route: Route, context: Context) =
 
 @Composable
 fun ScrollRoutes(stop: TripDetailsStopList.Entry, modifier: Modifier = Modifier) {
-    Row(modifier.horizontalScroll(rememberScrollState())) {
+    Row(
+        modifier.horizontalScroll(rememberScrollState()).padding(top = 8.dp, end = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
         for (route in stop.routes) {
             RoutePill(route, type = RoutePillType.Flex)
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -1,9 +1,13 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,13 +16,16 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.util.typeText
@@ -65,7 +72,12 @@ fun TripStops(
 
     val lastStopSequence = stops.stops.lastOrNull()?.stopSequence
 
-    Column(Modifier.background(colorResource(R.color.fill2))) {
+    Column(
+        Modifier.border(2.dp, colorResource(R.color.halo), shape = RoundedCornerShape(8.dp))
+            .padding(1.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(colorResource(R.color.fill2))
+    ) {
         if (splitStops != null && target != null) {
             if (showFirstStopSeparately) {
                 val firstStop = splitStops.firstStop
@@ -91,10 +103,13 @@ fun TripStops(
                                     target.stop.name
                                 )
                         }
+                        .padding(horizontal = 8.dp)
+                        .defaultMinSize(minHeight = 48.dp),
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         pluralStringResource(R.plurals.stops_away, stopsAway, stopsAway),
-                        style = MaterialTheme.typography.bodySmall
+                        style = MaterialTheme.typography.bodyLarge
                     )
                 }
                 if (stopsExpanded) {
@@ -117,7 +132,10 @@ fun TripStops(
                     now,
                     routeAccents,
                     targeted = true,
-                    firstStop = showFirstStopSeparately && target == stops.startTerminalEntry
+                    firstStop = showFirstStopSeparately && target == stops.startTerminalEntry,
+                    modifier =
+                        Modifier.background(colorResource(R.color.fill3))
+                            .border(2.dp, colorResource(R.color.halo))
                 )
             }
             StopList(splitStops.followingStops, lastStopSequence, now, routeAccents)


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | stop + trip details | Trip details UI](https://app.asana.com/0/1205732265579288/1209118487744430/f)

What is this PR for?

This PR adds the basic UI for the trip details stop list. It does *not* include the "Stop X stops away" UI or the trip line, but wanted to break off this small chunk bit before the[ UI ticket for the Trip Header Card ](https://app.asana.com/0/1205732265579288/1209118480622202/f) is picked up since this touches that a bit too.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ran locally, getting closer to final UI
![Screenshot_20250131_095546](https://github.com/user-attachments/assets/0aa7dde1-118e-4f3a-9b90-0417db0dcb2e)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
