### PR TITLE
fix(Android): Add map zoom bounds

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import com.mapbox.geojson.Point
+import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.MapView
 import com.mapbox.maps.RenderedQueryGeometry
 import com.mapbox.maps.RenderedQueryOptions
@@ -355,6 +356,9 @@ fun HomeMapView(
 
                 MapEffect(true) { map ->
                     map.mapboxMap.addOnMapClickListener { point -> handleStopClick(map, point) }
+                    map.mapboxMap.setBounds(
+                        CameraBoundsOptions.Builder().maxZoom(18.0).minZoom(6.0).build()
+                    )
                     map.location.setLocationProvider(locationProvider)
                     map.location.updateSettings {
                         locationPuck = createDefault2DPuck(withBearing = false)


### PR DESCRIPTION
### Summary

_Ticket:_ [Set min/max map zoom for Android](https://app.asana.com/0/1205732265579288/1209538649680545)

We've had this on iOS, but forgot to ever include it on Android

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~

### Testing

Manually tested to make sure it was bounded