### PR TITLE
refactor: add some indirection to setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,18 +1,9 @@
 name: Set up build environment
 description: Installs Java and/or Ruby
 inputs:
-  java:
-    default: false
-    description: Install Java
-  kotlin-cache:
-    default: false
-    description: Cache the Kotlin compiler directory
-  rsvg:
-    default: false
-    description: Install rsvg-convert (needed for Android builds)
-  ruby:
-    default: false
-    description: Install Ruby
+  for:
+    required: true
+    description: The context for which the build environment should be configured; implies which tasks to run
   gcp-provider:
     description: Google Cloud Platform Workload Identity Provider
     required: false
@@ -22,13 +13,39 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Determine required tools
+      id: settings
+      shell: bash
+      run: |
+        case ${{ inputs.for }} in
+          pre-commit)
+            tools="java"
+            ;;
+          android-test)
+            tools="java kotlin-cache rsvg"
+            ;;
+          android-build)
+            tools="java kotlin-cache rsvg ruby"
+            ;;
+          android-deploy)
+            tools="ruby"
+            ;;
+          *)
+            echo "::error::Unknown setup for: ${{ inputs.for }}"
+            false
+            ;;
+        esac
+        echo "tools=$tools"
+        for tool in $tools; do
+          echo "$tool=true" >> "$GITHUB_OUTPUT"
+        done
     - name: Read asdf versions
-      if: inputs.java == 'true'
+      if: steps.settings.outputs.java == 'true'
       id: asdf
       shell: bash
       run: cat .tool-versions | sed 's/ /=/' | tee -a "$GITHUB_OUTPUT"
     - name: Parse java version
-      if: inputs.java == 'true'
+      if: steps.settings.outputs.java == 'true'
       id: java-spec
       shell: bash
       run: |
@@ -37,20 +54,20 @@ runs:
         echo "java-distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
         echo "java-version=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Set up Java
-      if: inputs.java == 'true'
+      if: steps.settings.outputs.java == 'true'
       uses: actions/setup-java@v4
       with:
         distribution: ${{steps.java-spec.outputs.java-distribution}}
         java-version: ${{steps.java-spec.outputs.java-version}}
         cache: gradle
     - uses: actions/cache@v4
-      if: inputs.kotlin-cache == 'true'
+      if: steps.settings.outputs.kotlin-cache == 'true'
       with:
         path: ~/.konan
         key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
         restore-keys: konan-${{ runner.os }}
     - run: sudo apt-get install librsvg2-bin
-      if: inputs.rsvg == 'true'
+      if: steps.settings.outputs.rsvg == 'true'
       shell: bash
     - name: Configure GCP Credentials
       if: inputs.gcp-provider != '' && inputs.gcp-service-account != ''
@@ -60,11 +77,11 @@ runs:
         workload_identity_provider: ${{ inputs.gcp-provider }}
         service_account: ${{ inputs.gcp-service-account }}
     - name: Set up Ruby
-      if: inputs.ruby == 'true'
+      if: steps.settings.outputs.ruby == 'true'
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
     - name: Patch Fastlane to pick up application default credentials
-      if: inputs.ruby == 'true'
+      if: steps.settings.outputs.ruby == 'true'
       run: bin/patch-fastlane.sh
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -84,8 +84,9 @@ runs:
       with:
         secret-ids: |
           mobile-app-android-upload-key-passphrase
-    - name: Load code signing key
+    - name: Load Android code signing key
       if: steps.settings.outputs.aws-secrets-android == 'true' && inputs.aws-role != ''
+      shell: bash
       run: |
         cd androidApp
         aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,6 +4,9 @@ inputs:
   for:
     required: true
     description: The context for which the build environment should be configured; implies which tasks to run
+  aws-role:
+    description: Amazon Web Services role ARN to assume
+    required: false
   gcp-provider:
     description: Google Cloud Platform Workload Identity Provider
     required: false
@@ -25,7 +28,7 @@ runs:
             tools="java kotlin-cache rsvg"
             ;;
           android-build)
-            tools="java kotlin-cache rsvg ruby"
+            tools="java kotlin-cache rsvg ruby aws-secrets-android"
             ;;
           android-deploy)
             tools="ruby"
@@ -69,6 +72,23 @@ runs:
     - run: sudo apt-get install librsvg2-bin
       if: steps.settings.outputs.rsvg == 'true'
       shell: bash
+    - name: Configure AWS Credentials
+      if: inputs.aws-role != ''
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-role }}
+        aws-region: us-east-1
+    - name: Fetch AWS secrets for Android
+      if: steps.settings.outputs.aws-secrets-android == 'true' && inputs.aws-role != ''
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          mobile-app-android-upload-key-passphrase
+    - name: Load code signing key
+      if: steps.settings.outputs.aws-secrets-android == 'true' && inputs.aws-role != ''
+      run: |
+        cd androidApp
+        aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks
     - name: Configure GCP Credentials
       if: inputs.gcp-provider != '' && inputs.gcp-service-account != ''
       uses: google-github-actions/auth@v2

--- a/.github/workflows/android-deploy.yaml
+++ b/.github/workflows/android-deploy.yaml
@@ -22,22 +22,9 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           for: android-build
+          aws-role: ${{ secrets.AWS_ROLE_ARN }}
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Fetch AWS secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            mobile-app-android-upload-key-passphrase
-      - name: Load code signing key
-        run: |
-          cd androidApp
-          aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks
       - name: Build Android app
         env:
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}

--- a/.github/workflows/android-deploy.yaml
+++ b/.github/workflows/android-deploy.yaml
@@ -21,10 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
-          ruby: true
+          for: android-build
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Configure AWS Credentials
@@ -79,9 +76,9 @@ jobs:
           path: androidApp/build/outputs/bundle/prodRelease
       - uses: ./.github/actions/setup
         with:
+          for: android-deploy
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          ruby: true
       - name: Upload to Google Play
         run: |
           bundle exec fastlane android internal flavor:Prod

--- a/.github/workflows/android-staging-deploy.yaml
+++ b/.github/workflows/android-staging-deploy.yaml
@@ -105,22 +105,9 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           for: android-build
+          aws-role: ${{ secrets.AWS_ROLE_ARN }}
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Fetch AWS secrets
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: |
-            mobile-app-android-upload-key-passphrase
-      - name: Load code signing key
-        run: |
-          cd androidApp
-          aws secretsmanager get-secret-value --secret-id mobile-app-android-upload-key --output json | jq -r '.SecretBinary' | base64 --decode > upload-keystore.jks
       - name: Build Android app
         env:
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}

--- a/.github/workflows/android-staging-deploy.yaml
+++ b/.github/workflows/android-staging-deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
+          for: pre-commit
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -36,9 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
+          for: android-test
       - run: ./gradlew spotlessCheck
       - name: shared checks & unit tests
         run: ./gradlew shared:check
@@ -73,9 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
+          for: android-test
       # full setup including AVD snapshot caching from https://github.com/ReactiveCircus/android-emulator-runner/blob/a3dcdb348bb02349cd939d168a74e31a9094b7f0/README.md
       - name: Enable KVM
         run: |
@@ -108,10 +104,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
-          ruby: true
+          for: android-build
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Configure AWS Credentials
@@ -170,9 +163,9 @@ jobs:
           path: androidApp/build/outputs/bundle/stagingRelease
       - uses: ./.github/actions/setup
         with:
+          for: android-deploy
           gcp-provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          ruby: true
       - name: Upload to Google Play
         run: |
           bundle exec fastlane android internal flavor:Staging

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
+          for: pre-commit
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -35,9 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
+          for: android-test
       - run: ./gradlew spotlessCheck
       - name: shared checks & unit tests
         run: ./gradlew shared:check
@@ -72,9 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
+          for: android-test
       # full setup including AVD snapshot caching from https://github.com/ReactiveCircus/android-emulator-runner/blob/a3dcdb348bb02349cd939d168a74e31a9094b7f0/README.md
       - name: Enable KVM
         run: |
@@ -107,10 +103,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
         with:
-          java: true
-          kotlin-cache: true
-          rsvg: true
-          ruby: true
+          for: android-build
       - name: Build Android app
         env:
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}


### PR DESCRIPTION
### Summary

_Ticket:_ [Move iOS CI/CD to GitHub Actions](https://app.asana.com/0/1205732265579288/1209226816339255)

If we regularly need the same tools for the same reasons, it's more legible if we separate the reasons from the tools themselves. This is a change I had in #555 that seems worth splitting out into a standalone refactor.

I also realized that the AWS and Android code signing setup would make sense to have as part of this action. Hopefully that all works, because it'll be difficult to test from this branch.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Looked for uses of the setup action that are not updated here already and didn't see any.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
