### PR TITLE
feat: show track change alerts

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -1,20 +1,16 @@
 package com.mbta.tid.mbta_app.android.pages
 
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import androidx.compose.ui.test.printToLog
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
@@ -35,7 +31,7 @@ class MorePageTests : KoinTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun testSettings() = runTest {
+    fun testSettings() {
         var hideMapToggleCalled = false
 
         val koinApplication = koinApplication {
@@ -57,17 +53,12 @@ class MorePageTests : KoinTest {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }
 
-        try {
-            composeTestRule.waitUntilExactlyOneExists(hasText("Settings"))
-        } catch (ex: ComposeTimeoutException) {
-            composeTestRule.onRoot().printToLog("ci-keep")
-            throw ex
-        }
+        composeTestRule.waitUntilExactlyOneExists(hasText("Settings"))
         composeTestRule.onNodeWithText("Settings").performScrollTo()
         composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
         composeTestRule.onNodeWithText("Hide Maps").performClick()
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil { hideMapToggleCalled }
 
         assertTrue { hideMapToggleCalled }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -87,7 +87,11 @@ fun StopDetailsFilteredDeparturesView(
 
     val alertsHere: List<Alert> =
         if (global != null) {
-            patternsByStop.alertsHereFor(directionId = expectedDirection, global = global)
+            patternsByStop.alertsHereFor(
+                directionId = expectedDirection,
+                tripId = tripFilter?.tripId,
+                global = global
+            )
         } else {
             emptyList()
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -21,6 +21,7 @@ data class FormattedAlert(@StringRes val effect: Int) {
                     Alert.Effect.StopMove,
                     Alert.Effect.StopMoved -> R.string.station_moved
                     Alert.Effect.Suspension -> R.string.suspension
+                    Alert.Effect.TrackChange -> R.string.track_change
                     else -> return null
                 }
             return FormattedAlert(effect)

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -198,6 +198,7 @@
     <string name="switch_problem">Problema de cambio de carril</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="tie_replacement">Reemplazo de traviesas</string>
+    <string name="track_change">Cambio de pista</string>
     <string name="track_problem">Problema de vía</string>
     <string name="track_work">Trabajo en vía</string>
     <string name="traffic">Tráfico</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -206,6 +206,7 @@
     <string name="switch_problem">Pwoblèm Bouton</string>
     <string name="technical_problem">Pwoblèm Teknik</string>
     <string name="tie_replacement">Ranplasman kòd</string>
+    <string name="track_change">Track Chanjman</string>
     <string name="track_problem">Pwoblèm sou Ray</string>
     <string name="track_work">Travay sou Ray</string>
     <string name="traffic">Sikilasyon</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -198,6 +198,7 @@
     <string name="switch_problem">Problema de troca</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="tie_replacement">Troca de pneu</string>
+    <string name="track_change">Mudança de faixa</string>
     <string name="track_problem">Problema de trilho</string>
     <string name="track_work">Obras no trilho</string>
     <string name="traffic">Tráfego</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -192,6 +192,7 @@
     <string name="switch_problem">Vấn đề chuyển đổi</string>
     <string name="technical_problem">Vấn đề kỹ thuật</string>
     <string name="tie_replacement">Thay tà vẹt</string>
+    <string name="track_change">Theo dõi sự thay đổi</string>
     <string name="track_problem">Vấn đề về đường ray</string>
     <string name="track_work">Thi công đường ray</string>
     <string name="traffic">Giao thông</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -192,6 +192,7 @@
     <string name="switch_problem">道岔故障</string>
     <string name="technical_problem">技术故障</string>
     <string name="tie_replacement">更换轨枕</string>
+    <string name="track_change">追踪修订</string>
     <string name="track_problem">轨道故障</string>
     <string name="track_work">轨道作业</string>
     <string name="traffic">交通</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -192,6 +192,7 @@
     <string name="switch_problem">道岔故障</string>
     <string name="technical_problem">技術故障</string>
     <string name="tie_replacement">更換軌枕</string>
+    <string name="track_change">追蹤修訂</string>
     <string name="track_problem">軌道故障</string>
     <string name="track_work">軌道作業</string>
     <string name="traffic">交通</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="switch_problem">Switch Problem</string>
     <string name="technical_problem">Technical Problem</string>
     <string name="tie_replacement">Tie Replacement</string>
+    <string name="track_change">Track Change</string>
     <string name="track_problem">Track Problem</string>
     <string name="track_work">Track Work</string>
     <string name="traffic">Traffic</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -9509,6 +9509,47 @@
         }
       }
     },
+    "Track Change" : {
+      "comment" : "Possible alert effect",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cambio de pista"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Track Chanjman"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mudança de faixa"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Theo dõi sự thay đổi"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "追踪修订"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "追蹤修訂"
+          }
+        }
+      }
+    },
     "Track Problem" : {
       "comment" : "Possible alert cause",
       "localizations" : {

--- a/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
@@ -97,7 +97,7 @@ struct StopDetailsFilteredRouteView: View {
 
         if let patternsByStop, let expectedDirection {
             if let global {
-                alerts = patternsByStop.alertsHereFor(directionId: expectedDirection, global: global)
+                alerts = patternsByStop.alertsHereFor(directionId: expectedDirection, tripId: nil, global: global)
                 downstreamAlerts = patternsByStop.alertsDownstream(directionId: expectedDirection)
             } else {
                 alerts = []

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -68,7 +68,11 @@ struct StopDetailsFilteredView: View {
 
         if let departures, let patternsByStop {
             if let global = stopDetailsVM.global {
-                alerts = patternsByStop.alertsHereFor(directionId: stopFilter.directionId, global: global)
+                alerts = patternsByStop.alertsHereFor(
+                    directionId: stopFilter.directionId,
+                    tripId: tripFilter?.tripId,
+                    global: global
+                )
                 downstreamAlerts = patternsByStop.alertsDownstream(directionId: stopFilter.directionId)
             } else {
                 alerts = []

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -24,6 +24,7 @@ struct FormattedAlert {
         case .stopClosure: NSLocalizedString("Stop Closure", comment: "Possible alert effect")
         case .stopMove, .stopMoved: NSLocalizedString("Station Moved", comment: "Possible alert effect")
         case .suspension: NSLocalizedString("Suspension", comment: "Possible alert effect")
+        case .trackChange: NSLocalizedString("Track Change", comment: "Possible alert effect")
         default: nil
         } else { return nil }
         self.effect = effect

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -464,7 +464,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(AlertCard.self))
         XCTAssertNotNil(try sut.inspect().find(text: "Suspension ahead"))
         XCTAssertThrowsError(try sut.inspect().find(text: alert.header!))
-        try sut.inspect().find(AlertCard.self).button().tap()
+        try sut.inspect().find(AlertCard.self).implicitAnyView().button().tap()
         XCTAssertEqual(
             nearbyVM.navigationStack.last,
             .alertDetails(alertId: alert.id, line: nil, routes: [route], stop: stop)
@@ -514,7 +514,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(DepartureTile.self))
         XCTAssertNotNil(try sut.inspect().find(AlertCard.self))
         XCTAssertNotNil(try sut.inspect().find(text: alert.header!))
-        try sut.inspect().find(AlertCard.self).button().tap()
+        try sut.inspect().find(AlertCard.self).implicitAnyView().button().tap()
         XCTAssertEqual(
             nearbyVM.navigationStack.last,
             .alertDetails(alertId: alert.id, line: nil, routes: nil, stop: stop)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSignificance.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSignificance.kt
@@ -1,19 +1,22 @@
 package com.mbta.tid.mbta_app.model
 
-/**
- * | [AlertSignificance]     | [Major] | [Secondary] | [Accessibility] | [Minor] | [None] |
- * |-------------------------|---------|-------------|-----------------|---------|--------|
- * | Shown on map            | Yes     | No          | No              | No      | No     |
- * | Replaces upcoming trips | Yes     | No          | No              | No      | No     |
- * | Shown in nearby transit | Yes     | Yes         | Yes             | No      | No     |
- * | Shown in stop details   | Yes     | Yes         | Yes             | Yes     | No     |
- * | Shown in trip details   | Yes     | No          | No              | No      | No     |
- */
 enum class AlertSignificance : Comparable<AlertSignificance> {
     // defined in ascending order so that Major > Secondary > Minor > None
+    /** Hidden everywhere. */
     None,
+    /**
+     * Shown in filtered stop details but not indicated in nearby transit or at downstream stops.
+     */
     Minor,
+    /** May be shown in nearby transit and stop details if enabled, but not called out as ahead. */
     Accessibility,
+    /**
+     * Shown in nearby transit alongside predictions. Shown in stop details. Called out as ahead but
+     * not listed at downstream stops.
+     */
     Secondary,
+    /**
+     * Replaces predictions in nearby transit, stop details, and trip details. Called out as ahead.
+     */
     Major
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ExtrinsicProperties.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ExtrinsicProperties.kt
@@ -1,0 +1,13 @@
+package com.mbta.tid.mbta_app.model
+
+/** Grouped lines are displayed as though they are different branches of a single route. */
+val Line.isGrouped
+    get() = this.id in setOf("line-Green")
+
+private val crCoreStations = setOf("place-north", "place-sstat", "place-bbsta", "place-rugg")
+
+/**
+ * Commuter Rail core stations have realtime track numbers displayed and track change alerts hidden.
+ */
+val Stop.isCRCore
+    get() = this.id in crCoreStations || this.parentStationId in crCoreStations

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
@@ -240,8 +240,8 @@ data class NearbyHierarchy(private val data: ByLineOrRoute) {
 
         private fun lineOrRoute(global: GlobalResponse, routeId: String): LineOrRoute? {
             val route = global.routes[routeId] ?: return null
-            return if (NearbyStaticData.groupedLines.contains(route.lineId)) {
-                val line = global.lines[route.lineId] ?: return null
+            val line = global.lines[route.lineId]
+            return if (line?.isGrouped == true) {
                 val routes =
                     global.routes.values.filter { it.lineId == line.id && !it.isShuttle }.toSet()
                 LineOrRoute.Line(line, routes)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -250,7 +250,7 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
             patternsByRouteAndStop
                 .mapNotNull { (route, patternsByStop) ->
                     val line = global.lines[route.lineId]
-                    val isGrouped = groupedLines.contains(route.lineId) && line != null
+                    val isGrouped = line?.isGrouped == true
                     val lineRoutes = byLine[line?.id]?.map { (route, _) -> route } ?: emptyList()
 
                     if (isGrouped && touchedLines.contains(line)) {
@@ -289,8 +289,6 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
     )
 
     companion object {
-        val groupedLines = listOf("line-Green")
-
         fun getSchedulesTodayByPattern(schedules: ScheduleResponse?): Map<String, Boolean>? =
             schedules?.let { scheduleResponse ->
                 val scheduledTrips = scheduleResponse.trips

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -489,6 +489,7 @@ fun NearbyStaticData.withRealtimeInfoWithoutTripHeadsigns(
     showAllPatternsWhileLoading: Boolean,
     hideNonTypicalPatternsBeyondNext: Duration?,
     filterCancellations: Boolean,
+    includeMinorAlerts: Boolean,
     pinnedRoutes: Set<String>
 ): List<StopsAssociated>? {
     // if predictions or alerts are still loading, this is the loading state
@@ -496,7 +497,10 @@ fun NearbyStaticData.withRealtimeInfoWithoutTripHeadsigns(
 
     val activeRelevantAlerts =
         alerts.alerts.values.filter {
-            it.isActive(filterAtTime) && it.significance >= AlertSignificance.Accessibility
+            it.isActive(filterAtTime) &&
+                it.significance >=
+                    if (includeMinorAlerts) AlertSignificance.Minor
+                    else AlertSignificance.Accessibility
         }
 
     val allDataLoaded = schedules != null
@@ -661,6 +665,7 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
     showAllPatternsWhileLoading: Boolean,
     hideNonTypicalPatternsBeyondNext: Duration?,
     filterCancellations: Boolean,
+    includeMinorAlerts: Boolean,
     pinnedRoutes: Set<String>
 ): List<StopsAssociated>? {
     // if predictions or alerts are still loading, this is the loading state
@@ -671,7 +676,10 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
 
     val activeRelevantAlerts =
         alerts.alerts.values.filter {
-            it.isActive(filterAtTime) && it.significance >= AlertSignificance.Accessibility
+            it.isActive(filterAtTime) &&
+                it.significance >=
+                    if (includeMinorAlerts) AlertSignificance.Minor
+                    else AlertSignificance.Accessibility
         }
 
     val allDataLoaded = schedules != null
@@ -782,6 +790,7 @@ fun NearbyStaticData.withRealtimeInfo(
             showAllPatternsWhileLoading = false,
             hideNonTypicalPatternsBeyondNext = 120.minutes,
             filterCancellations = true,
+            includeMinorAlerts = false,
             pinnedRoutes
         )
     } else {
@@ -795,6 +804,7 @@ fun NearbyStaticData.withRealtimeInfo(
             showAllPatternsWhileLoading = false,
             hideNonTypicalPatternsBeyondNext = 120.minutes,
             filterCancellations = true,
+            includeMinorAlerts = false,
             pinnedRoutes
         )
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -49,12 +49,16 @@ data class PatternsByStop(
                                 upcomingTripsMap,
                                 staticData.stop.id,
                                 Alert.applicableAlerts(
-                                    alerts.toList(),
-                                    null,
-                                    listOf(it.route.id),
-                                    it.stopIds,
-                                    null
-                                ),
+                                        alerts.toList(),
+                                        null,
+                                        listOf(it.route.id),
+                                        it.stopIds,
+                                        null
+                                    )
+                                    .filterNot {
+                                        it.effect == Alert.Effect.TrackChange &&
+                                            staticData.stop.isCRCore
+                                    },
                                 alertsDownstream(
                                     alerts.toList(),
                                     it.patterns,
@@ -70,7 +74,9 @@ data class PatternsByStop(
                             it,
                             upcomingTripsMap,
                             staticData.stop.id,
-                            alerts,
+                            alerts.filterNot {
+                                it.effect == Alert.Effect.TrackChange && staticData.stop.isCRCore
+                            },
                             tripsById,
                             hasSchedulesTodayByPattern,
                             allDataLoaded
@@ -112,12 +118,15 @@ data class PatternsByStop(
                                 directionOrHeadsign,
                                 leaf,
                                 Alert.applicableAlerts(
-                                    alerts.toList(),
-                                    null,
-                                    listOf(directionOrHeadsign.route.id),
-                                    leaf.childStopIds,
-                                    null
-                                ),
+                                        alerts.toList(),
+                                        null,
+                                        listOf(directionOrHeadsign.route.id),
+                                        leaf.childStopIds,
+                                        null
+                                    )
+                                    .filterNot {
+                                        it.effect == Alert.Effect.TrackChange && stop.isCRCore
+                                    },
                                 alertsDownstream(
                                     alerts.toList(),
                                     leaf.routePatterns.filterNotNull(),
@@ -133,7 +142,9 @@ data class PatternsByStop(
                             checkNotNull(lineOrRoute as? NearbyHierarchy.LineOrRoute.Line),
                             directionOrHeadsign,
                             leaf,
-                            alerts,
+                            alerts.filterNot {
+                                it.effect == Alert.Effect.TrackChange && stop.isCRCore
+                            },
                             tripsById,
                             hasSchedulesTodayByPattern,
                             allDataLoaded

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternsByStop.kt
@@ -52,7 +52,8 @@ data class PatternsByStop(
                                     alerts.toList(),
                                     null,
                                     listOf(it.route.id),
-                                    it.stopIds
+                                    it.stopIds,
+                                    null
                                 ),
                                 alertsDownstream(
                                     alerts.toList(),
@@ -114,7 +115,8 @@ data class PatternsByStop(
                                     alerts.toList(),
                                     null,
                                     listOf(directionOrHeadsign.route.id),
-                                    leaf.childStopIds
+                                    leaf.childStopIds,
+                                    null
                                 ),
                                 alertsDownstream(
                                     alerts.toList(),
@@ -163,7 +165,7 @@ data class PatternsByStop(
 
     fun allUpcomingTrips(): List<UpcomingTrip> = this.patterns.flatMap { it.upcomingTrips }.sorted()
 
-    fun alertsHereFor(directionId: Int, global: GlobalResponse): List<Alert> {
+    fun alertsHereFor(directionId: Int, tripId: String?, global: GlobalResponse): List<Alert> {
         val patternsInDirection = this.patterns.filter { it.directionId() == directionId }
         val stopIds = arrayOf(this.stop.id) + this.stop.childStopIds
         val stopsInDirection =
@@ -180,7 +182,7 @@ data class PatternsByStop(
         return stopsInDirection
             .flatMap { stopId ->
                 patternsInDirection
-                    .flatMap { it.alertsHereFor(setOf(stopId), directionId) ?: emptyList() }
+                    .flatMap { it.alertsHereFor(setOf(stopId), directionId, tripId) ?: emptyList() }
                     .toSet()
             }
             .distinct()
@@ -251,7 +253,8 @@ data class PatternsByStop(
                             alerts.toList(),
                             null,
                             staticData.routeIds,
-                            staticData.stopIds
+                            staticData.stopIds,
+                            null
                         ),
                         alertsDownstream(
                             alerts.toList(),
@@ -300,7 +303,8 @@ data class PatternsByStop(
                             alerts.toList(),
                             null,
                             staticData.routeIds,
-                            staticData.stopIds
+                            staticData.stopIds,
+                            null
                         ),
                         alertsDownstream(
                             alerts.toList(),
@@ -323,7 +327,8 @@ data class PatternsByStop(
                         alerts.toList(),
                         null,
                         staticData.routeIds,
-                        staticData.stopIds
+                        staticData.stopIds,
+                        null
                     ),
                     alertsDownstream(
                         alerts.toList(),
@@ -349,7 +354,13 @@ data class PatternsByStop(
             val typicalPatternsByRoute = getTypicalPatternsByRoute(leaf)
 
             val alertsHere =
-                Alert.applicableAlerts(alerts, null, line.routes.map { it.id }, leaf.childStopIds)
+                Alert.applicableAlerts(
+                    alerts,
+                    null,
+                    line.routes.map { it.id },
+                    leaf.childStopIds,
+                    null
+                )
             val alertsDownstream =
                 alertsDownstream(
                     alerts.toList(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -210,14 +210,14 @@ sealed class RealtimePatterns {
         )
     }
 
-    fun alertsHereFor(stopIds: Set<String>, directionId: Int): List<Alert>? {
+    fun alertsHereFor(stopIds: Set<String>, directionId: Int, tripId: String?): List<Alert>? {
         val routeIds =
             when (this) {
                 is ByHeadsign -> listOf(this.route.id)
                 is ByDirection -> this.routes.map { it.id }
             }
         return if (alertsHere != null) {
-            Alert.applicableAlerts(alertsHere as List, directionId, routeIds, stopIds)
+            Alert.applicableAlerts(alertsHere as List, directionId, routeIds, stopIds, tripId)
         } else {
             null
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -194,6 +194,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                             showAllPatternsWhileLoading = true,
                             hideNonTypicalPatternsBeyondNext = null,
                             filterCancellations = false,
+                            includeMinorAlerts = true,
                             pinnedRoutes
                         )
                     } else {
@@ -207,6 +208,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
                             showAllPatternsWhileLoading = true,
                             hideNonTypicalPatternsBeyondNext = null,
                             filterCancellations = false,
+                            includeMinorAlerts = true,
                             pinnedRoutes
                         )
                     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -1472,6 +1472,7 @@ class NearbyResponseTest {
                 showAllPatternsWhileLoading = false,
                 hideNonTypicalPatternsBeyondNext = null,
                 filterCancellations = false,
+                includeMinorAlerts = false,
                 pinnedRoutes = setOf(),
             )
         )
@@ -1554,6 +1555,7 @@ class NearbyResponseTest {
                 showAllPatternsWhileLoading = false,
                 hideNonTypicalPatternsBeyondNext = null,
                 filterCancellations = false,
+                includeMinorAlerts = false,
                 pinnedRoutes = setOf(),
             )
         )
@@ -2501,6 +2503,84 @@ class NearbyResponseTest {
                                     listOf(routePattern),
                                     emptyList(),
                                     alertsHere = listOf(alert),
+                                    alertsDownstream = listOf()
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),
+                useTripHeadsigns = anyBoolean(),
+            )
+        )
+    }
+
+    @Test
+    fun `withRealtimeInfo ignores minor alerts`() = parametricTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route { sortOrder = 1 }
+        val routePattern =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+        objects.schedule {
+            this.trip = objects.trip(routePattern)
+            stopId = stop.id
+            departureTime = time.minus(1.hours)
+        }
+
+        val alert =
+            objects.alert {
+                activePeriod(
+                    Instant.parse("2024-03-18T04:30:00-04:00"),
+                    Instant.parse("2024-03-22T02:30:00-04:00")
+                )
+                effect = Alert.Effect.TrackChange
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board,
+                        Alert.InformedEntity.Activity.Exit,
+                        Alert.InformedEntity.Activity.Ride
+                    ),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = stop.id
+                )
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route) { stop(stop) { headsign("A", listOf(routePattern)) } }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePattern),
+                                    emptyList(),
+                                    alertsHere = listOf(),
                                     alertsDownstream = listOf()
                                 )
                             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
@@ -6,7 +6,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -193,9 +192,82 @@ class PatternsByStopTest {
         val alerts =
             patternsByStop.alertsHereFor(
                 directionId = routePatternAshmont.directionId,
+                tripId = null,
                 global = global
             )
         assertEquals(listOf(alert2), alerts)
+    }
+
+    @Test
+    fun `alertsHereFor filters by trip`() {
+        val objects = ObjectCollectionBuilder()
+
+        val route = objects.route()
+        val stop = objects.stop()
+        val pattern = objects.routePattern(route) { representativeTrip { stopIds = listOf(stop.id) }}
+
+        val time = Clock.System.now()
+
+        val trip1 = objects.trip(pattern)
+        val schedule1 =
+            objects.schedule {
+                trip = trip1
+                departureTime = time + 1.minutes
+            }
+        val upcomingTrip1 = objects.upcomingTrip(schedule1)
+
+        val trip2 = objects.trip(pattern)
+        val schedule2 =
+            objects.schedule {
+                trip = trip2
+                departureTime = time + 2.minutes
+            }
+        val upcomingTripBraintree = objects.upcomingTrip(schedule2)
+
+        val alert1 =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(time - 1.seconds, null)
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board),
+                    route = route.id,
+                    stop = stop.id,
+                    trip = trip1.id
+                )
+            }
+        val alert2 =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                activePeriod(time - 1.seconds, null)
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board),
+                    route = route.id,
+                    stop = stop.id,
+                    trip = trip2.id
+                )
+            }
+
+        val patternsByStop =
+            PatternsByStop(
+                route,
+                stop,
+                listOf(
+                    RealtimePatterns.ByHeadsign(
+                        route,
+                        "Headsign",
+                        null,
+                        listOf(pattern),
+                        listOf(upcomingTrip1, upcomingTripBraintree),
+                        listOf(alert1, alert2)
+                    )
+                )
+            )
+
+        val global = GlobalResponse(objects, mapOf(stop.id to listOf(pattern.id)))
+
+        assertEquals(listOf(alert1, alert2), patternsByStop.alertsHereFor(0, tripId = null, global))
+        assertEquals(listOf(alert1), patternsByStop.alertsHereFor(0, trip1.id, global))
+        assertEquals(listOf(alert2), patternsByStop.alertsHereFor(0, trip2.id, global))
     }
 
     @Test
@@ -302,8 +374,8 @@ class PatternsByStopTest {
                     platform2.id to listOf(pattern2.id, pattern4.id)
                 )
             )
-        assertEquals(listOf(alert), patternsByStop.alertsHereFor(0, global))
-        assertEquals(listOf(alert), patternsByStop.alertsHereFor(1, global))
+        assertEquals(listOf(alert), patternsByStop.alertsHereFor(0, null, global))
+        assertEquals(listOf(alert), patternsByStop.alertsHereFor(1, null, global))
     }
 
     @Test
@@ -377,7 +449,7 @@ class PatternsByStopTest {
                 effect = Alert.Effect.Shuttle
                 activePeriod(time - 1.seconds, null)
                 informedEntity(
-                    listOf(Alert.InformedEntity.Activity.Board),
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                     route = route.id,
                     stop = shawmut.id
                 )
@@ -388,7 +460,7 @@ class PatternsByStopTest {
                 effect = Alert.Effect.Shuttle
                 activePeriod(time - 1.seconds, null)
                 informedEntity(
-                    listOf(Alert.InformedEntity.Activity.Board),
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                     route = route.id,
                     stop = ashmont.id
                 )
@@ -399,7 +471,7 @@ class PatternsByStopTest {
                 effect = Alert.Effect.Shuttle
                 activePeriod(time - 1.seconds, null)
                 informedEntity(
-                    listOf(Alert.InformedEntity.Activity.Board),
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                     route = route.id,
                     stop = alewife.id
                 )
@@ -411,7 +483,7 @@ class PatternsByStopTest {
                 effect = Alert.Effect.Shuttle
                 activePeriod(time - 1.seconds, null)
                 informedEntity(
-                    listOf(Alert.InformedEntity.Activity.Board),
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                     route = route.id,
                     stop = park.id
                 )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -948,6 +948,86 @@ class StopDetailsDeparturesTest {
     }
 
     @Test
+    fun `fromData shows minor alerts`() = parametricTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route { sortOrder = 1 }
+        val routePattern =
+            objects.routePattern(route) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip {
+                    headsign = "A"
+                    stopIds = listOf(stop.id)
+                }
+            }
+
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+        objects.schedule {
+            this.trip = objects.trip(routePattern)
+            stopId = stop.id
+            departureTime = time.minus(1.hours)
+            stopSequence = 4
+        }
+
+        val alert =
+            objects.alert {
+                activePeriod(
+                    Instant.parse("2024-03-18T04:30:00-04:00"),
+                    Instant.parse("2024-03-22T02:30:00-04:00")
+                )
+                effect = Alert.Effect.TrackChange
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board
+                    ),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = stop.id
+                )
+            }
+
+        val departures =
+            StopDetailsDepartures.fromData(
+                stop,
+                GlobalResponse(
+                    objects,
+                    mapOf(stop.id to listOf(routePattern.id))
+                ),
+                ScheduleResponse(objects),
+                PredictionsStreamDataResponse(objects),
+                AlertsStreamDataResponse(objects),
+                emptySet(),
+                time,
+                useTripHeadsigns = anyBoolean(),
+            )
+
+        assertEquals(
+            StopDetailsDepartures(
+                listOf(
+                    PatternsByStop(
+                        route,
+                        stop,
+                        listOf(
+                            RealtimePatterns.ByHeadsign(
+                                route,
+                                "A",
+                                null,
+                                listOf(routePattern),
+                                emptyList(),
+                                listOf(alert),
+                                emptyList()
+                            )
+                        )
+                    )
+                )
+            ),
+            departures
+        )
+    }
+
+    @Test
     fun `autoStopFilter provides a default StopDetailsFilter given a single route and direction`() =
         parametricTest {
             val objects = ObjectCollectionBuilder()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -1028,6 +1028,83 @@ class StopDetailsDeparturesTest {
     }
 
     @Test
+    fun `fromData hides track change at core station`() = parametricTest {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop { id = "place-north" }
+        val route = objects.route { sortOrder = 1 }
+        val routePattern =
+            objects.routePattern(route) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip {
+                    headsign = "A"
+                    stopIds = listOf(stop.id)
+                }
+            }
+
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+
+        objects.schedule {
+            this.trip = objects.trip(routePattern)
+            stopId = stop.id
+            departureTime = time.minus(1.hours)
+            stopSequence = 4
+        }
+
+        objects.alert {
+            activePeriod(
+                Instant.parse("2024-03-18T04:30:00-04:00"),
+                Instant.parse("2024-03-22T02:30:00-04:00")
+            )
+            effect = Alert.Effect.TrackChange
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board),
+                route = route.id,
+                routeType = route.type,
+                stop = stop.id
+            )
+        }
+
+        val departures =
+            StopDetailsDepartures.fromData(
+                stop,
+                GlobalResponse(
+                    objects,
+                    mapOf(stop.id to listOf(routePattern.id))
+                ),
+                ScheduleResponse(objects),
+                PredictionsStreamDataResponse(objects),
+                AlertsStreamDataResponse(objects),
+                emptySet(),
+                time,
+                useTripHeadsigns = anyBoolean(),
+            )
+
+        assertEquals(
+            StopDetailsDepartures(
+                listOf(
+                    PatternsByStop(
+                        route,
+                        stop,
+                        listOf(
+                            RealtimePatterns.ByHeadsign(
+                                route,
+                                "A",
+                                null,
+                                listOf(routePattern),
+                                emptyList(),
+                                emptyList(),
+                                emptyList()
+                            )
+                        )
+                    )
+                )
+            ),
+            departures
+        )
+    }
+
+    @Test
     fun `autoStopFilter provides a default StopDetailsFilter given a single route and direction`() =
         parametricTest {
             val objects = ObjectCollectionBuilder()


### PR DESCRIPTION
### Summary

_Ticket:_ [CR information | Track Change Alerts](https://app.asana.com/0/1205732265579288/1209129050348919)

I probably could have done less tangential refactoring here to keep the PR smaller, but I did not.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually verified that track change alerts are correctly displayed on both Android and iOS, and that they are correctly hidden at core stations. Added unit tests for new functionality.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
