### PR TITLE
fix(android.weights): Adjust weights for elevator alert, stopped X stops away

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyStopView.kt
@@ -61,7 +61,7 @@ fun NearbyStopView(
                             start =
                                 if (showElevatorAccessibility && hasElevatorAlerts) 0.dp else 8.dp
                         )
-                        .weight(1f),
+                        .weight(.6f),
                 style = Typography.callout
             )
             if (showElevatorAccessibility && hasElevatorAlerts) {
@@ -72,7 +72,7 @@ fun NearbyStopView(
                             patternsAtStop.elevatorAlerts.size,
                             patternsAtStop.elevatorAlerts.size
                         ),
-                    modifier = Modifier.placeholderIfLoading().alpha(0.6f),
+                    modifier = Modifier.placeholderIfLoading().alpha(0.6f).weight(.4f),
                     style = Typography.footnote
                 )
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -129,7 +129,7 @@ fun TripStopRow(
                         ) {
                             UpcomingTripView(
                                 upcomingTripViewState(stop, now, routeAccents),
-                                Modifier.alpha(0.6f).padding(end = 12.dp).weight(0.6F),
+                                Modifier.alpha(0.6f).padding(end = 12.dp).width(IntrinsicSize.Min),
                                 routeType = routeAccents.type,
                                 hideRealtimeIndicators = true
                             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -129,7 +129,7 @@ fun TripStopRow(
                         ) {
                             UpcomingTripView(
                                 upcomingTripViewState(stop, now, routeAccents),
-                                Modifier.alpha(0.6f).padding(end = 12.dp),
+                                Modifier.alpha(0.6f).padding(end = 12.dp).weight(0.6F),
                                 routeType = routeAccents.type,
                                 hideRealtimeIndicators = true
                             )
@@ -255,6 +255,37 @@ private fun TripStopRowPreview() {
     val objects = ObjectCollectionBuilder()
     MyApplicationTheme {
         Column(Modifier.background(colorResource(R.color.fill3))) {
+            TripStopRow(
+                stop =
+                    TripDetailsStopList.Entry(
+                        objects.stop { name = "Charles/MGH" },
+                        stopSequence = 10,
+                        disruption = null,
+                        schedule = null,
+                        prediction = objects.prediction { status = "Stopped 5 stops away" },
+                        predictionStop = null,
+                        vehicle = null,
+                        routes =
+                            listOf(
+                                objects.route {
+                                    longName = "Red Line"
+                                    color = "DA291C"
+                                    textColor = "FFFFFF"
+                                },
+                                objects.route {
+                                    longName = "Green Line"
+                                    color = "00843D"
+                                    textColor = "FFFFFF"
+                                }
+                            )
+                    ),
+                Clock.System.now(),
+                onTapLink = {},
+                TripRouteAccents.default.copy(
+                    type = RouteType.HEAVY_RAIL,
+                    color = Color.fromHex("DA291C")
+                )
+            )
             TripStopRow(
                 stop =
                     TripDetailsStopList.Entry(


### PR DESCRIPTION
### Summary


What is this PR for?
No ticket, from [slack convo](https://mbta.slack.com/archives/C05QMG9GS9M/p1740174183461249). 

Adjusts some weights so that long text doesn't take up too much space in rows. Probably will play a bit more with the stopped X stops away weighting so it isn't cut off so badly

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
![Screenshot_20250221_172359](https://github.com/user-attachments/assets/347aca56-5e24-4fc9-8045-a4196c34a16d)

![Screenshot_20250221_170622](https://github.com/user-attachments/assets/b8a66602-77fe-4394-922e-e84c2aff6d1e)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
