### PR TITLE
fix(Android): draw map under sheet regardless of sheet state

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.map
 
 import android.location.Location
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -8,7 +9,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import androidx.navigation.compose.ComposeNavigator
+import androidx.compose.ui.unit.dp
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
@@ -25,24 +26,27 @@ class HomeMapViewTests {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testRecenterNotShownWhenNoPermissions() {
-
+    fun testRecenterNotShownWhenNoPermissions() = runBlocking {
         val locationManager = MockLocationDataManager(Location("mock"))
 
         locationManager.hasPermission = false
 
+        val viewModel =
+            MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewModel.loadConfig()
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = locationManager,
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = null,
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                viewModel = viewModel
             )
         }
 
@@ -58,12 +62,15 @@ class HomeMapViewTests {
         locationManager.hasPermission = true
         val viewModel =
             MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewModel.loadConfig()
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = locationManager,
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = null,
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
@@ -71,7 +78,6 @@ class HomeMapViewTests {
                 viewModel = viewModel
             )
         }
-        viewModel.loadConfig()
         composeTestRule
             .onNodeWithContentDescription("Recenter map on my location")
             .assertIsDisplayed()
@@ -84,12 +90,15 @@ class HomeMapViewTests {
         locationManager.hasPermission = false
         val viewModel =
             MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewModel.loadConfig()
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = locationManager,
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = SheetRoutes.NearbyTransit,
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
@@ -97,29 +106,31 @@ class HomeMapViewTests {
                 viewModel = viewModel
             )
         }
-        viewModel.loadConfig()
         composeTestRule.onNodeWithText("Location Services is off").assertIsDisplayed()
     }
 
     @Test
-    fun testLocationAuthNotShownWhenPermissions() {
-
+    fun testLocationAuthNotShownWhenPermissions() = runBlocking {
         val locationManager = MockLocationDataManager(Location("mock"))
 
         locationManager.hasPermission = true
 
+        val viewModel =
+            MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewModel.loadConfig()
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = locationManager,
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = null,
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                viewModel = viewModel
             )
         }
 
@@ -127,25 +138,27 @@ class HomeMapViewTests {
     }
 
     @Test
-    fun testLocationAuthNotShownStopDetails() {
-
+    fun testLocationAuthNotShownStopDetails() = runBlocking {
         val locationManager = MockLocationDataManager(Location("mock"))
 
         locationManager.hasPermission = false
 
-        val destination = ComposeNavigator().createDestination()
+        val viewModel =
+            MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewModel.loadConfig()
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = locationManager,
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = SheetRoutes.StopDetails("stopId", null, null),
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),
                 stopDetailsDepartures = null,
-                viewModel =
-                    MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+                viewModel = viewModel
             )
         }
 
@@ -156,12 +169,14 @@ class HomeMapViewTests {
     fun testPlaceholderGrid(): Unit = runBlocking {
         val viewModel =
             MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
+        val viewportProvider = ViewportProvider(MapViewportState())
         composeTestRule.setContent {
             HomeMapView(
+                sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
                 locationDataManager = MockLocationDataManager(Location("mock")),
-                viewportProvider = ViewportProvider(MapViewportState()),
+                viewportProvider = viewportProvider,
                 currentNavEntry = null,
                 handleStopNavigation = {},
                 vehiclesData = emptyList(),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -262,6 +262,8 @@ class NearbyTransitPageTest : KoinTest {
         )
     }
 
+    val viewportProvider = ViewportProvider(MapViewportState())
+
     @get:Rule
     val runtimePermissionRule =
         GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION)
@@ -288,7 +290,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
+                            viewportProvider = viewportProvider,
                         ),
                         false,
                         {},
@@ -381,7 +383,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
+                            viewportProvider = viewportProvider,
                         ),
                         false,
                         {},
@@ -421,7 +423,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
+                            viewportProvider = viewportProvider,
                         ),
                         false,
                         {},

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
+import MockRepositories
 import android.app.Activity
 import android.location.Location
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -20,7 +21,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.test.rule.GrantPermissionRule
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.MapboxExperimental
-import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.MainApplication
@@ -65,7 +66,6 @@ import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
-import org.koin.core.module.dsl.*
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.test.KoinTest
@@ -288,7 +288,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = ViewportProvider(rememberMapViewportState()),
+                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
                         ),
                         false,
                         {},
@@ -381,7 +381,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = ViewportProvider(rememberMapViewportState()),
+                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
                         ),
                         false,
                         {},
@@ -421,7 +421,7 @@ class NearbyTransitPageTest : KoinTest {
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
                             locationDataManager = MockLocationDataManager(Location("mock")),
-                            viewportProvider = ViewportProvider(rememberMapViewportState()),
+                            viewportProvider = remember { ViewportProvider(MapViewportState()) },
                         ),
                         false,
                         {},

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -62,6 +62,7 @@ import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.getStopMapData
 import com.mbta.tid.mbta_app.android.util.LazyObjectQueue
 import com.mbta.tid.mbta_app.android.util.isOverview
+import com.mbta.tid.mbta_app.android.util.plus
 import com.mbta.tid.mbta_app.android.util.rememberPrevious
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.android.util.toPoint
@@ -280,9 +281,14 @@ fun HomeMapView(
                 Modifier.fillMaxSize(),
                 compass = {},
                 scaleBar = {},
-                logo = { Logo(Modifier.clearAndSetSemantics {}, sheetPadding) },
+                logo = {
+                    Logo(Modifier.clearAndSetSemantics {}, sheetPadding + PaddingValues(8.dp))
+                },
                 attribution = {
-                    Attribution(contentPadding = sheetPadding, alignment = Alignment.BottomEnd)
+                    Attribution(
+                        contentPadding = sheetPadding + PaddingValues(8.dp),
+                        alignment = Alignment.BottomEnd
+                    )
                 },
                 mapViewportState = viewportProvider.viewport,
                 mapState = mapState,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -22,6 +23,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -75,7 +77,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun HomeMapView(
-    modifier: Modifier = Modifier,
+    sheetPadding: PaddingValues,
     lastNearbyTransitLocation: Position?,
     nearbyTransitSelectingLocationState: MutableState<Boolean>,
     locationDataManager: LocationDataManager,
@@ -115,6 +117,7 @@ fun HomeMapView(
     val analytics: Analytics = koinInject()
     val context = LocalContext.current
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
 
     fun handleStopClick(map: MapView, point: Point): Boolean {
         val pixel = map.mapboxMap.pixelForCoordinate(point)
@@ -253,7 +256,11 @@ fun HomeMapView(
         mapState.cameraChangedEvents.collect { viewportProvider.updateCameraState(it.cameraState) }
     }
 
-    Box(modifier, contentAlignment = Alignment.Center) {
+    LaunchedEffect(viewportProvider, sheetPadding) {
+        viewportProvider.setSheetPadding(sheetPadding, density, layoutDirection)
+    }
+
+    Box(contentAlignment = Alignment.Center) {
         /* Whether loading the config succeeds or not we show the Mapbox Map in case
          * the user has cached tiles on their device.
          */
@@ -269,8 +276,10 @@ fun HomeMapView(
                 Modifier.fillMaxSize(),
                 compass = {},
                 scaleBar = {},
-                logo = { Logo(Modifier.clearAndSetSemantics {}) },
-                attribution = { Attribution(alignment = Alignment.BottomEnd) },
+                logo = { Logo(Modifier.clearAndSetSemantics {}, sheetPadding) },
+                attribution = {
+                    Attribution(contentPadding = sheetPadding, alignment = Alignment.BottomEnd)
+                },
                 mapViewportState = viewportProvider.viewport,
                 mapState = mapState,
                 style = {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -479,7 +479,7 @@ fun NearbyTransitPage(
                     searchFocusRequester
                 ) {
                     HomeMapView(
-                        Modifier.padding(sheetPadding),
+                        sheetPadding = sheetPadding,
                         lastNearbyTransitLocation = nearbyTransit.lastNearbyTransitLocation,
                         nearbyTransitSelectingLocationState =
                             nearbyTransit.nearbyTransitSelectingLocationState,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/PaddingArithmetic.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/PaddingArithmetic.kt
@@ -1,0 +1,37 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+
+private class ArithmeticPadding(
+    private val p1: PaddingValues,
+    private val p2: PaddingValues,
+    private val math: (x: Dp, y: Dp) -> Dp
+) : PaddingValues {
+    override fun calculateBottomPadding(): Dp {
+        return math(p1.calculateBottomPadding(), p2.calculateBottomPadding())
+    }
+
+    override fun calculateLeftPadding(layoutDirection: LayoutDirection): Dp {
+        return math(
+            p1.calculateLeftPadding(layoutDirection),
+            p2.calculateLeftPadding(layoutDirection)
+        )
+    }
+
+    override fun calculateRightPadding(layoutDirection: LayoutDirection): Dp {
+        return math(
+            p1.calculateRightPadding(layoutDirection),
+            p2.calculateRightPadding(layoutDirection)
+        )
+    }
+
+    override fun calculateTopPadding(): Dp {
+        return math(p1.calculateTopPadding(), p2.calculateTopPadding())
+    }
+}
+
+operator fun PaddingValues.plus(other: PaddingValues): PaddingValues {
+    return ArithmeticPadding(this, other) { x, y -> x + y }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Fix partial black map issues](https://app.asana.com/0/1205732265579288/1209367654923213)

This was easy until I ran the tests.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manually verified that the map peeks out from under the corners of the sheet, that the Mapbox logo and attribution are visible when the map is visible, and that the logical center is properly maintained in all map states.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
