### PR TITLE
fix: make iOS CI compatible with asdf 0.16

### DIFF
--- a/iosApp/ci_scripts/ci_post_clone.sh
+++ b/iosApp/ci_scripts/ci_post_clone.sh
@@ -40,7 +40,7 @@ if [ -d $JDK_PATH ]; then
 fi
 
 retry brew install asdf
-retry asdf plugin-add java
+retry asdf plugin add java
 retry asdf install java
 DEFAULT_JAVA_PATH="$(asdf where java)"
 DEFAULT_JAVA_ROOT_DIR="$(dirname DEFAULT_JAVA_PATH)"


### PR DESCRIPTION
### Summary

_Ticket:_ none

Saw this in an iOS build failure. It's [documented](https://asdf-vm.com/guide/upgrading-to-v0-16.html#hyphenated-commands-have-been-removed) as an asdf 0.16 breaking change, although I don't understand why they couldn't just keep these as aliases.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

I still have asdf 0.15 locally, so I'm just kinda assuming based on the docs that this will work.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
