### PR TITLE
fix(Android): add French to list of languages with decimal plurals

### DIFF
--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -4,6 +4,7 @@
     <plurals name="affected_stops">
         <item quantity="one">&lt;b>%1$d&lt;/b> arrêt concerné</item>
         <item quantity="many">&lt;b>%1$d&lt;/b> arrêts concernés</item>
+        <item quantity="other">&lt;b>%1$d&lt;/b> arrêts concernés</item>
     </plurals>
     <string name="alert">Alerte</string>
     <string name="alert_details">Détails de l’alerte</string>
@@ -46,6 +47,7 @@
     <plurals name="elevator_closure_count">
         <item quantity="one">Ascenseur %1$d fermé</item>
         <item quantity="many">Ascenseurs %1$d fermés</item>
+        <item quantity="other">Ascenseurs %1$d fermés</item>
     </plurals>
     <string name="end">Fin</string>
     <string name="error_loading_data">Erreur dans le chargement des données</string>
@@ -193,6 +195,7 @@
     <plurals name="stops_away">
         <item quantity="one">%1$d arrêt restant</item>
         <item quantity="many">%1$d arrêts restants</item>
+        <item quantity="other">%1$d arrêts restants</item>
     </plurals>
     <string name="strike">Grève</string>
     <string name="suspension">Interruption</string>
@@ -213,6 +216,7 @@
     <plurals name="updated_mins_ago">
         <item quantity="one">Mis à jour il y a %1$d minute</item>
         <item quantity="many">Mis à jour il y a %1$d minutes</item>
+        <item quantity="other">Mis à jour il y a %1$d minutes</item>
     </plurals>
     <string name="vehicle_arriving_first">%1$s arrive maintenant</string>
     <string name="vehicle_arriving_other">et arrive maintenant</string>

--- a/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
+++ b/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/ConvertIosLocalizationTask.kt
@@ -118,11 +118,11 @@ abstract class ConvertIosLocalizationTask : DefaultTask() {
                 Plural(items.mapValues { convertIosTemplate(it.value) })
 
             fun itemsPotentiallyExtended(languageTag: String): Map<Quantity, String> {
-                // For Spanish and Portuguese, decimals are formatted under the `many` case rather
-                // than `other` (in Spanish, "2 days" is "2 días" but "0.5 days" is "0.5 de días"),
-                // and so Android complains that we have not given "many" even if it's not actually
-                // going to happen.
-                return if (languageTag in setOf("es", "pt-BR")) {
+                // For Spanish, French, and Portuguese, decimals are formatted under the `many` case
+                // rather than `other` (in Spanish, "2 days" is "2 días" but "0.5 days" is "0.5 de
+                // días"), and so Android complains that we have not given "many" even if it's not
+                // actually going to happen.
+                return if (languageTag in setOf("es", "fr", "pt-BR")) {
                     val otherTranslation = items.getValue(Quantity.other)
                     // only patch this if the quantity is actually formatted as an integer
                     if (otherTranslation.contains("%1\$d")) {


### PR DESCRIPTION
### Summary

_Ticket:_ none

This is a weird corner of the conversion script; if we planned to be adding new languages on a regular basis, it'd be worth trying to detect this issue in the script and give a more useful warning, but we do not.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Verified that the in-tree data now matches the script output and does not cause the lint message about missing cases.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
