### PR TITLE
fix: always exclude shuttles from Green Line grouping

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyHierarchy.kt
@@ -241,7 +241,7 @@ data class NearbyHierarchy(private val data: ByLineOrRoute) {
         private fun lineOrRoute(global: GlobalResponse, routeId: String): LineOrRoute? {
             val route = global.routes[routeId] ?: return null
             val line = global.lines[route.lineId]
-            return if (line?.isGrouped == true) {
+            return if (line?.isGrouped == true && !route.isShuttle) {
                 val routes =
                     global.routes.values.filter { it.lineId == line.id && !it.isShuttle }.toSet()
                 LineOrRoute.Line(line, routes)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -243,14 +243,17 @@ data class NearbyStaticData(val data: List<TransitWithStops>) {
                 }
             }
 
-            val byLine = patternsByRouteAndStop.entries.groupBy { it.key.lineId }
+            val byLine =
+                patternsByRouteAndStop.entries.groupBy { (route, _) ->
+                    route.lineId?.takeUnless { route.isShuttle }
+                }
 
             val touchedLines = mutableSetOf<Line>()
 
             patternsByRouteAndStop
                 .mapNotNull { (route, patternsByStop) ->
                     val line = global.lines[route.lineId]
-                    val isGrouped = line?.isGrouped == true
+                    val isGrouped = line?.isGrouped == true && !route.isShuttle
                     val lineRoutes = byLine[line?.id]?.map { (route, _) -> route } ?: emptyList()
 
                     if (isGrouped && touchedLines.contains(line)) {


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Remove shuttles from Green Line groups](https://app.asana.com/0/1205425564113216/1208091797262204)

This was so easy that we probably shouldn't've waited this long to do it.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Added a unit test. Verified by subtracting two days when loading schedules and when calculating nearby transit that this would have worked during the most recent shuttle instance.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
