### PR TITLE
fix(Android): slightly nicer error handling

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
@@ -1,0 +1,38 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun DebugView(modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
+    val color = colorResource(R.color.text)
+    Column(
+        modifier
+            .drawBehind {
+                // https://stackoverflow.com/a/67039676
+                drawRect(
+                    color,
+                    style =
+                        Stroke(
+                            width = 1f,
+                            pathEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 10f))
+                        )
+                )
+            }
+            .padding(4.dp)
+    ) {
+        ProvideTextStyle(TextStyle(fontSize = 13.sp)) { content() }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.map
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -160,7 +161,10 @@ open class MapViewModel(
     private suspend fun fetchRailRouteShapes(): MapFriendlyRouteResponse? {
         return when (val data = railRouteShapeRepository.getRailRouteShapes()) {
             is ApiResult.Ok -> data.data
-            is ApiResult.Error -> null
+            is ApiResult.Error -> {
+                Log.e("MapViewModel", "fetchRailRouteShapes failed: $data")
+                null
+            }
         }
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRailRouteShapes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRailRouteShapes.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.state
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
@@ -27,7 +28,8 @@ class RailRouteShapesViewModel(private val railRouteShapeRepository: IRailRouteS
     suspend fun getRailRouteShapes() {
         when (val data = railRouteShapeRepository.getRailRouteShapes()) {
             is ApiResult.Ok -> _railRouteShapes.value = data.data
-            is ApiResult.Error -> TODO("handle errors")
+            is ApiResult.Error ->
+                Log.e("RailRouteShapesViewModel", "getRailRouteShapes failed: $data")
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.state
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
@@ -42,7 +43,10 @@ class SearchResultsViewModel(
                     delay(500)
                     when (val data = searchResultRepository.getSearchResults(query)) {
                         is ApiResult.Ok -> _searchResults.emit(data.data)
-                        is ApiResult.Error -> _searchResults.emit(null)
+                        is ApiResult.Error -> {
+                            Log.e("SearchResultsViewModel", "getSearchResults failed: $data")
+                            _searchResults.emit(null)
+                        }
                         null -> {}
                     }
                 } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getStopMapData.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getStopMapData.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.state
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -24,9 +25,7 @@ class StopMapViewModel(private val stopRepository: IStopRepository) : ViewModel(
         CoroutineScope(Dispatchers.IO).launch {
             when (val data = stopRepository.getStopMapData(stopId)) {
                 is ApiResult.Ok -> _stopMapResponse.emit(data.data)
-                is ApiResult.Error -> {
-                    /* TODO: handle errors */
-                }
+                is ApiResult.Error -> Log.e("StopMapViewModel", "getStopMapData failed: $data")
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToAlerts.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToAlerts.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.state
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.lifecycle.ViewModel
@@ -34,7 +35,7 @@ class AlertsViewModel(
                         synchronized(alertFlow) { alertFlow.notifyAll() }
                 }
                 is ApiResult.Error -> {
-                    /* TODO: handle errors */
+                    Log.e("AlertsViewModel", "subscribeToAlerts failed: $it")
                 }
             }
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -302,6 +303,7 @@ class StopDetailsViewModel(
                     response.data.trip
                 }
                 is ApiResult.Error -> {
+                    Log.e("StopDetailsViewModel", "loadTrip failed: $response")
                     errorBannerRepository.setDataError(errorKey) {
                         clearAndLoadTripDetails(tripFilter)
                     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -86,7 +86,7 @@ fun TripDetailsView(
     if (tripFilter != null && tripData != null && globalResponse != null && stops != null) {
         val route = globalResponse.routes[tripData.trip.routeId]
         val routeAccents = route?.let { TripRouteAccents(it) } ?: TripRouteAccents.default
-        val terminalStop = getParentFor(tripData.trip.stopIds?.first(), globalResponse.stops)
+        val terminalStop = getParentFor(tripData.trip.stopIds?.firstOrNull(), globalResponse.stops)
         val vehicleStop =
             if (vehicle != null) getParentFor(vehicle.stopId, globalResponse.stops) else null
         val tripId = tripFilter.tripId

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.util
 
+import android.util.Log
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 
@@ -23,6 +24,7 @@ suspend fun <T : Any> fetchApi(
         }
     when (result) {
         is ApiResult.Error -> {
+            Log.e("fetchApi", "API request $errorKey failed: $result")
             errorBannerRepo.setDataError(key = errorKey, action = onRefreshAfterError)
         }
         is ApiResult.Ok -> {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Crash fixes | Consistent error handling](https://app.asana.com/0/1205425564113216/1209295122854611)

The two previously-discussed crashes in the ticket have both already been addressed, and two of the other crashes in the ticket are not realistic to debug for reasons I mention in the ticket, so there's only one crash that this PR actually fixes. I've just kinda tossed in some other error-related work I keep wishing was already in place.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
  - I'm not counting the error keys as user-facing since with debug mode off they aren't
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
