### PR TITLE
fix: keep showing BRD if vehicle is still present after prediction elapses

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -14,8 +14,8 @@ val SCHEDULE_CLOCK_CUTOFF = 60.minutes
 @Serializable
 data class Prediction(
     override val id: String,
-    @SerialName("arrival_time") val arrivalTime: Instant?,
-    @SerialName("departure_time") val departureTime: Instant?,
+    @SerialName("arrival_time") override val arrivalTime: Instant?,
+    @SerialName("departure_time") override val departureTime: Instant?,
     @SerialName("direction_id") val directionId: Int,
     val revenue: Boolean,
     @SerialName("schedule_relationship") val scheduleRelationship: ScheduleRelationship,
@@ -25,9 +25,7 @@ data class Prediction(
     @SerialName("stop_id") val stopId: String,
     @SerialName("trip_id") val tripId: String,
     @SerialName("vehicle_id") val vehicleId: String?,
-) : Comparable<Prediction>, BackendObject {
-    val predictionTime = arrivalTime ?: departureTime
-
+) : BackendObject, TripStopTime {
     @Serializable
     enum class ScheduleRelationship {
         @SerialName("added") Added,
@@ -37,7 +35,4 @@ data class Prediction(
         @SerialName("unscheduled") Unscheduled,
         @SerialName("scheduled") Scheduled
     }
-
-    override fun compareTo(other: Prediction): Int =
-        nullsLast<Instant>().compare(predictionTime, other.predictionTime)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
@@ -7,20 +7,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Schedule(
     override val id: String,
-    @SerialName("arrival_time") val arrivalTime: Instant?,
-    @SerialName("departure_time") val departureTime: Instant?,
+    @SerialName("arrival_time") override val arrivalTime: Instant?,
+    @SerialName("departure_time") override val departureTime: Instant?,
     @SerialName("drop_off_type") val dropOffType: StopEdgeType,
     @SerialName("pick_up_type") val pickUpType: StopEdgeType,
     @SerialName("stop_sequence") val stopSequence: Int,
     @SerialName("route_id") val routeId: String,
     @SerialName("stop_id") val stopId: String,
     @SerialName("trip_id") val tripId: String,
-) : Comparable<Schedule>, BackendObject {
-    val scheduleTime = arrivalTime ?: departureTime
-
-    override fun compareTo(other: Schedule): Int =
-        nullsLast<Instant>().compare(scheduleTime, other.scheduleTime)
-
+) : BackendObject, TripStopTime {
     @Serializable
     enum class StopEdgeType {
         /** Regularly scheduled drop off / pickup */

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -407,7 +407,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             tripId: String,
             directionId: Int
         ): RealtimePatterns.Format.Disruption? {
-            val entryTime = entry.prediction?.predictionTime ?: entry.schedule?.scheduleTime
+            val entryTime = (entry.prediction ?: entry.schedule)?.stopTime
             val entryRouteType = route?.type
 
             if (entryTime == null) return null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -1,0 +1,16 @@
+package com.mbta.tid.mbta_app.model
+
+import kotlinx.datetime.Instant
+
+interface TripStopTime : Comparable<TripStopTime> {
+    val arrivalTime: Instant?
+    val departureTime: Instant?
+
+    val stopTime
+        get() = arrivalTime ?: departureTime
+
+    fun stopTimeAfter(now: Instant) = arrivalTime?.takeUnless { it < now } ?: departureTime
+
+    override fun compareTo(other: TripStopTime): Int =
+        nullsLast<Instant>().compare(stopTime, other.stopTime)
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -39,9 +39,9 @@ constructor(
             prediction != null &&
                 prediction.scheduleRelationship != Prediction.ScheduleRelationship.Cancelled
         ) {
-            prediction.predictionTime
+            prediction.stopTime
         } else {
-            schedule?.scheduleTime
+            schedule?.stopTime
         }
 
     val stopId: String? = run {
@@ -58,7 +58,7 @@ constructor(
 
     val isCancelled: Boolean
         get() =
-            schedule?.scheduleTime != null &&
+            schedule?.stopTime != null &&
                 prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled
 
     val trackNumber: String? =
@@ -193,7 +193,7 @@ constructor(
                 .sorted()
                 .filter { upcomingTrip ->
                     if (upcomingTrip.prediction != null) return@filter true
-                    val scheduleTime = upcomingTrip.schedule?.scheduleTime ?: return@filter true
+                    val scheduleTime = upcomingTrip.schedule?.stopTime ?: return@filter true
                     scheduleTime >= filterAtTime
                 }
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -273,6 +273,34 @@ class TripInstantDisplayTest {
     }
 
     @Test
+    fun `still boarding if prediction in past`() = parametricTest {
+        val now = Clock.System.now()
+        val vehicle =
+            ObjectCollectionBuilder.Single.vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                stopId = "12345"
+                tripId = "trip1"
+            }
+        assertEquals(
+            TripInstantDisplay.Boarding,
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = now.minus(10.seconds)
+                        stopId = "12345"
+                        tripId = "trip1"
+                        vehicleId = vehicle.id
+                    },
+                schedule = null,
+                vehicle = vehicle,
+                now = now,
+                routeType = null,
+                context = nonTripDetails()
+            )
+        )
+    }
+
+    @Test
     fun `not boarding when stopped at stop but more than 90 seconds until departure`() =
         parametricTest {
             val now = Clock.System.now()


### PR DESCRIPTION
### Summary

_Ticket:_ [Show BRD even if prediction is in past](https://app.asana.com/0/1205732265579288/1209072793746974)

There are a lot of cases that we want to not change here, so I think this has made `TripInstantDisplay.from` more complicated. Perhaps it'd be worthwhile to have more explicitly diverging code paths per route type at some point.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Added unit test for new case.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
