### PR TITLE
fix(Android): Add crash button

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ ruby 3.2.2
 java temurin-17.0.9+9
 python 3.9.16
 nodejs 22.11.0
+direnv 2.35.0

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : ComponentActivity() {
         val dsn = BuildConfig.SENTRY_DSN
         val env = BuildConfig.SENTRY_ENVIRONMENT
 
-        if (dsn != null && env != null && !BuildConfig.DEBUG) {
+        if (dsn.isNotEmpty() && env.isNotEmpty() && !BuildConfig.DEBUG) {
             initializeSentry(dsn, env)
             Log.i("MainActivity", "Sentry initialized")
         } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreButton.kt
@@ -1,0 +1,74 @@
+package com.mbta.tid.mbta_app.android.more
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun MoreButton(
+    label: String,
+    action: () -> Unit,
+    note: String? = null,
+    icon: (@Composable () -> Unit)? = null,
+    isKey: Boolean = false
+) {
+    Row(
+        modifier =
+            Modifier.clickable { action() }
+                .semantics(mergeDescendants = true) {}
+                .background(
+                    color =
+                        if (isKey) {
+                            colorResource(R.color.key)
+                        } else {
+                            colorResource(R.color.fill3)
+                        }
+                )
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    label,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color =
+                        if (isKey) {
+                            colorResource(R.color.fill3)
+                        } else colorResource(R.color.text)
+                )
+                if (note != null) {
+                    Text(
+                        note,
+                        modifier = Modifier.padding(top = 2.dp).alpha(0.6f),
+                        color =
+                            if (isKey) {
+                                colorResource(R.color.fill3)
+                            } else colorResource(R.color.text),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+
+            if (icon != null) {
+                icon()
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreLink.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreLink.kt
@@ -4,26 +4,14 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 
@@ -31,62 +19,32 @@ import com.mbta.tid.mbta_app.android.R
 fun MoreLink(label: String, url: String, note: String? = null, isKey: Boolean = false) {
     val context = LocalContext.current
 
-    Row(
-        modifier =
-            Modifier.clickable {
-                    val webpage: Uri = Uri.parse(url)
-                    val intent = Intent(Intent.ACTION_VIEW, webpage)
-                    try {
-                        context.startActivity(intent)
-                    } catch (_: ActivityNotFoundException) {
-                        Log.i("More", "Failed to navigate to link on MoreLink click")
-                    }
-                }
-                .semantics(mergeDescendants = true) {}
-                .background(
-                    color =
-                        if (isKey) {
-                            colorResource(R.color.key)
-                        } else {
-                            colorResource(R.color.fill3)
-                        }
-                )
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text(
-                    label,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color =
-                        if (isKey) {
-                            colorResource(R.color.fill3)
-                        } else colorResource(R.color.text)
-                )
-                if (note != null) {
-                    Text(
-                        note,
-                        modifier = Modifier.padding(top = 2.dp).alpha(0.6f),
-                        color =
-                            if (isKey) {
-                                colorResource(R.color.fill3)
-                            } else colorResource(R.color.text),
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            }
-            Icon(
-                painterResource(R.drawable.arrow_up_right),
-                contentDescription = stringResource(id = R.string.more_link_external),
-                modifier = Modifier.size(12.dp),
-                tint =
-                    if (isKey) {
-                        colorResource(R.color.fill3)
-                    } else colorResource(R.color.deemphasized),
-            )
-        }
+    @Composable
+    fun LinkIcon() {
+        Icon(
+            painterResource(R.drawable.arrow_up_right),
+            contentDescription = stringResource(id = R.string.more_link_external),
+            modifier = Modifier.size(12.dp),
+            tint =
+                if (isKey) {
+                    colorResource(R.color.fill3)
+                } else colorResource(R.color.deemphasized),
+        )
     }
+
+    MoreButton(
+        label,
+        {
+            val webpage: Uri = Uri.parse(url)
+            val intent = Intent(Intent.ACTION_VIEW, webpage)
+            try {
+                context.startActivity(intent)
+            } catch (_: ActivityNotFoundException) {
+                Log.i("More", "Failed to navigate to link on MoreLink click")
+            }
+        },
+        note,
+        { LinkIcon() },
+        isKey,
+    )
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MorePhone.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MorePhone.kt
@@ -4,24 +4,14 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.util.Log
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 
@@ -29,24 +19,8 @@ import com.mbta.tid.mbta_app.android.R
 fun MorePhone(label: String, phoneNumber: String) {
     val context = LocalContext.current
 
-    Row(
-        modifier =
-            Modifier.clickable {
-                    val numberUri = Uri.parse("tel:$phoneNumber")
-                    val intent = Intent(Intent.ACTION_DIAL).apply { data = numberUri }
-                    try {
-                        context.startActivity(intent)
-                    } catch (_: ActivityNotFoundException) {
-                        Log.i("More", "Failed to dial number on MorePhone click")
-                    }
-                }
-                .semantics(mergeDescendants = true) {}
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Column { Text(label, style = MaterialTheme.typography.bodyMedium) }
+    @Composable
+    fun PhoneIcon() {
         Icon(
             painterResource(R.drawable.fa_phone),
             contentDescription = stringResource(id = R.string.more_link_call),
@@ -54,4 +28,18 @@ fun MorePhone(label: String, phoneNumber: String) {
             tint = colorResource(R.color.deemphasized),
         )
     }
+
+    MoreButton(
+        label,
+        {
+            val numberUri = Uri.parse("tel:$phoneNumber")
+            val intent = Intent(Intent.ACTION_DIAL).apply { data = numberUri }
+            try {
+                context.startActivity(intent)
+            } catch (_: ActivityNotFoundException) {
+                Log.i("More", "Failed to dial number on MorePhone click")
+            }
+        },
+        icon = { PhoneIcon() }
+    )
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
@@ -70,6 +70,7 @@ fun MoreSectionView(section: MoreSection, toggleSetting: ((Settings) -> Unit)) {
                             )
                         is MoreItem.Phone ->
                             MorePhone(label = item.label, phoneNumber = item.phoneNumber)
+                        is MoreItem.Action -> MoreButton(label = item.label, action = item.action)
                     }
 
                     if (index < section.items.size - 1) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import com.mbta.tid.mbta_app.model.morePage.localizedFeedbackFormUrl
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import io.sentry.kotlin.multiplatform.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -110,6 +111,13 @@ class MoreViewModel(
                             label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults,
                             value = settings[Settings.SearchRouteResults] ?: false
+                        ),
+                        MoreItem.Action(
+                            label = "Crash App",
+                            action = {
+                                Sentry.captureMessage("Local test")
+                                throw RuntimeException("Debug test crash")
+                            }
                         )
                     )
             ),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -115,7 +115,7 @@ class MoreViewModel(
                         MoreItem.Action(
                             label = "Crash App",
                             action = {
-                                Sentry.captureMessage("Local test")
+                                Sentry.captureMessage("Debug test sentry message")
                                 throw RuntimeException("Debug test crash")
                             }
                         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
@@ -4,17 +4,20 @@ import com.mbta.tid.mbta_app.repositories.Settings
 
 sealed class MoreItem {
 
-    data class Toggle(val label: String, val settings: Settings, val value: Boolean) : MoreItem()
+    data class Action(val label: String, val action: () -> Unit) : MoreItem()
 
     data class Link(val label: String, val url: String, val note: String? = null) : MoreItem()
 
     data class Phone(val label: String, val phoneNumber: String) : MoreItem()
 
+    data class Toggle(val label: String, val settings: Settings, val value: Boolean) : MoreItem()
+
     fun id() {
         when (this) {
-            is Toggle -> settings.name
+            is Action -> label
             is Link -> url
             is Phone -> phoneNumber
+            is Toggle -> settings.name
         }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Sentry | Fix integration again](https://app.asana.com/0/1205732265579288/1209295122854608)

This is step towards investigating the sentry issues, I was able to get logs showing up from a local dev build, but builds created through the workflow don't seem to be working. This adds a button to the more page in staging which crashes the app and also explicitly logs a message to Sentry. My guess is that the issue is somewhere in the env vars being set in the workflows.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Manually tested locally