### PR TITLE
fix(Android): show recenter button on stop details

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/MockLocationDataManager.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/MockLocationDataManager.kt
@@ -3,6 +3,6 @@ package com.mbta.tid.mbta_app.android.location
 import android.location.Location
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class MockLocationDataManager(location: Location) : LocationDataManager() {
+class MockLocationDataManager(location: Location?) : LocationDataManager() {
     override val currentLocation = MutableStateFlow(location)
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -104,8 +104,7 @@ class HomeMapViewTests {
 
     @Test
     fun testLocationAuthShownWhenNoPermissions(): Unit = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
-
+        val locationManager = MockLocationDataManager(null)
         locationManager.hasPermission = false
         val viewModel =
             MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
@@ -243,7 +242,7 @@ class HomeMapViewTests {
     }
 
     @Test
-    fun testOverviewNotShownStopDetails(): Unit = runBlocking {
+    fun testOverviewShownOnStopDetails(): Unit = runBlocking {
         val locationManager = MockLocationDataManager(Location("mock"))
 
         locationManager.hasPermission = true
@@ -272,9 +271,7 @@ class HomeMapViewTests {
                     )
             )
         }
-        composeTestRule
-            .onNodeWithContentDescription("Recenter map on my location")
-            .assertDoesNotExist()
+        composeTestRule.onNodeWithContentDescription("Recenter map on my location").assertExists()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -3,7 +3,9 @@ package com.mbta.tid.mbta_app.android.map
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -428,46 +430,54 @@ fun HomeMapView(
                     }
                 }
             }
-            val recenterModifier =
-                if (isNearby)
-                    Modifier.align(Alignment.TopEnd)
-                        .padding(top = 85.dp, start = 16.dp, end = 16.dp, bottom = 16.dp)
-                        .statusBarsPadding()
-                else Modifier.align(Alignment.TopEnd).padding(16.dp).statusBarsPadding()
 
-            if (!viewportProvider.isFollowingPuck && isNearby) {
-                if (locationDataManager.hasPermission && currentLocation != null) {
-                    RecenterButton(
-                        onClick = { viewportProvider.follow() },
-                        modifier = recenterModifier
-                    )
-                } else if (!locationDataManager.hasPermission) {
-                    LocationAuthButton(
-                        locationDataManager,
-                        modifier =
-                            Modifier.align(Alignment.TopCenter)
-                                .padding(top = 85.dp)
-                                .statusBarsPadding()
-                    )
-                }
+            if (
+                !locationDataManager.hasPermission &&
+                    isNearby &&
+                    currentLocation == null &&
+                    !viewportProvider.isFollowingPuck
+            ) {
+                LocationAuthButton(
+                    locationDataManager,
+                    modifier =
+                        Modifier.align(Alignment.TopCenter).padding(top = 85.dp).statusBarsPadding()
+                )
             }
 
-            if (!viewportProvider.viewport.isOverview && !searchResultsViewModel.expanded) {
-                if (selectedVehicle != null) {
-                    val routeType =
-                        (globalResponse?.routes ?: emptyMap())[selectedVehicle.routeId]?.type
-                    if (routeType != null) {
-                        TripCenterButton(
-                            routeType = routeType,
-                            onClick = {
-                                viewportProvider.vehicleOverview(
-                                    selectedVehicle,
-                                    selectedStop,
-                                    density
-                                )
-                            },
-                            modifier = recenterModifier
-                        )
+            val recenterContainerModifier =
+                if (isNearby)
+                    Modifier.align(Alignment.TopEnd).padding(top = 85.dp).statusBarsPadding()
+                else Modifier.align(Alignment.TopEnd).padding(top = 16.dp).statusBarsPadding()
+
+            Column(recenterContainerModifier, Arrangement.spacedBy(16.dp)) {
+                if (
+                    !viewportProvider.isFollowingPuck &&
+                        locationDataManager.hasPermission &&
+                        currentLocation != null
+                ) {
+                    RecenterButton(
+                        onClick = { viewportProvider.follow() },
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+
+                if (!viewportProvider.viewport.isOverview && !searchResultsViewModel.expanded) {
+                    if (selectedVehicle != null) {
+                        val routeType =
+                            (globalResponse?.routes ?: emptyMap())[selectedVehicle.routeId]?.type
+                        if (routeType != null) {
+                            TripCenterButton(
+                                routeType = routeType,
+                                onClick = {
+                                    viewportProvider.vehicleOverview(
+                                        selectedVehicle,
+                                        selectedStop,
+                                        density
+                                    )
+                                },
+                                modifier = Modifier.padding(horizontal = 16.dp)
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

No ticket

What is this PR for?

Show the recenter on current location button in stop details.

![Screenshot_20250221_164629](https://github.com/user-attachments/assets/b6889ef3-5ba5-4a91-99e4-1ed57cba3198)
![Screenshot_20250221_164353](https://github.com/user-attachments/assets/5e0af918-8306-400b-97b8-dafe9b032114)
![Screenshot_20250221_164341](https://github.com/user-attachments/assets/531a6572-8ea9-49d7-875c-80647d08b501)

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
