### PR TITLE
fix(Android): performance low-hanging fruit

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -57,7 +57,9 @@ class MoreViewModelTests {
             vm = MoreViewModel(subContext, MockSettingsRepository())
         }
 
-        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil {
+            vm.sections.value.any { it.id == MoreSection.Category.Feedback }
+        }
         assertEquals(
             "https://mbta.com/androidappfeedback?lang=es-US",
             vm.sections.value

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -126,26 +126,30 @@ open class MapViewModel(
     }
 
     override suspend fun refreshRouteLineData(now: Instant) {
-        val globalResponse = globalResponse.first() ?: return
-        val railRouteShapes = railRouteShapes.first() ?: return
-        _railRouteLineData.value =
-            RouteFeaturesBuilder.generateRouteLines(
-                railRouteShapes.routesWithSegmentedShapes,
-                globalResponse.routes,
-                globalResponse.stops,
-                globalMapData(now)?.alertsByStop
-            )
+        withContext(Dispatchers.Default) {
+            val globalResponse = globalResponse.first() ?: return@withContext
+            val railRouteShapes = railRouteShapes.first() ?: return@withContext
+            _railRouteLineData.value =
+                RouteFeaturesBuilder.generateRouteLines(
+                    railRouteShapes.routesWithSegmentedShapes,
+                    globalResponse.routes,
+                    globalResponse.stops,
+                    globalMapData(now)?.alertsByStop
+                )
+        }
     }
 
     override suspend fun refreshStopFeatures(now: Instant, selectedStop: Stop?) {
-        val routeLineData = railRouteLineData.first() ?: return
-        _stopSourceData.value =
-            StopFeaturesBuilder.buildCollection(
-                    StopSourceData(selectedStopId = selectedStop?.id),
-                    globalMapData(now)?.mapStops.orEmpty(),
-                    routeLineData
-                )
-                .toMapbox()
+        withContext(Dispatchers.Default) {
+            val routeLineData = railRouteLineData.first() ?: return@withContext
+            _stopSourceData.value =
+                StopFeaturesBuilder.buildCollection(
+                        StopSourceData(selectedStopId = selectedStop?.id),
+                        globalMapData(now)?.mapStops.orEmpty(),
+                        routeLineData
+                    )
+                    .toMapbox()
+        }
     }
 
     override suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -103,11 +103,13 @@ open class MapViewModel(
     }
 
     override suspend fun loadConfig() {
-        val latestConfig = configUseCase.getConfig()
-        if (latestConfig is ApiResult.Ok) {
-            configureMapboxToken(latestConfig.data.mapboxPublicToken)
+        withContext(Dispatchers.IO) {
+            val latestConfig = configUseCase.getConfig()
+            if (latestConfig is ApiResult.Ok) {
+                configureMapboxToken(latestConfig.data.mapboxPublicToken)
+            }
+            _config.value = latestConfig
         }
-        _config.value = latestConfig
     }
 
     override suspend fun globalMapData(now: Instant): GlobalMapData? =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
@@ -19,7 +19,6 @@ value class PhoenixSocketWrapper(private val socket: Socket) : PhoenixSocket {
     override fun detach() = socket.disconnect()
 
     fun attachLogging() {
-        socket.onMessage { message -> Log.i("Socket", message.toString()) }
         socket.onError { throwable, response ->
             Log.e("Socket", response?.toString() ?: throwable.toString(), throwable)
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 Re-profile app to identify performance issues](https://app.asana.com/0/1205732265579288/1209264000440745)

It might make sense to move these to a background thread inherently, but I don't want to make the iOS changes that that'd imply right now.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually verified that the map still looks reasonable and these functions appear in the profile on background threads.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
