### PR TITLE
fix(Android): handle NNBSP in 12-hour times when testing on recent API levels

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -3,6 +3,8 @@ package com.mbta.tid.mbta_app.android
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.captureToImage
@@ -13,6 +15,18 @@ fun hasClickActionLabel(expected: String?) =
     SemanticsMatcher("has click action label $expected") { node ->
         node.config[SemanticsActions.OnClick].label == expected
     }
+
+fun hasTextMatching(regex: Regex): SemanticsMatcher {
+    val propertyName = "${SemanticsProperties.Text.name} + ${SemanticsProperties.EditableText.name}"
+    return SemanticsMatcher("$propertyName matches $regex") {
+        val isInEditableTextValue =
+            it.config.getOrNull(SemanticsProperties.EditableText)?.text?.matches(regex) ?: false
+        val isInTextValue =
+            it.config.getOrNull(SemanticsProperties.Text)?.any { item -> item.text.matches(regex) }
+                ?: false
+        isInEditableTextValue || isInTextValue
+    }
+}
 
 @OptIn(ExperimentalStdlibApi::class)
 private fun colorToHex(color: Color): String {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -72,7 +73,11 @@ class AlertDetailsTest {
         composeTestRule.onNodeWithText("Full Description").assertIsDisplayed()
         composeTestRule.onNodeWithText(alert.description!!).assertIsDisplayed()
         composeTestRule.onNodeWithText(alert.header!!).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Updated: 1/22/25, 10:36 AM").assertIsDisplayed()
+        // as of probably API 34, this has a U+202F Narrow No-Break Space instead of U+0020 Space,
+        // so to make the test work either way we need a regex
+        composeTestRule
+            .onNode(hasTextMatching(Regex("Updated: 1/22/25, 10:36\\sAM")))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
@@ -81,7 +82,7 @@ class TripStopRowTest {
             )
         }
 
-        composeTestRule.onNodeWithText("3:37 PM").assertIsDisplayed()
+        composeTestRule.onNode(hasTextMatching(Regex("3:37\\sPM"))).assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
### Summary

_Ticket:_ none

I think it's Android 14 (API 34) that introduced this change, but it's hard to tell.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Ran the tests on a recent API level AVD and confirmed that they now pass instead of failing.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
