### PR TITLE
feat(android.MorePage): Remove debug sentry crash button

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -9,7 +9,6 @@ import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import com.mbta.tid.mbta_app.model.morePage.localizedFeedbackFormUrl
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
-import io.sentry.kotlin.multiplatform.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -112,13 +111,6 @@ class MoreViewModel(
                             label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults,
                             value = settings[Settings.SearchRouteResults] ?: false
-                        ),
-                        MoreItem.Action(
-                            label = "Crash App",
-                            action = {
-                                Sentry.captureMessage("Debug test sentry message")
-                                throw RuntimeException("Debug test crash")
-                            }
                         )
                     )
             ),


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket. Removes the sentry test crash button now that we know Sentry is properly configured. Something that is crawling the staging app keeps hitting this button and causing [noise in our alerts channel](https://mbta.slack.com/archives/C08242XU3RR/p1739289614762199).

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ran locally, confirmed no crash button

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
