### PR TITLE
feat(android.feedbackFormUrl): Separate android feedback form

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -35,7 +35,7 @@ android {
         targetSdk = 34
         versionCode =
             Integer.parseInt((findProperty("android.injected.version.code") ?: "1") as String)
-        versionName = "0.2.0"
+        versionName = "0.2.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -59,7 +59,7 @@ class MoreViewModelTests {
 
         composeTestRule.waitForIdle()
         assertEquals(
-            "https://mbta.com/appfeedback?lang=es-US",
+            "https://mbta.com/androidappfeedback?lang=es-US",
             vm.sections.value
                 .first { it.id == MoreSection.Category.Feedback }
                 .items

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
-import com.mbta.tid.mbta_app.model.morePage.feedbackFormUrl
+import com.mbta.tid.mbta_app.model.morePage.localizedFeedbackFormUrl
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.coroutines.CoroutineScope
@@ -46,7 +46,7 @@ class MoreViewModel(
                     primaryLocale.language == "zh" && primaryLocale.script == "Hant" -> "zh-Hant-TW"
                     else -> "en"
                 }
-            feedbackFormUrl(translation)
+            localizedFeedbackFormUrl("https://mbta.com/androidappfeedback", translation)
         }
         return listOf(
             MoreSection(

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -29,7 +29,10 @@ class SettingsViewModel: ObservableObject {
     // swiftlint:disable:next function_body_length
     @MainActor func getSections() async {
         do {
-            let feedbackFormUrl = feedbackFormUrl(translation: Bundle.main.preferredLocalizations.first ?? "en")
+            let feedbackFormUrl = localizedFeedbackFormUrl(
+                baseUrl: "https://mbta.com/appfeedback",
+                translation: Bundle.main.preferredLocalizations.first ?? "en"
+            )
             settings = try await settingsRepository.getSettings().mapValues { $0.boolValue }
             sections = [
                 MoreSection(id: .feedback, items: [

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -31,7 +31,8 @@ class SettingsViewModel: ObservableObject {
         do {
             let feedbackFormUrl = localizedFeedbackFormUrl(
                 baseUrl: "https://mbta.com/appfeedback",
-                translation: Bundle.main.preferredLocalizations.first ?? "en"
+                translation: Bundle.main.preferredLocalizations.first ?? "en",
+                separateHTForm: true
             )
             settings = try await settingsRepository.getSettings().mapValues { $0.boolValue }
             sections = [

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
@@ -1,12 +1,14 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-fun feedbackFormUrl(translation: String) =
-    when (translation) {
-        "es" -> "https://mbta.com/appfeedback?lang=es-US"
-        "ht" -> "https://mbta.com/appfeedback-ht"
-        "pt-BR" -> "https://mbta.com/appfeedback?lang=pt-BR"
-        "vi" -> "https://mbta.com/appfeedback?lang=vi"
-        "zh-Hans-CN" -> "https://mbta.com/appfeedback?lang=zh-Hans"
-        "zh-Hant-TW" -> "https://mbta.com/appfeedback?lang=zh-Hant"
-        else -> "https://mbta.com/appfeedback"
+fun feedbackFormUrl(translation: String): String {
+    val formLink = "https://mbta.com/androidappfeedback"
+    return when (translation) {
+        "es" -> "${formLink}?lang=es-US"
+        "ht" -> formLink
+        "pt-BR" -> "${formLink}?lang=pt-BR"
+        "vi" -> "${formLink}?lang=vi"
+        "zh-Hans-CN" -> "${formLink}?lang=zh-Hans"
+        "zh-Hant-TW" -> "${formLink}?lang=zh-Hant"
+        else -> formLink
     }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
@@ -1,14 +1,13 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-fun feedbackFormUrl(translation: String): String {
-    val formLink = "https://mbta.com/androidappfeedback"
+fun localizedFeedbackFormUrl(baseUrl: String, translation: String): String {
     return when (translation) {
-        "es" -> "${formLink}?lang=es-US"
-        "ht" -> formLink
-        "pt-BR" -> "${formLink}?lang=pt-BR"
-        "vi" -> "${formLink}?lang=vi"
-        "zh-Hans-CN" -> "${formLink}?lang=zh-Hans"
-        "zh-Hant-TW" -> "${formLink}?lang=zh-Hant"
-        else -> formLink
+        "es" -> "${baseUrl}?lang=es-US"
+        "ht" -> baseUrl
+        "pt-BR" -> "${baseUrl}?lang=pt-BR"
+        "vi" -> "${baseUrl}?lang=vi"
+        "zh-Hans-CN" -> "${baseUrl}?lang=zh-Hans"
+        "zh-Hant-TW" -> "${baseUrl}?lang=zh-Hant"
+        else -> baseUrl
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
@@ -1,9 +1,13 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-fun localizedFeedbackFormUrl(baseUrl: String, translation: String): String {
+fun localizedFeedbackFormUrl(
+    baseUrl: String,
+    translation: String,
+    separateHTForm: Boolean = false
+): String {
     return when (translation) {
         "es" -> "${baseUrl}?lang=es-US"
-        "ht" -> baseUrl
+        "ht" -> if (separateHTForm) "${baseUrl}-ht" else baseUrl
         "pt-BR" -> "${baseUrl}?lang=pt-BR"
         "vi" -> "${baseUrl}?lang=vi"
         "zh-Hans-CN" -> "${baseUrl}?lang=zh-Hans"

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
@@ -3,44 +3,44 @@ package com.mbta.tid.mbta_app.model.morePage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class FeedbackFormUrlTest {
+class LocalizedFeedbackFormUrlTest {
     @Test
     fun testEN() {
-        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("en"))
+        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl","en"))
     }
 
     @Test
     fun testES() {
-        assertEquals("https://mbta.com/androidappfeedback?lang=es-US", feedbackFormUrl("es"))
+        assertEquals("baseUrl?lang=es-US", localizedFeedbackFormUrl("baseUrl","es"))
     }
 
     @Test
     fun testHT() {
-        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("ht"))
+        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl", "ht"))
     }
 
     @Test
     fun testPTBR() {
-        assertEquals("https://mbta.com/androidappfeedback?lang=pt-BR", feedbackFormUrl("pt-BR"))
+        assertEquals("baseUrl?lang=pt-BR", localizedFeedbackFormUrl("baseUrl","pt-BR"))
     }
 
     @Test
     fun testVI() {
-        assertEquals("https://mbta.com/androidappfeedback?lang=vi", feedbackFormUrl("vi"))
+        assertEquals("baseUrl?lang=vi", localizedFeedbackFormUrl("baseUrl","vi"))
     }
 
     @Test
     fun testZHHans() {
-        assertEquals("https://mbta.com/androidappfeedback?lang=zh-Hans", feedbackFormUrl("zh-Hans-CN"))
+        assertEquals("baseUrl?lang=zh-Hans", localizedFeedbackFormUrl("baseUrl","zh-Hans-CN"))
     }
 
     @Test
     fun testZHHant() {
-        assertEquals("https://mbta.com/androidappfeedback?lang=zh-Hant", feedbackFormUrl("zh-Hant-TW"))
+        assertEquals("baseUrl?lang=zh-Hant", localizedFeedbackFormUrl("baseUrl","zh-Hant-TW"))
     }
 
     @Test
     fun testUnknown() {
-        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("tok"))
+        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl","tok"))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
@@ -17,6 +17,8 @@ class LocalizedFeedbackFormUrlTest {
     @Test
     fun testHT() {
         assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl", "ht"))
+        assertEquals("baseUrl-ht", localizedFeedbackFormUrl("baseUrl", "ht", true))
+
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
@@ -6,41 +6,41 @@ import kotlin.test.assertEquals
 class FeedbackFormUrlTest {
     @Test
     fun testEN() {
-        assertEquals("https://mbta.com/appfeedback", feedbackFormUrl("en"))
+        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("en"))
     }
 
     @Test
     fun testES() {
-        assertEquals("https://mbta.com/appfeedback?lang=es-US", feedbackFormUrl("es"))
+        assertEquals("https://mbta.com/androidappfeedback?lang=es-US", feedbackFormUrl("es"))
     }
 
     @Test
     fun testHT() {
-        assertEquals("https://mbta.com/appfeedback-ht", feedbackFormUrl("ht"))
+        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("ht"))
     }
 
     @Test
     fun testPTBR() {
-        assertEquals("https://mbta.com/appfeedback?lang=pt-BR", feedbackFormUrl("pt-BR"))
+        assertEquals("https://mbta.com/androidappfeedback?lang=pt-BR", feedbackFormUrl("pt-BR"))
     }
 
     @Test
     fun testVI() {
-        assertEquals("https://mbta.com/appfeedback?lang=vi", feedbackFormUrl("vi"))
+        assertEquals("https://mbta.com/androidappfeedback?lang=vi", feedbackFormUrl("vi"))
     }
 
     @Test
     fun testZHHans() {
-        assertEquals("https://mbta.com/appfeedback?lang=zh-Hans", feedbackFormUrl("zh-Hans-CN"))
+        assertEquals("https://mbta.com/androidappfeedback?lang=zh-Hans", feedbackFormUrl("zh-Hans-CN"))
     }
 
     @Test
     fun testZHHant() {
-        assertEquals("https://mbta.com/appfeedback?lang=zh-Hant", feedbackFormUrl("zh-Hant-TW"))
+        assertEquals("https://mbta.com/androidappfeedback?lang=zh-Hant", feedbackFormUrl("zh-Hant-TW"))
     }
 
     @Test
     fun testUnknown() {
-        assertEquals("https://mbta.com/appfeedback", feedbackFormUrl("tok"))
+        assertEquals("https://mbta.com/androidappfeedback", feedbackFormUrl("tok"))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Name](URL)

What is this PR for?
No ticket, [request on slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1738340696065619) to change the feedback URL for the beta.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Updated unit tests
* Ran locally & confirmed taken to the android form as expected
* Confirmed iOS link still goes to /appfeedback

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
