### PR TITLE
feat(iOS): Draw map behind top bar safe area

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -362,7 +362,10 @@ struct ContentView: View {
 
     @ViewBuilder
     var searchHeaderBackground: some View {
-        (searchObserver.isSearching ? Color.fill2 : Color.clear).ignoresSafeArea(.all)
+        (
+            searchObserver.isSearching && nearbyVM.navigationStack.lastSafe() == .nearby
+                ? Color.fill2 : Color.clear
+        ).ignoresSafeArea(.all)
     }
 
     private func recenterOnVehicleButtonInfo() -> (RouteType, Vehicle, Stop)? {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -182,21 +182,28 @@ struct ContentView: View {
     var nearbyTab: some View {
         VStack {
             if contentVM.hideMaps {
-                if nearbyVM.navigationStack.lastSafe() == .nearby {
-                    SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
-                    if !searchObserver.isSearching {
-                        LocationAuthButton(showingAlert: $showingLocationPermissionAlert)
-                            .padding(.bottom, 8)
+                ZStack(alignment: .top) {
+                    searchHeaderBackground
+                    VStack {
+                        if nearbyVM.navigationStack.lastSafe() == .nearby {
+                            SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
+                                .padding(.top, 12)
+                            if !searchObserver.isSearching {
+                                LocationAuthButton(showingAlert: $showingLocationPermissionAlert)
+                                    .padding(.bottom, 8)
+                            }
+                        }
+
+                        if !(nearbyVM.navigationStack.lastSafe() == .nearby && searchObserver.isSearching) {
+                            mapWithSheets
+                        }
                     }
-                }
-                if !(nearbyVM.navigationStack.lastSafe() == .nearby && searchObserver.isSearching) {
-                    mapWithSheets
                 }
             } else {
                 ZStack(alignment: .top) {
-                    mapWithSheets
-                        .accessibilityHidden(searchObserver.isSearching)
-                    VStack(alignment: .center, spacing: 0) {
+                    mapWithSheets.accessibilityHidden(searchObserver.isSearching)
+                    searchHeaderBackground
+                    VStack(alignment: .center, spacing: 20) {
                         if nearbyVM.navigationStack.lastSafe() == .nearby {
                             SearchOverlay(searchObserver: searchObserver, nearbyVM: nearbyVM, searchVM: searchVM)
 
@@ -204,23 +211,25 @@ struct ContentView: View {
                                 LocationAuthButton(showingAlert: $showingLocationPermissionAlert)
                             }
                         }
-                        if !searchObserver.isSearching, !viewportProvider.viewport.isFollowing,
-                           locationDataManager.currentLocation != nil {
-                            VStack(alignment: .trailing) {
-                                RecenterButton(icon: .faLocationArrowSolid, size: 17.33) {
-                                    viewportProvider.follow()
+                        if !searchObserver.isSearching {
+                            VStack(alignment: .trailing, spacing: 20) {
+                                if !viewportProvider.viewport.isFollowing,
+                                   locationDataManager.currentLocation != nil {
+                                    RecenterButton(icon: .faLocationArrowSolid, size: 17.33) {
+                                        viewportProvider.follow()
+                                    }
+                                }
+                                if !viewportProvider.viewport.isOverview,
+                                   let (routeType, selectedVehicle, stop) = recenterOnVehicleButtonInfo() {
+                                    RecenterButton(icon: routeIconResource(routeType), size: 32) {
+                                        viewportProvider.vehicleOverview(vehicle: selectedVehicle, stop: stop)
+                                    }
                                 }
                             }.frame(maxWidth: .infinity, alignment: .topTrailing)
                         }
-                        if !searchObserver.isSearching, !viewportProvider.viewport.isOverview,
-                           let (routeType, selectedVehicle, stop) = recenterOnVehicleButtonInfo() {
-                            VStack(alignment: .trailing) {
-                                RecenterButton(icon: routeIconResource(routeType), size: 32) {
-                                    viewportProvider.vehicleOverview(vehicle: selectedVehicle, stop: stop)
-                                }
-                            }.frame(maxWidth: .infinity, alignment: .topTrailing)
-                        }
-                    }.frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.top, 12)
                 }
             }
         }
@@ -349,6 +358,11 @@ struct ContentView: View {
             .background { Color.fill2.ignoresSafeArea(edges: .all) }
             .animation(.easeInOut, value: nearbyVM.navigationStack.lastSafe().sheetItemIdentifiable()?.id)
         }
+    }
+
+    @ViewBuilder
+    var searchHeaderBackground: some View {
+        (searchObserver.isSearching ? Color.fill2 : Color.clear).ignoresSafeArea(.all)
     }
 
     private func recenterOnVehicleButtonInfo() -> (RouteType, Vehicle, Stop)? {

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -67,6 +67,7 @@ struct AnnotatedMap: View {
             }
             .additionalSafeAreaInsets(.bottom, sheetHeight + 8)
             .additionalSafeAreaInsets(.top, 20)
+            .ignoresSafeArea(.all)
             .accessibilityIdentifier("transitMap")
             .onReceive(viewportProvider.cameraStatePublisher) { newCameraState in
                 zoomLevel = newCameraState.zoom

--- a/iosApp/iosApp/Pages/Map/RecenterButton.swift
+++ b/iosApp/iosApp/Pages/Map/RecenterButton.swift
@@ -23,9 +23,7 @@ struct RecenterButton: View {
             .clipShape(Circle())
             .overlay(Circle().stroke(Color.halo, lineWidth: 2).frame(width: 50, height: 50))
             .padding(.horizontal, 20)
-            .padding(.top, 16)
             .onTapGesture(perform: perform)
-            .transition(AnyTransition.opacity.animation(.linear(duration: 0.25)))
             .accessibilityLabel(Text(
                 "Recenter map on my location",
                 comment: "Screen reader text describing the behavior of the map recenter button"

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
@@ -35,7 +35,6 @@ struct SearchResultsView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                         StopResultsView(stops: stops, handleStopTap: handleStopTap)
                     }
-                    .padding(.top, 8)
                 case let .results(stopResults, routeResults, includeRoutes):
                     VStack(spacing: 8) {
                         StopResultsView(stops: stopResults, handleStopTap: handleStopTap)
@@ -81,7 +80,7 @@ struct SearchResultsView: View {
             }
             .animation(.easeInOut(duration: 0.25), value: state)
             .frame(maxWidth: .infinity, alignment: .topLeading)
-            .padding(.top, 8)
+            .padding(.vertical, 16)
             .padding(.horizontal, 16)
         }
         .background(Color.fill1)

--- a/iosApp/iosApp/Pages/Search/SearchField.swift
+++ b/iosApp/iosApp/Pages/Search/SearchField.swift
@@ -71,7 +71,6 @@ struct SearchField: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.top, 12)
         .onAppear { isFocused = searchObserver.isFocused }
         .onChange(of: isFocused) { searchObserver.isFocused = $0 }
         .onChange(of: searchObserver.isFocused) { isFocused = $0 }

--- a/iosApp/iosApp/Pages/Search/SearchOverlay.swift
+++ b/iosApp/iosApp/Pages/Search/SearchOverlay.swift
@@ -34,8 +34,6 @@ struct SearchOverlay: View {
     var body: some View {
         VStack(spacing: .zero) {
             SearchField(searchObserver: searchObserver)
-                .padding(.bottom, 12)
-                .background(searchObserver.isSearching ? Color.fill2 : Color.clear)
             if searchObserver.isSearching {
                 ZStack(alignment: .top) {
                     SearchResultsContainer(
@@ -47,8 +45,8 @@ struct SearchOverlay: View {
                     Divider()
                         .frame(height: 2)
                         .overlay(Color.halo)
-                }
+                }.padding(.top, 16)
             }
-        }
+        }.background(searchObserver.isSearching ? Color.fill2 : Color.clear)
     }
 }

--- a/iosApp/iosApp/Utils/PresentationDetentExtension.swift
+++ b/iosApp/iosApp/Utils/PresentationDetentExtension.swift
@@ -18,6 +18,6 @@ extension PresentationDetent {
 private struct AlmostFull: CustomPresentationDetent {
     static func height(in context: Context) -> CGFloat? {
         // Prevent the background content from shrinking underneath the expanded sheet
-        context.maxDetentValue - 1
+        context.maxDetentValue - 0.5
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS | Map extends to top of screen](https://app.asana.com/0/1205732265579288/1207426150145420)

This required a bit of extra padding and background color fiddling to get everything working properly, especially with the search overlay (initially it was still showing a slice of the map above the open search bar).

![Simulator Screenshot - iPhone 15 - 2025-03-11 at 16 00 08](https://github.com/user-attachments/assets/d200ba14-c789-4f31-8823-4b16c2e3d0d3)


iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Manual testing that everything looked reasonable with hide maps turned on and off.