### PR TITLE
chore(iOS): Switch to XCode 16 and iOS 18 SDK

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -125,7 +125,7 @@ runs:
       if: steps.settings.outputs.xcode == 'true'
       shell: bash
       run: |
-        sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+        sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer
     - name: Cache CocoaPods dependencies
       if: steps.settings.outputs.xcode == 'true'
       uses: actions/cache@v4

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -11497,7 +11497,7 @@
       }
     },
     "Service suspended" : {
-      "comment" : "Possible alert effect\n   Suspension alert VoiceOver text",
+      "comment" : "Possible alert effect\nSuspension alert VoiceOver text",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Utils/SelectedTab.swift
+++ b/iosApp/iosApp/Utils/SelectedTab.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2025 MBTA. All rights reserved.
 //
 
+import DeveloperToolsSupport
 import Foundation
 
 enum SelectedTab: Hashable, CaseIterable {

--- a/iosApp/iosAppTests/Pages/StopDetails/DepartureTileTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DepartureTileTests.swift
@@ -94,10 +94,10 @@ final class DepartureTileTests: XCTestCase {
         let notSelected = DepartureTile(data: tileData, onTap: {})
         XCTAssertEqual(
             "displays more information about this trip",
-            try notSelected.inspect().button().accessibilityHint().string()
+            try notSelected.inspect().implicitAnyView().button().accessibilityHint().string()
         )
 
         let selected = DepartureTile(data: tileData, onTap: {}, isSelected: true)
-        XCTAssertEqual("", try selected.inspect().button().accessibilityHint().string())
+        XCTAssertEqual("", try selected.inspect().implicitAnyView().button().accessibilityHint().string())
     }
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/ExplainerPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/ExplainerPageTests.swift
@@ -54,7 +54,7 @@ final class ExplainerPageTests: XCTestCase {
             explainer: .init(type: .noPrediction, routeAccents: .init()),
             onClose: { closeExpectation.fulfill() }
         )
-        try sut.inspect().find(ActionButton.self).button().tap()
+        try sut.inspect().find(ActionButton.self).implicitAnyView().button().tap()
         wait(for: [closeExpectation], timeout: 1)
     }
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -148,12 +148,10 @@ final class StopDetailsPageTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().find(StopDetailsView.self).callOnChange(newValue: ScenePhase.background)
-
+        try sut.inspect().findAndCallOnChange(newValue: ScenePhase.background)
         wait(for: [leaveExpectation], timeout: 1)
 
-        try sut.inspect().find(StopDetailsView.self).callOnChange(newValue: ScenePhase.active)
-
+        try sut.inspect().findAndCallOnChange(newValue: ScenePhase.active)
         wait(for: [joinExpectation], timeout: 1)
     }
 

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -327,7 +327,7 @@ final class TripHeaderCardTests: XCTestCase {
         )
         XCTAssertEqual(
             "displays more information",
-            try withTap.inspect().zStack().accessibilityHint().string()
+            try withTap.inspect().find(TripHeaderCard.self).implicitAnyView().zStack().accessibilityHint().string()
         )
 
         let withoutTap = TripHeaderCard(
@@ -340,7 +340,7 @@ final class TripHeaderCardTests: XCTestCase {
         )
         XCTAssertEqual(
             "",
-            try withoutTap.inspect().zStack().accessibilityHint().string()
+            try withoutTap.inspect().find(TripHeaderCard.self).implicitAnyView().zStack().accessibilityHint().string()
         )
 
         let vehicle = objects.vehicle { vehicle in

--- a/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Views/NearbyTransitViewTests.swift
@@ -379,19 +379,30 @@ final class NearbyTransitViewTests: XCTestCase {
         let exp = sut.on(\.didAppear) { view in
             try view.implicitAnyView().vStack().callOnChange(newValue: predictionsByStop)
             let stops = view.findAll(NearbyStopView.self)
-            XCTAssertNotNil(try stops[0].find(text: "Charles River Loop")
-                .parent().parent().find(ViewType.ProgressView.self))
+            XCTAssertNotNil(try stops[0]
+                .find(text: "Charles River Loop")
+                .find(DestinationRowView.self, relation: .parent)
+                .find(ViewType.ProgressView.self))
 
-            XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
-                .parent().parent().find(text: "10 min"))
-            XCTAssertNotNil(try stops[0].find(text: "Dedham Mall")
-                .parent().parent().find(text: "Overridden"))
+            XCTAssertNotNil(try stops[0]
+                .find(text: "Dedham Mall")
+                .find(DestinationRowView.self, relation: .parent)
+                .find(text: "10 min"))
+            XCTAssertNotNil(try stops[0]
+                .find(text: "Dedham Mall")
+                .find(DestinationRowView.self, relation: .parent)
+                .find(text: "Overridden"))
 
-            XCTAssertNotNil(try stops[1].find(text: "Watertown Yard")
-                .parent().parent().find(text: "1 min"))
+            XCTAssertNotNil(try stops[1]
+                .find(text: "Watertown Yard")
+                .find(DestinationRowView.self, relation: .parent)
+                .find(text: "1 min"))
+
             let expectedMinutes = distantMinutes
             let expectedState = UpcomingTripView.State.some(.Minutes(minutes: Int32(expectedMinutes)))
-            XCTAssert(try !stops[1].find(text: "Watertown Yard").parent().parent()
+            XCTAssert(try !stops[1]
+                .find(text: "Watertown Yard")
+                .find(DestinationRowView.self, relation: .parent)
                 .findAll(UpcomingTripView.self, where: { sut in
                     try sut.actualView().prediction == expectedState
                 }).isEmpty)
@@ -518,7 +529,8 @@ final class NearbyTransitViewTests: XCTestCase {
             XCTAssertNotNil(try kenmoreDirection.find(text: "Overridden"))
 
             XCTAssertNotNil(try stops[0].find(text: "Heath Street")
-                .parent().parent().find(text: "5 min"))
+                .find(DestinationRowView.self, relation: .parent)
+                .find(text: "5 min"))
 
             let parkDirection = try stops[0].find(text: "Park St & North")
                 .find(DirectionRowView.self, relation: .parent)

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -109,29 +109,17 @@ final class UpcomingTripViewTests: XCTestCase {
                                    routeType: .heavyRail,
                                    isFirst: true,
                                    isOnly: false)
-        let predictionView = try sut.inspect().find(PredictionText.self)
-        XCTAssertEqual(
-            "trains arriving in 5 min",
-            try predictionView.accessibilityLabel().string(locale: Locale(identifier: "en"))
-        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "trains arriving in 5 min"))
     }
 
     func testPredictedAccessibilityLabel() throws {
         let sut = UpcomingTripView(prediction: .some(.Minutes(minutes: 5)), isFirst: false)
-        let predictionView = try sut.inspect().find(PredictionText.self)
-        XCTAssertEqual(
-            "and in 5 min",
-            try predictionView.accessibilityLabel().string(locale: Locale(identifier: "en"))
-        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "and in 5 min"))
     }
 
     func testPredictedHourAccessibilityLabel() throws {
         let sut = UpcomingTripView(prediction: .some(.Minutes(minutes: 67)), isFirst: false)
-        let predictionView = try sut.inspect().find(PredictionText.self)
-        XCTAssertEqual(
-            "and in 1 hr 7 min",
-            try predictionView.accessibilityLabel().string(locale: Locale(identifier: "en"))
-        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "and in 1 hr 7 min"))
     }
 
     func testCancelledAccessibilityLabel() throws {

--- a/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
+++ b/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
@@ -15,25 +15,18 @@ final class EndToEndOpenStopDetailsTest: XCTestCase {
         app.launchArguments = ["--e2e-mocks"]
         XCUIDevice.shared.location = XCUILocation(location: .init(latitude: 42.356395, longitude: -71.062424))
 
-        // In UI tests it is usually best to stop immediately when a failure occurs.
         continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests
-        // before they run. The setUp method is a good place to do this.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
     func testOpenStopDetails() throws {
-        // UI tests must launch the application that they test.
         app.launch()
         let alewifeHeadsign = app.staticTexts["Alewife"]
         XCTAssert(alewifeHeadsign.waitForExistence(timeout: 30))
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        app.staticTexts["Alewife"].tap()
+        alewifeHeadsign.tap()
+
+        let rlPill = app.staticTexts["RL"]
+        XCTAssert(rlPill.waitForExistence(timeout: 30))
 
         XCTAssertFalse(app.staticTexts["Nearby Transit"].exists)
         XCTAssertTrue(app.staticTexts["Northbound to"].exists)


### PR DESCRIPTION
### Summary

_Ticket:_ [Build with Xcode 16](https://app.asana.com/0/1205732265579288/1209498488512445)

Upgrade the iOS build SDK to 18 by upgrading the XCode version CI uses to 16.2.

This builds fine for iOS 18 devices and all tests pass running locally on 16.2.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

All tests broken by XCode 16 behavior have been fixed