### PR TITLE
Android location issues

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import MockRepositories
 import android.app.Activity
+import android.location.Location
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +25,7 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.MainApplication
 import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
@@ -347,7 +349,8 @@ class NearbyTransitPageTest : KoinTest {
             override val configLoadAttempted: StateFlow<Boolean> = MutableStateFlow(value = false)
             override val globalMapData: Flow<GlobalMapData?> = MutableStateFlow(value = null)
             override val selectedStop: StateFlow<Stop?> = MutableStateFlow(value = null)
-
+            override val showRecenterButton: StateFlow<Boolean> = MutableStateFlow(value = false)
+            override val showTripCenterButton: StateFlow<Boolean> = MutableStateFlow(value = false)
             var loadConfigCalledCount = 0
 
             override suspend fun loadConfig() {
@@ -374,6 +377,19 @@ class NearbyTransitPageTest : KoinTest {
             override fun setSelectedVehicle(selectedVehicle: Vehicle?) {}
 
             override fun setSelectedStop(stop: Stop?) {
+                TODO("Not yet implemented")
+            }
+
+            override fun hideCenterButtons() {
+                TODO("Not yet implemented")
+            }
+
+            override fun updateCenterButtonVisibility(
+                locationDataManager: LocationDataManager,
+                currentLocation: Location?,
+                viewportProvider: ViewportProvider,
+                searchRexsultsViewModel: SearchResultsViewModel
+            ) {
                 TODO("Not yet implemented")
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -385,10 +385,10 @@ class NearbyTransitPageTest : KoinTest {
             }
 
             override fun updateCenterButtonVisibility(
-                locationDataManager: LocationDataManager,
                 currentLocation: Location?,
-                viewportProvider: ViewportProvider,
-                searchRexsultsViewModel: SearchResultsViewModel
+                locationDataManager: LocationDataManager,
+                searchResultsViewModel: SearchResultsViewModel,
+                viewportProvider: ViewportProvider
             ) {
                 TODO("Not yet implemented")
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -14,7 +14,6 @@ import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
-import com.mapbox.maps.extension.style.expressions.dsl.generated.zoom
 import com.mapbox.maps.plugin.animation.MapAnimationOptions
 import com.mapbox.maps.plugin.viewport.data.DefaultViewportTransitionOptions
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
@@ -124,7 +123,7 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
         }
     }
 
-    fun stopOverview(stop: Stop) {
+    fun stopCenter(stop: Stop) {
         isFollowingPuck = false
         isVehicleOverview = false
         animateTo(stop.position.toMapbox())
@@ -204,7 +203,6 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
     }
 
     fun restoreNearbyTransitViewport() {
-        // TODO preserve zoom
         isFollowingPuck = savedNearbyTransitViewport?.isFollowingPuck ?: false
         isVehicleOverview = false
         isAnimating = true

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -194,6 +194,9 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
         // TODO preserve zoom
         savedNearbyTransitViewport?.restoreOn(viewport)
         savedNearbyTransitViewport = null
+        if (isFollowingPuck) {
+            follow()
+        }
     }
 
     fun setIsManuallyCentering(isManuallyCentering: Boolean) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -125,9 +125,8 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
     fun animateTo(
         coordinates: Point,
         animation: MapAnimationOptions = MapAnimationDefaults.options,
-        zoom: Double? = null
+        zoom: Double? = null,
     ) {
-        isFollowingPuck = false
         animateToCamera(
             options =
                 CameraOptions.Builder()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -152,7 +152,7 @@ fun HomeMapView(
 
     fun positionViewportToStop() {
         if (selectedStop != null) {
-            viewportProvider.stopOverview(selectedStop!!)
+            viewportProvider.stopCenter(selectedStop!!)
             viewModel.updateCenterButtonVisibility(
                 locationDataManager,
                 currentLocation,
@@ -344,10 +344,10 @@ fun HomeMapView(
                         viewModel.hideCenterButtons()
                     } else {
                         viewModel.updateCenterButtonVisibility(
-                            locationDataManager,
                             currentLocation,
-                            viewportProvider,
-                            searchResultsViewModel
+                            locationDataManager,
+                            searchResultsViewModel,
+                            viewportProvider
                         )
                     }
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -154,10 +154,10 @@ fun HomeMapView(
         if (selectedStop != null) {
             viewportProvider.stopCenter(selectedStop!!)
             viewModel.updateCenterButtonVisibility(
-                locationDataManager,
                 currentLocation,
-                viewportProvider,
-                searchResultsViewModel
+                locationDataManager,
+                searchResultsViewModel,
+                viewportProvider
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -2,8 +2,6 @@ package com.mbta.tid.mbta_app.android.map
 
 import android.location.Location
 import android.util.Log
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -77,10 +75,10 @@ interface IMapViewModel {
     fun setSelectedStop(stop: Stop?)
 
     fun updateCenterButtonVisibility(
-        locationDataManager: LocationDataManager,
         currentLocation: Location?,
-        viewportProvider: ViewportProvider,
-        searchResultsViewModel: SearchResultsViewModel
+        locationDataManager: LocationDataManager,
+        searchResultsViewModel: SearchResultsViewModel,
+        viewportProvider: ViewportProvider
     )
 
     fun hideCenterButtons()
@@ -211,10 +209,10 @@ open class MapViewModel(
     }
 
     override fun updateCenterButtonVisibility(
-        locationDataManager: LocationDataManager,
         currentLocation: Location?,
-        viewportProvider: ViewportProvider,
-        searchResultsViewModel: SearchResultsViewModel
+        locationDataManager: LocationDataManager,
+        searchResultsViewModel: SearchResultsViewModel,
+        viewportProvider: ViewportProvider
     ) {
         setShowRecenterButton(
             locationDataManager.hasPermission &&

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -425,6 +425,7 @@ fun NearbyTransitPage(
 
                 fun panToDefaultCenter() {
                     nearbyTransit.viewportProvider.isManuallyCentering = true
+                    nearbyTransit.viewportProvider.isFollowingPuck = false
                     nearbyTransit.viewportProvider.animateTo(
                         ViewportProvider.Companion.Defaults.center,
                         zoom = 13.75


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Android location issues](https://app.asana.com/0/1205732265579288/1209485724244302)

What is this PR for?

This PR fixes the issue in the second bullet of the linked ticket. The issue in the first bullet did not reproduce, but [Paul found another bug with the recenter button](https://mbta.slack.com/archives/C05QMG9GS9M/p1740672500855899?thread_ts=1740672061.625109&cid=C05QMG9GS9M) which this PR corrects.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?

Manual testing since we don't have a good way of testing location behavior

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
