### PR TITLE
fix button toggling and add some extra padding around vehicle overview viewport

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -101,6 +101,7 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
 
     fun vehicleOverview(vehicle: Vehicle, stop: Stop?, density: Density) {
         isVehicleOverview = true
+        isFollowingPuck = false
         if (stop == null) {
             animateTo(vehicle.position.toMapbox())
         } else {
@@ -214,7 +215,7 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
             fun overviewPadding(density: Density) =
                 with(density) {
                     EdgeInsets(
-                        75.dp.toPx().toDouble(),
+                        95.dp.toPx().toDouble(),
                         50.dp.toPx().toDouble(),
                         75.dp.toPx().toDouble(),
                         50.dp.toPx().toDouble()


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: stop details map buttons ](https://app.asana.com/0/1205732265579288/1209485723122809)

What is this PR for?

Fixes an issue where both recenter and trip center buttons would disappear when toggling between them. Also adds a 20px padding for when the selected vehicle is in the top right of the screen.

![Screenshot_20250224_154858](https://github.com/user-attachments/assets/81fc9812-a590-492a-8e78-9a00720d68c8)

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
Manual, unfortunately hard to test map interactions currently

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
