### PR TITLE
fix(ci): correctly reference lowercase values when uploading artifacts

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -72,9 +72,9 @@ jobs:
         if: ${{ inputs.upload-artifacts }}
         with:
           name: android-apk
-          path: androidApp/build/outputs/apk/${{ steps.lowercase.outputs.flavor }}/${{ inputs.build-type }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ inputs.build-type }}.apk
+          path: androidApp/build/outputs/apk/${{ steps.lowercase.outputs.flavor }}/${{ steps.lowercase.outputs.build-type }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ steps.lowercase.outputs.build-type }}.apk
       - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-artifacts }}
         with:
           name: android-aab
-          path: androidApp/build/outputs/bundle/${{ steps.lowercase.outputs.flavor }}{{ inputs.build-type-caps }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ inputs.build-type }}.aab
+          path: androidApp/build/outputs/bundle/${{ steps.lowercase.outputs.flavor }}{{ inputs.build-type }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ steps.lowercase.outputs.build-type }}.aab


### PR DESCRIPTION
### Summary

_Ticket:_ none

I missed a couple of spots when tweaking #807 to convert inputs to lowercase itself rather than requiring both cases as separate inputs.

This sort of thing is why I don't actually like GitHub Actions. A real programming language would have functionality like "convert this string to lowercase" and "error early if referencing an input that doesn't exist".

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Not testable.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
