### PR TITLE
Disable RTL support

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="MBTA Go"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"


### PR DESCRIPTION
At the moment, the app doesn't support any languages that are written from right to left, such as Hebrew or Arabic.

However, AndroidManifest.xml says android:supportsRtl="true", which is the default value. This causes the app to display incorrectly in English on phones that are set to work in a right to left language.

This patch sets rtlandroid:supportsRtl="false",
so that the app won't try to flip itself for
right to left languages unnecessarily.

If full support for such languages is ever added,
set it back to "true".
