### PR TITLE
fix(Android): update location with hide maps on

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.component
 
-import android.location.Location
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -18,7 +17,7 @@ class LocationAuthButtonTest {
     @Test
     fun testShowsWhenPermissionsNotGranted() {
 
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
         locationManager.hasPermission = false
 
         composeTestRule.setContent { LocationAuthButton(locationDataManager = locationManager) }
@@ -29,7 +28,7 @@ class LocationAuthButtonTest {
     @Test
     fun testHiddenWhenHasPermissions() {
 
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
         locationManager.hasPermission = true
 
         composeTestRule.setContent { LocationAuthButton(locationDataManager = locationManager) }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/MockLocationDataManager.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/MockLocationDataManager.kt
@@ -1,8 +1,20 @@
 package com.mbta.tid.mbta_app.android.location
 
 import android.location.Location
+import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class MockLocationDataManager(location: Location?) : LocationDataManager() {
-    override val currentLocation = MutableStateFlow(location)
+class MockLocationDataManager(position: Position? = Position(latitude = 0.0, longitude = 0.0)) :
+    LocationDataManager() {
+    override val currentLocation = MutableStateFlow(position?.let { MockLocation(it) })
+
+    fun moveTo(position: Position?) {
+        currentLocation.value = position?.let { MockLocation(it) }
+    }
+
+    data class MockLocation(val coordinates: Position) : Location("mock") {
+        override fun getLatitude() = coordinates.latitude
+
+        override fun getLongitude() = coordinates.longitude
+    }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.map
 
-import android.location.Location
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsDisplayed
@@ -32,7 +31,7 @@ class HomeMapViewTests {
 
     @Test
     fun testRecenterNotShownWhenNoPermissions() = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = false
 
@@ -69,7 +68,7 @@ class HomeMapViewTests {
 
     @Test
     fun testRecenterNotShownWhenPermissions(): Unit = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = true
         val viewModel =
@@ -136,7 +135,7 @@ class HomeMapViewTests {
 
     @Test
     fun testLocationAuthNotShownWhenPermissions() = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = true
 
@@ -171,7 +170,7 @@ class HomeMapViewTests {
 
     @Test
     fun testLocationAuthNotShownStopDetails() = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = false
 
@@ -206,7 +205,7 @@ class HomeMapViewTests {
 
     @Test
     fun testOverviewNotShownWhenNoPermissionsStopDetails() = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = false
 
@@ -243,7 +242,7 @@ class HomeMapViewTests {
 
     @Test
     fun testOverviewShownOnStopDetails(): Unit = runBlocking {
-        val locationManager = MockLocationDataManager(Location("mock"))
+        val locationManager = MockLocationDataManager()
 
         locationManager.hasPermission = true
         val viewModel =
@@ -284,7 +283,7 @@ class HomeMapViewTests {
                 sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
                 nearbyTransitSelectingLocationState = mutableStateOf(false),
-                locationDataManager = MockLocationDataManager(Location("mock")),
+                locationDataManager = MockLocationDataManager(),
                 viewportProvider = viewportProvider,
                 currentNavEntry = null,
                 handleStopNavigation = {},

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import MockRepositories
 import android.app.Activity
-import android.location.Location
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
@@ -292,7 +291,7 @@ class NearbyTransitPageTest : KoinTest {
                             nearbyTransitSelectingLocationState =
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(Location("mock")),
+                            locationDataManager = MockLocationDataManager(),
                             viewportProvider = viewportProvider,
                         ),
                         false,
@@ -397,7 +396,7 @@ class NearbyTransitPageTest : KoinTest {
                             nearbyTransitSelectingLocationState =
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(Location("mock")),
+                            locationDataManager = MockLocationDataManager(),
                             viewportProvider = viewportProvider,
                         ),
                         false,
@@ -443,7 +442,7 @@ class NearbyTransitPageTest : KoinTest {
                             nearbyTransitSelectingLocationState =
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(Location("mock")),
+                            locationDataManager = MockLocationDataManager(),
                             viewportProvider = viewportProvider,
                         ),
                         false,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.onboarding
 
-import android.location.Location
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -26,7 +25,7 @@ class OnboardingScreenViewTest {
     @Test
     fun testLocationFlow() {
         var advanced = false
-        val locationDataManager = MockLocationDataManager(Location("mock"))
+        val locationDataManager = MockLocationDataManager()
         composeTestRule.setContent {
             OnboardingScreenView(
                 screen = OnboardingScreen.Location,
@@ -63,7 +62,7 @@ class OnboardingScreenViewTest {
             OnboardingScreenView(
                 screen = OnboardingScreen.StationAccessibility,
                 advance = { advanced = true },
-                locationDataManager = MockLocationDataManager(Location("mock")),
+                locationDataManager = MockLocationDataManager(),
                 settingsRepository = settingsRepo
             )
         }
@@ -96,7 +95,7 @@ class OnboardingScreenViewTest {
             OnboardingScreenView(
                 screen = OnboardingScreen.HideMaps,
                 advance = { advanced = true },
-                locationDataManager = MockLocationDataManager(Location("mock")),
+                locationDataManager = MockLocationDataManager(),
                 settingsRepository = settingsRepo
             )
         }
@@ -120,7 +119,7 @@ class OnboardingScreenViewTest {
             OnboardingScreenView(
                 screen = OnboardingScreen.Feedback,
                 advance = { advanced = true },
-                locationDataManager = MockLocationDataManager(Location("mock")),
+                locationDataManager = MockLocationDataManager(),
             )
         }
         composeTestRule

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPageTest.kt
@@ -1,0 +1,164 @@
+package com.mbta.tid.mbta_app.android.pages
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
+import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.MainApplication
+import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.INearbyRepository
+import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
+import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.ITripRepository
+import com.mbta.tid.mbta_app.repositories.IVehicleRepository
+import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
+import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
+import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockTripRepository
+import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
+import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
+import com.mbta.tid.mbta_app.repositories.NearbyRepository
+import com.mbta.tid.mbta_app.repositories.PinnedRoutesRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import org.junit.Rule
+import org.junit.Test
+import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.KoinContext
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class NearbyTransitPageTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
+    @Test
+    fun testHideMapsLocationUpdates() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 =
+            objects.stop {
+                latitude = 1.0
+                longitude = 1.0
+                name = "Stop A"
+                vehicleType = RouteType.BUS
+            }
+        val stop2 =
+            objects.stop {
+                latitude = 2.0
+                longitude = 2.0
+                name = "Stop B"
+                vehicleType = RouteType.BUS
+            }
+        val route = objects.route { type = RouteType.BUS }
+        objects.routePattern(route) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
+        }
+
+        val alertData = AlertsStreamDataResponse(objects)
+        val globalResponse = GlobalResponse(objects)
+
+        val koin = koinApplication {
+            modules(
+                module {
+                    single<Analytics> { MockAnalytics() }
+                    single<IErrorBannerStateRepository> { MockErrorBannerStateRepository() }
+                    single<IGlobalRepository> { MockGlobalRepository(globalResponse) }
+                    single<INearbyRepository> { NearbyRepository() }
+                    single<IPinnedRoutesRepository> { PinnedRoutesRepository() }
+                    single<IPredictionsRepository> {
+                        MockPredictionsRepository(
+                            connectV2Response = PredictionsByStopJoinResponse(objects)
+                        )
+                    }
+                    single<ISchedulesRepository> {
+                        MockScheduleRepository(ScheduleResponse(objects))
+                    }
+                    single<ISearchResultRepository> { MockSearchResultRepository() }
+                    single<ISettingsRepository> {
+                        MockSettingsRepository(mapOf(Settings.HideMaps to true))
+                    }
+                    single<ITripRepository> { MockTripRepository() }
+                    single<ITripPredictionsRepository> { MockTripPredictionsRepository() }
+                    single<IVehicleRepository> { MockVehicleRepository() }
+                    single<IVehiclesRepository> { MockVehiclesRepository() }
+                    single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
+                    singleOf(::TogglePinnedRouteUsecase)
+                    singleOf(::VisitHistoryUsecase)
+                },
+                MainApplication.koinViewModelModule
+            )
+        }
+
+        val locationDataManager = MockLocationDataManager(stop1.position)
+
+        lateinit var viewportProvider: ViewportProvider
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                val mapViewportState = rememberMapViewportState()
+                viewportProvider = remember { ViewportProvider(mapViewportState) }
+
+                NearbyTransitPage(
+                    nearbyTransit =
+                        NearbyTransit(
+                            alertData = alertData,
+                            globalResponse = globalResponse,
+                            hideMaps = true,
+                            lastNearbyTransitLocationState = remember { mutableStateOf(null) },
+                            nearbyTransitSelectingLocationState =
+                                remember { mutableStateOf(false) },
+                            scaffoldState = rememberBottomSheetScaffoldState(),
+                            locationDataManager = locationDataManager,
+                            viewportProvider = viewportProvider
+                        ),
+                    navBarVisible = false,
+                    showNavBar = {},
+                    hideNavBar = {},
+                    bottomBar = {},
+                    searchResultsViewModel = koinViewModel()
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop1.name))
+        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
+
+        locationDataManager.moveTo(stop2.position)
+
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop2.name))
+        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/OnboardingPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/OnboardingPageTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.pages
 
-import android.location.Location
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -28,7 +27,7 @@ class OnboardingPageTest {
         composeTestRule.setContent {
             OnboardingPage(
                 screens = OnboardingScreen.entries,
-                locationDataManager = MockLocationDataManager(Location("mock")),
+                locationDataManager = MockLocationDataManager(),
                 onFinish = { finished = true },
                 onboardingRepository = onboardingRepository,
                 skipLocationDialogue = true,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -459,6 +459,13 @@ fun NearbyTransitPage(
         outerSheetPadding ->
         if (nearbyTransit.hideMaps) {
             val isNearbyTransit = currentNavEntry?.let { it is SheetRoutes.NearbyTransit } ?: true
+
+            LaunchedEffect(null) {
+                nearbyTransit.locationDataManager.currentLocation.collect { location ->
+                    nearbyTransit.viewportProvider.updateCameraState(location)
+                }
+            }
+
             SearchBarOverlay(
                 searchExpanded,
                 ::handleSearchExpandedChange,


### PR DESCRIPTION
### Summary

_Ticket:_ [Android | Fix hide maps location getting stuck](https://app.asana.com/0/1205732265579288/1209558421439038)

I was going to feel bad for leaving this out in #621, but I didn't, it's right there, it got removed in #622. Presumably it was a merge conflict thing, since those PRs have adjacent numbers.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manually verified that this issue is not present on iOS. Manually checked that this issue is now fixed on Android. Added a test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
