### PR TITLE
feat(iOS): Combined stop + trip promo UX

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
@@ -30,7 +30,7 @@ class StopDetailsNoTripCardTests {
         composeTestRule
             .onNodeWithText(
                 "Service is running, but predicted arrival times aren’t available." +
-                    " The map shows where buses on this route currently are."
+                    " Check the map to see where buses are right now."
             )
             .assertIsDisplayed()
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -320,7 +320,7 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithContentDescription(
-                "bus Approaching stop, selected stop",
+                "Selected bus Approaching stop, selected stop",
                 useUnmergedTree = true
             )
             .assertIsDisplayed()
@@ -347,7 +347,10 @@ class TripHeaderCardTest {
         }
 
         composeTestRule
-            .onNodeWithContentDescription("bus Approaching other stop", useUnmergedTree = true)
+            .onNodeWithContentDescription(
+                "Selected bus Approaching other stop",
+                useUnmergedTree = true
+            )
             .assertIsDisplayed()
     }
 

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -216,7 +216,6 @@
     <string name="vehicle_boarding_other">abordando ahora</string>
     <string name="vehicle_cancelled_first">%1$s que llega a las %2$s cancelado</string>
     <string name="vehicle_cancelled_other">y a las %1$s cancelado</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s llegará en %2$d min.</string>
     <string name="vehicle_prediction_minutes_other">y en %1$d min.</string>
     <string name="vehicle_prediction_time_first">%1$s llegará a la(s) %2$s</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -227,7 +227,6 @@
     <string name="vehicle_boarding_other">epi ap pran moun kounye a</string>
     <string name="vehicle_cancelled_first">%1$s ap rive a %2$s anile</string>
     <string name="vehicle_cancelled_other">epi a %1$s anile</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s ap rive nan %2$d minit</string>
     <string name="vehicle_prediction_minutes_other">epi nan %1$d minit</string>
     <string name="vehicle_prediction_time_first">%1$s ap rive a %2$s</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -216,7 +216,6 @@
     <string name="vehicle_boarding_other">e embarcando agora</string>
     <string name="vehicle_cancelled_first">%1$s chegando às %2$s cancelado</string>
     <string name="vehicle_cancelled_other">e às %1$s cancelado</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s chegando em %2$d min</string>
     <string name="vehicle_prediction_minutes_other">e em %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s chegando às %2$s</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -208,7 +208,6 @@
     <string name="vehicle_boarding_other">và đang cho khách lên</string>
     <string name="vehicle_cancelled_first">%1$s đến %2$s bị hủy</string>
     <string name="vehicle_cancelled_other">và tại %1$s đã hủy</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s sẽ đến sau %2$d phút nữa</string>
     <string name="vehicle_prediction_minutes_other">và sau %1$d phút nữa</string>
     <string name="vehicle_prediction_time_first">%1$s sẽ đến lúc %2$s</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -208,7 +208,6 @@
     <string name="vehicle_boarding_other">正在上客</string>
     <string name="vehicle_cancelled_first">于%2$s到站的%1$s已取消</string>
     <string name="vehicle_cancelled_other">于%1$s到站的下一趟车已取消</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s将在%2$d分钟内到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟车将在%1$d分钟内抵达</string>
     <string name="vehicle_prediction_time_first">%1$s于%2$s到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -208,7 +208,6 @@
     <string name="vehicle_boarding_other">正在上客</string>
     <string name="vehicle_cancelled_first">於%2$s到站的%1$s已取消</string>
     <string name="vehicle_cancelled_other">於%1$s到站的下一趟車已取消</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
     <string name="vehicle_prediction_minutes_first">%1$s將在%2$d分鐘內到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟車將在%1$d分鐘內抵達</string>
     <string name="vehicle_prediction_time_first">%1$s於%2$s到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="police_action">Police Action</string>
     <string name="police_activity">Police Activity</string>
     <string name="power_problem">Power Problem</string>
-    <string name="predictions_unavailable_details">Service is running, but predicted arrival times aren’t available. The map shows where %1$s on this route currently are.</string>
+    <string name="predictions_unavailable_details">Service is running, but predicted arrival times aren’t available. Check the map to see where %1$s are right now.</string>
     <string name="predictions_unavailable_details_hide_maps">Service is running, but predicted arrival times aren’t available.</string>
     <string name="real_time_arrivals_updating_live">Real-time arrivals updating live</string>
     <string name="recenter" tools:ignore="MissingTranslation">Recenter</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -216,8 +216,8 @@
     <string name="vehicle_boarding_other">and boarding now</string>
     <string name="vehicle_cancelled_first">%1$s arriving at %2$s cancelled</string>
     <string name="vehicle_cancelled_other">and at %1$s cancelled</string>
-    <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s</string>
-    <string name="vehicle_desc_accessibility_desc_selected_stop" translatable="false">%1$s %2$s %3$s, selected stop</string>
+    <string name="vehicle_desc_accessibility_desc" translatable="false">Selected %1$s %2$s %3$s</string>
+    <string name="vehicle_desc_accessibility_desc_selected_stop" translatable="false">Selected %1$s %2$s %3$s, selected stop</string>
     <string name="vehicle_prediction_minutes_first">%1$s arriving in %2$d min</string>
     <string name="vehicle_prediction_minutes_other">and in %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s arriving at %2$s</string>

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -206,6 +206,8 @@
 		9AAA26A72C2DC06700A7745A /* DirectionLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAA26A62C2DC06600A7745A /* DirectionLabelTests.swift */; };
 		9AB335192D53ECBA0041A109 /* PromoPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB335182D53ECBA0041A109 /* PromoPage.swift */; };
 		9AB3351B2D53ECC70041A109 /* PromoScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */; };
+		9AB3351F2D5403200041A109 /* PromoPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB3351E2D5403200041A109 /* PromoPageTests.swift */; };
+		9AB335212D5404A60041A109 /* PromoScreenViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB335202D5404A60041A109 /* PromoScreenViewTests.swift */; };
 		9AB3F50D2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 9AB3F50C2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport */; };
 		9AB3F50F2BE45382008D9E40 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9AB3F50E2BE45382008D9E40 /* GoogleService-Info.plist */; };
 		9AB44A112B8FC43E00E8FFB3 /* ErrorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB44A102B8FC43E00E8FFB3 /* ErrorCard.swift */; };
@@ -514,6 +516,8 @@
 		9AAA26A62C2DC06600A7745A /* DirectionLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionLabelTests.swift; sourceTree = "<group>"; };
 		9AB335182D53ECBA0041A109 /* PromoPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoPage.swift; sourceTree = "<group>"; };
 		9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoScreenView.swift; sourceTree = "<group>"; };
+		9AB3351E2D5403200041A109 /* PromoPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoPageTests.swift; sourceTree = "<group>"; };
+		9AB335202D5404A60041A109 /* PromoScreenViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoScreenViewTests.swift; sourceTree = "<group>"; };
 		9AB3F50E2BE45382008D9E40 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9AB44A102B8FC43E00E8FFB3 /* ErrorCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCard.swift; sourceTree = "<group>"; };
 		9AB44A122B911E6400E8FFB3 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
@@ -1060,6 +1064,7 @@
 				9A5B275E2BB24326009A6FC6 /* Map */,
 				6EF64C012C1B7C17005F365D /* NearbyTransit */,
 				8CD423F02CD009E300C8569E /* Onboarding */,
+				9AB3351D2D5403040041A109 /* Promo */,
 				8CD81A222BE55B150090585F /* Settings */,
 				9A2BCBDC2CED35FF00FB2913 /* StopDetails */,
 				8CB823D72BC5EDBF002C87E0 /* LegacyStopDetails */,
@@ -1103,6 +1108,15 @@
 			children = (
 				9AB335182D53ECBA0041A109 /* PromoPage.swift */,
 				9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */,
+			);
+			path = Promo;
+			sourceTree = "<group>";
+		};
+		9AB3351D2D5403040041A109 /* Promo */ = {
+			isa = PBXGroup;
+			children = (
+				9AB3351E2D5403200041A109 /* PromoPageTests.swift */,
+				9AB335202D5404A60041A109 /* PromoScreenViewTests.swift */,
 			);
 			path = Promo;
 			sourceTree = "<group>";
@@ -1531,6 +1545,7 @@
 				6E973DAB2C178C0200CBF341 /* SheetHeaderTests.swift in Sources */,
 				8C7FA86F2B5EEA34009B699D /* LocationDataManagerTests.swift in Sources */,
 				6EED5E8F2B3DC6A00052A1B8 /* IosAppTests.swift in Sources */,
+				9AB3351F2D5403200041A109 /* PromoPageTests.swift in Sources */,
 				6EA231732C21C58A00789173 /* NearbyTransitPageViewTests.swift in Sources */,
 				8C7FA8712B5F2EF2009B699D /* NearbyTransitViewTests.swift in Sources */,
 				8C5F47662C40842200FB71DA /* TripDetailsStopViewTests.swift in Sources */,
@@ -1539,6 +1554,7 @@
 				9AF29E042CFA3F77005AA4A3 /* DepartureTileTests.swift in Sources */,
 				8CA1FB772BF813F500384658 /* TripDetailsStopListSplitViewTests.swift in Sources */,
 				6E2D6CA12CC2EDD700959605 /* ErrorBannerViewModelTests.swift in Sources */,
+				9AB335212D5404A60041A109 /* PromoScreenViewTests.swift in Sources */,
 				8CB823DB2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift in Sources */,
 				6E4EACFC2B7A82AC0011AB8B /* MockLocationFetcher.swift in Sources */,
 				9A8E55AE2CFE6E55004ED059 /* StopDetailsFilteredHeaderTests.swift in Sources */,

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -171,7 +171,7 @@
 		9A6FA0232BC70D0B0067769C /* InspectionEmissary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6FA0222BC70D0A0067769C /* InspectionEmissary.swift */; };
 		9A6FA0252BC714360067769C /* HomeMapViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6FA0242BC714360067769C /* HomeMapViewTest.swift */; };
 		9A6FA0282BC72F110067769C /* LegacyStopDetailsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A6FA0272BC72F110067769C /* LegacyStopDetailsPageTests.swift */; };
-		9A719E152CD12309007377F7 /* OnboardingButtonModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A719E142CD12309007377F7 /* OnboardingButtonModifiers.swift */; };
+		9A719E152CD12309007377F7 /* FullWidthButtonModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A719E142CD12309007377F7 /* FullWidthButtonModifiers.swift */; };
 		9A719E172CD1725E007377F7 /* UIWindowExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A719E162CD1725E007377F7 /* UIWindowExtension.swift */; };
 		9A74A2112BE2D71400E57102 /* AnnotationLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A74A2102BE2D71400E57102 /* AnnotationLabel.swift */; };
 		9A76022D2C5468C300B69A35 /* AlertIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A76022C2C5468C300B69A35 /* AlertIcon.swift */; };
@@ -204,6 +204,8 @@
 		9AAA26A12C2DB43600A7745A /* PredictionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAA26A02C2DB43600A7745A /* PredictionRowView.swift */; };
 		9AAA26A32C2DB79E00A7745A /* DirectionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAA26A22C2DB79E00A7745A /* DirectionRowView.swift */; };
 		9AAA26A72C2DC06700A7745A /* DirectionLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AAA26A62C2DC06600A7745A /* DirectionLabelTests.swift */; };
+		9AB335192D53ECBA0041A109 /* PromoPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB335182D53ECBA0041A109 /* PromoPage.swift */; };
+		9AB3351B2D53ECC70041A109 /* PromoScreenView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */; };
 		9AB3F50D2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 9AB3F50C2BE44B49008D9E40 /* FirebaseAnalyticsWithoutAdIdSupport */; };
 		9AB3F50F2BE45382008D9E40 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 9AB3F50E2BE45382008D9E40 /* GoogleService-Info.plist */; };
 		9AB44A112B8FC43E00E8FFB3 /* ErrorCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB44A102B8FC43E00E8FFB3 /* ErrorCard.swift */; };
@@ -477,7 +479,7 @@
 		9A6FA0222BC70D0A0067769C /* InspectionEmissary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectionEmissary.swift; sourceTree = "<group>"; };
 		9A6FA0242BC714360067769C /* HomeMapViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMapViewTest.swift; sourceTree = "<group>"; };
 		9A6FA0272BC72F110067769C /* LegacyStopDetailsPageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyStopDetailsPageTests.swift; sourceTree = "<group>"; };
-		9A719E142CD12309007377F7 /* OnboardingButtonModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButtonModifiers.swift; sourceTree = "<group>"; };
+		9A719E142CD12309007377F7 /* FullWidthButtonModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthButtonModifiers.swift; sourceTree = "<group>"; };
 		9A719E162CD1725E007377F7 /* UIWindowExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtension.swift; sourceTree = "<group>"; };
 		9A74A2102BE2D71400E57102 /* AnnotationLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationLabel.swift; sourceTree = "<group>"; };
 		9A76022C2C5468C300B69A35 /* AlertIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertIcon.swift; sourceTree = "<group>"; };
@@ -510,6 +512,8 @@
 		9AAA26A02C2DB43600A7745A /* PredictionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionRowView.swift; sourceTree = "<group>"; };
 		9AAA26A22C2DB79E00A7745A /* DirectionRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionRowView.swift; sourceTree = "<group>"; };
 		9AAA26A62C2DC06600A7745A /* DirectionLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DirectionLabelTests.swift; sourceTree = "<group>"; };
+		9AB335182D53ECBA0041A109 /* PromoPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoPage.swift; sourceTree = "<group>"; };
+		9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromoScreenView.swift; sourceTree = "<group>"; };
 		9AB3F50E2BE45382008D9E40 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		9AB44A102B8FC43E00E8FFB3 /* ErrorCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorCard.swift; sourceTree = "<group>"; };
 		9AB44A122B911E6400E8FFB3 /* DateExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtension.swift; sourceTree = "<group>"; };
@@ -863,7 +867,6 @@
 			children = (
 				8C97F7C82CCBF4E100A06B34 /* OnboardingPage.swift */,
 				8C97F7CF2CCC01E200A06B34 /* OnboardingScreenView.swift */,
-				9A719E142CD12309007377F7 /* OnboardingButtonModifiers.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -918,6 +921,7 @@
 				8C3D640E2BE19DA60026DD53 /* More */,
 				9A2005C12B97B56C00F562E1 /* NearbyTransit */,
 				8C97F7C92CCBF4E100A06B34 /* Onboarding */,
+				9AB335172D53EC920041A109 /* Promo */,
 				9A2005C32B97B5A000F562E1 /* Search */,
 				9AFCD9DD2CE66AE1001A2384 /* StopDetails */,
 				8C5054562BB5EB5000C6A51C /* LegacyStopDetails */,
@@ -1094,10 +1098,18 @@
 			path = AlertDetails;
 			sourceTree = "<group>";
 		};
+		9AB335172D53EC920041A109 /* Promo */ = {
+			isa = PBXGroup;
+			children = (
+				9AB335182D53ECBA0041A109 /* PromoPage.swift */,
+				9AB3351A2D53ECC70041A109 /* PromoScreenView.swift */,
+			);
+			path = Promo;
+			sourceTree = "<group>";
+		};
 		9AC10BD82B80060E00EA4605 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				ED85C0272D42CAD2007F91A7 /* SelectedTab.swift */,
 				6EC6F18C2CE661680022799F /* AlertExtension.swift */,
 				8C1587032C76524600AB5036 /* AppVariantExtension.swift */,
 				EDDE72EE2CBF19EF0000180D /* ArrayExtension.swift */,
@@ -1112,6 +1124,7 @@
 				9A6DDF902B976FDF004D141A /* EmptyWhenModifier.swift */,
 				8CE36C8E2CAB231500D77F22 /* FetchApi.swift */,
 				8C72B12D2D396D6400A6E73E /* FormattedAlert.swift */,
+				9A719E142CD12309007377F7 /* FullWidthButtonModifiers.swift */,
 				9ADB849C2BAD05BC006581CE /* Inspection.swift */,
 				8CE1D6752CC9690400E3BDB1 /* LoadingPlaceholderModifier.swift */,
 				8CD79F102C46F6E200AFF17D /* MapboxBridge.swift */,
@@ -1121,6 +1134,7 @@
 				9A18DEAC2D07DDC800DA0A3B /* RouteExtension.swift */,
 				9A4850562CB56A1500F50EE7 /* RouteTypeExtension.swift */,
 				6EFEE42C2BED0FA800810319 /* ScenePhaseChangeModifier.swift */,
+				ED85C0272D42CAD2007F91A7 /* SelectedTab.swift */,
 				9A3739972D41450100BBE127 /* SettingsExtension.swift */,
 				8CE0141A2BBF059A00918FAE /* SheetNavigationStackEntry.swift */,
 				9ADB84A12BAE37C0006581CE /* StopExtension.swift */,
@@ -1666,11 +1680,12 @@
 				9AC4FDF12BACE216004479BF /* NearbyTransitPageView.swift in Sources */,
 				7555FF83242A565900829871 /* ContentView.swift in Sources */,
 				ED85C0282D42CAD5007F91A7 /* SelectedTab.swift in Sources */,
+				9AB335192D53ECBA0041A109 /* PromoPage.swift in Sources */,
 				9AAA26A32C2DB79E00A7745A /* DirectionRowView.swift in Sources */,
 				9ADB84A22BAE37C0006581CE /* StopExtension.swift in Sources */,
 				9AF093782BD943A4001DF39F /* DirectionPicker.swift in Sources */,
 				9AB44A112B8FC43E00E8FFB3 /* ErrorCard.swift in Sources */,
-				9A719E152CD12309007377F7 /* OnboardingButtonModifiers.swift in Sources */,
+				9A719E152CD12309007377F7 /* FullWidthButtonModifiers.swift in Sources */,
 				ED87C88D2C10E754009D398F /* PhoenixChannelError.swift in Sources */,
 				8C05C57F2CD56891000381E8 /* DependencyExtension.swift in Sources */,
 				9A37F3072BACCCA5001714FE /* CoordinateExtension.swift in Sources */,
@@ -1701,6 +1716,7 @@
 				8C5054A02CA47C3C00137CFE /* ErrorBanner.swift in Sources */,
 				9AF28F112D2D8D2A00EC1C12 /* StopDetailsIconCard.swift in Sources */,
 				9A18DEAD2D07DDC800DA0A3B /* RouteExtension.swift in Sources */,
+				9AB3351B2D53ECC70041A109 /* PromoScreenView.swift in Sources */,
 				6E973DA52C17384C00CBF341 /* SheetHeader.swift in Sources */,
 				9A9E7DD32C2203BE000DA1FD /* TransitCard.swift in Sources */,
 				9AF29DFA2CF548E5005AA4A3 /* StopDetailsUnfilteredView.swift in Sources */,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -92,6 +92,10 @@ struct ContentView: View {
             OnboardingPage(screens: onboardingScreensPending, onFinish: {
                 contentVM.onboardingScreensPending = []
             })
+        } else if let featurePromosPending = contentVM.featurePromosPending, !featurePromosPending.isEmpty {
+            PromoPage(screens: featurePromosPending, onFinish: {
+                contentVM.featurePromosPending = []
+            })
         } else {
             TabView(selection: $selectedTab) {
                 nearbyTab

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7644,43 +7644,43 @@
         }
       }
     },
-    "Service is running, but predicted arrival times aren’t available. The map shows where %@ on this route currently are." : {
+    "Service is running, but predicted arrival times aren’t available. Check the map to see where %@ are right now." : {
       "comment" : "Explanation under the 'Predictions unavailable' header in stop details when maps are enabled.\nThe interpolated value can be \"buses\" or \"trains\".",
       "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "El servicio está en funcionamiento, pero no hay horarios de llegada previstos. El mapa muestra dónde se encuentra %@ en esta ruta en este momento."
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "El servicio está en funcionamiento, pero no hay horarios de llegada previstos. El mapa muestra dónde se encuentra %@ en esta ruta en este momento."
           }
         },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Sèvis ap fonksyone, men lè yo prevwa arive pa disponib. Kat la montre ki kote %@ sou wout sa a ye kounye a."
+        "ht": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Sèvis ap fonksyone, men lè yo prevwa arive pa disponib. Kat la montre ki kote %@ sou wout sa a ye kounye a."
           }
         },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "O serviço está em execução, mas os horários de chegada previstos não estão disponíveis. O mapa mostra onde %@ nesta rota estão atualmente."
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "O serviço está em execução, mas os horários de chegada previstos não estão disponíveis. O mapa mostra onde %@ nesta rota estão atualmente."
           }
         },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Dịch vụ đang chạy, nhưng thời gian đến dự kiến không khả dụng. Bản đồ hiển thị vị trí hiện tại của %@ trên tuyến đường này."
+        "vi": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Dịch vụ đang chạy, nhưng thời gian đến dự kiến không khả dụng. Bản đồ hiển thị vị trí hiện tại của %@ trên tuyến đường này."
           }
         },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "服务正在运行，但无法提供预计到达时间。地图显示此路线上的%@目前所在的位置。"
+        "zh-Hans-CN": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "服务正在运行，但无法提供预计到达时间。地图显示此路线上的%@目前所在的位置。"
           }
         },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "服務正在運行，但無法提供預計到達時間。地圖顯示了該路線上%@目前所在的位置。"
+        "zh-Hant-TW": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "服務正在運行，但無法提供預計到達時間。地圖顯示了該路線上%@目前所在的位置。"
           }
         }
       }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -4374,6 +4374,9 @@
         }
       }
     },
+    "Got it" : {
+
+    },
     "Hazmat Condition" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -7235,6 +7238,9 @@
           }
         }
       }
+    },
+    "See arrivals and track vehicles in one place" : {
+
     },
     "See transit near you" : {
       "localizations" : {
@@ -10282,6 +10288,9 @@
           }
         }
       }
+    },
+    "We created a new view that allows you to see arrivals at your stop and track vehicle locations all at once. Send us feedback to let us know what you think!" : {
+
     },
     "We don’t have live predictions for this trip yet, but they will appear closer to the scheduled time. If the trip is delayed or cancelled, we’ll let you know here." : {
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -4375,7 +4375,45 @@
       }
     },
     "Got it" : {
-
+      "comment" : "The continue button text on a page displaying new features since last update",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Entiendo"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Konprann"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Entendi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hiểu rồi"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "明白了"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "知道了"
+          }
+        }
+      }
     },
     "Hazmat Condition" : {
       "comment" : "Possible alert cause",
@@ -7240,7 +7278,45 @@
       }
     },
     "See arrivals and track vehicles in one place" : {
-
+      "comment" : "Promo text header that displays when users first open the app after a redesign of the stop page",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vea las llegadas y rastree los vehículos en un solo lugar"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Gade arive epi swiv machin yo nan yon sèl kote"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Veja chegadas e rastreie veículos em um só lugar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Xem thông tin về xe đến và theo dõi xe ở một nơi"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在一个地方查看到达情况并跟踪车辆"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "在一個地方查看到達情況並追蹤車輛"
+          }
+        }
+      }
     },
     "See transit near you" : {
       "localizations" : {
@@ -10290,7 +10366,45 @@
       }
     },
     "We created a new view that allows you to see arrivals at your stop and track vehicle locations all at once. Send us feedback to let us know what you think!" : {
-
+      "comment" : "Promo text that displays when users first open the app after a redesign of the stop page",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Creamos una nueva vista que te permite ver las llegadas a tu parada y rastrear las ubicaciones de los vehículos al mismo tiempo. ¡Envíanos tus comentarios para que sepamos qué opinas!"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nou kreye yon nouvo vi ki pèmèt ou wè arive yo nan arè ou epi swiv kote machin yo tout an menm tan. Voye nou fidbak pou fè nou konnen sa ou panse!"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Criamos uma nova visualização que permite que você veja as chegadas em sua parada e rastreie os locais dos veículos de uma só vez. Envie-nos um feedback para que saibamos o que você acha!"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chúng tôi đã tạo ra một chế độ xem mới cho phép bạn xem các điểm đến tại điểm dừng và vị trí xe theo dõi cùng một lúc. Hãy gửi phản hồi cho chúng tôi để cho chúng tôi biết suy nghĩ của bạn!"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "我们创建了一个新视图，让您可以同时查看站点的到达情况和车辆位置。向我们发送反馈，让我们知道您的想法！"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "我們建立了一個新視圖，讓您可以同時查看站點的到達情況並追蹤車輛位置。向我們發送回饋，讓我們知道您的想法！"
+          }
+        }
+      }
     },
     "We don’t have live predictions for this trip yet, but they will appear closer to the scheduled time. If the trip is delayed or cancelled, we’ll let you know here." : {
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -315,7 +315,7 @@
       }
     },
     "%@ %@ %@" : {
-      "comment" : "Screen reader text for the vehicle status on the trip details page,\nex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard]'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"\nVoiceOver text for the vehicle status on the trip details page,\nex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard]'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"",
+      "comment" : "VoiceOver text for the vehicle status on the trip details page,\nex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard]'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -357,17 +357,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@ %3$@"
-          }
-        }
-      }
-    },
-    "%@ %@ %@, selected stop" : {
-      "comment" : "Screen reader text for the vehicle status on the trip details page when the stop is selected,\nex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard], selected stop'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ %2$@ %3$@, selected stop"
           }
         }
       }
@@ -7439,6 +7428,28 @@
         }
       }
     },
+    "Selected %@ %@ %@" : {
+      "comment" : "Screen reader text for the vehicle status on the trip details page,\nex 'Selected [train] [approaching] [Alewife]' or 'Selected [bus] [now at] [Harvard]'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected %1$@ %2$@ %3$@"
+          }
+        }
+      }
+    },
+    "Selected %@ %@ %@, selected stop" : {
+      "comment" : "Screen reader text for the vehicle status on the trip details page when the stop is selected,\nex 'Selected [train] [approaching] [Alewife], selected stop' or 'Selected [bus] [now at] [Harvard], selected stop'\nPossible values for the vehicle status are \"Approaching\", \"Next stop\", or \"Now at\"",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected %1$@ %2$@ %3$@, selected stop"
+          }
+        }
+      }
+    },
     "Send app feedback" : {
       "comment" : "Label for a More page link to a form to provide feedback on the app itself",
       "localizations" : {
@@ -7647,40 +7658,40 @@
     "Service is running, but predicted arrival times aren’t available. Check the map to see where %@ are right now." : {
       "comment" : "Explanation under the 'Predictions unavailable' header in stop details when maps are enabled.\nThe interpolated value can be \"buses\" or \"trains\".",
       "localizations" : {
-        "es": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "El servicio está en funcionamiento, pero no hay horarios de llegada previstos. El mapa muestra dónde se encuentra %@ en esta ruta en este momento."
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "El servicio está en funcionamiento, pero no hay horarios de llegada previstos. El mapa muestra dónde se encuentra %@ en esta ruta en este momento."
           }
         },
-        "ht": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Sèvis ap fonksyone, men lè yo prevwa arive pa disponib. Kat la montre ki kote %@ sou wout sa a ye kounye a."
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sèvis ap fonksyone, men lè yo prevwa arive pa disponib. Kat la montre ki kote %@ sou wout sa a ye kounye a."
           }
         },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "O serviço está em execução, mas os horários de chegada previstos não estão disponíveis. O mapa mostra onde %@ nesta rota estão atualmente."
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "O serviço está em execução, mas os horários de chegada previstos não estão disponíveis. O mapa mostra onde %@ nesta rota estão atualmente."
           }
         },
-        "vi": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "Dịch vụ đang chạy, nhưng thời gian đến dự kiến không khả dụng. Bản đồ hiển thị vị trí hiện tại của %@ trên tuyến đường này."
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dịch vụ đang chạy, nhưng thời gian đến dự kiến không khả dụng. Bản đồ hiển thị vị trí hiện tại của %@ trên tuyến đường này."
           }
         },
-        "zh-Hans-CN": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "服务正在运行，但无法提供预计到达时间。地图显示此路线上的%@目前所在的位置。"
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服务正在运行，但无法提供预计到达时间。地图显示此路线上的%@目前所在的位置。"
           }
         },
-        "zh-Hant-TW": {
-          "stringUnit": {
-            "state": "needs_review",
-            "value": "服務正在運行，但無法提供預計到達時間。地圖顯示了該路線上%@目前所在的位置。"
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "服務正在運行，但無法提供預計到達時間。地圖顯示了該路線上%@目前所在的位置。"
           }
         }
       }

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -88,7 +88,7 @@ struct OnboardingScreenView: View {
                         Spacer()
                     }
                     Button(action: advance) {
-                        Text("Get started").onboardingKeyButton()
+                        Text("Get started").fullWidthKeyButton()
                     }
                 }
                 .padding(.horizontal, sidePadding)
@@ -143,11 +143,11 @@ struct OnboardingScreenView: View {
                     Spacer()
                     Button(action: { hideMaps(true) }) {
                         Text("Hide maps", comment: "Onboarding button text for setting maps to hidden")
-                            .onboardingKeyButton()
+                            .fullWidthKeyButton()
                     }
                     Button(action: { hideMaps(false) }) {
                         Text("Show maps", comment: "Onboarding button text for setting maps to shown")
-                            .onboardingSecondaryButton()
+                            .fullWidthSecondaryButton()
                     }
                 }
                 .padding(.horizontal, sidePadding)
@@ -176,7 +176,7 @@ struct OnboardingScreenView: View {
                         Spacer()
                     }
                     Button(action: shareLocation) {
-                        Text("Continue").onboardingKeyButton()
+                        Text("Continue").fullWidthKeyButton()
                     }
                     Text("You can always change location settings later in the Settings app.")
                         .padding(.bottom, 8)
@@ -227,11 +227,11 @@ struct OnboardingScreenView: View {
                             "Show elevator closures",
                             comment: "Onboarding button text for setting station accessibility to shown"
                         )
-                        .onboardingKeyButton()
+                        .fullWidthKeyButton()
                     }
                     Button(action: { showStationAccessibility(false) }) {
                         Text("Skip", comment: "Onboarding button text for setting station accessibility to hidden")
-                            .onboardingSecondaryButton()
+                            .fullWidthSecondaryButton()
                     }
                 }
                 .dynamicTypeSize(...DynamicTypeSize.accessibility4)

--- a/iosApp/iosApp/Pages/Promo/PromoPage.swift
+++ b/iosApp/iosApp/Pages/Promo/PromoPage.swift
@@ -1,0 +1,49 @@
+//
+//  PromoPage.swift
+//  iosApp
+//
+//  Created by esimon on 2/5/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreLocation
+import shared
+import SwiftUI
+
+struct PromoPage: View {
+    let screens: [FeaturePromo]
+    @State var selectedIndex: Int = 0
+
+    let onFinish: () -> Void
+
+    let onAdvance: () -> Void
+
+    let inspection = Inspection<Self>()
+
+    init(
+        screens: [FeaturePromo],
+        onFinish: @escaping () -> Void,
+        onAdvance: @escaping () -> Void = {}
+
+    ) {
+        self.screens = screens
+        self.onFinish = onFinish
+        self.onAdvance = onAdvance
+    }
+
+    var body: some View {
+        let screen = screens[selectedIndex]
+        PromoScreenView(screen: screen, advance: {
+            if selectedIndex < screens.count - 1 {
+                selectedIndex += 1
+                onAdvance()
+            } else {
+                onFinish()
+            }
+        })
+    }
+}
+
+#Preview {
+    PromoPage(screens: FeaturePromo.allCases, onFinish: {})
+}

--- a/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
+++ b/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
@@ -54,7 +54,9 @@ struct PromoScreenView: View {
             Spacer()
             Text(
                 "See arrivals and track vehicles in one place",
-                comment: "Promo text header that displays when users first open the app after a redesign of the stop page"
+                comment: """
+                Promo text header that displays when users first open the app after a redesign of the stop page
+                """
             )
             .font(Typography.title1Bold)
             .accessibilityHeading(.h1)

--- a/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
+++ b/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
@@ -1,0 +1,98 @@
+//
+//  PromoScreenView.swift
+//  iosApp
+//
+//  Created by esimon on 2/5/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreLocation
+import shared
+import SwiftUI
+
+struct PromoScreenView: View {
+    let screen: FeaturePromo
+    let advance: () -> Void
+
+    @AccessibilityFocusState private var focusHeader: FeaturePromo?
+    @Environment(\.dynamicTypeSize) var typeSize
+
+    private var screenHeight: CGFloat { UIScreen.current?.bounds.height ?? 852.0 }
+    private var screenWidth: CGFloat { UIScreen.current?.bounds.width ?? 393.0 }
+
+    // Use less padding on smaller screens
+    private var bottomPadding: CGFloat { screenHeight < 812 ? 16 : 52 }
+    private var sidePadding: CGFloat { screenWidth < 393 ? 16 : 32 }
+
+    let inspection = Inspection<Self>()
+
+    init(screen: FeaturePromo, advance: @escaping () -> Void) {
+        self.screen = screen
+        self.advance = advance
+        focusHeader = screen
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            switch screen {
+            case .combinedStopAndTrip: combinedStopAndTrip
+            default: EmptyView()
+            }
+        }
+        .onChange(of: screen) { nextScreen in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                // Voiceover won't pick this up if it's not delayed slightly
+                focusHeader = nextScreen
+            }
+        }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
+
+    @ViewBuilder
+    var combinedStopAndTrip: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Spacer()
+            Text(
+                "See arrivals and track vehicles in one place",
+                comment: "Promo text header that displays when users first open the app after a redesign of the stop page"
+            )
+            .font(Typography.title1Bold)
+            .accessibilityHeading(.h1)
+            .accessibilityAddTraits(.isHeader)
+            .accessibilityFocused($focusHeader, equals: .combinedStopAndTrip)
+            Text(
+                "We created a new view that allows you to see arrivals at your stop and track vehicle locations all at once. Send us feedback to let us know what you think!",
+                comment: "Promo text that displays when users first open the app after a redesign of the stop page"
+            )
+            .font(Typography.title3)
+            .padding(.bottom, 16)
+            .dynamicTypeSize(...DynamicTypeSize.accessibility3)
+            if typeSize >= .accessibility2, typeSize < .accessibility5 {
+                Spacer()
+            }
+            Button(action: advance) {
+                Text(
+                    "Got it",
+                    comment: "The continue button text on a page displaying new features since last update"
+                ).fullWidthKeyButton()
+            }
+        }
+        .padding(.horizontal, sidePadding)
+        .padding(.bottom, bottomPadding)
+        .background {
+            ZStack(alignment: .center) {
+                Color.fill2.edgesIgnoringSafeArea(.all)
+                if typeSize < .accessibility2 {
+                    // TODO: Add finalized graphic
+//                    Image(.promoCombinedStop)
+//                        .resizable()
+//                        .accessibilityHidden(true)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PromoScreenView(screen: .combinedStopAndTrip, advance: {})
+}

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsNoTripCard.swift
@@ -54,7 +54,7 @@ struct StopDetailsNoTripCard: View {
 
     var predictionsUnavailableString: String {
         String(format: NSLocalizedString(
-            "Service is running, but predicted arrival times aren’t available. The map shows where %@ on this route currently are.",
+            "Service is running, but predicted arrival times aren’t available. Check the map to see where %@ are right now.",
             comment: """
             Explanation under the 'Predictions unavailable' header in stop details when maps are enabled.
             The interpolated value can be "buses" or "trains".

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -139,17 +139,17 @@ struct TripHeaderCard: View {
         _ stopEntry: TripDetailsStopList.Entry?
     ) -> Text {
         targetId == stop.id ? Text(
-            "\(routeAccents.type.typeText(isOnly: true)) \(vehicleStatusString(vehicle.currentStatus, stopEntry)) \(stop.name), selected stop",
+            "Selected \(routeAccents.type.typeText(isOnly: true)) \(vehicleStatusString(vehicle.currentStatus, stopEntry)) \(stop.name), selected stop",
             comment: """
             Screen reader text for the vehicle status on the trip details page when the stop is selected,
-            ex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard], selected stop'
+            ex 'Selected [train] [approaching] [Alewife], selected stop' or 'Selected [bus] [now at] [Harvard], selected stop'
             Possible values for the vehicle status are "Approaching", "Next stop", or "Now at"
             """
         ) : Text(
-            "\(routeAccents.type.typeText(isOnly: true)) \(vehicleStatusString(vehicle.currentStatus, stopEntry)) \(stop.name)",
+            "Selected \(routeAccents.type.typeText(isOnly: true)) \(vehicleStatusString(vehicle.currentStatus, stopEntry)) \(stop.name)",
             comment: """
             Screen reader text for the vehicle status on the trip details page,
-            ex '[train] [approaching] [Alewife]' or '[bus] [now at] [Harvard]'
+            ex 'Selected [train] [approaching] [Alewife]' or 'Selected [bus] [now at] [Harvard]'
             Possible values for the vehicle status are "Approaching", "Next stop", or "Now at"
             """
         )

--- a/iosApp/iosApp/Utils/FullWidthButtonModifiers.swift
+++ b/iosApp/iosApp/Utils/FullWidthButtonModifiers.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingButtonModifiers.swift
+//  FullWidthButtonModifiers.swift
 //  iosApp
 //
 //  Created by esimon on 10/29/24.
@@ -33,11 +33,11 @@ struct SecondaryButton: ViewModifier {
 }
 
 extension View {
-    func onboardingKeyButton() -> some View {
+    func fullWidthKeyButton() -> some View {
         modifier(KeyButton())
     }
 
-    func onboardingSecondaryButton() -> some View {
+    func fullWidthSecondaryButton() -> some View {
         modifier(SecondaryButton())
     }
 }

--- a/iosApp/iosAppTests/Pages/Promo/PromoPageTests.swift
+++ b/iosApp/iosAppTests/Pages/Promo/PromoPageTests.swift
@@ -1,0 +1,31 @@
+//
+//  PromoPageTests.swift
+//  iosAppTests
+//
+//  Created by esimon on 2/5/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Combine
+@testable import iosApp
+import shared
+import ViewInspector
+import XCTest
+
+final class PromoPageTest: XCTestCase {
+    @MainActor func testFlow() throws {
+        let finishExp = expectation(description: "calls onFinish")
+        let stepChannel = PassthroughSubject<Void, Never>()
+
+        let sut = PromoPage(
+            screens: [FeaturePromo.combinedStopAndTrip],
+            onFinish: { finishExp.fulfill() },
+            onAdvance: { stepChannel.send() }
+        )
+
+        ViewHosting.host(view: sut)
+
+        try sut.inspect().find(button: "Got it").tap()
+        wait(for: [finishExp], timeout: 2)
+    }
+}

--- a/iosApp/iosAppTests/Pages/Promo/PromoScreenViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Promo/PromoScreenViewTests.swift
@@ -1,0 +1,34 @@
+//
+//  PromoScreenViewTests.swift
+//  iosAppTests
+//
+//  Created by esimon on 2/5/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreLocation
+@testable import iosApp
+import shared
+import ViewInspector
+import XCTest
+
+final class PromoScreenViewTests: XCTestCase {
+    @MainActor func testCombinedStopPromoFlow() throws {
+        let advanceExp = expectation(description: "calls advance()")
+        let sut = PromoScreenView(
+            screen: .combinedStopAndTrip,
+            advance: { advanceExp.fulfill() }
+        )
+        let exp = sut.inspection.inspect { view in
+            XCTAssertNotNil(try view.find(text: "See arrivals and track vehicles in one place"))
+            XCTAssertNotNil(try view.find(
+                text: "We created a new view that allows you to see arrivals at your stop "
+                    + "and track vehicle locations all at once. Send us feedback to let us know what you think!"
+            ))
+            try view.find(button: "Got it").tap()
+            await self.fulfillment(of: [advanceExp], timeout: 1)
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 5)
+    }
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
@@ -31,7 +31,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(ViewType.Divider.self))
         XCTAssertNotNil(try sut.inspect().find(
             text: "Service is running, but predicted arrival times aren’t available." +
-                " The map shows where buses on this route currently are."
+                " Check the map to see where buses are right now."
         ))
     }
 

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -309,7 +309,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
         XCTAssertNotNil(try withVehicleAtStop.inspect().find(
-            viewWithAccessibilityLabel: "bus Approaching stop, selected stop"
+            viewWithAccessibilityLabel: "Selected bus Approaching stop, selected stop"
         ))
 
         let otherStop = objects.stop { stop in
@@ -323,7 +323,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
         XCTAssertNotNil(try withVehicleAtOtherStop.inspect().find(
-            viewWithAccessibilityLabel: "bus Approaching other stop"
+            viewWithAccessibilityLabel: "Selected bus Approaching other stop"
         ))
 
         let schedule = objects.schedule { schedule in

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
@@ -2,7 +2,8 @@ package com.mbta.tid.mbta_app.model
 
 enum class FeaturePromo(val addedInAndroidVersion: AppVersion, val addedInIosVersion: AppVersion) {
     // ktfmt does not like empty enums as of the version we get with spotless
-    Nothing(AppVersion(0u, 0u, 0u));
+    Nothing(AppVersion(0u, 0u, 0u)),
+    CombinedStopAndTrip(AppVersion(0u, 0u, 0u), AppVersion(1u, 2u, 0u));
 
     constructor(addedInVersion: AppVersion) : this(addedInVersion, addedInVersion)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
@@ -1,8 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 enum class FeaturePromo(val addedInAndroidVersion: AppVersion, val addedInIosVersion: AppVersion) {
-    // ktfmt does not like empty enums as of the version we get with spotless
-    Nothing(AppVersion(0u, 0u, 0u)),
+
     CombinedStopAndTrip(AppVersion(0u, 0u, 0u), AppVersion(1u, 2u, 0u));
 
     constructor(addedInVersion: AppVersion) : this(addedInVersion, addedInVersion)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
@@ -39,7 +39,7 @@ class FeaturePromoUsecaseTest {
             MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
             MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
         )
-        assertEquals(listOf(), useCase.getFeaturePromos())
+        assertEquals(listOf(FeaturePromo.CombinedStopAndTrip), useCase.getFeaturePromos())
     }
 
     @Test
@@ -50,6 +50,6 @@ class FeaturePromoUsecaseTest {
             MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
             MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
         )
-        assertEquals(emptyList(), useCase.getFeaturePromos())
+        assertEquals(listOf(FeaturePromo.CombinedStopAndTrip), useCase.getFeaturePromos())
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Combined Stop + Trip Details: Launch promo](https://app.asana.com/0/1205732265579288/1209309195022071)

Adds the UX for the combined stop + trip promo page. We don't have a finalized graphic yet, so that's left as a todo, and it's only set to show up once we update the version number to 1.2.0, so currently you can only make it show up by manually updating the version locally.

![Simulator Screenshot - iPhone 15 - 2025-02-05 at 16 20 01](https://github.com/user-attachments/assets/37d5ea68-b8b0-4f74-80e3-dfa4bbb27c32)

iOS
- [X] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [X] Add temporary machine translations, marked "Needs Review"

### Testing

Added some basic UI tests