### PR TITLE
feat: use route color for major alert icons in UpcomingTripView

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -1,9 +1,57 @@
 package com.mbta.tid.mbta_app.android
 
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.captureToImage
+import kotlin.math.abs
+import org.junit.Assert.fail
 
 fun hasClickActionLabel(expected: String?) =
     SemanticsMatcher("has click action label $expected") { node ->
         node.config[SemanticsActions.OnClick].label == expected
     }
+
+@OptIn(ExperimentalStdlibApi::class)
+private fun colorToHex(color: Color): String {
+    fun valToHex(value: Float): String {
+        val byteValue = (value * 255).toInt().toByte()
+        return byteValue.toHexString(HexFormat.UpperCase)
+    }
+    return "#${valToHex(color.red)}${valToHex(color.green)}${valToHex(color.blue)}"
+}
+
+private fun Color.isGrey(): Boolean =
+    abs(this.red - this.green) < 0.01 && abs(this.green - this.blue) < 0.01
+
+/**
+ * It's difficult to determine if a view hierarchy contains the correct image when the image is
+ * semantically invisible, but it's easy to capture a screenshot of the view and check it pixel by
+ * pixel.
+ */
+fun SemanticsNodeInteraction.assertHasColor(targetColor: Color) {
+    val pixelMap = this.captureToImage().toPixelMap()
+    val pixelCounts = mutableMapOf<Color, Int>()
+    for (x in 0.rangeUntil(pixelMap.width)) {
+        for (y in 0.rangeUntil(pixelMap.height)) {
+            val colorHere = pixelMap[x, y]
+            if (colorHere == targetColor) {
+                return
+            }
+            pixelCounts[colorHere] = pixelCounts.getOrDefault(colorHere, 0) + 1
+        }
+    }
+    // never returned so did not find the target
+    val legibleResult =
+        pixelCounts.entries
+            .groupBy(
+                { if (it.key.isGrey()) "grey" else "not grey" },
+                { colorToHex(it.key) to it.value }
+            )
+            .mapValues { it.value.sortedByDescending { it.second } }
+            .toSortedMap(reverseOrder())
+
+    fail("Did not contain specified color, but did have $legibleResult")
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -43,7 +43,9 @@ fun SemanticsNodeInteraction.assertHasColor(targetColor: Color) {
             pixelCounts[colorHere] = pixelCounts.getOrDefault(colorHere, 0) + 1
         }
     }
-    // never returned so did not find the target
+    // never returned so did not find the target. hopefully the color that is present instead of the
+    // target is either the most common non-grey color or among the most common grey colors (the
+    // most common grey will likely be a background, though)
     val legibleResult =
         pixelCounts.entries
             .groupBy(
@@ -51,7 +53,15 @@ fun SemanticsNodeInteraction.assertHasColor(targetColor: Color) {
                 { colorToHex(it.key) to it.value }
             )
             .mapValues { it.value.sortedByDescending { it.second } }
-            .toSortedMap(reverseOrder())
+            .toSortedMap(
+                compareBy {
+                    when (it) {
+                        "not grey" -> 1
+                        "grey" -> 2
+                        else -> 3
+                    }
+                }
+            )
 
     fail("Did not contain specified color, but did have $legibleResult")
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
@@ -117,7 +117,10 @@ class HeadsignRowViewTest {
     fun showsAlert() {
         init(
             "Headsign",
-            RealtimePatterns.Format.Disruption(alert { effect = Alert.Effect.Shuttle })
+            RealtimePatterns.Format.Disruption(
+                alert { effect = Alert.Effect.Shuttle },
+                mapStopRoute = null
+            )
         )
 
         composeTestRule.onNodeWithText("Shuttle", ignoreCase = true).assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertContentDescriptionContains
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -7,6 +8,13 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onParent
+import androidx.compose.ui.test.onRoot
+import com.mbta.tid.mbta_app.android.assertHasColor
+import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.MapStopRoute
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import kotlinx.datetime.Clock
@@ -240,5 +248,16 @@ class UpcomingTripViewTest {
     fun testUpcomingTripViewWithLoading() {
         composeTestRule.setContent { UpcomingTripView(UpcomingTripViewState.Loading) }
         composeTestRule.onNodeWithContentDescription("Loading...").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithDisruption() {
+        val alert = ObjectCollectionBuilder.Single.alert { effect = Alert.Effect.Suspension }
+        val disruption =
+            RealtimePatterns.Format.Disruption(alert, mapStopRoute = MapStopRoute.FERRY)
+        composeTestRule.setContent {
+            UpcomingTripView(UpcomingTripViewState.Disruption(alert.effect, disruption.iconName))
+        }
+        composeTestRule.onRoot().assertHasColor(Color.fromHex("008eaa"))
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -194,7 +194,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = stop,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction = prediction,
                         predictionStop = stop,
@@ -259,7 +259,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = stop,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction = prediction,
                         predictionStop = platformStop,
@@ -296,7 +296,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = stop,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = schedule,
                         prediction = null,
                         predictionStop = null,
@@ -417,7 +417,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = stop,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction = prediction,
                         predictionStop = platformStop,
@@ -488,7 +488,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = stop,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = schedule,
                         prediction = null,
                         predictionStop = null,
@@ -529,7 +529,7 @@ class TripHeaderCardTest {
                     TripDetailsStopList.Entry(
                         stop = other,
                         stopSequence = 0,
-                        alert = null,
+                        disruption = null,
                         schedule = schedule,
                         prediction = null,
                         predictionStop = null,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -75,7 +75,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop1,
                         stopSequence = 1,
-                        alert = null,
+                        disruption = null,
                         schedule1,
                         prediction1,
                         stop1,
@@ -85,7 +85,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop2,
                         stopSequence = 2,
-                        alert = null,
+                        disruption = null,
                         schedule2,
                         prediction2,
                         stop2,
@@ -95,7 +95,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop3Target,
                         stopSequence = 3,
-                        alert = null,
+                        disruption = null,
                         schedule3,
                         prediction3,
                         stop3Target,
@@ -105,7 +105,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop4,
                         stopSequence = 4,
-                        alert = null,
+                        disruption = null,
                         schedule4,
                         prediction4,
                         stop4,
@@ -115,7 +115,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop5,
                         stopSequence = 5,
-                        alert = null,
+                        disruption = null,
                         schedule5,
                         prediction5,
                         stop5,
@@ -194,7 +194,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop1,
                         stopSequence = 1,
-                        alert = null,
+                        disruption = null,
                         schedule1,
                         prediction1,
                         stop1,
@@ -204,7 +204,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop2,
                         stopSequence = 2,
-                        alert = null,
+                        disruption = null,
                         schedule2,
                         prediction2,
                         stop2,
@@ -214,7 +214,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop3,
                         stopSequence = 3,
-                        alert = null,
+                        disruption = null,
                         schedule3,
                         prediction3,
                         stop3,
@@ -286,7 +286,7 @@ class TripStopsTest {
             TripDetailsStopList.Entry(
                 stop1,
                 stopSequence = 1,
-                alert = null,
+                disruption = null,
                 schedule1,
                 prediction1,
                 stop1,
@@ -301,7 +301,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop2,
                         stopSequence = 2,
-                        alert = null,
+                        disruption = null,
                         schedule2,
                         prediction2,
                         stop2,
@@ -375,7 +375,7 @@ class TripStopsTest {
             TripDetailsStopList.Entry(
                 stop1,
                 stopSequence = 1,
-                alert = null,
+                disruption = null,
                 schedule1,
                 prediction1,
                 stop1,
@@ -390,7 +390,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop2,
                         stopSequence = 2,
-                        alert = null,
+                        disruption = null,
                         schedule2,
                         prediction2,
                         stop2,
@@ -400,7 +400,7 @@ class TripStopsTest {
                     TripDetailsStopList.Entry(
                         stop3,
                         stopSequence = 3,
-                        alert = null,
+                        disruption = null,
                         schedule3,
                         prediction3,
                         stop3,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.RouteType
@@ -90,7 +91,8 @@ private fun DirectionRowViewPreview() {
                         alert =
                             ObjectCollectionBuilder.Single.alert {
                                 effect = Alert.Effect.Suspension
-                            }
+                            },
+                        mapStopRoute = MapStopRoute.GREEN
                     )
             )
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.route
 import com.mbta.tid.mbta_app.model.RealtimePatterns
@@ -113,7 +114,10 @@ fun HeadsignRowViewPreview() {
             HeadsignRowView("Loading", RealtimePatterns.Format.Loading)
             HeadsignRowView(
                 "No Service",
-                RealtimePatterns.Format.Disruption(alert { effect = Alert.Effect.Suspension })
+                RealtimePatterns.Format.Disruption(
+                    alert { effect = Alert.Effect.Suspension },
+                    MapStopRoute.ORANGE
+                )
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -107,7 +107,10 @@ fun PredictionRowView(
                             }
                         is RealtimePatterns.Format.Disruption ->
                             UpcomingTripView(
-                                UpcomingTripViewState.Disruption(predictions.alert.effect)
+                                UpcomingTripViewState.Disruption(
+                                    predictions.alert.effect,
+                                    iconName = predictions.iconName
+                                )
                             )
                         is RealtimePatterns.Format.NoTrips ->
                             UpcomingTripView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStatus.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStatus.kt
@@ -14,7 +14,12 @@ fun TripStatus(predictions: RealtimePatterns.Format) {
                 else -> UpcomingTripView(UpcomingTripViewState.Some(trip.format))
             }
         is RealtimePatterns.Format.Disruption ->
-            UpcomingTripView(UpcomingTripViewState.Disruption(predictions.alert.effect))
+            UpcomingTripView(
+                UpcomingTripViewState.Disruption(
+                    predictions.alert.effect,
+                    iconName = predictions.iconName
+                )
+            )
         is RealtimePatterns.Format.NoTrips ->
             UpcomingTripView(UpcomingTripViewState.NoTrips(predictions.noTripsFormat))
         RealtimePatterns.Format.Loading -> UpcomingTripView(UpcomingTripViewState.Loading)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -215,9 +215,9 @@ private fun upcomingTripViewState(
     now: Instant,
     routeAccents: TripRouteAccents
 ): UpcomingTripViewState {
-    val alert = stop.alert
-    return if (alert != null) {
-        UpcomingTripViewState.Disruption(alert.effect)
+    val disruption = stop.disruption
+    return if (disruption != null) {
+        UpcomingTripViewState.Disruption(disruption.alert.effect, iconName = disruption.iconName)
     } else {
         UpcomingTripViewState.Some(stop.format(now, routeAccents.type))
     }
@@ -259,7 +259,7 @@ private fun TripStopRowPreview() {
                     TripDetailsStopList.Entry(
                         objects.stop { name = "Park Street" },
                         stopSequence = 10,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction =
                             objects.prediction {
@@ -293,7 +293,7 @@ private fun TripStopRowPreview() {
                     TripDetailsStopList.Entry(
                         objects.stop { name = "South Station" },
                         stopSequence = 10,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction =
                             objects.prediction {

--- a/iosApp/iosApp/ComponentViews/DirectionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionRowView.swift
@@ -78,7 +78,7 @@ struct DirectionRowView_Previews: PreviewProvider {
                     predictions: RealtimePatterns.FormatDisruption(
                         alert: ObjectCollectionBuilder.Single.shared.alert { alert in
                             alert.effect = .suspension
-                        }
+                        }, mapStopRoute: .green
                     )
                 )
             }

--- a/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
+++ b/iosApp/iosApp/ComponentViews/HeadsignRowView.swift
@@ -125,7 +125,7 @@ struct HeadsignRowView_Previews: PreviewProvider {
                     predictions: RealtimePatterns.FormatDisruption(
                         alert: ObjectCollectionBuilder.Single.shared.alert { alert in
                             alert.effect = .suspension
-                        }
+                        }, mapStopRoute: .orange
                     )
                 )
             }

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -69,7 +69,7 @@ struct PredictionRowView: View {
 
         case let .disruption(alert):
             UpcomingTripView(
-                prediction: .disruption(alert.alert.effect),
+                prediction: .disruption(alert.alert.effect, iconName: alert.iconName),
                 isFirst: true,
                 isOnly: true
             )

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -32,7 +32,7 @@ struct UpcomingTripView: View {
     enum State: Equatable {
         case loading
         case noTrips(RealtimePatterns.NoTripsFormat)
-        case disruption(shared.Alert.Effect)
+        case disruption(shared.Alert.Effect, iconName: String)
         case some(TripInstantDisplay)
     }
 
@@ -152,8 +152,8 @@ struct UpcomingTripView: View {
                     )
                     : accessibilityFormatters.cancelledOther(date: format.scheduledTime.toNSDate()))
             }
-        case let .disruption(alertEffect):
-            DisruptionView(effect: .from(alertEffect: alertEffect))
+        case let .disruption(alertEffect, iconName: iconName):
+            DisruptionView(effect: .from(alertEffect: alertEffect), iconName: iconName)
         case let .noTrips(format):
             switch onEnum(of: format) {
             case .predictionsUnavailable:
@@ -187,6 +187,7 @@ func makeTimeFormatter() -> DateFormatter {
 
 struct DisruptionView: View {
     let effect: Effect
+    let iconName: String
 
     @ScaledMetric private var iconSize: CGFloat = 20
 
@@ -240,13 +241,7 @@ struct DisruptionView: View {
     }
 
     var rawImage: Image {
-        switch effect {
-        case .detour: Image(systemName: "exclamationmark.triangle.fill")
-        case .shuttle: Image(.modeBus)
-        case .stopClosed: Image(systemName: "xmark.octagon.fill")
-        case .suspension: Image(systemName: "exclamationmark.triangle.fill")
-        case .unknown: Image(systemName: "questionmark.circle.fill")
-        }
+        Image(iconName)
     }
 
     var fullText: some View {
@@ -266,17 +261,27 @@ struct DisruptionView: View {
 }
 
 struct UpcomingTripView_Previews: PreviewProvider {
+    static let route = MapStopRoute.orange
+
+    static func disruption(_ effect: shared.Alert.Effect) -> UpcomingTripView.State {
+        let alert = ObjectCollectionBuilder.Single.shared.alert { $0.effect = effect }
+        let format = RealtimePatterns.FormatDisruption(alert: alert, mapStopRoute: route)
+        return .disruption(effect, iconName: format.iconName)
+    }
+
     static var previews: some View {
         VStack(alignment: .trailing) {
-            UpcomingTripView(prediction: .disruption(.suspension), routeType: .heavyRail)
-            UpcomingTripView(prediction: .disruption(.shuttle), routeType: .heavyRail)
-            UpcomingTripView(prediction: .disruption(.stopClosure), routeType: .heavyRail)
-            UpcomingTripView(prediction: .disruption(.detour), routeType: .heavyRail)
-            UpcomingTripView(prediction: .disruption(.detour), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.suspension), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.stopClosure), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.stationClosure), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.dockClosure), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.detour), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.snowRoute), routeType: .heavyRail)
+            UpcomingTripView(prediction: disruption(.shuttle), routeType: .heavyRail)
         }
         .padding(8)
         .frame(maxWidth: 150)
-        .background(Color.fill1)
+        .background(Color.fill3)
         .previewDisplayName("No Service")
     }
 }

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -240,10 +240,6 @@ struct DisruptionView: View {
         }
     }
 
-    var rawImage: Image {
-        Image(iconName)
-    }
-
     var fullText: some View {
         rawText
             .font(Typography.footnote)
@@ -251,7 +247,7 @@ struct DisruptionView: View {
     }
 
     var fullImage: some View {
-        rawImage
+        Image(iconName)
             .resizable()
             .scaledToFill()
             .foregroundStyle(Color.deemphasized)

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -304,8 +304,8 @@ struct TripHeaderCard: View {
         default: nil
         }
         guard let entry else { return nil }
-        if let alert = entry.alert {
-            return .disruption(alert.effect)
+        if let disruption = entry.disruption {
+            return .disruption(disruption.alert.effect, iconName: disruption.iconName)
         } else {
             let formatted = entry.format(now: now.toKotlinInstant(), routeType: routeAccents.type)
             return switch onEnum(of: formatted) {

--- a/iosApp/iosApp/Pages/StopDetails/TripStatus.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStatus.swift
@@ -23,7 +23,7 @@ struct TripStatus: View {
                 EmptyView()
             }
         case let .disruption(alert):
-            UpcomingTripView(prediction: .disruption(alert.alert.effect))
+            UpcomingTripView(prediction: .disruption(alert.alert.effect, iconName: alert.iconName))
         case let .noTrips(format):
             UpcomingTripView(prediction: .noTrips(format.noTripsFormat))
         case .loading:

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -182,8 +182,8 @@ struct TripStopRow: View {
     }
 
     var upcomingTripViewState: UpcomingTripView.State {
-        if let alert = stop.alert {
-            .disruption(alert.effect)
+        if let disruption = stop.disruption {
+            .disruption(disruption.alert.effect, iconName: disruption.iconName)
         } else {
             .some(stop.format(now: now, routeType: routeAccents.type))
         }
@@ -196,7 +196,7 @@ struct TripStopRow: View {
         stop: .init(
             stop: objects.stop { $0.name = "ABC" },
             stopSequence: 10,
-            alert: nil,
+            disruption: nil,
             schedule: nil,
             prediction: nil,
             predictionStop: nil,

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListSplitView.swift
@@ -80,7 +80,7 @@ struct TripDetailsStopListSplitView: View {
         TripDetailsStopList.Entry(
             stop: stop,
             stopSequence: Int32(stopSequence),
-            alert: nil,
+            disruption: nil,
             schedule: nil,
             prediction: prediction,
             predictionStop: nil,

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopListView.swift
@@ -45,7 +45,7 @@ struct TripDetailsStopListView: View {
             .init(
                 stop: stop1,
                 stopSequence: 1,
-                alert: nil,
+                disruption: nil,
                 schedule: nil,
                 prediction: nil,
                 predictionStop: nil,
@@ -55,7 +55,7 @@ struct TripDetailsStopListView: View {
             .init(
                 stop: stop2,
                 stopSequence: 2,
-                alert: nil,
+                disruption: nil,
                 schedule: sched2,
                 prediction: pred2,
                 predictionStop: stop2,

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -76,8 +76,8 @@ struct TripDetailsStopView: View {
     }
 
     var upcomingTripViewState: UpcomingTripView.State {
-        if let alert = stop.alert {
-            .disruption(alert.effect)
+        if let disruption = stop.disruption {
+            .disruption(disruption.alert.effect, iconName: disruption.iconName)
         } else {
             .some(stop.format(now: now, routeType: routeType))
         }
@@ -103,7 +103,7 @@ struct TripDetailsStopView: View {
         stop: .init(
             stop: objects.stop { $0.name = "ABC" },
             stopSequence: 10,
-            alert: nil,
+            disruption: nil,
             schedule: nil,
             prediction: nil,
             predictionStop: nil,

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -300,7 +300,7 @@ final class TripDetailsViewTests: XCTestCase {
         sut.onTapStop(entry: newNavEntry,
                       stop: TripDetailsStopList.Entry(
                           stop: targetStop, stopSequence: 0,
-                          alert: nil, schedule: nil, prediction: nil, predictionStop: nil,
+                          disruption: nil, schedule: nil, prediction: nil, predictionStop: nil,
                           vehicle: nil, routes: []
                       ),
                       connectingRouteId: "route")

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -177,7 +177,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .vehicle(vehicle, stop, .init(
                 stop: stop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: nil,
                 prediction: prediction,
                 predictionStop: nil,
@@ -224,7 +224,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .vehicle(vehicle, stop, .init(
                 stop: stop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: nil,
                 prediction: prediction,
                 predictionStop: platformStop,
@@ -254,7 +254,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .scheduled(stop, .init(
                 stop: stop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: schedule,
                 prediction: nil,
                 predictionStop: nil,
@@ -291,7 +291,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .scheduled(stop, .init(
                 stop: stop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: schedule,
                 prediction: nil,
                 predictionStop: nil,
@@ -379,7 +379,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .scheduled(stop, .init(
                 stop: stop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: schedule,
                 prediction: nil,
                 predictionStop: nil,
@@ -400,7 +400,7 @@ final class TripHeaderCardTests: XCTestCase {
             spec: .scheduled(otherStop, .init(
                 stop: otherStop,
                 stopSequence: 0,
-                alert: nil,
+                disruption: nil,
                 schedule: schedule,
                 prediction: nil,
                 predictionStop: nil,
@@ -431,7 +431,7 @@ final class TripHeaderCardTests: XCTestCase {
         }
         let withTrackNumber = TripHeaderCard(
             spec: .vehicle(boardingVehicle, coreCRStop, .init(
-                stop: stop, stopSequence: 0, alert: nil, schedule: nil,
+                stop: stop, stopSequence: 0, disruption: nil, schedule: nil,
                 prediction: objects.prediction { prediction in
                     prediction.departureTime = now.addingTimeInterval(5 * 60).toKotlinInstant()
                     prediction.stopId = platformStop.id

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -31,7 +31,7 @@ final class TripStopRowTests: XCTestCase {
 
         let sut = TripStopRow(
             stop: .init(
-                stop: stop, stopSequence: 0, alert: nil,
+                stop: stop, stopSequence: 0, disruption: nil,
                 schedule: schedule, prediction: prediction, predictionStop: nil,
                 vehicle: nil, routes: [route]
             ),
@@ -57,7 +57,7 @@ final class TripStopRowTests: XCTestCase {
 
         let sut = TripStopRow(
             stop: .init(
-                stop: stop, stopSequence: 0, alert: nil,
+                stop: stop, stopSequence: 0, disruption: nil,
                 schedule: schedule, prediction: prediction, predictionStop: nil,
                 vehicle: nil, routes: [route]
             ),
@@ -89,7 +89,7 @@ final class TripStopRowTests: XCTestCase {
 
         let sut = TripStopRow(
             stop: .init(
-                stop: stop, stopSequence: 0, alert: nil,
+                stop: stop, stopSequence: 0, disruption: nil,
                 schedule: schedule, prediction: prediction, predictionStop: platformStop,
                 vehicle: nil, routes: [route]
             ),
@@ -116,7 +116,7 @@ final class TripStopRowTests: XCTestCase {
 
         let targeted = TripStopRow(
             stop: .init(
-                stop: stop, stopSequence: 0, alert: nil,
+                stop: stop, stopSequence: 0, disruption: nil,
                 schedule: schedule, prediction: prediction, predictionStop: nil,
                 vehicle: nil, routes: [route]
             ),
@@ -132,7 +132,7 @@ final class TripStopRowTests: XCTestCase {
 
         let notTargeted = TripStopRow(
             stop: .init(
-                stop: stop, stopSequence: 0, alert: nil,
+                stop: stop, stopSequence: 0, disruption: nil,
                 schedule: schedule, prediction: prediction, predictionStop: nil,
                 vehicle: nil, routes: [route]
             ),
@@ -159,7 +159,7 @@ final class TripStopRowTests: XCTestCase {
         let route = objects.route()
 
         let stopEntry = TripDetailsStopList.Entry(
-            stop: stop, stopSequence: 0, alert: nil,
+            stop: stop, stopSequence: 0, disruption: nil,
             schedule: schedule, prediction: prediction, predictionStop: nil,
             vehicle: nil, routes: [route]
         )

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -67,27 +67,27 @@ final class TripStopsTests: XCTestCase {
 
         let stops = TripDetailsStopList(tripId: trip.id, stops: [
             .init(
-                stop: stop1, stopSequence: 1, alert: nil,
+                stop: stop1, stopSequence: 1, disruption: nil,
                 schedule: schedule1, prediction: prediction1, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop2, stopSequence: 2, alert: nil,
+                stop: stop2, stopSequence: 2, disruption: nil,
                 schedule: schedule2, prediction: prediction2, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop3Target, stopSequence: 3, alert: nil,
+                stop: stop3Target, stopSequence: 3, disruption: nil,
                 schedule: schedule3, prediction: prediction3, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop4, stopSequence: 4, alert: nil,
+                stop: stop4, stopSequence: 4, disruption: nil,
                 schedule: schedule4, prediction: prediction4, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop5, stopSequence: 5, alert: nil,
+                stop: stop5, stopSequence: 5, disruption: nil,
                 schedule: schedule5, prediction: prediction5, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
@@ -157,17 +157,17 @@ final class TripStopsTests: XCTestCase {
 
         let stops = TripDetailsStopList(tripId: trip.id, stops: [
             .init(
-                stop: stop1, stopSequence: 1, alert: nil,
+                stop: stop1, stopSequence: 1, disruption: nil,
                 schedule: schedule1, prediction: prediction1, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop2, stopSequence: 2, alert: nil,
+                stop: stop2, stopSequence: 2, disruption: nil,
                 schedule: schedule2, prediction: prediction2, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
             .init(
-                stop: stop3, stopSequence: 3, alert: nil,
+                stop: stop3, stopSequence: 3, disruption: nil,
                 schedule: schedule3, prediction: prediction3, predictionStop: nil,
                 vehicle: vehicle, routes: [route]
             ),
@@ -232,7 +232,7 @@ final class TripStopsTests: XCTestCase {
         let prediction2 = makePrediction(schedule: schedule2)
 
         let firstStop: TripDetailsStopList.Entry = .init(
-            stop: stop1, stopSequence: 1, alert: nil,
+            stop: stop1, stopSequence: 1, disruption: nil,
             schedule: schedule1, prediction: prediction1, predictionStop: nil,
             vehicle: vehicle, routes: [route]
         )
@@ -241,7 +241,7 @@ final class TripStopsTests: XCTestCase {
             stops: [
                 firstStop,
                 .init(
-                    stop: stop2, stopSequence: 2, alert: nil,
+                    stop: stop2, stopSequence: 2, disruption: nil,
                     schedule: schedule2, prediction: prediction2, predictionStop: nil,
                     vehicle: vehicle, routes: [route]
                 ),
@@ -309,7 +309,7 @@ final class TripStopsTests: XCTestCase {
         let prediction3 = makePrediction(schedule: schedule3)
 
         let firstStop: TripDetailsStopList.Entry = .init(
-            stop: stop1, stopSequence: 1, alert: nil,
+            stop: stop1, stopSequence: 1, disruption: nil,
             schedule: schedule1, prediction: prediction1, predictionStop: nil,
             vehicle: vehicle, routes: [route]
         )
@@ -318,12 +318,12 @@ final class TripStopsTests: XCTestCase {
             stops: [
                 firstStop,
                 .init(
-                    stop: stop2, stopSequence: 2, alert: nil,
+                    stop: stop2, stopSequence: 2, disruption: nil,
                     schedule: schedule2, prediction: prediction2, predictionStop: nil,
                     vehicle: vehicle, routes: [route]
                 ),
                 .init(
-                    stop: stop3, stopSequence: 3, alert: nil,
+                    stop: stop3, stopSequence: 3, disruption: nil,
                     schedule: schedule3, prediction: prediction3, predictionStop: nil,
                     vehicle: vehicle, routes: [route]
                 ),

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -530,7 +530,7 @@ final class TripDetailsPageTests: XCTestCase {
                 stop: .init(
                     stop: childStop,
                     stopSequence: 1,
-                    alert: nil,
+                    disruption: nil,
                     schedule: nil,
                     prediction: nil,
                     predictionStop: nil,

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopListSplitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopListSplitViewTests.swift
@@ -25,7 +25,7 @@ final class TripDetailsStopListSplitViewTests: XCTestCase {
         TripDetailsStopList.Entry(
             stop: stop,
             stopSequence: Int32(stopSequence),
-            alert: nil,
+            disruption: nil,
             schedule: nil,
             prediction: prediction,
             predictionStop: stop,

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsStopViewTests.swift
@@ -33,7 +33,8 @@ final class TripDetailsStopViewTests: XCTestCase {
         }
         let sut = TripDetailsStopView(
             stop: .init(
-                stop: stop, stopSequence: 1, alert: alert,
+                stop: stop, stopSequence: 1,
+                disruption: .init(alert: alert, mapStopRoute: nil),
                 schedule: nil, prediction: prediction, predictionStop: nil,
                 vehicle: nil, routes: []
             ),
@@ -58,7 +59,7 @@ final class TripDetailsStopViewTests: XCTestCase {
         let stopListEntry = TripDetailsStopList.Entry(
             stop: stop,
             stopSequence: 1,
-            alert: nil,
+            disruption: nil,
             schedule: nil,
             prediction: prediction,
             predictionStop: nil,

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -139,7 +139,10 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testShuttleAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .disruption(.shuttle), isFirst: false)
+        let sut = UpcomingTripView(
+            prediction: .disruption(.shuttle, iconName: "alert-borderless-shuttle"),
+            isFirst: false
+        )
         XCTAssertEqual(
             "Shuttle buses replace service",
             try sut.inspect().find(text: "Shuttle")
@@ -148,7 +151,10 @@ final class UpcomingTripViewTests: XCTestCase {
     }
 
     func testSuspensionAccessibilityLabel() throws {
-        let sut = UpcomingTripView(prediction: .disruption(.suspension), isFirst: false)
+        let sut = UpcomingTripView(
+            prediction: .disruption(.suspension, iconName: "alert-borderless-suspension"),
+            isFirst: false
+        )
         XCTAssertEqual(
             "Service suspended",
             try sut.inspect().find(text: "Suspension")
@@ -181,5 +187,14 @@ final class UpcomingTripViewTests: XCTestCase {
             "and at 4:00 PM",
             foundText
         )
+    }
+
+    func testDisruptionIconName() throws {
+        let alert = ObjectCollectionBuilder.Single.shared.alert { $0.effect = .snowRoute }
+        let disruption = RealtimePatterns.FormatDisruption(alert: alert, mapStopRoute: .bus)
+        let sut = UpcomingTripView(prediction: .disruption(alert.effect, iconName: disruption.iconName))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "alert-large-bus-issue"
+        }))
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -132,7 +132,7 @@ object LoadingPlaceholders {
                     TripDetailsStopList.Entry(
                         stop,
                         sequence,
-                        alert = null,
+                        disruption = null,
                         schedule = null,
                         prediction,
                         predictionStop = null,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -202,7 +202,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
                 return Entry(
                     stop,
                     working.stopSequence,
-                    getDisruption(working, alertsData, globalData, route, tripId, directionId),
+                    getDisruption(working, alertsData, route, tripId, directionId),
                     working.schedule,
                     working.prediction,
                     globalData.stops[working.prediction?.stopId],
@@ -403,15 +403,12 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
         private fun getDisruption(
             entry: WorkingEntry,
             alertsData: AlertsStreamDataResponse?,
-            globalData: GlobalResponse,
             route: Route?,
             tripId: String,
             directionId: Int
         ): RealtimePatterns.Format.Disruption? {
             val entryTime = entry.prediction?.predictionTime ?: entry.schedule?.scheduleTime
-            val entryRoute = entry.prediction?.routeId ?: entry.schedule?.routeId
-            val entryRouteType =
-                globalData.routes[entry.prediction?.routeId ?: entry.schedule?.routeId]?.type
+            val entryRouteType = route?.type
 
             if (entryTime == null) return null
             val alert =
@@ -420,7 +417,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
                         alert.anyInformedEntity {
                             it.appliesTo(
                                 directionId = directionId,
-                                routeId = entryRoute,
+                                routeId = route?.id,
                                 routeType = entryRouteType,
                                 stopId = entry.stopId,
                                 tripId = tripId

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -13,7 +13,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
     data class Entry(
         val stop: Stop,
         val stopSequence: Int,
-        val alert: Alert?,
+        val disruption: RealtimePatterns.Format.Disruption?,
         val schedule: Schedule?,
         val prediction: Prediction?,
         // The prediction stop can be the same as `stop`, but it can also be a child stop which
@@ -158,13 +158,15 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
         ): TripDetailsStopList? {
             if (alertsData == null) return null
             val entries = mutableMapOf<Int, WorkingEntry>()
+            val routeId =
+                tripPredictions?.trips?.values?.singleOrNull()?.routeId ?: tripSchedules?.routeId()
+            val route = globalData.routes[routeId]
 
             var predictions = emptyList<Prediction>()
             if (tripPredictions != null) {
-                val tripRoute = tripPredictions.trips.values.singleOrNull()?.routeId
                 val tripPredictionsWithCorrectRoute =
                     tripPredictions.predictions.values.filter {
-                        tripRoute == null || it.routeId == tripRoute
+                        routeId == null || it.routeId == routeId
                     }
                 predictions =
                     deduplicatePredictionsByStopSequence(
@@ -200,7 +202,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
                 return Entry(
                     stop,
                     working.stopSequence,
-                    getAlert(working, alertsData, globalData, tripId, directionId),
+                    getDisruption(working, alertsData, globalData, route, tripId, directionId),
                     working.schedule,
                     working.prediction,
                     globalData.stops[working.prediction?.stopId],
@@ -398,33 +400,40 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             }
         }
 
-        private fun getAlert(
+        private fun getDisruption(
             entry: WorkingEntry,
             alertsData: AlertsStreamDataResponse?,
             globalData: GlobalResponse,
+            route: Route?,
             tripId: String,
             directionId: Int
-        ): Alert? {
+        ): RealtimePatterns.Format.Disruption? {
             val entryTime = entry.prediction?.predictionTime ?: entry.schedule?.scheduleTime
             val entryRoute = entry.prediction?.routeId ?: entry.schedule?.routeId
             val entryRouteType =
                 globalData.routes[entry.prediction?.routeId ?: entry.schedule?.routeId]?.type
 
             if (entryTime == null) return null
-            return alertsData?.alerts?.values?.find { alert ->
-                alert.isActive(entryTime) &&
-                    alert.anyInformedEntity {
-                        it.appliesTo(
-                            directionId = directionId,
-                            routeId = entryRoute,
-                            routeType = entryRouteType,
-                            stopId = entry.stopId,
-                            tripId = tripId
-                        )
-                    } &&
-                    // there's no UI yet for secondary alerts in trip details
-                    alert.significance >= AlertSignificance.Major
-            }
+            val alert =
+                alertsData?.alerts?.values?.find { alert ->
+                    alert.isActive(entryTime) &&
+                        alert.anyInformedEntity {
+                            it.appliesTo(
+                                directionId = directionId,
+                                routeId = entryRoute,
+                                routeType = entryRouteType,
+                                stopId = entry.stopId,
+                                tripId = tripId
+                            )
+                        } &&
+                        // there's no UI yet for secondary alerts in trip details
+                        alert.significance >= AlertSignificance.Major
+                }
+            if (alert == null) return null
+            return RealtimePatterns.Format.Disruption(
+                alert,
+                route?.let { MapStopRoute.matching(it) }
+            )
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
@@ -12,6 +12,8 @@ sealed class TripSchedulesResponse {
     data class Schedules(val schedules: List<Schedule>) : TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
             schedules.mapNotNull { globalData.stops[it.stopId] }
+
+        override fun routeId(): String? = schedules.map { it.routeId }.distinct().singleOrNull()
     }
 
     @Serializable
@@ -20,13 +22,19 @@ sealed class TripSchedulesResponse {
         TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
             stopIds.mapNotNull { globalData.stops[it] }
+
+        override fun routeId() = null
     }
 
     @Serializable
     @SerialName("unknown")
     data object Unknown : TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop>? = null
+
+        override fun routeId() = null
     }
 
     abstract fun stops(globalData: GlobalResponse): List<Stop>?
+
+    abstract fun routeId(): String?
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -29,12 +29,12 @@ class RealtimePatternsTest {
         val now = Clock.System.now()
 
         val objects = ObjectCollectionBuilder()
-        val route = objects.route()
+        val route = objects.route { id = "Red" }
 
         val alert = objects.alert { effect = Alert.Effect.Suspension }
 
         assertEquals(
-            RealtimePatterns.Format.Disruption(alert),
+            RealtimePatterns.Format.Disruption(alert, "alert-large-red-suspension"),
             RealtimePatterns.ByHeadsign(route, "", null, emptyList(), emptyList(), listOf(alert))
                 .format(now, anyNonScheduleBasedRouteType(), anyContext())
         )
@@ -89,7 +89,7 @@ class RealtimePatternsTest {
         val now = Clock.System.now()
 
         val objects = ObjectCollectionBuilder()
-        val route = objects.route()
+        val route = objects.route { id = "743" }
 
         val trip = objects.trip()
         val prediction =
@@ -102,7 +102,7 @@ class RealtimePatternsTest {
         val alert = objects.alert { effect = Alert.Effect.Suspension }
 
         assertEquals(
-            RealtimePatterns.Format.Disruption(alert),
+            RealtimePatterns.Format.Disruption(alert, "alert-large-silver-suspension"),
             RealtimePatterns.ByHeadsign(
                     route,
                     "",

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -96,7 +96,7 @@ class TripDetailsStopListTest {
         fun entry(
             stopId: String,
             stopSequence: Int,
-            alert: Alert? = null,
+            disruption: RealtimePatterns.Format.Disruption? = null,
             schedule: Schedule? = null,
             prediction: Prediction? = null,
             predictionStop: Stop? = null,
@@ -106,7 +106,7 @@ class TripDetailsStopListTest {
             TripDetailsStopList.Entry(
                 stop(stopId),
                 stopSequence,
-                alert,
+                disruption,
                 schedule,
                 prediction,
                 predictionStop ?: objects.stops[prediction?.stopId],
@@ -755,12 +755,13 @@ class TripDetailsStopListTest {
     }
 
     @Test
-    fun `fromPieces keeps alerts`() = test {
-        trip {}
+    fun `fromPieces keeps alerts and picks icon based on route`() = test {
+        objects.route { id = "Red" }
+        trip { routeId = "Red" }
         val now = Clock.System.now()
-        val pred1 = prediction("A", 10, time = now + 1.minutes)
-        val pred2 = prediction("B", 20, time = now + 2.minutes)
-        val pred3 = prediction("C", 30, time = now + 3.minutes)
+        val pred1 = prediction("A", 10, routeId = "Red", time = now + 1.minutes)
+        val pred2 = prediction("B", 20, routeId = "Red", time = now + 2.minutes)
+        val pred3 = prediction("C", 30, routeId = "Red", time = now + 3.minutes)
         val alert =
             alert(Alert.Effect.Detour) {
                 informedEntity(listOf(Alert.InformedEntity.Activity.Board), stop = "B")
@@ -768,7 +769,7 @@ class TripDetailsStopListTest {
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
-                entry("B", 20, alert = alert, prediction = pred2),
+                entry("B", 20, disruption = RealtimePatterns.Format.Disruption(alert, iconName = "alert-large-red-issue"), prediction = pred2),
                 entry("C", 30, prediction = pred3)
             ),
             fromPieces(null, predictions())


### PR DESCRIPTION
### Summary

_Ticket:_ [Disruptions UI updates in Nearby Transit and unfiltered Stop Details](https://app.asana.com/0/1205732265579288/1208091797262212) & [Fix handling of Snow Route alerts](https://app.asana.com/0/1205732265579288/1209342902372065)

Using the same solution for major alert icons that we used for secondary alert icons seems like a really good approach to me.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually verified that disruption icons appear with the correct color. Added unit tests to verify this behavior on Android and iOS.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
