### PR TITLE
fix(Android): give sheet padding to map crosshair while panning

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/Crosshairs.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/Crosshairs.kt
@@ -1,15 +1,18 @@
 package com.mbta.tid.mbta_app.android.map
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import com.mbta.tid.mbta_app.android.R
 
 @Composable
-fun Crosshairs() {
-    Column {
+fun Crosshairs(sheetPadding: PaddingValues) {
+    Column(Modifier.padding(sheetPadding)) {
         Icon(
             painterResource(R.drawable.map_nearby_location_cursor),
             contentDescription = null,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -394,7 +394,7 @@ fun HomeMapView(
                                 .annotationAnchor { anchor(ViewAnnotationAnchor.CENTER) }
                                 .build()
                     ) {
-                        Crosshairs()
+                        Crosshairs(PaddingValues(0.dp))
                     }
                 }
 
@@ -472,7 +472,7 @@ fun HomeMapView(
             }
 
             if (nearbyTransitSelectingLocation) {
-                Crosshairs()
+                Crosshairs(sheetPadding = sheetPadding)
             }
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ none

I forgot to check this in #765; the crosshair currently draws at the center of the full map regardless of how much of the map is behind the sheet, which is incorrect and not helpful.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
