### PR TITLE
fix(Android): correct color for CR status in deselected tile

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -204,7 +205,7 @@ fun UpcomingTripView(
                         }
                         Text(
                             state.trip.status,
-                            color = colorResource(R.color.text).copy(alpha = 0.6f),
+                            color = LocalContentColor.current.copy(alpha = 0.6f),
                             fontWeight = FontWeight.SemiBold,
                             textAlign = TextAlign.End,
                             style = MaterialTheme.typography.labelLarge


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack message](https://mbta.slack.com/archives/C05QMG9GS9M/p1739462362128799?thread_ts=1739457500.701929&cid=C05QMG9GS9M)

I should have checked this in #724.

|Before|After|
|------|-----|
|<img width="439" alt="Screenshot 2025-02-13 at 11 25 07 AM" src="https://github.com/user-attachments/assets/187830a8-99bf-4499-b310-f8473785aec0" />|<img width="443" alt="Screenshot 2025-02-13 at 11 24 37 AM" src="https://github.com/user-attachments/assets/6efccbdc-0b7e-42a7-9e94-4bcf362fb41e" />|

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Checked in the Android Studio preview that the fix works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
