### PR TITLE
Android recenter on vehicle

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -249,7 +249,7 @@ class HomeMapViewTests {
         viewModel.loadConfig()
         composeTestRule
             .onNodeWithContentDescription("Recenter map on my location")
-            .assertIsDisplayed()
+            .assertDoesNotExist()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -188,6 +188,71 @@ class HomeMapViewTests {
     }
 
     @Test
+    fun testOverviewNotShownWhenNoPermissionsStopDetails() {
+
+        val locationManager = MockLocationDataManager(Location("mock"))
+
+        locationManager.hasPermission = false
+
+        composeTestRule.setContent {
+            HomeMapView(
+                lastNearbyTransitLocation = null,
+                nearbyTransitSelectingLocationState = mutableStateOf(false),
+                locationDataManager = locationManager,
+                viewportProvider = ViewportProvider(MapViewportState()),
+                currentNavEntry = SheetRoutes.StopDetails("stopId", null, null),
+                handleStopNavigation = {},
+                vehiclesData = emptyList(),
+                stopDetailsDepartures = null,
+                viewModel =
+                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {}),
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Recenter map on my location")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun testOverviewNotShownStopDetails(): Unit = runBlocking {
+        val locationManager = MockLocationDataManager(Location("mock"))
+
+        locationManager.hasPermission = true
+        val viewModel =
+            MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        composeTestRule.setContent {
+            HomeMapView(
+                lastNearbyTransitLocation = null,
+                nearbyTransitSelectingLocationState = mutableStateOf(false),
+                locationDataManager = locationManager,
+                viewportProvider = ViewportProvider(MapViewportState()),
+                currentNavEntry = SheetRoutes.StopDetails("stopId", null, null),
+                handleStopNavigation = {},
+                vehiclesData = emptyList(),
+                stopDetailsDepartures = null,
+                viewModel = viewModel,
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
+            )
+        }
+        viewModel.loadConfig()
+        composeTestRule
+            .onNodeWithContentDescription("Recenter map on my location")
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun testPlaceholderGrid(): Unit = runBlocking {
         val viewModel =
             MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -10,12 +10,17 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.navigation.compose.ComposeNavigator
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
+import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +47,13 @@ class HomeMapViewTests {
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
                 viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {}),
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
 
@@ -68,7 +79,13 @@ class HomeMapViewTests {
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel = viewModel
+                viewModel = viewModel,
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
         viewModel.loadConfig()
@@ -94,7 +111,13 @@ class HomeMapViewTests {
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel = viewModel
+                viewModel = viewModel,
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
         viewModel.loadConfig()
@@ -119,7 +142,13 @@ class HomeMapViewTests {
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
                 viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {}),
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
 
@@ -145,7 +174,13 @@ class HomeMapViewTests {
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
                 viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {}),
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
 
@@ -166,7 +201,13 @@ class HomeMapViewTests {
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel = viewModel
+                viewModel = viewModel,
+                searchResultsViewModel =
+                    SearchResultsViewModel(
+                        MockAnalytics(),
+                        MockSearchResultRepository(),
+                        VisitHistoryUsecase(MockVisitHistoryRepository())
+                    )
             )
         }
         composeTestRule.onNodeWithTag("Empty map grid").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -31,6 +31,7 @@ import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.IMapViewModel
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.util.LocalActivity
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
@@ -55,6 +56,9 @@ import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
+import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.Flow
@@ -293,7 +297,13 @@ class NearbyTransitPageTest : KoinTest {
                         false,
                         {},
                         {},
-                        bottomBar = {}
+                        searchResultsViewModel =
+                            SearchResultsViewModel(
+                                MockAnalytics(),
+                                MockSearchResultRepository(),
+                                VisitHistoryUsecase(MockVisitHistoryRepository())
+                            ),
+                        bottomBar = {},
                     )
                 }
             }
@@ -386,6 +396,12 @@ class NearbyTransitPageTest : KoinTest {
                         false,
                         {},
                         {},
+                        searchResultsViewModel =
+                            SearchResultsViewModel(
+                                MockAnalytics(),
+                                MockSearchResultRepository(),
+                                VisitHistoryUsecase(MockVisitHistoryRepository())
+                            ),
                         bottomBar = {},
                         mapViewModel = mockMapVM
                     )
@@ -426,6 +442,12 @@ class NearbyTransitPageTest : KoinTest {
                         false,
                         {},
                         {},
+                        searchResultsViewModel =
+                            SearchResultsViewModel(
+                                MockAnalytics(),
+                                MockSearchResultRepository(),
+                                VisitHistoryUsecase(MockVisitHistoryRepository())
+                            ),
                         bottomBar = {}
                     )
                 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -116,6 +116,7 @@ class SearchBarOverlayTest : KoinTest {
                     onStopNavigation = { navigated.value = true },
                     currentNavEntry = currentNavEntry.value,
                     inputFieldFocusRequester = focusRequester,
+                    searchResultsVm = koinApplication.koin.get(),
                 ) {
                     Text("Content")
                 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.MainApplication
 import com.mbta.tid.mbta_app.android.SheetRoutes
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.history.Visit
 import com.mbta.tid.mbta_app.history.VisitHistory
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -94,6 +95,7 @@ class SearchBarOverlayTest : KoinTest {
                         }
                     }
                 }
+                single<SearchResultsViewModel> { SearchResultsViewModel(get(), get(), get()) }
             }
         )
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -30,6 +30,7 @@ import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.pages.NearbyTransitPage
 import com.mbta.tid.mbta_app.android.pages.OnboardingPage
 import com.mbta.tid.mbta_app.android.phoenix.PhoenixSocketWrapper
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.subscribeToAlerts
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -67,6 +68,7 @@ fun ContentView(
     val scaffoldState =
         rememberBottomSheetScaffoldState(bottomSheetState = rememberStandardBottomSheetState())
     var navBarVisible by remember { mutableStateOf(true) }
+    val searchResultsVm = koinViewModel<SearchResultsViewModel>()
 
     LifecycleResumeEffect(null) {
         socket.attach()
@@ -120,7 +122,8 @@ fun ContentView(
                             navigateToMore = { navController.navigate(Routes.More) }
                         )
                     }
-                }
+                },
+                searchResultsViewModel = searchResultsVm,
             )
         }
         composable<Routes.More> {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -22,6 +22,7 @@ import com.mbta.tid.mbta_app.android.util.MapAnimationDefaults
 import com.mbta.tid.mbta_app.android.util.ViewportSnapshot
 import com.mbta.tid.mbta_app.android.util.followPuck
 import com.mbta.tid.mbta_app.android.util.isFollowingPuck
+import com.mbta.tid.mbta_app.android.util.isOverview
 import com.mbta.tid.mbta_app.android.util.isRoughlyEqualTo
 import com.mbta.tid.mbta_app.map.MapDefaults
 import com.mbta.tid.mbta_app.model.Stop
@@ -36,6 +37,7 @@ constructor(var viewport: MapViewportState, isManuallyCentering: Boolean = false
     var isManuallyCentering by mutableStateOf(isManuallyCentering)
     @OptIn(MapboxExperimental::class)
     var isFollowingPuck by mutableStateOf(viewport.isFollowingPuck)
+    @OptIn(MapboxExperimental::class) var isVehicleOverview by mutableStateOf(viewport.isOverview)
 
     private var savedNearbyTransitViewport: ViewportSnapshot? = null
 
@@ -63,6 +65,7 @@ constructor(var viewport: MapViewportState, isManuallyCentering: Boolean = false
         defaultTransitionOptions: DefaultViewportTransitionOptions = Defaults.viewportTransition
     ) {
         isFollowingPuck = true
+        isVehicleOverview = false
         this.viewport.transitionToFollowPuckState(
             followPuckViewportStateOptions =
                 FollowPuckViewportStateOptions.Builder()
@@ -77,6 +80,7 @@ constructor(var viewport: MapViewportState, isManuallyCentering: Boolean = false
     }
 
     fun vehicleOverview(vehicle: Vehicle, stop: Stop?, density: Density) {
+        isVehicleOverview = true
         if (stop == null) {
             animateTo(vehicle.position.toMapbox())
         } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -56,8 +56,10 @@ import com.mbta.tid.mbta_app.android.appVariant
 import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.getStopMapData
 import com.mbta.tid.mbta_app.android.util.LazyObjectQueue
+import com.mbta.tid.mbta_app.android.util.isOverview
 import com.mbta.tid.mbta_app.android.util.rememberPrevious
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.android.util.toPoint
@@ -84,7 +86,8 @@ fun HomeMapView(
     handleStopNavigation: (String) -> Unit,
     vehiclesData: List<Vehicle>,
     stopDetailsDepartures: StopDetailsDepartures?,
-    viewModel: IMapViewModel
+    viewModel: IMapViewModel,
+    searchResultsViewModel: SearchResultsViewModel,
 ) {
     var nearbyTransitSelectingLocation by nearbyTransitSelectingLocationState
     val previousNavEntry: SheetRoutes? = rememberPrevious(current = currentNavEntry)
@@ -103,6 +106,7 @@ fun HomeMapView(
             currentNavEntry is SheetRoutes.StopDetails
         }
     val previousSelectedVehicleId = rememberPrevious(current = selectedVehicle?.id)
+    val currentLocation = locationDataManager.currentLocation.collectAsState(initial = null).value
 
     val now = timer(updateInterval = 300.seconds)
     val globalMapData = viewModel.rememberGlobalMapData(now)
@@ -270,7 +274,6 @@ fun HomeMapView(
                 compass = {},
                 scaleBar = {},
                 logo = { Logo(Modifier.clearAndSetSemantics {}) },
-                attribution = { Attribution(alignment = Alignment.BottomEnd) },
                 mapViewportState = viewportProvider.viewport,
                 mapState = mapState,
                 style = {
@@ -399,31 +402,47 @@ fun HomeMapView(
                     }
                 }
             }
+            val recenterModifier =
+                if (isNearby)
+                    Modifier.align(Alignment.TopEnd)
+                        .padding(top = 85.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
+                        .statusBarsPadding()
+                else Modifier.align(Alignment.TopEnd).padding(16.dp).statusBarsPadding()
 
-            if (!viewportProvider.isFollowingPuck) {
-                val recenterModifier =
-                    if (isNearby) {
-                        Modifier.align(Alignment.TopEnd)
-                            .padding(top = 85.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
-                            .statusBarsPadding()
-                    } else {
-                        Modifier.align(Alignment.TopEnd).padding(16.dp).statusBarsPadding()
-                    }
-
-                if (locationDataManager.hasPermission) {
+            if (!viewportProvider.isFollowingPuck && isNearby) {
+                if (locationDataManager.hasPermission && currentLocation != null) {
                     RecenterButton(
                         onClick = { viewportProvider.follow() },
                         modifier = recenterModifier
                     )
-                }
-                if (isNearby) {
+                } else if (!locationDataManager.hasPermission) {
                     LocationAuthButton(
                         locationDataManager,
                         modifier =
                             Modifier.align(Alignment.TopCenter)
-                                .padding(top = 86.dp)
+                                .padding(top = 85.dp)
                                 .statusBarsPadding()
                     )
+                }
+            }
+
+            if (!viewportProvider.viewport.isOverview && !searchResultsViewModel.expanded) {
+                if (selectedVehicle != null) {
+                    val routeType =
+                        (globalResponse?.routes ?: emptyMap())[selectedVehicle.routeId]?.type
+                    if (routeType != null) {
+                        TripCenterButton(
+                            routeType = routeType,
+                            onClick = {
+                                viewportProvider.vehicleOverview(
+                                    selectedVehicle,
+                                    selectedStop,
+                                    density
+                                )
+                            },
+                            modifier = recenterModifier
+                        )
+                    }
                 }
             }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/TripCenterButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/TripCenterButton.kt
@@ -1,0 +1,29 @@
+package com.mbta.tid.mbta_app.android.map
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.routeIcon
+import com.mbta.tid.mbta_app.model.RouteType
+
+@Composable
+fun TripCenterButton(modifier: Modifier = Modifier, routeType: RouteType, onClick: () -> Unit) {
+    IconButton(
+        onClick = onClick,
+        modifier.semantics(mergeDescendants = true) {},
+        colors =
+            IconButtonDefaults.iconButtonColors(
+                containerColor = colorResource(R.color.fill3),
+                contentColor = colorResource(R.color.key)
+            )
+    ) {
+        val painter = routeIcon(routeType).first
+        Icon(painter, stringResource(R.string.recenter))
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -62,6 +62,7 @@ import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitView
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NoNearbyStopsView
 import com.mbta.tid.mbta_app.android.search.SearchBarOverlay
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
 import com.mbta.tid.mbta_app.android.stopDetails.stopDetailsManagedVM
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
@@ -117,6 +118,7 @@ fun NearbyTransitPage(
     hideNavBar: () -> Unit,
     bottomBar: @Composable () -> Unit,
     mapViewModel: IMapViewModel = viewModel(factory = MapViewModel.Factory()),
+    searchResultsViewModel: SearchResultsViewModel,
     errorBannerViewModel: ErrorBannerViewModel =
         viewModel(
             factory =
@@ -220,6 +222,7 @@ fun NearbyTransitPage(
 
     fun handleSearchExpandedChange(expanded: Boolean) {
         searchExpanded = expanded
+        searchResultsViewModel.expanded = expanded
         if (expanded) {
             hideNavBar()
             if (!nearbyTransit.hideMaps) {
@@ -429,7 +432,8 @@ fun NearbyTransitPage(
                 ::handleSearchExpandedChange,
                 ::handleStopNavigation,
                 currentNavEntry,
-                searchFocusRequester
+                searchFocusRequester,
+                searchResultsViewModel
             ) {
                 SheetContent(
                     Modifier.padding(top = if (isNearbyTransit) 94.dp else 0.dp)
@@ -476,7 +480,8 @@ fun NearbyTransitPage(
                     ::handleSearchExpandedChange,
                     ::handleStopNavigation,
                     currentNavEntry,
-                    searchFocusRequester
+                    searchFocusRequester,
+                    searchResultsViewModel
                 ) {
                     HomeMapView(
                         Modifier.padding(sheetPadding),
@@ -489,7 +494,8 @@ fun NearbyTransitPage(
                         handleStopNavigation = ::handleStopNavigation,
                         vehiclesData = vehiclesData,
                         stopDetailsDepartures = stopDetailsDepartures,
-                        viewModel = mapViewModel
+                        viewModel = mapViewModel,
+                        searchResultsViewModel = searchResultsViewModel,
                     )
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -42,7 +42,6 @@ import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
-import org.koin.androidx.compose.koinViewModel
 
 @ExperimentalMaterial3Api
 @Composable
@@ -52,6 +51,7 @@ fun SearchBarOverlay(
     onStopNavigation: (stopId: String) -> Unit,
     currentNavEntry: SheetRoutes?,
     inputFieldFocusRequester: FocusRequester,
+    searchResultsVm: SearchResultsViewModel,
     content: @Composable () -> Unit
 ) {
     var visible =
@@ -60,7 +60,6 @@ fun SearchBarOverlay(
         }
     var searchInputState by rememberSaveable { mutableStateOf("") }
     val globalResponse = getGlobalData("SearchBar.getGlobalData")
-    val searchResultsVm: SearchResultsViewModel = koinViewModel()
     val searchResults = searchResultsVm.searchResults.collectAsState(initial = null).value
 
     val buttonColors =
@@ -153,7 +152,7 @@ fun SearchBarOverlay(
                     onExpandedChange = {},
                 ) {
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize().background(colorResource(R.color.fill1)),
+                        modifier = Modifier.fillMaxSize().background(colorResource(R.color.fill2)),
                         contentPadding = PaddingValues(16.dp)
                     ) {
                         if (searchInputState.isEmpty()) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -152,7 +152,7 @@ fun SearchBarOverlay(
                     onExpandedChange = {},
                 ) {
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize().background(colorResource(R.color.fill2)),
+                        modifier = Modifier.fillMaxSize().background(colorResource(R.color.fill1)),
                         contentPadding = PaddingValues(16.dp)
                     ) {
                         if (searchInputState.isEmpty()) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSearchResults.kt
@@ -29,6 +29,7 @@ class SearchResultsViewModel(
     private var _searchResults: MutableStateFlow<SearchResults?> = MutableStateFlow(null)
     private var job: Job? = null
     val searchResults: StateFlow<SearchResults?> = _searchResults
+    var expanded = false
 
     fun getSearchResults(query: String, globalResponse: GlobalResponse?) {
         analytics.performedSearch(query)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
@@ -41,6 +41,7 @@ val MapViewportState.isOverview: Boolean
             ViewportStatus.Idle -> false
             is ViewportStatus.State -> status.state is OverviewViewportState
             is ViewportStatus.Transition -> status.toState is OverviewViewportState
+            null -> false
         }
 
 fun Double.roundedTo(places: Int): Double {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
@@ -6,6 +6,7 @@ import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mapbox.maps.plugin.viewport.ViewportStatus
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
 import com.mapbox.maps.plugin.viewport.state.FollowPuckViewportState
+import com.mapbox.maps.plugin.viewport.state.OverviewViewportState
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.math.pow
 import kotlin.math.round
@@ -31,6 +32,15 @@ val MapViewportState.isFollowingPuck: Boolean
             is ViewportStatus.State -> status.state is FollowPuckViewportState
             is ViewportStatus.Transition -> status.toState is FollowPuckViewportState
             null -> false
+        }
+
+@OptIn(MapboxExperimental::class)
+val MapViewportState.isOverview: Boolean
+    get() =
+        when (val status = this.mapViewportStatus) {
+            ViewportStatus.Idle -> false
+            is ViewportStatus.State -> status.state is OverviewViewportState
+            is ViewportStatus.Transition -> status.toState is OverviewViewportState
         }
 
 fun Double.roundedTo(places: Int): Double {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | stop + trip details | Recenter on vehicle button](https://app.asana.com/0/1205732265579288/1209118824865491)

What is this PR for?
Adds the button to show the overview of your selected vehicle/trip

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

Automated testing for reproducible map states, manual testing for the states we can't currently create in the test environment (going off existing test coverage).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
