### PR TITLE
fix(iOS): Never hide background tab bar

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -33,7 +33,6 @@ struct ContentView: View {
 
     @State private var selectedTab = SelectedTab.nearby
     @State private var sheetTabBarVisibility = Visibility.hidden
-    @State private var baseTabBarVisibility = Visibility.hidden
 
     func updateTabBarVisibility(_ tab: SelectedTab) {
         let shouldShowSheetTabBar = !contentVM.hideMaps
@@ -42,11 +41,6 @@ struct ContentView: View {
             && !searchObserver.isSearching
 
         sheetTabBarVisibility = shouldShowSheetTabBar ? .visible : .hidden
-
-        let shouldShowBaseTabBar = tab == SelectedTab.more || (
-            contentVM.hideMaps && nearbyVM.navigationStack.lastSafe() == .nearby && !searchObserver.isSearching
-        )
-        baseTabBarVisibility = shouldShowBaseTabBar ? .visible : .hidden
     }
 
     var body: some View {
@@ -120,21 +114,13 @@ struct ContentView: View {
         } else {
             TabView(selection: $selectedTab) {
                 nearbyTab
-                    .toolbar(baseTabBarVisibility, for: .tabBar, .bottomBar)
                     .tag(SelectedTab.nearby)
                     .tabItem { TabLabel(tab: SelectedTab.nearby) }
                 MorePage(viewModel: settingsVM)
                     .tag(SelectedTab.more)
                     .tabItem { TabLabel(tab: SelectedTab.more) }
                     .onAppear { analytics.track(screen: .settings) }
-            }.accessibilityHidden(
-                // We don't want the nav bar behind the sheet to show up in VoiceOver when the sheet is open,
-                // but setting accessibilityHidden to true on this TabView also results in all of the non-sheet
-                // content in nearbyTab to be hidden, including the search bar and recenter button. The extra check
-                // to make it visible to VO when nearby transit is open is to ensure that the search is not hidden,
-                // though it does result in a second tab bar in VoiceOver on the nearby page and search overlay.
-                baseTabBarVisibility == .hidden && !contentVM.hideMaps && nearbyVM.navigationStack.lastSafe() != .nearby
-            )
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Fix: Extra tab bar when hide maps enabled](https://app.asana.com/0/1205732265579288/1209391330487797)

Follow up removing the partial fix for the background tab bar showing up in VoiceOver when it isn't visible on the page, since hiding it was breaking the mapbox attribution positioning and the more page tab bar.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Verified that the mapbox attributions are now positioned properly, but I could never reproduce the missing tab bar background on More.