### PR TITLE
fix(Android): only persist zoom and center, not edge insets

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ViewportSnapshot.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ViewportSnapshot.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.util
 
+import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.CameraState
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
-import com.mapbox.maps.toCameraOptions
 
 @OptIn(MapboxExperimental::class)
 class ViewportSnapshot(val isFollowingPuck: Boolean?, val camera: CameraState?) {
@@ -19,7 +19,7 @@ class ViewportSnapshot(val isFollowingPuck: Boolean?, val camera: CameraState?) 
             mapViewportState.followPuck(zoom = camera?.zoom)
         } else if (camera != null) {
             mapViewportState.easeTo(
-                camera.toCameraOptions(),
+                CameraOptions.Builder().zoom(camera.zoom).center(camera.center).build(),
                 animationOptions = MapAnimationDefaults.options
             )
         }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1740173937802989)

Re-applying the insets when we restore might've worked too.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Verified that the bug Paul recorded doesn't happen anymore.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
