### PR TITLE
fix(Android): Info icon layout

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TightWrapText.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/TightWrapText.kt
@@ -1,0 +1,50 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import kotlin.math.ceil
+import kotlin.math.floor
+
+// Copied from here: https://issuetracker.google.com/issues/206039942#comment32
+// Workaround for that bug, which causes all Text components with line breaks to take up
+// the maximum available width, leaving a bunch of empty whitespace after the string.
+@Composable
+fun TightWrapText(text: String, modifier: Modifier = Modifier, style: TextStyle = TextStyle()) {
+    var textLayoutResult: TextLayoutResult? by remember { mutableStateOf(null) }
+    Text(
+        text = text,
+        modifier =
+            modifier.layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                val newTextLayoutResult = textLayoutResult
+
+                if (newTextLayoutResult == null || newTextLayoutResult.lineCount == 0) {
+                    // Default behavior if there is no text
+                    layout(placeable.width, placeable.height) { placeable.placeRelative(0, 0) }
+                } else {
+                    val minX =
+                        (0 until newTextLayoutResult.lineCount).minOf(
+                            newTextLayoutResult::getLineLeft
+                        )
+                    val maxX =
+                        (0 until newTextLayoutResult.lineCount).maxOf(
+                            newTextLayoutResult::getLineRight
+                        )
+
+                    layout(ceil(maxX - minX).toInt(), placeable.height) {
+                        placeable.place(-floor(minX).toInt(), 0)
+                    }
+                }
+            },
+        onTextLayout = { textLayoutResult = it },
+        style = style
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -46,6 +48,7 @@ import androidx.compose.ui.zIndex
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.InfoCircle
+import com.mbta.tid.mbta_app.android.component.TightWrapText
 import com.mbta.tid.mbta_app.android.component.UpcomingTripView
 import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.component.routeIcon
@@ -202,7 +205,11 @@ private fun ScheduleDescription(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(stringResource(R.string.scheduled_to_depart), style = Typography.footnote)
+                TightWrapText(
+                    stringResource(R.string.scheduled_to_depart),
+                    Modifier.weight(1f, fill = false),
+                    style = Typography.footnote
+                )
                 if (clickable) {
                     InfoCircle(Modifier.aspectRatio(1f).size(16.dp))
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
@@ -23,8 +23,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Fix scheduled to depart info icon](https://app.asana.com/0/1205732265579288/1209465916321750)

Workaround for an annoying and old [Android bug](https://issuetracker.google.com/issues/206039942).

![Screenshot_20250221_155708](https://github.com/user-attachments/assets/449d9b1f-4b82-493f-85c7-948b74537302) ![Screenshot_20250221_155607](https://github.com/user-attachments/assets/7415acc8-82e8-4141-bb4a-de392e6e40e2) ![Screenshot_20250221_155633](https://github.com/user-attachments/assets/e8234564-4596-45db-b006-24b50bd7734b)



android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Tested layout at different text sizes.
