### PR TITLE
fix(Android): Set sentry env vars in workflow

### DIFF
--- a/.github/workflows/android-deploy.yaml
+++ b/.github/workflows/android-deploy.yaml
@@ -51,6 +51,8 @@ jobs:
           KEY_PASSWORD: ${{ env.MOBILE_APP_ANDROID_UPLOAD_KEY_PASSPHRASE }}
           MAPBOX_SECRET_TOKEN: ${{ secrets.MAPBOX_SECRET_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN_ANDROID: ${{ secrets.SENTRY_DSN_ANDROID }}
+          SENTRY_ENVIRONMENT: "prod"
         run: |
           bundle exec fastlane android build flavor:Prod
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,6 +147,9 @@ jobs:
           KEY_PASSWORD: ${{ env.MOBILE_APP_ANDROID_UPLOAD_KEY_PASSPHRASE }}
           MAPBOX_SECRET_TOKEN: ${{ secrets.MAPBOX_SECRET_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_DSN_ANDROID: ${{ secrets.SENTRY_DSN_ANDROID }}
+          SENTRY_ENVIRONMENT: "staging"
+
         run: |
           bundle exec fastlane android build flavor:Staging
       - uses: actions/upload-artifact@v4

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -43,8 +43,8 @@ class MainActivity : ComponentActivity() {
         val dsn = BuildConfig.SENTRY_DSN
         val env = BuildConfig.SENTRY_ENVIRONMENT
 
-        if (dsn.isNotEmpty() && env.isNotEmpty() && !BuildConfig.DEBUG) {
-            initializeSentry(dsn, env)
+        if (dsn.isNotEmpty() && !BuildConfig.DEBUG) {
+            initializeSentry(dsn, env.ifEmpty { "debug" })
             Log.i("MainActivity", "Sentry initialized")
         } else {
             Log.w("MainActivity", "skipping sentry initialization")


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Sentry | Fix integration again](https://app.asana.com/0/1205732265579288/1209295122854608)

Set sentry env vars in workflow build step. Also don't require the sentry environment to be set in the app, and fall back to "debug" if none is defined.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Can't test build steps locally