### PR TITLE
fix(iOS): Make map padding uniform

### DIFF
--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -48,7 +48,10 @@ struct AnnotatedMap: View {
             .debugOptions(devDebugMode ? .camera : [])
             .cameraBounds(.init(maxZoom: 18, minZoom: 6))
             .onCameraChanged { change in handleCameraChange(change) }
-            .ornamentOptions(.init(scaleBar: .init(visibility: .hidden)))
+            .ornamentOptions(.init(
+                scaleBar: .init(visibility: .hidden),
+                attributionButton: .init(margins: .init(x: 0, y: 8))
+            ))
             .onLayerTapGesture(StopLayerGenerator.shared.stopLayerId, perform: handleTapStopLayer)
             .onLayerTapGesture(StopLayerGenerator.shared.stopTouchTargetLayerId, perform: handleTapStopLayer)
             .onStyleLoaded { _ in
@@ -61,7 +64,8 @@ struct AnnotatedMap: View {
                     handleStyleLoaded()
                 }
             }
-            .additionalSafeAreaInsets(.bottom, sheetHeight)
+            .additionalSafeAreaInsets(.bottom, sheetHeight + 8)
+            .additionalSafeAreaInsets(.top, 20)
             .accessibilityIdentifier("transitMap")
             .onReceive(viewportProvider.cameraStatePublisher) { newCameraState in
                 zoomLevel = newCameraState.zoom

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -208,9 +208,9 @@ struct HomeMapView: View {
 
     private var crosshairs: some View {
         VStack {
-            Image("map-nearby-location-cursor")
+            Image(.mapNearbyLocationCursor)
             Spacer()
-                .frame(height: sheetHeight)
+                .frame(height: sheetHeight - 12)
         }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

I noticed this in the app listing screenshots and it bothered me enough that I couldn't help myself. Note the position of the logo and info icon at the bottom. The top inset also repositions the map debug view underneath the search bar on nearby transit, and makes the current location/nearby cursor more centered within the map.

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2025-02-06 at 15 26 11](https://github.com/user-attachments/assets/74493c78-ae7f-418a-9880-62c82c02c023) | ![Simulator Screenshot - iPhone 15 - 2025-02-06 at 15 24 03](https://github.com/user-attachments/assets/5f065842-05da-458a-a5d9-942e0d7cfc9c) |


iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

N/A