### PR TITLE
ci: run iOS tests in GitHub Actions

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -27,6 +27,9 @@ runs:
           android-test)
             tools="java kotlin-cache rsvg"
             ;;
+          ios-test)
+            tools="java kotlin-cache ruby xcode"
+            ;;
           android-build)
             tools="java kotlin-cache rsvg ruby aws-secrets-android"
             ;;
@@ -67,8 +70,8 @@ runs:
       if: steps.settings.outputs.kotlin-cache == 'true'
       with:
         path: ~/.konan
-        key: konan-${{ runner.os }}-${{ hashFiles('build.gradle.kts') }}
-        restore-keys: konan-${{ runner.os }}
+        key: konan-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('build.gradle.kts') }}
+        restore-keys: konan-${{ runner.os }}-${{ runner.arch }}
     - run: sudo apt-get install librsvg2-bin
       if: steps.settings.outputs.rsvg == 'true'
       shell: bash
@@ -106,3 +109,19 @@ runs:
       if: steps.settings.outputs.ruby == 'true'
       run: bin/patch-fastlane.sh
       shell: bash
+    - name: Configure Xcode version
+      if: steps.settings.outputs.xcode == 'true'
+      shell: bash
+      run: |
+        sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+    - name: Cache CocoaPods dependencies
+      if: steps.settings.outputs.xcode == 'true'
+      uses: actions/cache@v4
+      with:
+        path: iosApp/Pods
+        key: cocoapods-${{ hashFiles('iosApp/Podfile.lock') }}
+        restore-keys: cocoapods-
+    - name: Install SwiftLint and xcbeautify
+      if: steps.settings.outputs.xcode == 'true'
+      shell: bash
+      run: brew install swiftlint xcbeautify

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,13 +83,13 @@ jobs:
             echo "export SENTRY_DSN=${SENTRY_DSN}"
             echo "export SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}"
             echo "export FIREBASE_KEY=${FIREBASE_KEY}"
-            echo "export GOOGLE_APP_ID=${GOOGLE_APP_ID}"
+            echo "export GOOGLE_APP_ID_IOS=${GOOGLE_APP_ID_IOS}"
           } >> .envrc
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
-          GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
+          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
       - name: Run emulator tests
         run: |
           bundle exec fastlane ios test \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,55 @@ jobs:
         with:
           name: android-android-reports
           path: androidApp/build/reports
+  test-ios:
+    name: Test for iOS
+    runs-on: macos-14-xlarge
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          for: ios-test
+      - name: Install CocoaPods dependencies
+        run: |
+          ./gradlew :shared:generateDummyFramework
+          pushd iosApp
+          bundle exec pod install
+          popd
+          bundle exec ./gradlew :shared:podInstallSyntheticIos
+      - name: shared checks & unit tests
+        run: ./gradlew shared:iosSimulatorArm64Test shared:iosX64Test
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ios-shared-reports
+          path: shared/build/reports
+      - name: Add build environment variables
+        run: |
+          {
+            echo "export SENTRY_DSN=${SENTRY_DSN}"
+            echo "export SENTRY_ENVIRONMENT=${SENTRY_ENVIRONMENT}"
+            echo "export FIREBASE_KEY=${FIREBASE_KEY}"
+            echo "export GOOGLE_APP_ID=${GOOGLE_APP_ID}"
+          } >> .envrc
+        env:
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          SENTRY_ENVIRONMENT: staging
+          FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
+          GOOGLE_APP_ID: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
+      - name: Run emulator tests
+        run: |
+          bundle exec fastlane ios test \
+            output_directory:~/xctest \
+            xcodebuild_formatter:"xcbeautify --renderer github-actions"
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: ios-ios-results
+          path: ~/xctest/resultbundle-*.xcresult
   emulator-test-android:
     name: Run Android instrumented tests in emulator
     runs-on: mobile_app_runner

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,13 +93,12 @@ jobs:
       - name: Run emulator tests
         run: |
           bundle exec fastlane ios test \
-            output_directory:~/xctest \
             xcodebuild_formatter:"xcbeautify --renderer github-actions"
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ios-ios-results
-          path: ~/xctest/resultbundle-*.xcresult
+          path: fastlane/test_output/*
   emulator-test-android:
     name: Run Android instrumented tests in emulator
     runs-on: mobile_app_runner

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ xcuserdata
 .kotlin
 
 fastlane/report.xml
+fastlane/test_output
 
 /iosApp/secrets/*
 /iosApp/Pods/*

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,3 +79,18 @@ platform :android do
     )
   end
 end
+
+platform :ios do
+  desc "Run tests"
+  lane :test do |options|
+    run_tests(
+      workspace: "iosApp/iosApp.xcworkspace",
+      scheme: "Staging",
+      device: "iPhone 15 (17.5)",
+      testplan: "iosAppRetries",
+      output_directory: options[:output_directory],
+      xcodebuild_formatter: options[:xcodebuild_formatter],
+      number_of_retries: 3
+    )
+  end
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -33,6 +33,19 @@ Deploy a new version to Google Play for internal testing
 
 ----
 
+
+## iOS
+
+### ios test
+
+```sh
+[bundle exec] fastlane ios test
+```
+
+Run tests
+
+----
+
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 
 More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -140,13 +140,17 @@ if (DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX) {
     tasks.getByName("compileKotlinIosSimulatorArm64").dependsOn("bomCodegenIos")
 }
 
-if (System.getenv("CI_XCODE_CLOUD") != "TRUE") {
+// don't run Android BOM codegen for iOS-only CI
+if (
+    !(System.getenv("CI")?.lowercase() == "true" &&
+        DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX)
+) {
     tasks.getByName("preBuild").dependsOn("bomCodegenAndroid")
 }
 
 task<DependencyCodegenTask>("bomCodegenAndroid") {
     dependsOn("bomAndroid")
-    mustRunAfter("spotlessKotlin")
+    mustRunAfter("spotlessKotlin", "cyclonedxBom")
     inputPath = layout.buildDirectory.file("boms/bom-android.json")
     outputPath =
         layout.projectDirectory.file(


### PR DESCRIPTION
### Summary

_Ticket:_ [Move iOS CI/CD to GitHub Actions](https://app.asana.com/0/1205732265579288/1209226816339255)

I think this piece works and could be merged as-is to replace our PR CI workflow in Xcode Cloud. It's been a while, though; it might not still work. Also, there's risk of drift between our GitHub Actions CI for PRs and our Xcode Cloud CD for staging and production deploys, and if something works from GitHub Actions but fails from Xcode Cloud then our misery will be ceaseless, so it might make sense to leave the Xcode Cloud CI running until we get deployments from GitHub Actions working properly.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manually verified that on my local machine `bundle exec fastlane ios test` works (I think the tests that fail are the tests that always fail in Xcode 16). Checked that in #555 at this stage the workflow was working.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
