### PR TITLE
i18n: Translation pass before sending to vendor

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -43,7 +43,9 @@ class HomeMapViewTests {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Recenter").assertDoesNotExist()
+        composeTestRule
+            .onNodeWithContentDescription("Recenter map on my location")
+            .assertDoesNotExist()
     }
 
     @Test
@@ -68,7 +70,9 @@ class HomeMapViewTests {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Recenter").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Recenter map on my location")
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -386,7 +386,7 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithContentDescription(
-                "bus scheduled to depart stop, selected stop",
+                "Selected bus scheduled to depart stop, selected stop",
                 useUnmergedTree = true
             )
             .assertIsDisplayed()
@@ -426,7 +426,7 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithContentDescription(
-                "bus scheduled to depart other stop",
+                "Selected bus scheduled to depart other stop",
                 useUnmergedTree = true
             )
             .assertIsDisplayed()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import com.mbta.tid.mbta_app.android.R
 
@@ -16,7 +17,7 @@ import com.mbta.tid.mbta_app.android.R
 fun RecenterButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     IconButton(
         onClick = onClick,
-        modifier,
+        modifier.semantics(mergeDescendants = true) {},
         colors =
             IconButtonDefaults.iconButtonColors(
                 containerColor = colorResource(R.color.fill3),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreLink.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreLink.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 
@@ -41,6 +42,7 @@ fun MoreLink(label: String, url: String, note: String? = null, isKey: Boolean = 
                         Log.i("More", "Failed to navigate to link on MoreLink click")
                     }
                 }
+                .semantics(mergeDescendants = true) {}
                 .background(
                     color =
                         if (isKey) {
@@ -78,7 +80,7 @@ fun MoreLink(label: String, url: String, note: String? = null, isKey: Boolean = 
             }
             Icon(
                 painterResource(R.drawable.arrow_up_right),
-                contentDescription = stringResource(id = R.string.icon_description_external_link),
+                contentDescription = stringResource(id = R.string.more_link_external),
                 modifier = Modifier.size(12.dp),
                 tint =
                     if (isKey) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MorePhone.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MorePhone.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 
@@ -39,6 +40,7 @@ fun MorePhone(label: String, phoneNumber: String) {
                         Log.i("More", "Failed to dial number on MorePhone click")
                     }
                 }
+                .semantics(mergeDescendants = true) {}
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -47,7 +49,7 @@ fun MorePhone(label: String, phoneNumber: String) {
         Column { Text(label, style = MaterialTheme.typography.bodyMedium) }
         Icon(
             painterResource(R.drawable.fa_phone),
-            contentDescription = stringResource(id = R.string.icon_description_external_link),
+            contentDescription = stringResource(id = R.string.more_link_call),
             modifier = Modifier.size(12.dp),
             tint = colorResource(R.color.deemphasized),
         )

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -37,6 +37,7 @@
     <string name="disabled_train">Tren averiado</string>
     <string name="displays_more_info">muestra más información</string>
     <string name="dock_closure">Cierre del muelle</string>
+    <string name="drag_handle">Mango de arrastre</string>
     <string name="drawbridge_being_raised">Puente levadizo en elevación</string>
     <string name="eastbound">En dirección este</string>
     <string name="effect_ahead">%1$s adelante</string>
@@ -96,6 +97,8 @@
     <string name="medical_emergency">Emergencia médica</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="more_link">Más</string>
+    <string name="more_link_call">Seleccionar para llamar</string>
+    <string name="more_link_external">Enlace externo</string>
     <string name="more_page_footer">Hecho con ♥ por T</string>
     <string name="more_section_feature_flags">Banderas de características</string>
     <string name="more_section_resources">Recursos</string>
@@ -143,6 +146,7 @@
     <string name="predictions_unavailable_details">El servicio está en funcionamiento, pero no hay horarios de llegada previstos. El mapa muestra dónde se encuentra %1$s en esta ruta en este momento.</string>
     <string name="predictions_unavailable_details_hide_maps">El servicio está funcionando, pero los horarios de llegada previstos no están disponibles.</string>
     <string name="real_time_arrivals_updating_live">Llegadas en tiempo real actualizadas en vivo</string>
+    <string name="recenter">Volver a centrar el mapa en mi ubicación</string>
     <string name="recently_viewed">Visto recientemente</string>
     <string name="refresh">Refrescar</string>
     <string name="refresh_predictions">Refrescar predicciones</string>
@@ -154,7 +158,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Programado para salir</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s programado para salir de %2$s</string>
     <string name="search_by_stop">Buscar por parada</string>
     <string name="selected_stop">%1$s, parada seleccionada</string>
     <string name="selected_stop_first_stop">%1$s, parada seleccionada, primera parada</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -40,6 +40,7 @@
     <string name="disabled_train">Tren Ki Pa Aktif</string>
     <string name="displays_more_info">montre plis enfòmasyon</string>
     <string name="dock_closure">Waf la Fèmen</string>
+    <string name="drag_handle">Trennen manch</string>
     <string name="drawbridge_being_raised">Y ap Leve Pon ki ka Bouje a</string>
     <string name="eastbound">Pran direksyon lès</string>
     <string name="effect_ahead">%1$s devan</string>
@@ -101,6 +102,8 @@
     <string name="medical_emergency">Ijans Medikal</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> minit</string>
     <string name="more_link">Plis</string>
+    <string name="more_link_call">Chwazi rele</string>
+    <string name="more_link_external">Lyen ekstèn</string>
     <string name="more_page_footer">Ki fèt ak ♥ pa T a</string>
     <string name="more_section_feature_flags">Drapo Opsyon</string>
     <string name="more_section_resources">Resous</string>
@@ -148,6 +151,7 @@
     <string name="predictions_unavailable_details">Sèvis ap fonksyone, men lè yo prevwa arive pa disponib. Kat la montre ki kote %1$s sou wout sa a ye kounye a.</string>
     <string name="predictions_unavailable_details_hide_maps">Sèvis ap fonksyone, men lè yo prevwa arive pa disponib.</string>
     <string name="real_time_arrivals_updating_live">Arive an tan reyèl yo mete ajou an dirèk</string>
+    <string name="recenter">Resantre kat jeyografik sou kote mwen an</string>
     <string name="recently_viewed">Sa w fenk sot Wè</string>
     <string name="refresh">Rafrechi</string>
     <string name="refresh_predictions">Rafrechi prediksyon</string>
@@ -159,7 +163,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Pwograme pou ale</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s ki pwograme pou kite %2$s</string>
     <string name="search_by_stop">Chèche pa kanpe</string>
     <string name="selected_stop">%1$s, chwazi sispann</string>
     <string name="selected_stop_first_stop">%1$s, chwazi kanpe, premye kanpe</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -37,6 +37,7 @@
     <string name="disabled_train">Trem desativado</string>
     <string name="displays_more_info">exibe mais informações</string>
     <string name="dock_closure">Fechamento de doca</string>
+    <string name="drag_handle">Alça de arrasto</string>
     <string name="drawbridge_being_raised">Ponte móvel em elevação</string>
     <string name="eastbound">Sentido leste</string>
     <string name="effect_ahead">%1$s à frente</string>
@@ -96,6 +97,8 @@
     <string name="medical_emergency">Emergência médica</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="more_link">Mais</string>
+    <string name="more_link_call">Selecionar para chamar</string>
+    <string name="more_link_external">Link externo</string>
     <string name="more_page_footer">Feito com ♥ pelo T</string>
     <string name="more_section_feature_flags">Exibir sinalizações</string>
     <string name="more_section_resources">Recursos</string>
@@ -143,6 +146,7 @@
     <string name="predictions_unavailable_details">O serviço está em execução, mas os horários de chegada previstos não estão disponíveis. O mapa mostra onde %1$s nesta rota estão atualmente.</string>
     <string name="predictions_unavailable_details_hide_maps">O serviço está em execução, mas os horários previstos de chegada não estão disponíveis.</string>
     <string name="real_time_arrivals_updating_live">Atualização em tempo real ao vivo das chegadas</string>
+    <string name="recenter">Mapa mais recente sobre minha localização</string>
     <string name="recently_viewed">Visto(s) recentemente</string>
     <string name="refresh">Atualizar</string>
     <string name="refresh_predictions">Atualizar previsões</string>
@@ -154,7 +158,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Programado para partir</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s programado para partir de %2$s</string>
     <string name="search_by_stop">Pesquisar por parada</string>
     <string name="selected_stop">%1$s, parada selecionada</string>
     <string name="selected_stop_first_stop">%1$s, parada selecionada, primeira parada</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -35,6 +35,7 @@
     <string name="disabled_train">Tàu bị sự cố</string>
     <string name="displays_more_info">hiển thị thêm thông tin</string>
     <string name="dock_closure">Đóng bến tàu</string>
+    <string name="drag_handle">Tay cầm kéo</string>
     <string name="drawbridge_being_raised">Cầu rút đang nâng</string>
     <string name="eastbound">Về hướng đông</string>
     <string name="effect_ahead">%1$s phía trước</string>
@@ -92,6 +93,8 @@
     <string name="medical_emergency">Cấp cứu y tế</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> phút</string>
     <string name="more_link">Thêm</string>
+    <string name="more_link_call">Chọn để gọi</string>
+    <string name="more_link_external">Liên kết ngoài</string>
     <string name="more_page_footer">Được tạo ra với ♥ bởi T</string>
     <string name="more_section_feature_flags">Cờ tính năng</string>
     <string name="more_section_resources">Nguồn</string>
@@ -139,6 +142,7 @@
     <string name="predictions_unavailable_details">Dịch vụ đang chạy, nhưng thời gian đến dự kiến không khả dụng. Bản đồ hiển thị vị trí hiện tại của %1$s trên tuyến đường này.</string>
     <string name="predictions_unavailable_details_hide_maps">Dịch vụ đang chạy nhưng không có thời gian đến dự kiến.</string>
     <string name="real_time_arrivals_updating_live">Cập nhật giờ đến theo thời gian thực</string>
+    <string name="recenter">Bản đồ định vị lại vị trí của tôi</string>
     <string name="recently_viewed">Đã xem gần đây</string>
     <string name="refresh">Làm mới</string>
     <string name="refresh_predictions">Làm mới dự đoán</string>
@@ -150,7 +154,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Đã lên lịch khởi hành</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s dự kiến khởi hành %2$s</string>
     <string name="search_by_stop">Tìm kiếm theo điểm dừng</string>
     <string name="selected_stop">%1$s, điểm dừng được chọn</string>
     <string name="selected_stop_first_stop">%1$s, điểm dừng đã chọn, điểm dừng đầu tiên</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -35,6 +35,7 @@
     <string name="disabled_train">列车停运</string>
     <string name="displays_more_info">显示详细信息</string>
     <string name="dock_closure">码头关闭</string>
+    <string name="drag_handle">拖动控制柄</string>
     <string name="drawbridge_being_raised">吊桥升起</string>
     <string name="eastbound">东行</string>
     <string name="effect_ahead">%1$s 前面</string>
@@ -92,6 +93,8 @@
     <string name="medical_emergency">医疗急救</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b>分钟</string>
     <string name="more_link">更多</string>
+    <string name="more_link_call">选择呼叫</string>
+    <string name="more_link_external">外部链接</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">功能标记</string>
     <string name="more_section_resources">资源</string>
@@ -139,6 +142,7 @@
     <string name="predictions_unavailable_details">服务正在运行，但无法提供预计到达时间。地图显示此路线上的%1$s目前所在的位置。</string>
     <string name="predictions_unavailable_details_hide_maps">服务正在运行，但无法提供预计到达时间。</string>
     <string name="real_time_arrivals_updating_live">实时到达实时更新</string>
+    <string name="recenter">将地图重新定位到我的位置</string>
     <string name="recently_viewed">近期查看过</string>
     <string name="refresh">刷新</string>
     <string name="refresh_predictions">刷新预测</string>
@@ -150,7 +154,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">预计出发</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s计划从 %2$s 出发</string>
     <string name="search_by_stop">按站点搜索</string>
     <string name="selected_stop">%1$s，选定站点</string>
     <string name="selected_stop_first_stop">%1$s，选定站点，第一站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -35,6 +35,7 @@
     <string name="disabled_train">列車停運</string>
     <string name="displays_more_info">顯示更多資訊</string>
     <string name="dock_closure">碼頭關閉</string>
+    <string name="drag_handle">拖曳控制柄</string>
     <string name="drawbridge_being_raised">吊橋升起</string>
     <string name="eastbound">東行</string>
     <string name="effect_ahead">%1$s 前面</string>
@@ -92,6 +93,8 @@
     <string name="medical_emergency">醫療急救</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b>分鐘</string>
     <string name="more_link">更多</string>
+    <string name="more_link_call">選擇呼叫</string>
+    <string name="more_link_external">外部連結</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">功能標記</string>
     <string name="more_section_resources">資源</string>
@@ -139,6 +142,7 @@
     <string name="predictions_unavailable_details">服務正在運行，但無法提供預計到達時間。地圖顯示了該路線上%1$s目前所在的位置。</string>
     <string name="predictions_unavailable_details_hide_maps">服務正在運行，但無法提供預計到達時間。</string>
     <string name="real_time_arrivals_updating_live">即時到達即時更新</string>
+    <string name="recenter">將地圖重新定位到我的位置</string>
     <string name="recently_viewed">近期查看過</string>
     <string name="refresh">重新整理</string>
     <string name="refresh_predictions">重新整理預測</string>
@@ -150,7 +154,6 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">預定出發</string>
-    <string name="scheduled_to_depart_accessibility_desc">這%1$s預定從 %2$s 出發</string>
     <string name="search_by_stop">按站點搜尋</string>
     <string name="selected_stop">%1$s，選定站點</string>
     <string name="selected_stop_first_stop">%1$s，選定站點，第一站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="disabled_train">Disabled Train</string>
     <string name="displays_more_info">displays more information</string>
     <string name="dock_closure">Dock Closure</string>
-    <string name="drag_handle" tools:ignore="MissingTranslation">Drag handle</string>
+    <string name="drag_handle">Drag handle</string>
     <string name="drawbridge_being_raised">Drawbridge Being Raised</string>
     <string name="eastbound">Eastbound</string>
     <string name="effect_ahead">%1$s ahead</string>
@@ -79,7 +79,6 @@
     <string name="hr_min_abbr">&lt;b&gt;%1$d&lt;/b&gt; hr &lt;b&gt;%2$d&lt;/b&gt; min</string>
     <string name="hurricane">Hurricane</string>
     <string name="ice_in_harbor">Ice In Harbor</string>
-    <string name="icon_description_external_link" tools:ignore="MissingTranslation">External Link</string>
     <string name="inbound">Inbound</string>
     <string name="is_stops_away_from">%1$s is %2$d stops away from %3$s</string>
     <string name="lists_remaining_stops">Lists remaining stops</string>
@@ -96,6 +95,8 @@
     <string name="medical_emergency">Medical Emergency</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="more_link">More</string>
+    <string name="more_link_call">Select to call</string>
+    <string name="more_link_external">External link</string>
     <string name="more_page_footer">Made with ♥ by the T</string>
     <string name="more_section_feature_flags">Feature Flags</string>
     <string name="more_section_resources">Resources</string>
@@ -143,7 +144,7 @@
     <string name="predictions_unavailable_details">Service is running, but predicted arrival times aren’t available. Check the map to see where %1$s are right now.</string>
     <string name="predictions_unavailable_details_hide_maps">Service is running, but predicted arrival times aren’t available.</string>
     <string name="real_time_arrivals_updating_live">Real-time arrivals updating live</string>
-    <string name="recenter" tools:ignore="MissingTranslation">Recenter</string>
+    <string name="recenter">Recenter map on my location</string>
     <string name="recently_viewed">Recently Viewed</string>
     <string name="refresh">Refresh</string>
     <string name="refresh_predictions">Refresh predictions</string>
@@ -155,8 +156,8 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Scheduled to depart</string>
-    <string name="scheduled_to_depart_accessibility_desc">%1$s scheduled to depart %2$s</string>
-    <string name="scheduled_to_depart_selected_stop_accessibility_desc" translatable="false">%1$s scheduled to depart %2$s, selected stop</string>
+    <string name="scheduled_to_depart_accessibility_desc" translatable="false">Selected %1$s scheduled to depart %2$s</string>
+    <string name="scheduled_to_depart_selected_stop_accessibility_desc" translatable="false">Selected %1$s scheduled to depart %2$s, selected stop</string>
     <string name="search_by_stop">Search by stop</string>
     <string name="selected_stop">%1$s, selected stop</string>
     <string name="selected_stop_first_stop">%1$s, selected stop, first stop</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -156,8 +156,8 @@
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_with_type">%1$s %2$s</string>
     <string name="scheduled_to_depart">Scheduled to depart</string>
-    <string name="scheduled_to_depart_accessibility_desc" translatable="false">Selected %1$s scheduled to depart %2$s</string>
-    <string name="scheduled_to_depart_selected_stop_accessibility_desc" translatable="false">Selected %1$s scheduled to depart %2$s, selected stop</string>
+    <string name="scheduled_to_depart_accessibility_desc" tools:ignore="MissingTranslation">Selected %1$s scheduled to depart %2$s</string>
+    <string name="scheduled_to_depart_selected_stop_accessibility_desc" tools:ignore="MissingTranslation">Selected %1$s scheduled to depart %2$s, selected stop</string>
     <string name="search_by_stop">Search by stop</string>
     <string name="selected_stop">%1$s, selected stop</string>
     <string name="selected_stop_first_stop">%1$s, selected stop, first stop</string>
@@ -217,8 +217,8 @@
     <string name="vehicle_boarding_other">and boarding now</string>
     <string name="vehicle_cancelled_first">%1$s arriving at %2$s cancelled</string>
     <string name="vehicle_cancelled_other">and at %1$s cancelled</string>
-    <string name="vehicle_desc_accessibility_desc" translatable="false">Selected %1$s %2$s %3$s</string>
-    <string name="vehicle_desc_accessibility_desc_selected_stop" translatable="false">Selected %1$s %2$s %3$s, selected stop</string>
+    <string name="vehicle_desc_accessibility_desc" tools:ignore="MissingTranslation">Selected %1$s %2$s %3$s</string>
+    <string name="vehicle_desc_accessibility_desc_selected_stop" tools:ignore="MissingTranslation">Selected %1$s %2$s %3$s, selected stop</string>
     <string name="vehicle_prediction_minutes_first">%1$s arriving in %2$d min</string>
     <string name="vehicle_prediction_minutes_other">and in %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s arriving at %2$s</string>

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -173,7 +173,6 @@ struct ContentView: View {
                                 RecenterButton(icon: .faLocationArrowSolid, size: 17.33) {
                                     viewportProvider.follow()
                                 }
-                                .accessibilityIdentifier("mapRecenterButton")
                             }.frame(maxWidth: .infinity, alignment: .topTrailing)
                         }
                         if !searchObserver.isSearching, !viewportProvider.viewport.isOverview,

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -901,64 +901,6 @@
         }
       }
     },
-    "%@ scheduled to depart %@" : {
-      "comment" : "Screen reader text for the departure status on the trip details page,\nex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard]'",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ scheduled to depart %2$@"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%1$@ programado para salir de %2$@"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%1$@ ki pwograme pou kite %2$@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%1$@ programado para partir de %2$@"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%1$@ dự kiến khởi hành %2$@"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "%1$@计划从 %2$@ 出发"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "這%1$@預定從 %2$@ 出發"
-          }
-        }
-      }
-    },
-    "%@ scheduled to depart %@, selected stop" : {
-      "comment" : "Screen reader text for the departure status on the trip details page when the stop is selected,\nex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard], selected stop'",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ scheduled to depart %2$@, selected stop"
-          }
-        }
-      }
-    },
     "%@ to" : {
       "comment" : "Label the direction a list of arrivals is for.\nPossible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.\nFor example, \"[Northbound] to [Alewife]",
       "localizations" : {
@@ -3585,6 +3527,48 @@
         }
       }
     },
+    "Drag handle" : {
+      "comment" : "Screen reader text for the sheet drag handle to move the textual content over the map",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mango de arrastre"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trennen manch"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Alça de arrasto"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tay cầm kéo"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "拖动控制柄"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "拖曳控制柄"
+          }
+        }
+      }
+    },
     "Drawbridge Being Raised" : {
       "comment" : "Possible alert cause",
       "localizations" : {
@@ -3827,6 +3811,48 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "載入資料時發生錯誤"
+          }
+        }
+      }
+    },
+    "External link" : {
+      "comment" : "Screen reader text describing an external link on the more page",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Enlace externo"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Lyen ekstèn"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Link externo"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Liên kết ngoài"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "外部链接"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "外部連結"
           }
         }
       }
@@ -6819,6 +6845,47 @@
         }
       }
     },
+    "Recenter map on my location" : {
+      "comment" : "Screen reader text describing the behavior of the map recenter button",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Volver a centrar el mapa en mi ubicación"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Resantre kat jeyografik sou kote mwen an"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mapa mais recente sobre minha localização"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bản đồ định vị lại vị trí của tôi"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "将地图重新定位到我的位置"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將地圖重新定位到我的位置"
+          }
+        }
+      }
+    },
     "Recently Viewed" : {
       "localizations" : {
         "es" : {
@@ -7389,6 +7456,7 @@
       }
     },
     "Select to call" : {
+      "comment" : "Screen reader text for a link to call a phone number",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -7446,6 +7514,28 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Selected %1$@ %2$@ %3$@, selected stop"
+          }
+        }
+      }
+    },
+    "Selected %@ scheduled to depart %@" : {
+      "comment" : "Screen reader text for the departure status on the trip details page,\nex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard]'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected %1$@ scheduled to depart %2$@"
+          }
+        }
+      }
+    },
+    "Selected %@ scheduled to depart %@, selected stop" : {
+      "comment" : "Screen reader text for the departure status on the trip details page when the stop is selected,\nex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard], selected stop'",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Selected %1$@ scheduled to depart %2$@, selected stop"
           }
         }
       }

--- a/iosApp/iosApp/Pages/Map/RecenterButton.swift
+++ b/iosApp/iosApp/Pages/Map/RecenterButton.swift
@@ -26,5 +26,12 @@ struct RecenterButton: View {
             .padding(.top, 16)
             .onTapGesture(perform: perform)
             .transition(AnyTransition.opacity.animation(.linear(duration: 0.25)))
+            .accessibilityLabel(Text(
+                "Recenter map on my location",
+                comment: "Screen reader text describing the behavior of the map recenter button"
+            ))
+            .accessibilityRemoveTraits(.isImage)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier("mapRecenterButton")
     }
 }

--- a/iosApp/iosApp/Pages/More/MorePhone.swift
+++ b/iosApp/iosApp/Pages/More/MorePhone.swift
@@ -40,6 +40,6 @@ struct MorePhone: View {
             }
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityHint(Text("Select to call"))
+        .accessibilityHint(Text("Select to call", comment: "Screen reader text for a link to call a phone number"))
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -104,13 +104,13 @@ struct TripHeaderCard: View {
         _ stopEntry: TripDetailsStopList.Entry
     ) -> Text {
         targetId == stopEntry.stop.id ? Text(
-            "\(routeAccents.type.typeText(isOnly: true)) scheduled to depart \(stopEntry.stop.name), selected stop",
+            "Selected \(routeAccents.type.typeText(isOnly: true)) scheduled to depart \(stopEntry.stop.name), selected stop",
             comment: """
             Screen reader text for the departure status on the trip details page when the stop is selected,
             ex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard], selected stop'
             """
         ) : Text(
-            "\(routeAccents.type.typeText(isOnly: true)) scheduled to depart \(stopEntry.stop.name)",
+            "Selected \(routeAccents.type.typeText(isOnly: true)) scheduled to depart \(stopEntry.stop.name)",
             comment: """
             Screen reader text for the departure status on the trip details page,
             ex '[train] scheduled to depart [Alewife]' or '[bus] scheduled to depart [Harvard]'

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -346,7 +346,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
         XCTAssertNotNil(try withScheduleAtStop.inspect().find(
-            viewWithAccessibilityLabel: "bus scheduled to depart stop, selected stop"
+            viewWithAccessibilityLabel: "Selected bus scheduled to depart stop, selected stop"
         ))
 
         let withScheduleAtOtherStop = TripHeaderCard(
@@ -366,7 +366,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
         XCTAssertNotNil(try withScheduleAtOtherStop.inspect().find(
-            viewWithAccessibilityLabel: "bus scheduled to depart other stop"
+            viewWithAccessibilityLabel: "Selected bus scheduled to depart other stop"
         ))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[send out another batch of translations]](https://app.asana.com/0/1205732265579288/1209230846082285)

This updates a final few localizable strings on across both Android and iOS, it adds a few to the iOS source of truth that only exist on Android, and updated a few on both platforms which were identified during QA.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Updated tests that rely on the updated translations, verified that updated screen reader behavior is as expected