### PR TITLE
enable edge-to-edge map coverage of the screen

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:label="MBTA Go"
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="false"
+        android:windowSoftInputMode="adjustResize"
         android:theme="@style/AppTheme">
         <activity
             android:name=".MainActivity"

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -32,12 +32,12 @@ class MainActivity : ComponentActivity() {
             navigationBarStyle =
                 if (isDarkModeOn()) {
                     SystemBarStyle.dark(
-                        scrim = Color(0xFF192026).toArgb(),
+                        scrim = getColor(R.color.fill2),
                     )
                 } else {
                     SystemBarStyle.light(
-                        scrim = Color(0xFFF5F4F2).toArgb(),
-                        darkScrim = Color(0xFF192026).toArgb()
+                        scrim = getColor(R.color.fill2),
+                        darkScrim = getColor(R.color.fill2)
                     )
                 },
             statusBarStyle =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -7,6 +8,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
@@ -27,13 +29,34 @@ class MainActivity : ComponentActivity() {
         initSentry()
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
         enableEdgeToEdge(
-            navigationBarStyle = SystemBarStyle.dark(scrim = Color(0x00000000).toArgb())
+            navigationBarStyle =
+                if (isDarkModeOn()) {
+                    SystemBarStyle.dark(
+                        scrim = Color(0xFF192026).toArgb(),
+                    )
+                } else {
+                    SystemBarStyle.light(
+                        scrim = Color(0xFFF5F4F2).toArgb(),
+                        darkScrim = Color(0xFF192026).toArgb()
+                    )
+                },
+            statusBarStyle =
+                if (isDarkModeOn()) {
+                    SystemBarStyle.dark(
+                        scrim = Color(0x00000000).toArgb(),
+                    )
+                } else {
+                    SystemBarStyle.light(
+                        scrim = Color(0x00000000).toArgb(),
+                        darkScrim = Color(0x00000000).toArgb(),
+                    )
+                },
         )
 
         setContent {
             MyApplicationTheme {
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().navigationBarsPadding(),
                     color = MaterialTheme.colorScheme.background
                 ) {
                     CompositionLocalProvider(
@@ -45,6 +68,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
+    }
+
+    private fun isDarkModeOn(): Boolean {
+        val nightModeFlags = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val isDarkModeOn = nightModeFlags == Configuration.UI_MODE_NIGHT_YES
+        return isDarkModeOn
     }
 
     private fun initSentry() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -3,12 +3,16 @@ package com.mbta.tid.mbta_app.android
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.mbta.tid.mbta_app.android.util.LocalActivity
@@ -22,6 +26,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         initSentry()
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+        enableEdgeToEdge(
+            navigationBarStyle = SystemBarStyle.dark(scrim = Color(0x00000000).toArgb())
+        )
+
         setContent {
             MyApplicationTheme {
                 Surface(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -3,10 +3,8 @@ package com.mbta.tid.mbta_app.android.search
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -31,13 +29,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -60,10 +55,6 @@ fun SearchBarOverlay(
     var visible =
         remember(currentNavEntry) {
             currentNavEntry?.let { it is SheetRoutes.NearbyTransit } ?: true
-        }
-    val navigationBarHeight =
-        with(LocalDensity.current) {
-            WindowInsets.navigationBars.getBottom(Density(LocalContext.current)).toDp()
         }
     var searchInputState by rememberSaveable { mutableStateOf("") }
     val globalResponse = getGlobalData("SearchBar.getGlobalData")

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -32,10 +34,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -58,6 +63,10 @@ fun SearchBarOverlay(
     var visible =
         remember(currentNavEntry) {
             currentNavEntry?.let { it is SheetRoutes.NearbyTransit } ?: true
+        }
+    val navigationBarHeight =
+        with(LocalDensity.current) {
+            WindowInsets.navigationBars.getBottom(Density(LocalContext.current)).toDp()
         }
     var searchInputState by rememberSaveable { mutableStateOf("") }
     val globalResponse = getGlobalData("SearchBar.getGlobalData")
@@ -93,7 +102,7 @@ fun SearchBarOverlay(
             if (visible) {
                 Box(
                     modifier =
-                        Modifier.absoluteOffset(y = 4.dp)
+                        Modifier.absoluteOffset(y = 3.dp + navigationBarHeight)
                             .height(60.dp)
                             .width(364.dp)
                             .border(2.dp, colorResource(R.color.halo), RoundedCornerShape(12.dp))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -1,16 +1,13 @@
 package com.mbta.tid.mbta_app.android.search
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -100,13 +97,6 @@ fun SearchBarOverlay(
             contentAlignment = Alignment.Center,
         ) {
             if (visible) {
-                Box(
-                    modifier =
-                        Modifier.absoluteOffset(y = 3.dp + navigationBarHeight)
-                            .height(60.dp)
-                            .width(364.dp)
-                            .border(2.dp, colorResource(R.color.halo), RoundedCornerShape(12.dp))
-                )
                 SearchBar(
                     shape = RoundedCornerShape(10.dp),
                     colors =


### PR DESCRIPTION
### Summary

_Ticket:_ [Android | Map extends to top of screen](https://app.asana.com/0/1205732265579288/1209343093134602)

What is this PR for?

Removes the black bar behind the top system icons and extends the map to cover the whole screen.

![Screenshot_20250210_104304](https://github.com/user-attachments/assets/703d27a2-9a19-4bfa-8cf7-9571fc7bead3)
![Screenshot_20250210_103837](https://github.com/user-attachments/assets/5f485502-566a-442f-a432-879f8c1f587b)


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
