### PR TITLE
fix(android.PredictionRowView): Don't crash if missing trip from map

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -96,18 +96,21 @@ fun PredictionRowView(
                                         isOnly = index == 0 && predictions.trips.count() == 1
                                     )
                                     if (pillDecoration is PillDecoration.OnPrediction) {
-                                        val route =
-                                            pillDecoration.routesByTrip.getValue(prediction.id)
-                                        RoutePill(
-                                            route,
-                                            null,
-                                            RoutePillType.Flex,
-                                            modifier =
-                                                Modifier.wrapContentHeight(
-                                                        Alignment.CenterVertically
-                                                    )
-                                                    .scale(0.75f)
-                                        )
+                                        val route: Route? =
+                                            pillDecoration.routesByTrip[prediction.id]
+
+                                        if (route != null) {
+                                            RoutePill(
+                                                route,
+                                                null,
+                                                RoutePillType.Flex,
+                                                modifier =
+                                                    Modifier.wrapContentHeight(
+                                                            Alignment.CenterVertically
+                                                        )
+                                                        .scale(0.75f)
+                                            )
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Fix Added trip crash ](https://app.asana.com/0/1205732265579288/1209465916321745)

What is this PR for?
There was a crash report for when there was a prediction for an added trip that wasn't yet present in the trip map. 

For consistency with the [iOS PredictionRowView](https://github.com/mbta/mobile_app/blob/e261a263e0d7e4cfefcad026d9e4ee25c0a6f754/iosApp/iosApp/ComponentViews/PredictionRowView.swift#L90), the RoutePill is only rendered if there is a route present in `routesByTrip`.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ran locally with the route forced to null, confirmed that GL predictions still render without the pill.
![Screenshot_20250221_124500](https://github.com/user-attachments/assets/3231fbd2-6ca8-45b7-935a-8092cef5c6c0)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
