### PR TITLE
feat: add TimeWithStatus display state for commuter rail

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -127,6 +127,23 @@ class UpcomingTripViewTest {
     }
 
     @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithStatus() {
+        val instant = Instant.fromEpochSeconds(1722535384)
+        val shortTime = formatTime(instant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(TripInstantDisplay.TimeWithStatus(instant, "All aboard"))
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(instant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("arriving at $shortTime", substring = true)
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithText("All aboard").assertDoesNotExist()
+    }
+
+    @Test
     fun testUpcomingTripViewWithSomeScheduleTime() {
         val instant = Instant.fromEpochSeconds(1722535384)
         val shortTime = formatTime(instant)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -182,6 +182,24 @@ fun UpcomingTripView(
                             fontWeight = FontWeight.Bold
                         )
                     }
+                is TripInstantDisplay.TimeWithStatus ->
+                    WithRealtimeIndicator(modifier, hideRealtimeIndicators) {
+                        Text(
+                            formatTime(state.trip.predictionTime),
+                            Modifier.semantics {
+                                    contentDescription =
+                                        UpcomingTripAccessibilityFormatters.predictedTimeLabel(
+                                            context,
+                                            time = formatTime(state.trip.predictionTime),
+                                            isFirst,
+                                            vehicleType
+                                        )
+                                }
+                                .placeholderIfLoading(),
+                            textAlign = TextAlign.End,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
                 is TripInstantDisplay.ScheduleTime ->
                     Text(
                         formatTime(state.trip.scheduledTime),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/WithRealtimeIndicator.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/WithRealtimeIndicator.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.component
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.LocalContentColor
@@ -19,7 +20,7 @@ import com.mbta.tid.mbta_app.android.R
 fun WithRealtimeIndicator(
     modifier: Modifier = Modifier,
     hideIndicator: Boolean = false,
-    prediction: @Composable () -> Unit
+    prediction: @Composable RowScope.() -> Unit
 ) {
     val subjectSpacing = 4.dp
     val iconSize = 20.dp

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -89,6 +89,17 @@ struct UpcomingTripView: View {
                         )
                         : accessibilityFormatters
                         .distantFutureOther(date: format.predictionTime.toNSDate()))
+            case let .timeWithStatus(format):
+                Text(Date(instant: format.predictionTime), style: .time)
+                    .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
+                    .realtime(hideIndicator: hideRealtimeIndicators)
+                    .accessibilityLabel(isFirst
+                        ? accessibilityFormatters.distantFutureFirst(
+                            date: format.predictionTime.toNSDate(),
+                            vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                        )
+                        : accessibilityFormatters
+                        .distantFutureOther(date: format.predictionTime.toNSDate()))
             case let .minutes(format):
                 PredictionText(minutes: format.minutes)
                     .realtime(hideIndicator: hideRealtimeIndicators)

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -72,6 +72,20 @@ final class UpcomingTripViewTests: XCTestCase {
         XCTAssertEqual("and at 4:00 PM", foundText)
     }
 
+    func testTimeWithStatus() throws {
+        let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
+        let sut = UpcomingTripView(
+            prediction: .some(.TimeWithStatus(
+                predictionTime: date.toKotlinInstant(),
+                status: "All aboard",
+                headline: true
+            )),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "train arriving at 4:00\u{202F}PM"))
+        XCTAssertThrowsError(try sut.inspect().find(text: "All aboard"))
+    }
+
     func testFirstScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
         let text: any View = UpcomingTripAccessibilityFormatters().scheduleTimeFirst(date: date, vehicleText: "buses")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -30,7 +30,7 @@ class TripInstantDisplayTest {
                 prediction = ObjectCollectionBuilder.Single.prediction { status = "Custom Text" },
                 schedule = null,
                 vehicle = null,
-                routeType = null,
+                routeType = anyEnumValueExcept(RouteType.COMMUTER_RAIL),
                 now = Clock.System.now(),
                 context = anyEnumValue()
             )
@@ -529,6 +529,28 @@ class TripInstantDisplayTest {
                 routeType = scheduleBased(),
                 now = now,
                 context = context
+            )
+        )
+    }
+
+    @Test
+    fun `time with status`() = parametricTest {
+        val now = Clock.System.now()
+        val predictionTime = now + 2.minutes
+        val prediction = ObjectCollectionBuilder.Single.prediction {
+            status = "All aboard"
+            departureTime = predictionTime
+        }
+
+        assertEquals(
+            TripInstantDisplay.TimeWithStatus(predictionTime, "All aboard", true),
+            TripInstantDisplay.from(
+                prediction,
+                schedule = null,
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now,
+                context = anyEnumValueExcept(TripInstantDisplay.Context.TripDetails)
             )
         )
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [CR information | Represent CR status that can co-exist with prediction](https://app.asana.com/0/1205732265579288/1209128916172065)

Formats the new TimeWithStatus the same way as the prior Time so that if we deploy something in the middle of working on this feature it won't include a clumsy provisional design.

I do have a few questions about how this needs to work, which I've raised in the Slack standup thread.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Checked before reverting the styles that the status was properly displayed alongside the prediction.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
