### PR TITLE
fix: tweak disruption styles to match designs

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -22,11 +22,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.generated.drawableByName
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
 import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
@@ -124,14 +128,16 @@ fun PredictionRowView(
                 //
             }
 
-            Column(
-                modifier = Modifier.padding(8.dp).widthIn(max = 8.dp),
-            ) {
-                Icon(
-                    painterResource(id = R.drawable.baseline_chevron_right_24),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.tertiary
-                )
+            if (predictions !is RealtimePatterns.Format.Disruption) {
+                Column(
+                    modifier = Modifier.padding(8.dp).widthIn(max = 8.dp),
+                ) {
+                    Icon(
+                        painterResource(id = R.drawable.baseline_chevron_right_24),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.tertiary
+                    )
+                }
             }
         }
     }
@@ -153,74 +159,85 @@ private fun PredictionRowViewPreview() {
         }
     val trip = objects.trip()
 
-    Column {
-        PredictionRowView(
-            predictions =
+    MyApplicationTheme {
+        Column {
+            PredictionRowView(
+                predictions =
+                    RealtimePatterns.Format.Some(
+                        listOf(
+                            RealtimePatterns.Format.Some.FormatWithId(
+                                trip.id,
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Boarding
+                            )
+                        ),
+                        null
+                    ),
+                pillDecoration = PillDecoration.OnPrediction(mapOf(trip.id to greenB))
+            ) {
+                Text("Destination")
+            }
+
+            PredictionRowView(
                 RealtimePatterns.Format.Some(
                     listOf(
                         RealtimePatterns.Format.Some.FormatWithId(
                             trip.id,
                             RouteType.LIGHT_RAIL,
-                            TripInstantDisplay.Boarding
+                            TripInstantDisplay.Overridden("Stopped 10 stops away")
                         )
                     ),
                     null
                 ),
-            pillDecoration = PillDecoration.OnPrediction(mapOf(trip.id to greenB))
-        ) {
-            Text("Destination")
-        }
+                pillDecoration = PillDecoration.OnRow(greenB)
+            ) {
+                Text("Destination")
+            }
 
-        PredictionRowView(
-            RealtimePatterns.Format.Some(
-                listOf(
-                    RealtimePatterns.Format.Some.FormatWithId(
-                        trip.id,
-                        RouteType.LIGHT_RAIL,
-                        TripInstantDisplay.Overridden("Stopped 10 stops away")
-                    )
-                ),
-                null
-            ),
-            pillDecoration = PillDecoration.OnRow(greenB)
-        ) {
-            Text("Destination")
-        }
-
-        PredictionRowView(
-            RealtimePatterns.Format.Some(
-                listOf(
-                    RealtimePatterns.Format.Some.FormatWithId(
-                        trip.id,
-                        RouteType.LIGHT_RAIL,
-                        TripInstantDisplay.Overridden("Stopped 10 stops away")
-                    )
-                ),
-                null
-            ),
-            pillDecoration = PillDecoration.OnPrediction(mapOf(trip.id to greenB))
-        ) {
-            Text("Destination")
-        }
-
-        PredictionRowView(
-            RealtimePatterns.Format.Some(
-                listOf(
-                    RealtimePatterns.Format.Some.FormatWithId(
-                        "a",
-                        RouteType.BUS,
-                        TripInstantDisplay.ScheduleMinutes(6)
+            PredictionRowView(
+                RealtimePatterns.Format.Some(
+                    listOf(
+                        RealtimePatterns.Format.Some.FormatWithId(
+                            trip.id,
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Overridden("Stopped 10 stops away")
+                        )
                     ),
-                    RealtimePatterns.Format.Some.FormatWithId(
-                        "b",
-                        RouteType.BUS,
-                        TripInstantDisplay.ScheduleMinutes(15)
-                    ),
+                    null
                 ),
-                null
-            )
-        ) {
-            Text("Destination")
+                pillDecoration = PillDecoration.OnPrediction(mapOf(trip.id to greenB))
+            ) {
+                Text("Destination")
+            }
+
+            PredictionRowView(
+                RealtimePatterns.Format.Some(
+                    listOf(
+                        RealtimePatterns.Format.Some.FormatWithId(
+                            "a",
+                            RouteType.BUS,
+                            TripInstantDisplay.ScheduleMinutes(6)
+                        ),
+                        RealtimePatterns.Format.Some.FormatWithId(
+                            "b",
+                            RouteType.BUS,
+                            TripInstantDisplay.ScheduleMinutes(15)
+                        ),
+                    ),
+                    null
+                )
+            ) {
+                Text("Destination")
+            }
+
+            PredictionRowView(
+                RealtimePatterns.Format.Disruption(
+                    alert { effect = Alert.Effect.Detour },
+                    MapStopRoute.GREEN
+                )
+            ) {
+                Text("Destination")
+            }
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -386,15 +386,21 @@ fun DisruptionView(
     val icon = painterResource(drawableByName(iconName))
     Row(
         modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
             spec.text,
             modifier =
-                spec.contentDescription?.let { Modifier.semantics { contentDescription = it } }
-                    ?: Modifier,
-            fontSize = 12.sp
+                Modifier.alpha(0.6f)
+                    .then(
+                        spec.contentDescription?.let {
+                            Modifier.semantics { contentDescription = it }
+                        }
+                            ?: Modifier
+                    ),
+            fontWeight = FontWeight.SemiBold,
+            style = MaterialTheme.typography.labelLarge
         )
         Image(icon, null, Modifier.size(20.dp))
     }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		8C5054582BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5054572BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift */; };
 		8C5054A02CA47C3C00137CFE /* ErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C50549F2CA47C3C00137CFE /* ErrorBanner.swift */; };
 		8C5F47662C40842200FB71DA /* TripDetailsStopViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5F47652C40842200FB71DA /* TripDetailsStopViewTests.swift */; };
+		8C61F5822D5FF1960029A334 /* DestinationRowViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C61F5812D5FF1960029A334 /* DestinationRowViewTests.swift */; };
 		8C6A48402BC09A2E0032A554 /* StopDetailsFilteredRouteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6A483F2BC09A2E0032A554 /* StopDetailsFilteredRouteView.swift */; };
 		8C72B12E2D396D6900A6E73E /* FormattedAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C72B12D2D396D6400A6E73E /* FormattedAlert.swift */; };
 		8C7726152BE58FE30088D423 /* TripDetailsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C7726142BE58FE20088D423 /* TripDetailsPage.swift */; };
@@ -386,6 +387,7 @@
 		8C5054572BB5EB6C00C6A51C /* LegacyStopDetailsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyStopDetailsPage.swift; sourceTree = "<group>"; };
 		8C50549F2CA47C3C00137CFE /* ErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorBanner.swift; sourceTree = "<group>"; };
 		8C5F47652C40842200FB71DA /* TripDetailsStopViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailsStopViewTests.swift; sourceTree = "<group>"; };
+		8C61F5812D5FF1960029A334 /* DestinationRowViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestinationRowViewTests.swift; sourceTree = "<group>"; };
 		8C6A483F2BC09A2E0032A554 /* StopDetailsFilteredRouteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StopDetailsFilteredRouteView.swift; sourceTree = "<group>"; };
 		8C72B12D2D396D6400A6E73E /* FormattedAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedAlert.swift; sourceTree = "<group>"; };
 		8C7726142BE58FE20088D423 /* TripDetailsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDetailsPage.swift; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 		6EF64C012C1B7C17005F365D /* NearbyTransit */ = {
 			isa = PBXGroup;
 			children = (
+				8C61F5812D5FF1960029A334 /* DestinationRowViewTests.swift */,
 				6EA231722C21C58A00789173 /* NearbyTransitPageViewTests.swift */,
 				8C2F26972CDE7B3600386D4F /* NoNearbyStopsViewTests.swift */,
 				6EF64C022C1B7C2E005F365D /* RouteCardTests.swift */,
@@ -1554,6 +1557,7 @@
 				9AB335212D5404A60041A109 /* PromoScreenViewTests.swift in Sources */,
 				8CB823DB2BC5F053002C87E0 /* StopDetailsRoutesViewTests.swift in Sources */,
 				6E4EACFC2B7A82AC0011AB8B /* MockLocationFetcher.swift in Sources */,
+				8C61F5822D5FF1960029A334 /* DestinationRowViewTests.swift in Sources */,
 				9A8E55AE2CFE6E55004ED059 /* StopDetailsFilteredHeaderTests.swift in Sources */,
 				8CE36C932CADEDD300D77F22 /* FetchApiTests.swift in Sources */,
 				8CB823D92BC5EDD2002C87E0 /* StopDetailsRouteViewTests.swift in Sources */,

--- a/iosApp/iosApp/ComponentViews/OptionalNavigationLink.swift
+++ b/iosApp/iosApp/ComponentViews/OptionalNavigationLink.swift
@@ -14,11 +14,12 @@ import SwiftUI
 struct OptionalNavigationLink<Label>: View where Label: View {
     let value: SheetNavigationStackEntry?
     let action: (SheetNavigationStackEntry) -> Void
+    let showChevron: Bool
     let label: () -> Label
 
     var body: some View {
         if let value {
-            SheetNavigationLink(value: value, action: action, label: label)
+            SheetNavigationLink(value: value, action: action, showChevron: showChevron, label: label)
         } else {
             label()
         }

--- a/iosApp/iosApp/ComponentViews/SheetNavigationLink.swift
+++ b/iosApp/iosApp/ComponentViews/SheetNavigationLink.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct SheetNavigationLink<Label>: View where Label: View {
     let value: SheetNavigationStackEntry
     let action: (SheetNavigationStackEntry) -> Void
+    let showChevron: Bool
     let label: () -> Label
 
     @ScaledMetric private var chevronHeight: CGFloat = 14
@@ -21,12 +22,14 @@ struct SheetNavigationLink<Label>: View where Label: View {
         Button(action: { action(value) }) {
             HStack(spacing: 0) {
                 label()
-                Image(.faChevronRight)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: chevronWidth, height: chevronHeight)
-                    .padding(5)
-                    .foregroundStyle(Color.deemphasized)
+                if showChevron {
+                    Image(.faChevronRight)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: chevronWidth, height: chevronHeight)
+                        .padding(5)
+                        .foregroundStyle(Color.deemphasized)
+                }
             }
         }
     }

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -193,17 +193,17 @@ struct DisruptionView: View {
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
-            HStack {
+            HStack(spacing: 4) {
                 fullText
                     .lineLimit(1)
                 fullImage
             }
-            VStack(alignment: .trailing) {
+            VStack(alignment: .trailing, spacing: 4) {
                 fullText
                     .lineLimit(1)
                 fullImage
             }
-            HStack {
+            HStack(spacing: 4) {
                 fullText
                 fullImage
             }
@@ -230,7 +230,6 @@ struct DisruptionView: View {
             .scaledToFill()
             .foregroundStyle(Color.deemphasized)
             .frame(width: iconSize, height: iconSize)
-            .padding(2)
     }
 }
 

--- a/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
+++ b/iosApp/iosApp/Pages/LegacyStopDetails/StopDetailsFilteredRouteView.swift
@@ -214,6 +214,10 @@ struct StopDetailsFilteredRouteView: View {
                                 }
                                 ForEach(Array(rows.enumerated()), id: \.offset) { index, row in
                                     VStack(spacing: 0) {
+                                        let showChevron = switch onEnum(of: row.formatted) {
+                                        case .disruption: false
+                                        default: true
+                                        }
                                         OptionalNavigationLink(value: row.navigationTarget, action: { entry in
                                             let noTrips: RealtimePatterns
                                                 .NoTripsFormat? = switch onEnum(of: row.formatted) {
@@ -229,7 +233,7 @@ struct StopDetailsFilteredRouteView: View {
                                                 routeType: patternsByStop.representativeRoute.type,
                                                 noTrips: noTrips
                                             )
-                                        }) {
+                                        }, showChevron: showChevron) {
                                             HeadsignRowView(
                                                 headsign: row.headsign,
                                                 predictions: row.formatted,

--- a/iosApp/iosApp/Pages/NearbyTransit/DestinationRowView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/DestinationRowView.swift
@@ -54,6 +54,10 @@ struct DestinationRowView: View {
                 count: condenseHeadsignPredictions ? 1 : 2,
                 context: context
             )
+            let showChevron = switch onEnum(of: predictions) {
+            case .disruption: false
+            default: true
+            }
             SheetNavigationLink(
                 value: .legacyStopDetails(
                     stop,
@@ -65,7 +69,8 @@ struct DestinationRowView: View {
                 action: { entry in
                     pushNavEntry(entry)
                     analyticsTappedDeparture(predictions: predictions)
-                }
+                },
+                showChevron: showChevron
             ) {
                 HeadsignRowView(
                     headsign: patternsByHeadsign.headsign,
@@ -80,6 +85,10 @@ struct DestinationRowView: View {
                 routeType: patternsByDirection.representativeRoute.type,
                 context: context
             )
+            let showChevron = switch onEnum(of: predictions) {
+            case .disruption: false
+            default: true
+            }
             SheetNavigationLink(
                 value: .legacyStopDetails(
                     stop,
@@ -91,7 +100,8 @@ struct DestinationRowView: View {
                 action: { entry in
                     pushNavEntry(entry)
                     analyticsTappedDeparture(predictions: predictions)
-                }
+                },
+                showChevron: showChevron
             ) {
                 DirectionRowView(
                     direction: patternsByDirection.direction,

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsStopView.swift
@@ -20,6 +20,7 @@ struct TripDetailsStopView: View {
             SheetNavigationLink(
                 value: .legacyStopDetails(stop.stop, nil),
                 action: { entry in onTapLink(entry, stop, nil) },
+                showChevron: stop.disruption == nil,
                 label: {
                     HStack {
                         Text(stop.stop.name).foregroundStyle(Color.text)

--- a/iosApp/iosAppTests/Pages/NearbyTransit/DestinationRowViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/DestinationRowViewTests.swift
@@ -1,0 +1,68 @@
+//
+//  DestinationRowViewTests.swift
+//  iosAppTests
+//
+//  Created by Horn, Melody on 2025-02-14.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import shared
+import ViewInspector
+import XCTest
+
+final class DestinationRowViewTests: XCTestCase {
+    func testSkipsChevronOnDisruption() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let line = objects.line()
+        let route = objects.route()
+        let pattern = objects.routePattern(route: route) { _ in }
+        let alert = objects.alert { $0.effect = .shuttle }
+        let now = Date.now.toKotlinInstant()
+        let dataByHeadsign = RealtimePatterns.ByHeadsign(
+            route: route,
+            headsign: "A",
+            line: nil,
+            patterns: [pattern],
+            upcomingTrips: [],
+            alertsHere: [alert]
+        )
+        let sutByHeadsign = DestinationRowView(
+            patterns: dataByHeadsign,
+            stop: stop,
+            routeId: route.id,
+            now: now,
+            context: .nearbyTransit,
+            pushNavEntry: { _ in },
+            analytics: MockAnalytics(),
+            pinned: false,
+            routeType: route.type
+        )
+        XCTAssertThrowsError(try sutByHeadsign.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-chevron-right"
+        }))
+        let dataByDirection = RealtimePatterns.ByDirection(
+            line: line,
+            routes: [route],
+            direction: .init(name: "", destination: "", id: 0),
+            patterns: [pattern],
+            upcomingTrips: [],
+            alertsHere: [alert]
+        )
+        let sutByDirection = DestinationRowView(
+            patterns: dataByDirection,
+            stop: stop,
+            routeId: route.id,
+            now: now,
+            context: .nearbyTransit,
+            pushNavEntry: { _ in },
+            analytics: MockAnalytics(),
+            pinned: false,
+            routeType: route.type
+        )
+        XCTAssertThrowsError(try sutByDirection.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-chevron-right"
+        }))
+    }
+}

--- a/iosApp/iosAppTests/Views/OptionalNavigationLinkTests.swift
+++ b/iosApp/iosAppTests/Views/OptionalNavigationLinkTests.swift
@@ -28,7 +28,7 @@ final class OptionalNavigationLinkTests: XCTestCase {
                 tappedExp.fulfill()
             }
         }
-        let sut = OptionalNavigationLink(value: target, action: action) {
+        let sut = OptionalNavigationLink(value: target, action: action, showChevron: true) {
             Text("This is a link")
         }
 
@@ -38,7 +38,8 @@ final class OptionalNavigationLinkTests: XCTestCase {
     }
 
     func testIsNotLink() throws {
-        let sut = OptionalNavigationLink(value: nil, action: { _ in }) { Text("Ceci n'est pas un lien") }
+        let sut = OptionalNavigationLink(value: nil, action: { _ in
+        }, showChevron: true) { Text("Ceci n'est pas un lien") }
 
         XCTAssertNotNil(try sut.inspect().find(text: "Ceci n'est pas un lien"))
         XCTAssertThrowsError(try sut.inspect().find(button: "Ceci n'est pas un lien"))


### PR DESCRIPTION
### Summary

_Ticket:_ [Disruptions UI updates in Nearby Transit and unfiltered Stop Details](https://app.asana.com/0/1205732265579288/1208091797262212)

Drops the chevron for alerting departure rows, tweaks text color on Android, and fine tunes spacing on both iOS and Android to match the designs.

Stacked on #747.

|Android|iOS|
|-------|---|
|![Screenshot_20250214_151420](https://github.com/user-attachments/assets/0e9e4c0f-6c48-4ab5-bd8a-5af38f3956a5)|![IMG_0047](https://github.com/user-attachments/assets/23ab44be-aacf-40c9-a2ef-87dc4af43e54)|

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Manually verified new styles in IDE previews and full app. Added iOS unit test for elided chevron (this would be tougher on Android and I'm not sure checking for the color would be sufficient).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
