### PR TITLE
fix(iOS): work through onboarding punchlist

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -10720,7 +10720,7 @@
       }
     },
     "Service suspended" : {
-      "comment" : "Possible alert effect\n   Suspension alert VoiceOver text",
+      "comment" : "Possible alert effect\nSuspension alert VoiceOver text",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -249,9 +249,11 @@ struct AlertDetails: View {
         if !alertDescriptionParagraphs.isEmpty {
             VStack(alignment: .leading, spacing: 16) {
                 if isElevatorClosure {
-                    Text("Alternative path", comment: "Header for the details of an elevator closure").bold()
+                    Text("Alternative path", comment: "Header for the details of an elevator closure")
+                        .font(Typography.bodySemibold)
                 } else {
-                    Text("Full Description", comment: "Header for the details of a disruption").bold()
+                    Text("Full Description", comment: "Header for the details of a disruption")
+                        .font(Typography.bodySemibold)
                 }
                 ForEach(alertDescriptionParagraphs, id: \.hashValue) { section in
                     Text(section).fixedSize(horizontal: false, vertical: true)
@@ -297,6 +299,7 @@ struct AlertDetails: View {
 
     var body: some View {
         scrollContent
+            .font(Typography.body)
     }
 }
 

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -29,7 +29,7 @@ struct OnboardingScreenView: View {
 
     // Use less padding on smaller screens
     private var bottomPadding: CGFloat { screenHeight < 812 ? 16 : 52 }
-    private var sidePadding: CGFloat { screenWidth < 393 ? 16 : 32 }
+    private var sidePadding: CGFloat { 32 }
 
     private var locationHaloSize: CGFloat { screenWidth * 0.8 }
     private var moreHaloSize: CGFloat { screenWidth * 0.55 }
@@ -237,6 +237,7 @@ struct OnboardingScreenView: View {
                 .dynamicTypeSize(...DynamicTypeSize.accessibility4)
                 .padding(.horizontal, sidePadding)
                 .padding(.bottom, bottomPadding)
+                .foregroundStyle(Color.text)
                 .background {
                     ZStack(alignment: .center) {
                         Image(.onboardingBackgroundMap)

--- a/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
+++ b/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
@@ -15,6 +15,7 @@ struct PromoScreenView: View {
     let advance: () -> Void
 
     @AccessibilityFocusState private var focusHeader: FeaturePromo?
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.dynamicTypeSize) var typeSize
 
     private var screenHeight: CGFloat { UIScreen.current?.bounds.height ?? 852.0 }
@@ -22,7 +23,7 @@ struct PromoScreenView: View {
 
     // Use less padding on smaller screens
     private var bottomPadding: CGFloat { screenHeight < 812 ? 16 : 52 }
-    private var sidePadding: CGFloat { screenWidth < 393 ? 16 : 32 }
+    private var sidePadding: CGFloat { 32 }
 
     let inspection = Inspection<Self>()
 
@@ -95,11 +96,13 @@ struct PromoScreenView: View {
                 ).fullWidthKeyButton()
             }
         }
+        .foregroundStyle(Color.text)
         .padding(.horizontal, sidePadding)
         .padding(.bottom, bottomPadding)
+        .frame(maxWidth: .infinity)
         .background {
             ZStack(alignment: .center) {
-                Color.fill2.edgesIgnoringSafeArea(.all)
+                (colorScheme == .dark ? Color.fill1 : Color.fill2).edgesIgnoringSafeArea(.all)
             }
         }
     }

--- a/iosApp/iosApp/Utils/Typography.swift
+++ b/iosApp/iosApp/Utils/Typography.swift
@@ -10,51 +10,112 @@ import SwiftUI
 
 /// Presets for all fonts in the design system of the app. Any style not included here is not present in the design
 /// system and is probably not supposed to be used.
-enum Typography {
-    static let largeTitle = Font.custom("Inter", size: 36, relativeTo: .largeTitle).monospacedDigit()
-    static let largeTitleBold = largeTitle.bold()
+///
+/// For some reason, SwiftUI Fonts can only have a leading of Font.Leading.standard, .loose (+2pt), or .tight (-2pt).
+/// Our designs call for more control than that.
+struct Typography {
+    let font: Font
+    let lineSpacing: CGFloat
 
-    static let title1 = Font.custom("Inter", size: 32, relativeTo: .title).monospacedDigit()
+    private init(font: Font, lineSpacing: CGFloat) {
+        self.font = font
+        self.lineSpacing = lineSpacing
+    }
+
+    init(size: CGFloat, lineHeight: CGFloat, relativeTo: Font.TextStyle) {
+        font = Font.custom("Inter", size: size, relativeTo: relativeTo).monospacedDigit()
+        // Inter's intrinsic line height ratio appears to be 1.21x, and SwiftUI lineSpacing is additional on top of the
+        // intrinsic value
+        lineSpacing = lineHeight - (size * (40 / 33))
+    }
+
+    func weight(_ weight: Font.Weight) -> Self {
+        .init(font: font.weight(weight), lineSpacing: lineSpacing)
+    }
+
+    func bold() -> Self { weight(.bold) }
+
+    func italic() -> Self { .init(font: font.italic(), lineSpacing: lineSpacing) }
+
+    static let largeTitle = Typography(size: 36, lineHeight: 40, relativeTo: .largeTitle)
+    static let largeTileBold = largeTitle.bold()
+
+    static let title1 = Typography(size: 32, lineHeight: 36, relativeTo: .title)
     static let title1Bold = title1.bold()
 
-    static let title2 = Font.custom("Inter", size: 24, relativeTo: .title2).monospacedDigit()
+    static let title2 = Typography(size: 24, lineHeight: 32, relativeTo: .title2)
     static let title2Bold = title2.bold()
 
-    static let title3 = Font.custom("Inter", size: 20, relativeTo: .title3).monospacedDigit()
+    static let title3 = Typography(size: 20, lineHeight: 28, relativeTo: .title3)
     static let title3Semibold = title3.weight(.semibold)
 
-    static let headline = Font.custom("Inter", size: 17, relativeTo: .headline).monospacedDigit()
+    static let headline = Typography(size: 17, lineHeight: 24, relativeTo: .headline)
     static let headlineSemibold = headline.weight(.semibold)
     static let headlineBold = headline.bold()
     static let headlineBoldItalic = headlineBold.italic()
 
-    static let body = Font.custom("Inter", size: 17, relativeTo: .body).monospacedDigit()
+    static let body = Typography(size: 17, lineHeight: 24, relativeTo: .body)
     static let bodySemibold = body.weight(.semibold)
     static let bodyItalic = body.italic()
     static let bodySemiboldItalic = bodySemibold.italic()
 
-    static let callout = Font.custom("Inter", size: 16, relativeTo: .callout).monospacedDigit()
+    static let callout = Typography(size: 16, lineHeight: 22, relativeTo: .callout)
     static let calloutSemibold = callout.weight(.semibold)
     static let calloutItalic = callout.italic()
     static let calloutSemiboldItalic = calloutSemibold.italic()
 
-    static let subheadline = Font.custom("Inter", size: 15, relativeTo: .subheadline).monospacedDigit()
+    static let subheadline = Typography(size: 15, lineHeight: 20, relativeTo: .subheadline)
     static let subheadlineSemibold = subheadline.weight(.semibold)
     static let subheadlineItalic = subheadline.italic()
     static let subheadlineSemiboldItalic = subheadlineSemibold.italic()
 
-    static let footnote = Font.custom("Inter", size: 13, relativeTo: .footnote).monospacedDigit()
+    static let footnote = Typography(size: 13, lineHeight: 18, relativeTo: .footnote)
     static let footnoteSemibold = footnote.weight(.semibold)
     static let footnoteItalic = footnote.italic()
     static let footnoteSemiboldItalic = footnoteSemibold.italic()
 
-    static let caption = Font.custom("Inter", size: 12, relativeTo: .caption).monospacedDigit()
+    static let caption = Typography(size: 12, lineHeight: 16, relativeTo: .caption)
     static let captionMedium = caption.weight(.medium)
     static let captionItalic = caption.italic()
     static let captionMediumItalic = captionMedium.italic()
 
-    static let caption2 = Font.custom("Inter", size: 11, relativeTo: .caption2).monospacedDigit()
+    static let caption2 = Typography(size: 11, lineHeight: 13, relativeTo: .caption2)
     static let caption2Semibold = caption2.weight(.semibold)
     static let caption2Italic = caption2.italic()
     static let caption2SemiboldItalic = caption2Semibold.italic()
+}
+
+extension View {
+    func font(_ typography: Typography) -> some View {
+        font(typography.font).lineSpacing(typography.lineSpacing)
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 24) {
+        Text(verbatim: "Samples").font(Typography.caption).textCase(.uppercase).tracking(1)
+        Text(verbatim: "Long titles may wrap onto one or more lines")
+            .font(Typography.largeTileBold)
+        Text(verbatim: "Section title").font(Typography.title1Bold)
+        Text(
+            verbatim: "Body text empowers riders who rely on public transit to easily get to their destination in all service conditions."
+        )
+        .font(Typography.body)
+        Text(verbatim: "Riders use the app to make decisions based on trustworthy, curated, MBTA-specific information.")
+            .font(Typography.bodySemibold)
+        Text(verbatim: """
+        12:34—>
+        10:45—>
+        11:56—>
+        """)
+        .font(Typography.body)
+        VStack(alignment: .leading) {
+            Text(verbatim: "Tabular numerals are monospaced for better readability").font(Typography.caption)
+            Text(verbatim: "All caps label, based on “Caption” style?").textCase(.uppercase).tracking(1)
+                .font(Typography.caption)
+        }
+    }
+    .multilineTextAlignment(.leading)
+    .frame(width: 334)
+    .padding(64)
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS | Onboarding punch list](https://app.asana.com/0/1201654106676769/1209433125172607)

I forgot that we would be able to use the same name for the typography extension method; that simplifies things a lot. It's weird that the way SwiftUI handles line height is so inflexible.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Checked in previews and in the live app that things look more correct now than they did previously.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
