### PR TITLE
feat: remove old TripHeadsigns feature flag & add new GroupByDirection flag

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -137,7 +137,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     AlertsStreamDataResponse(emptyMap()),
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
         val viewModel = StopDetailsViewModel.mocked()
@@ -197,7 +196,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     AlertsStreamDataResponse(emptyMap()),
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
         val viewModel = StopDetailsViewModel.mocked()
@@ -431,7 +429,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     alertResponse,
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
         val viewModel = StopDetailsViewModel.mocked()
@@ -508,7 +505,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     alertResponse,
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
         val viewModel = StopDetailsViewModel.mocked()
@@ -570,7 +566,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     AlertsStreamDataResponse(emptyMap()),
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
         val settings =

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -113,7 +113,6 @@ class StopDetailsUnfilteredRoutesViewTest {
                     AlertsStreamDataResponse(emptyMap()),
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )
             )
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -1303,8 +1303,7 @@ class StopDetailsViewModelTest {
                         PredictionsStreamDataResponse(objects),
                         AlertsStreamDataResponse(objects),
                         setOf(),
-                        now,
-                        false
+                        now
                     )
                 )
             }
@@ -1381,8 +1380,7 @@ class StopDetailsViewModelTest {
                         PredictionsStreamDataResponse(objects),
                         AlertsStreamDataResponse(objects),
                         setOf(),
-                        now,
-                        false
+                        now
                     )
                 )
             }
@@ -1457,8 +1455,7 @@ class StopDetailsViewModelTest {
                         PredictionsStreamDataResponse(objects),
                         AlertsStreamDataResponse(objects),
                         setOf(),
-                        now,
-                        false
+                        now
                     )
                 )
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -109,6 +109,11 @@ class MoreViewModel(
                             value = settings[Settings.DevDebugMode] ?: false
                         ),
                         MoreItem.Toggle(
+                            label = context.getString(R.string.group_by_direction),
+                            settings = Settings.GroupByDirection,
+                            value = settings[Settings.GroupByDirection] ?: false
+                        ),
+                        MoreItem.Toggle(
                             label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults,
                             value = settings[Settings.SearchRouteResults] ?: false

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -114,7 +114,6 @@ fun NearbyTransitView(
                         alertData,
                         now,
                         pinnedRoutes.orEmpty(),
-                        useTripHeadsigns = false,
                     )
                 } else {
                     null

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -531,7 +531,6 @@ fun stopDetailsManagedVM(
                         alertData,
                         pinnedRoutes,
                         now,
-                        useTripHeadsigns = false,
                     )
                 } else null
             )

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="fog">Fog</string>
     <string name="freight_train_interference">Freight Train Interference</string>
     <string name="full_description">Full Description</string>
+    <string name="group_by_direction" translatable="false">Group by Direction</string>
     <string name="hazmat_condition">Hazmat Condition</string>
     <string name="header_at_stop">at &lt;b>%1$s&lt;/b></string>
     <string name="heading">Heading</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -11309,7 +11309,7 @@
       }
     },
     "Service suspended" : {
-      "comment" : "Possible alert effect\n   Suspension alert VoiceOver text",
+      "comment" : "Possible alert effect\nSuspension alert VoiceOver text",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -172,7 +172,6 @@ struct NearbyTransitView: View {
     var didLoadData: ((Self) -> Void)?
 
     private func loadEverything() {
-        nearbyVM.loadTripHeadsigns()
         getGlobal()
         getNearby(location: location, globalData: globalData)
         joinPredictions(state.nearbyByRouteAndStop?.stopIds())
@@ -354,8 +353,7 @@ struct NearbyTransitView: View {
             predictions: predictions,
             alerts: alerts,
             filterAtTime: filterAtTime,
-            pinnedRoutes: pinnedRoutes,
-            useTripHeadsigns: nearbyVM.tripHeadsignsEnabled
+            pinnedRoutes: pinnedRoutes
         )
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -182,7 +182,6 @@ struct StopDetailsPage: View {
             let nextDepartures = stopDetailsVM.getDepartures(
                 stopId: stopId,
                 alerts: nearbyVM.alerts,
-                useTripHeadsigns: nearbyVM.tripHeadsignsEnabled,
                 now: now
             )
             Task { @MainActor in

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -42,7 +42,6 @@ class NearbyViewModel: ObservableObject {
     @Published var alerts: AlertsStreamDataResponse?
     @Published var nearbyState = NearbyTransitState()
     @Published var selectingLocation = false
-    @Published var tripHeadsignsEnabled = false
 
     private let alertsRepository: IAlertsRepository
     private let errorBannerRepository: IErrorBannerStateRepository
@@ -227,13 +226,6 @@ class NearbyViewModel: ObservableObject {
 
     func leaveAlertsChannel() {
         alertsRepository.disconnect()
-    }
-
-    func loadTripHeadsigns() {
-        Task {
-            let result = try await settingsRepository.getSettings()[.tripHeadsigns]?.boolValue ?? false
-            DispatchQueue.main.async { self.tripHeadsignsEnabled = result }
-        }
     }
 }
 

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -107,12 +107,6 @@ class SettingsViewModel: ObservableObject {
                         setting: .searchRouteResults,
                         value: settings[.searchRouteResults] ?? false
                     ),
-                    .toggle(
-                        // not localized since it's a feature flag
-                        label: "Trip Headsigns",
-                        setting: .tripHeadsigns,
-                        value: settings[.tripHeadsigns] ?? false
-                    ),
                 ]),
                 MoreSection(id: .other, items: [
                     .link(

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -142,7 +142,6 @@ class StopDetailsViewModel: ObservableObject {
     func getDepartures(
         stopId: String,
         alerts: AlertsStreamDataResponse?,
-        useTripHeadsigns: Bool,
         now: Date
     ) -> StopDetailsDepartures? {
         if let global, let schedules = stopData?.schedules {
@@ -153,8 +152,7 @@ class StopDetailsViewModel: ObservableObject {
                 predictions: stopData?.predictionsByStop?.toPredictionsStreamDataResponse(),
                 alerts: alerts,
                 pinnedRoutes: pinnedRoutes,
-                filterAtTime: now.toKotlinInstant(),
-                useTripHeadsigns: useTripHeadsigns
+                filterAtTime: now.toKotlinInstant()
             )
         } else {
             nil

--- a/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
+++ b/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
@@ -162,7 +162,6 @@ final class StopDetailsViewModelTests: XCTestCase {
         let departures = stopDetailsVM.getDepartures(
             stopId: stop.id,
             alerts: .init(objects: objects),
-            useTripHeadsigns: false,
             now: now
         )
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -803,37 +803,20 @@ fun NearbyStaticData.withRealtimeInfo(
     alerts: AlertsStreamDataResponse?,
     filterAtTime: Instant,
     pinnedRoutes: Set<String>,
-    useTripHeadsigns: Boolean,
 ): List<StopsAssociated>? {
-    if (useTripHeadsigns) {
-        return this.withRealtimeInfoViaTripHeadsigns(
-            globalData,
-            sortByDistanceFrom,
-            schedules,
-            predictions,
-            alerts,
-            filterAtTime,
-            showAllPatternsWhileLoading = false,
-            hideNonTypicalPatternsBeyondNext = 120.minutes,
-            filterCancellations = true,
-            includeMinorAlerts = false,
-            pinnedRoutes
-        )
-    } else {
-        return this.withRealtimeInfoWithoutTripHeadsigns(
-            globalData,
-            sortByDistanceFrom,
-            schedules,
-            predictions,
-            alerts,
-            filterAtTime,
-            showAllPatternsWhileLoading = false,
-            hideNonTypicalPatternsBeyondNext = 120.minutes,
-            filterCancellations = true,
-            includeMinorAlerts = false,
-            pinnedRoutes
-        )
-    }
+    return this.withRealtimeInfoWithoutTripHeadsigns(
+        globalData,
+        sortByDistanceFrom,
+        schedules,
+        predictions,
+        alerts,
+        filterAtTime,
+        showAllPatternsWhileLoading = false,
+        hideNonTypicalPatternsBeyondNext = 120.minutes,
+        filterCancellations = true,
+        includeMinorAlerts = false,
+        pinnedRoutes
+    )
 }
 
 class NearbyStaticDataBuilder {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDepartures.kt
@@ -152,22 +152,12 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             alerts: AlertsStreamDataResponse?,
             pinnedRoutes: Set<String>,
             filterAtTime: Instant,
-            useTripHeadsigns: Boolean,
         ): StopDetailsDepartures? {
             val stop = global.stops[stopId]
             return if (stop == null) {
                 null
             } else {
-                fromData(
-                    stop,
-                    global,
-                    schedules,
-                    predictions,
-                    alerts,
-                    pinnedRoutes,
-                    filterAtTime,
-                    useTripHeadsigns
-                )
+                fromData(stop, global, schedules, predictions, alerts, pinnedRoutes, filterAtTime)
             }
         }
 
@@ -178,8 +168,7 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
             predictions: PredictionsStreamDataResponse?,
             alerts: AlertsStreamDataResponse?,
             pinnedRoutes: Set<String>,
-            filterAtTime: Instant,
-            useTripHeadsigns: Boolean,
+            filterAtTime: Instant
         ): StopDetailsDepartures? {
             val allStopIds =
                 if (global.patternIdsByStop.containsKey(stop.id)) {
@@ -190,35 +179,20 @@ data class StopDetailsDepartures(val routes: List<PatternsByStop>) {
 
             val staticData = NearbyStaticData(global, NearbyResponse(allStopIds))
             val routes =
-                if (useTripHeadsigns) {
-                        staticData.withRealtimeInfoViaTripHeadsigns(
-                            global,
-                            null,
-                            schedules,
-                            predictions,
-                            alerts,
-                            filterAtTime,
-                            showAllPatternsWhileLoading = true,
-                            hideNonTypicalPatternsBeyondNext = null,
-                            filterCancellations = false,
-                            includeMinorAlerts = true,
-                            pinnedRoutes
-                        )
-                    } else {
-                        staticData.withRealtimeInfoWithoutTripHeadsigns(
-                            global,
-                            null,
-                            schedules,
-                            predictions,
-                            alerts,
-                            filterAtTime,
-                            showAllPatternsWhileLoading = true,
-                            hideNonTypicalPatternsBeyondNext = null,
-                            filterCancellations = false,
-                            includeMinorAlerts = true,
-                            pinnedRoutes
-                        )
-                    }
+                staticData
+                    .withRealtimeInfoWithoutTripHeadsigns(
+                        global,
+                        null,
+                        schedules,
+                        predictions,
+                        alerts,
+                        filterAtTime,
+                        showAllPatternsWhileLoading = true,
+                        hideNonTypicalPatternsBeyondNext = null,
+                        filterCancellations = false,
+                        includeMinorAlerts = true,
+                        pinnedRoutes
+                    )
                     ?.flatMap { it.patternsByStop }
 
             return routes?.let { StopDetailsDepartures(it) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -39,7 +39,6 @@ enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     CombinedStopAndTrip(booleanPreferencesKey("combined_stop_and_trip")),
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
-    TripHeadsigns(booleanPreferencesKey("tripHeadsigns_featureFlag")),
     ElevatorAccessibility(booleanPreferencesKey("elevator_accessibility")),
     HideMaps(booleanPreferencesKey("hide_maps")),
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -38,9 +38,10 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     CombinedStopAndTrip(booleanPreferencesKey("combined_stop_and_trip")),
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
-    SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
     ElevatorAccessibility(booleanPreferencesKey("elevator_accessibility")),
+    GroupByDirection(booleanPreferencesKey("groupByDirection_featureFlag")),
     HideMaps(booleanPreferencesKey("hide_maps")),
+    SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
 }
 
 class MockSettingsRepository

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -36,7 +36,6 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 }
 
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
-    CombinedStopAndTrip(booleanPreferencesKey("combined_stop_and_trip")),
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     ElevatorAccessibility(booleanPreferencesKey("elevator_accessibility")),
     GroupByDirection(booleanPreferencesKey("groupByDirection_featureFlag")),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -979,7 +979,7 @@ class NearbyResponseTest {
                     alerts = AlertsStreamDataResponse(emptyMap()),
                     filterAtTime = time,
                     pinnedRoutes = setOf(),
-                    useTripHeadsigns = anyBoolean(),
+
                 )
             )
         }
@@ -1140,9 +1140,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -1314,9 +1312,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -1430,9 +1426,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(emptyMap(), emptyMap(), emptyMap()),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -1732,9 +1726,7 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         assertEquals(
             listOf(closeSubwayRoute, farSubwayRoute, closeBusRoute, farBusRoute),
             checkNotNull(realtimeRoutesSorted).flatMap {
@@ -1855,9 +1847,7 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),)
         assertEquals(
             listOf(farSubwayRoute, farBusRoute, closeSubwayRoute, closeBusRoute),
             checkNotNull(realtimeRoutesSorted).flatMap {
@@ -2038,9 +2028,7 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),)
 
         // Routes with no service today should sort below all routes with any service today,
         // unless they are a pinned route, in which case we want them to sort beneath all other
@@ -2166,7 +2154,7 @@ class NearbyResponseTest {
                     alerts = AlertsStreamDataResponse(objects),
                     filterAtTime = time,
                     pinnedRoutes = setOf(),
-                    useTripHeadsigns = anyBoolean(),
+
                 )
 
             // If a route has major disruptions and doesn't have any scheduled trips, it should
@@ -2241,9 +2229,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2312,9 +2298,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2396,9 +2380,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2497,9 +2479,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2575,9 +2555,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2653,9 +2631,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -2862,93 +2838,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = anyBoolean(),
-            )
-        )
-    }
-
-    @Test
-    fun `withRealtimeInfo uses trip headsigns`() {
-        val objects = ObjectCollectionBuilder()
-
-        val stop = objects.stop()
-
-        val route = objects.route()
-
-        val pattern =
-            objects.routePattern(route) {
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Static Headsign" }
-            }
-
-        val staticData =
-            NearbyStaticData.build {
-                route(route) { stop(stop) { headsign("Static Headsign", listOf(pattern)) } }
-            }
-
-        val time = Instant.parse("2024-11-15T16:12:19-05:00")
-
-        val schedule =
-            objects.schedule {
-                trip = objects.trip(pattern)
-                stopId = stop.id
-                arrivalTime = time
-                departureTime = time
-            }
-
-        objects.prediction(schedule) {
-            scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
-        }
-
-        val prediction =
-            objects.prediction {
-                trip = objects.trip(pattern) { headsign = "Realtime Headsign" }
-                stopId = stop.id
-                arrivalTime = time
-                departureTime = time
-            }
-
-        assertEquals(
-            listOf(
-                StopsAssociated.WithRoute(
-                    route,
-                    listOf(
-                        PatternsByStop(
-                            route,
-                            stop,
-                            listOf(
-                                RealtimePatterns.ByHeadsign(
-                                    route,
-                                    "Realtime Headsign",
-                                    null,
-                                    listOf(pattern),
-                                    listOf(
-                                        objects.upcomingTrip(prediction),
-                                    ),
-                                ),
-                                RealtimePatterns.ByHeadsign(
-                                    route,
-                                    "Static Headsign",
-                                    null,
-                                    listOf(pattern),
-                                    emptyList(),
-                                )
-                            )
-                        )
-                    )
-                ),
-            ),
-            staticData.withRealtimeInfo(
-                globalData = GlobalResponse(objects),
-                sortByDistanceFrom = stop.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = true,
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 
@@ -3264,7 +3154,6 @@ class NearbyResponseTest {
                 alerts = AlertsStreamDataResponse(mapOf(alert.id to alert)),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
-                useTripHeadsigns = false
             )
         )
     }
@@ -3368,7 +3257,6 @@ class NearbyResponseTest {
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
                 pinnedRoutes = setOf(),
-                useTripHeadsigns = false
             )
         )
     }
@@ -3474,9 +3362,7 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),
-                useTripHeadsigns = false
-            )
+                pinnedRoutes = setOf(),)
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -652,7 +652,6 @@ class RealtimePatternsTest {
                 AlertsStreamDataResponse(objects),
                 Clock.System.now(),
                 emptySet(),
-                useTripHeadsigns = false,
             )
 
         assertEquals(
@@ -750,7 +749,6 @@ class RealtimePatternsTest {
                 AlertsStreamDataResponse(objects),
                 now,
                 emptySet(),
-                useTripHeadsigns = false,
             )
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -96,7 +96,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(),
                 filterAtTime = time1,
-                useTripHeadsigns = anyBoolean(),
             )
         )
     }
@@ -254,7 +253,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(),
                 filterAtTime = time,
-                useTripHeadsigns = anyBoolean(),
             )
 
         assertEquals(
@@ -426,7 +424,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(),
                 filterAtTime = time,
-                useTripHeadsigns = anyBoolean(),
             )
         val vehicleB =
             objects.vehicle {
@@ -565,7 +562,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(),
                 filterAtTime = time,
-                useTripHeadsigns = anyBoolean(),
             )
 
         assertEquals(null, actual(includeSchedules = false, includePredictions = false))
@@ -695,7 +691,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 emptySet(),
                 now,
-                useTripHeadsigns = anyBoolean(),
             )
         assertEquals(expectedBeforeLoaded, actualBeforeLoaded)
 
@@ -721,7 +716,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(),
                 now,
-                useTripHeadsigns = anyBoolean(),
             )
         assertEquals(expectedAfterLoaded, actualAfterLoaded)
     }
@@ -827,7 +821,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 setOf(routePinned.id),
                 filterAtTime = time,
-                useTripHeadsigns = anyBoolean(),
             )
         )
     }
@@ -911,7 +904,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 emptySet(),
                 time,
-                useTripHeadsigns = anyBoolean(),
             )
 
         assertEquals(
@@ -1000,7 +992,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 emptySet(),
                 time,
-                useTripHeadsigns = anyBoolean(),
             )
 
         assertEquals(
@@ -1077,7 +1068,6 @@ class StopDetailsDeparturesTest {
                 AlertsStreamDataResponse(objects),
                 emptySet(),
                 time,
-                useTripHeadsigns = anyBoolean(),
             )
 
         assertEquals(
@@ -1126,7 +1116,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1166,7 +1155,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(null, checkNotNull(departures).autoStopFilter())
@@ -1236,7 +1224,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1277,7 +1264,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(null, checkNotNull(departures).autoTripFilter(null, null, time))
@@ -1314,7 +1300,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(null, checkNotNull(departures)
@@ -1400,7 +1385,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1457,7 +1441,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1554,7 +1537,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1651,7 +1633,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1745,7 +1726,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1823,7 +1803,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(
@@ -1916,7 +1895,6 @@ class StopDetailsDeparturesTest {
                     AlertsStreamDataResponse(objects),
                     emptySet(),
                     time,
-                    useTripHeadsigns = anyBoolean(),
                 )
 
             assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -372,7 +372,6 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet(),
-                    useTripHeadsigns = false,
                 )!!
                 .condensed()
         )
@@ -386,7 +385,6 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )!!
                 .asNearby()
                 .condensed()
@@ -434,7 +432,6 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet(),
-                    useTripHeadsigns = false,
                 )!!
                 .condensed()
         )
@@ -448,7 +445,6 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )!!
                 .asNearby()
                 .condensed()
@@ -500,7 +496,6 @@ class TemporaryTerminalTest {
                     alerts,
                     now,
                     emptySet(),
-                    useTripHeadsigns = false,
                 )!!
                 .condensed()
         )
@@ -514,7 +509,6 @@ class TemporaryTerminalTest {
                     alerts,
                     emptySet(),
                     now,
-                    useTripHeadsigns = false,
                 )!!
                 .asNearby()
                 .condensed()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -37,10 +37,8 @@ class SettingsRepositoryTest : KoinTest {
 
         assertEquals(
             mapOf(
-                Settings.CombinedStopAndTrip to false,
                 Settings.DevDebugMode to true,
                 Settings.SearchRouteResults to false,
-                Settings.TripHeadsigns to false,
                 Settings.ElevatorAccessibility to false,
                 Settings.HideMaps to false,
             ),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -38,6 +38,7 @@ class SettingsRepositoryTest : KoinTest {
         assertEquals(
             mapOf(
                 Settings.DevDebugMode to true,
+                Settings.GroupByDirection to false,
                 Settings.SearchRouteResults to false,
                 Settings.ElevatorAccessibility to false,
                 Settings.HideMaps to false,


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | Feature flags](https://app.asana.com/0/1205732265579288/1209536961544694)

What is this PR for?

Removes old TripHeadsigns feature flag & adds a new GroupByDirection flag. This leaves the old TripHeadsigns functions in place so that we can easily reference them while building up the group by direction functionality, but removes all entry points from the UI to those functions so that we can freely break them as needed.

Also removes the now unused `CombinedStopAndTrip` feature flag.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ran iOS application, android application, confirmed both run.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
