### PR TITLE
fix(Android): Fix direction toggle nav bug

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModelTest.kt
@@ -53,6 +53,25 @@ class NearbyTransitTabViewModelTest {
     }
 
     @Test
+    fun testSetStopDetailsFilterDoesNothingIfFilterMatches() {
+        val vm = NearbyTransitTabViewModel()
+        val sameFilter = StopDetailsFilter("route_1", 0)
+
+        var popCalled = false
+        var pushCalled = false
+
+        vm.setStopFilter(
+            SheetRoutes.StopDetails("a", sameFilter, null),
+            "a",
+            sameFilter,
+            { popCalled = true },
+            { pushCalled = true }
+        )
+        assertFalse(pushCalled)
+        assertFalse(popCalled)
+    }
+
+    @Test
     fun testSetStopDetailsFilterOldFilterPoppedWhenNewAutoFilter() {
         val vm = NearbyTransitTabViewModel()
         val newFilter = StopDetailsFilter("route_1", 0, autoFilter = true)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModel.kt
@@ -26,11 +26,10 @@ class NearbyTransitTabViewModel : ViewModel() {
         pushNavEntry: (SheetRoutes) -> Unit
     ) {
 
-        if (
-            lastNavEntry is SheetRoutes.StopDetails &&
-                stopId == lastNavEntry.stopId &&
-                stopFilter != lastNavEntry.stopFilter
-        ) {
+        if (lastNavEntry is SheetRoutes.StopDetails && stopId == lastNavEntry.stopId) {
+            if (lastNavEntry.stopFilter == stopFilter) {
+                return
+            }
             if (shouldPopLastStopEntry(lastNavEntry.stopFilter, stopFilter)) {
                 popLastNavEntry()
             }
@@ -65,9 +64,8 @@ class NearbyTransitTabViewModel : ViewModel() {
         newStopId: String,
         newFilter: StopDetailsFilter?
     ): Boolean {
-        // If the new filter is nil and there is already a nil filter in the stack for the same stop
-        // ID,
-        // we don't want a duplicate unfiltered entry, so skip appending a new one
+        // If the new filter is null and there is already a null filter in the stack for the same
+        // stop ID, we don't want a duplicate unfiltered entry, so skip appending a new one
 
         return when (lastNavEntry) {
             is SheetRoutes.StopDetails -> {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Fix: Tapping direction toggle adds to nav stack](https://app.asana.com/0/1205732265579288/1209433346935160)

Don't add new navigation items to the stack when the direction toggle is tapped in the same direction that's already selected.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Manual testing