### PR TITLE
feat(RouteCardData): Add upcoming trips & filter

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -299,20 +299,10 @@ sealed class RealtimePatterns {
      * should be hidden until data is available.
      */
     fun isUpcomingWithin(currentTime: Instant, cutoffTime: Instant) =
-        upcomingTrips.any {
-            val tripTime = it.time
-            tripTime != null &&
-                tripTime < cutoffTime &&
-                (tripTime >= currentTime ||
-                    (it.prediction != null && it.prediction.stopId == it.vehicle?.stopId))
-        }
+        upcomingTrips.isUpcomingWithin(currentTime, cutoffTime)
 
     /** Checks if a trip exists. */
-    fun isUpcoming() =
-        upcomingTrips.any {
-            val tripTime = it.time
-            tripTime != null
-        }
+    fun isUpcoming() = upcomingTrips.isUpcoming()
 
     /**
      * Checks if this headsign ends at this stop, i.e. all trips are arrival-only.
@@ -322,13 +312,7 @@ sealed class RealtimePatterns {
      * - No trips are scheduled or predicted with a departure
      */
     fun isArrivalOnly(): Boolean {
-        // Intermediate variable set because kotlin can't smart cast properties with open getters
-        val upcoming = upcomingTrips
-        return upcoming
-            .mapTo(mutableSetOf()) { it.isArrivalOnly() }
-            .let { upcomingTripsArrivalOnly ->
-                upcomingTripsArrivalOnly.contains(true) && !upcomingTripsArrivalOnly.contains(false)
-            }
+        return upcomingTrips.isArrivalOnly()
     }
 
     fun directionId(): Int {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -64,6 +64,13 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
                 is Route -> this.route.type.isSubway()
             }
         }
+
+        fun id(): String {
+            return when (this) {
+                is Line -> this.line.id
+                is Route -> this.route.id
+            }
+        }
     }
 
     companion object {
@@ -374,7 +381,9 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
                                 )
                             }
                 }
+                byStopId.stopData = byStopId.stopData.filterNot { it.value.data.isEmpty() }
             }
+            this.data = this.data.filterNot { it.value.stopData.isEmpty() }
             return this
         }
 
@@ -388,7 +397,7 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
         }
     }
 
-    data class Builder(val lineOrRoute: LineOrRoute, val stopData: ByStopIdBuilder) {
+    data class Builder(val lineOrRoute: LineOrRoute, var stopData: ByStopIdBuilder) {
 
         fun build(): RouteCardData {
             return RouteCardData(this.lineOrRoute, stopData.values.map { it.build() })
@@ -439,9 +448,9 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
                 directionId,
                 checkNotNull(routePatterns),
                 checkNotNull(stopIds),
-                checkNotNull(this.upcomingTrips),
+                this.upcomingTrips ?: emptyList(),
                 alertsHere ?: emptyList(),
-                checkNotNull(allDataLoaded)
+                allDataLoaded ?: false
             )
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
 
 // type aliases can't be nested :(
@@ -87,7 +88,6 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
             predictions: PredictionsStreamDataResponse?,
             alerts: AlertsStreamDataResponse?,
             filterAtTime: Instant,
-            hideNonTypicalPatternsBeyondNext: Duration?,
             pinnedRoutes: Set<String>,
             context: Context
         ): List<RouteCardData>? {
@@ -98,6 +98,13 @@ data class RouteCardData(private val lineOrRoute: LineOrRoute, val stopData: Lis
             // if global data was still loading, there'd be no nearby data, and null handling is
             // annoying
             if (globalData == null) return null
+
+            val hideNonTypicalPatternsBeyondNext: Duration? =
+                when (context) {
+                    Context.NearbyTransit -> 120.minutes
+                    Context.StopDetailsFiltered -> 120.minutes
+                    Context.StopDetailsUnfiltered -> null
+                }
 
             val cutoffTime = hideNonTypicalPatternsBeyondNext?.let { filterAtTime + it }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -24,3 +24,10 @@ data class RoutePattern(
 
     override fun compareTo(other: RoutePattern) = sortOrder.compareTo(other.sortOrder)
 }
+/**
+ * Checks if any pattern under this headsign is [RoutePattern.Typicality.Typical].
+ *
+ * If any typicality is unknown, the route should be shown, and so this will return true.
+ */
+fun List<RoutePattern>.isTypical() =
+    this.any { it.typicality == null || it.typicality == RoutePattern.Typicality.Typical }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -1,10 +1,21 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.parametric.parametricTest
+import kotlinx.datetime.Instant
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class RouteCardDataTest {
 
@@ -23,7 +34,6 @@ class RouteCardDataTest {
                 directionId = 0
             }
         }
-
 
         val global =
             GlobalResponse(
@@ -638,10 +648,2500 @@ class RouteCardDataTest {
                             )
                         )
             ),
-            RouteCardData.ListBuilder().addStaticStopsData(nearby.stopIds, global).data
+            RouteCardData.ListBuilder()
+                .addStaticStopsData(nearby.stopIds, global)
+                .data
         )
 
 
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips includes predictions filtered to the correct stop and direction`() {
+            val objects = ObjectCollectionBuilder()
+
+            val stop1 = objects.stop()
+            val stop2 = objects.stop()
+
+            val route1 = objects.route()
+
+            val pattern1 =
+                objects.routePattern(route1) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Harvard" }
+                }
+            val trip1 = objects.trip(pattern1)
+            val pattern2 =
+                objects.routePattern(route1) {
+                    sortOrder = 2
+                    representativeTrip { headsign = "Harvard" }
+                }
+            val trip2 = objects.trip(pattern2)
+            val pattern3 =
+                objects.routePattern(route1) {
+                    sortOrder = 3
+                    representativeTrip { headsign = "Nubian" }
+                }
+            val trip3 = objects.trip(pattern3)
+
+        val global = GlobalResponse(objects, patternIdsByStop = mapOf(stop1.id to listOf(pattern1.id, pattern2.id),
+            stop2.id to listOf(pattern3.id)) )
+
+            val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+            // should be sorted before the pattern 1 prediction under Harvard
+            val stop1Pattern2Prediction =
+                objects.prediction {
+                    arrivalTime = time
+                    departureTime = time + 10.seconds
+                    stopId = stop1.id
+                    trip = trip2
+                }
+
+            // should be sorted after the pattern 2 prediction under Harvard
+            val stop1Pattern1Prediction =
+                objects.prediction {
+                    arrivalTime = time + 5.seconds
+                    departureTime = time + 15.seconds
+                    stopId = stop1.id
+                    trip = trip1
+                }
+
+            // should *not* be ignored since pattern 1 shows at stop, but pattern 3 does not
+            val stop2Pattern1Prediction =
+                objects.prediction {
+                    arrivalTime = time + 10.seconds
+                    departureTime = time + 20.seconds
+                    stopId = stop2.id
+                    trip = trip1
+                }
+
+            // should be shown under Nubian
+            val stop2Pattern3Prediction =
+                objects.prediction {
+                    arrivalTime = time + 20.seconds
+                    departureTime = time + 30.seconds
+                    stopId = stop2.id
+                    trip = trip3
+                }
+
+        assertEquals(
+            mapOf(
+                route1.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route1), mapOf(
+                                stop1.id to RouteCardData.RouteStopDataBuilder(
+                                    stop1, emptyList(), mapOf(
+                                        0 to RouteCardData.LeafBuilder(
+                                            routePatterns = listOf(pattern1, pattern2),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips = listOf(
+                                                objects.upcomingTrip(stop1Pattern2Prediction),
+                                                objects.upcomingTrip(stop1Pattern1Prediction)
+                                            ),
+                                        )
+                                    )
+                                ),
+                                stop2.id to RouteCardData.RouteStopDataBuilder(
+                                    stop2, emptyList(), mapOf(
+                                        0 to RouteCardData.LeafBuilder(
+                                            routePatterns = listOf(pattern3),
+                                            stopIds = setOf(stop2.id),
+                                            upcomingTrips = listOf(
+                                                objects.upcomingTrip(stop2Pattern1Prediction),
+                                                objects.upcomingTrip(stop2Pattern3Prediction),
+                                            ),
+                                        )
+                                    )
+                                )
+                            )
+                        )
+            ),
+            RouteCardData.ListBuilder().addStaticStopsData(listOf(stop1.id, stop2.id), global)
+                .addUpcomingTrips(null, PredictionsStreamDataResponse(objects), filterAtTime = time, globalData = global)
+                .data)
+        }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips hides rare patterns with no predictions`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // should be included because typical and has prediction
+        val typicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical Out" }
+            }
+        // should be included because typical
+        val typicalInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 2
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical In" }
+            }
+        // should be included because prediction within 90 minutes
+        val deviationOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 3
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation Out" }
+            }
+        // should be included because prediction beyond 90 minutes
+        val deviationInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 4
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation In" }
+            }
+        // should be included because prediction
+        val atypicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 5
+                typicality = RoutePattern.Typicality.Atypical
+                representativeTrip { headsign = "Atypical Out" }
+            }
+        // should be excluded because no prediction
+        val atypicalInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 6
+                typicality = RoutePattern.Typicality.Atypical
+                representativeTrip { headsign = "Atypical In" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(stop1) {
+                        headsign("Typical Out", listOf(typicalOutbound))
+                        headsign("Typical In", listOf(typicalInbound))
+                        headsign("Deviation Out", listOf(deviationOutbound))
+                        headsign("Deviation In", listOf(deviationInbound))
+                        headsign("Atypical Out", listOf(atypicalOutbound))
+                        headsign("Atypical In", listOf(atypicalInbound))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+        val typicalOutboundPrediction =
+            objects.prediction {
+                departureTime = time
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = typicalOutbound.representativeTripId
+            }
+        val deviationOutboundPrediction =
+            objects.prediction {
+                departureTime = time + 119.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = deviationOutbound.representativeTripId
+            }
+        val deviationInboundPrediction =
+            objects.prediction {
+                departureTime = time + 121.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = deviationInbound.representativeTripId
+            }
+        val atypicalInboundPrediction =
+            objects.prediction {
+                departureTime = time + 1.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = atypicalInbound.representativeTripId
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical Out",
+                                    null,
+                                    listOf(typicalOutbound),
+                                    listOf(objects.upcomingTrip(typicalOutboundPrediction)),
+                                    allDataLoaded = false
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Deviation Out",
+                                    null,
+                                    listOf(deviationOutbound),
+                                    listOf(objects.upcomingTrip(deviationOutboundPrediction)),
+                                    allDataLoaded = false
+                                ),
+                                // since this has trips it's sorted earlier than typical in
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Atypical In",
+                                    null,
+                                    listOf(atypicalInbound),
+                                    listOf(objects.upcomingTrip(atypicalInboundPrediction)),
+                                    allDataLoaded = false
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical In",
+                                    null,
+                                    listOf(typicalInbound),
+                                    emptyList(),
+                                    allDataLoaded = false
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop1.position,
+                schedules = null,
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips handles schedule and predictions edge cases`()  {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // exclude, schedule in past
+        val schedulePast =
+            objects.routePattern(route1) {
+                sortOrder = 1
+                representativeTrip { headsign = "Schedule Past" }
+            }
+        // include, schedule upcoming
+        val scheduleSoon =
+            objects.routePattern(route1) {
+                sortOrder = 2
+                representativeTrip { headsign = "Schedule Soon" }
+            }
+        // exclude, schedule too late
+        val scheduleLater =
+            objects.routePattern(route1) {
+                sortOrder = 3
+                representativeTrip { headsign = "Schedule Later" }
+            }
+        // exclude, prediction in past
+        val predictionPast =
+            objects.routePattern(route1) {
+                sortOrder = 4
+                representativeTrip { headsign = "Prediction Past" }
+            }
+        // include, prediction in past but BRD
+        val predictionBrd =
+            objects.routePattern(route1) {
+                sortOrder = 5
+                representativeTrip { headsign = "Prediction BRD" }
+            }
+        // include, prediction upcoming
+        val predictionSoon =
+            objects.routePattern(route1) {
+                sortOrder = 6
+                representativeTrip { headsign = "Prediction Soon" }
+            }
+        // exclude, prediction later
+        val predictionLater =
+            objects.routePattern(route1) {
+                sortOrder = 7
+                representativeTrip { headsign = "Prediction Later" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(stop1) {
+                        headsign("Schedule Past", listOf(schedulePast))
+                        headsign("Schedule Soon", listOf(scheduleSoon))
+                        headsign("Schedule Later", listOf(scheduleLater))
+                        headsign("Prediction Past", listOf(predictionPast))
+                        headsign("Prediction BRD", listOf(predictionBrd))
+                        headsign("Prediction Soon", listOf(predictionSoon))
+                        headsign("Prediction Later", listOf(predictionLater))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-09-19T13:43:19-04:00")
+
+        val schedulePastSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(schedulePast)
+                departureTime = time - 1.minutes
+            }
+        val scheduleSoonSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(scheduleSoon)
+                departureTime = time + 5.minutes
+            }
+        val scheduleLaterSchedule =
+            objects.schedule {
+                stopId = stop1.id
+                trip = objects.trip(scheduleLater)
+                departureTime = time + 121.minutes
+            }
+        val predictionPastPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionPast)
+                departureTime = time - 1.minutes
+            }
+        val predictionBrdTrip = objects.trip(predictionBrd)
+        val predictionBrdVehicle =
+            objects.vehicle {
+                stopId = stop1.id
+                tripId = predictionBrdTrip.id
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+            }
+        val predictionBrdPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = predictionBrdTrip
+                departureTime = time - 1.minutes
+                vehicleId = predictionBrdVehicle.id
+            }
+        val predictionSoonPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionSoon)
+                departureTime = time + 5.minutes
+            }
+        val predictionLaterPrediction =
+            objects.prediction {
+                stopId = stop1.id
+                trip = objects.trip(predictionLater)
+                departureTime = time + 121.minutes
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Schedule Soon",
+                                    null,
+                                    listOf(scheduleSoon),
+                                    listOf(objects.upcomingTrip(scheduleSoonSchedule))
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Prediction BRD",
+                                    null,
+                                    listOf(predictionBrd),
+                                    listOf(
+                                        objects.upcomingTrip(
+                                            prediction = predictionBrdPrediction,
+                                            vehicle = predictionBrdVehicle
+                                        )
+                                    ),
+                                    hasSchedulesToday = false
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Prediction Soon",
+                                    null,
+                                    listOf(predictionSoon),
+                                    listOf(objects.upcomingTrip(predictionSoonPrediction)),
+                                    hasSchedulesToday = false
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop1.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips hides rare patterns while loading`()  {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // should be included because typical and has prediction
+        val typicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical Out" }
+            }
+        // should be included because typical
+        val typicalInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 2
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical In" }
+            }
+        // should be included because prediction within 90 minutes
+        val deviationOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 3
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation Out" }
+            }
+        // should be included because prediction beyond 90 minutes
+        val deviationInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 4
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation In" }
+            }
+        // should be included because prediction
+        val atypicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 5
+                typicality = RoutePattern.Typicality.Atypical
+                representativeTrip { headsign = "Atypical Out" }
+            }
+        // should be excluded because no prediction
+        val atypicalInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 6
+                typicality = RoutePattern.Typicality.Atypical
+                representativeTrip { headsign = "Atypical In" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(stop1) {
+                        headsign("Typical Out", listOf(typicalOutbound))
+                        headsign("Typical In", listOf(typicalInbound))
+                        headsign("Deviation Out", listOf(deviationOutbound))
+                        headsign("Deviation In", listOf(deviationInbound))
+                        headsign("Atypical Out", listOf(atypicalOutbound))
+                        headsign("Atypical In", listOf(atypicalInbound))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical Out",
+                                    null,
+                                    listOf(typicalOutbound),
+                                    upcomingTrips = emptyList(),
+                                    allDataLoaded = false
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical In",
+                                    null,
+                                    listOf(typicalInbound),
+                                    upcomingTrips = emptyList(),
+                                    allDataLoaded = false
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop1.position,
+                schedules = null,
+                predictions = PredictionsStreamDataResponse(emptyMap(), emptyMap(), emptyMap()),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips hideNonTypicalPatternsBeyondNext when null doesn't filter`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // should be included because typical and has prediction
+        val typicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical Out" }
+            }
+
+        // should be included because hideNonTypicalPatternsBeyondNext is null
+        val deviationInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 4
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation In" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(stop1) {
+                        headsign("Typical Out", listOf(typicalOutbound))
+                        headsign("Deviation In", listOf(deviationInbound))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+        val typicalOutboundPrediction =
+            objects.prediction {
+                departureTime = time
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = typicalOutbound.representativeTripId
+            }
+
+        val deviationInboundPrediction =
+            objects.prediction {
+                departureTime = time + 95.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = deviationInbound.representativeTripId
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical Out",
+                                    null,
+                                    listOf(typicalOutbound),
+                                    listOf(objects.upcomingTrip(typicalOutboundPrediction)),
+                                    allDataLoaded = false
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Deviation In",
+                                    null,
+                                    listOf(deviationInbound),
+                                    listOf(objects.upcomingTrip(deviationInboundPrediction)),
+                                    allDataLoaded = false
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfoWithoutTripHeadsigns(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop1.position,
+                schedules = null,
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                showAllPatternsWhileLoading = false,
+                hideNonTypicalPatternsBeyondNext = null,
+                filterCancellations = false,
+                includeMinorAlerts = false,
+                pinnedRoutes = setOf(),
+            )
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips includes cancellations when filterCancellations false`() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop()
+        val route1 = objects.route()
+
+        // should be included because typical and has cancelled prediction
+        val typicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical Out" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) { stop(stop1) { headsign("Typical Out", listOf(typicalOutbound)) } }
+            }
+
+        val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+        val typicalOutboundSchedule =
+            objects.schedule {
+                routeId = route1.id
+                tripId = typicalOutbound.representativeTripId
+                stopId = stop1.id
+                arrivalTime = time
+                departureTime = time
+            }
+
+        val typicalOutboundPrediction =
+            objects.prediction {
+                departureTime = null
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = typicalOutbound.representativeTripId
+                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop1,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Typical Out",
+                                    null,
+                                    listOf(typicalOutbound),
+                                    listOf(
+                                        objects.upcomingTrip(
+                                            typicalOutboundSchedule,
+                                            typicalOutboundPrediction
+                                        )
+                                    ),
+                                    allDataLoaded = true
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfoWithoutTripHeadsigns(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop1.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                showAllPatternsWhileLoading = false,
+                hideNonTypicalPatternsBeyondNext = null,
+                filterCancellations = false,
+                includeMinorAlerts = false,
+                pinnedRoutes = setOf(),
+            )
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips sorts subway first then by distance`()  {
+        val objects = ObjectCollectionBuilder()
+
+        val closeBusStop = objects.stop()
+        val farBusStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.1
+                longitude = closeBusStop.longitude + 0.1
+            }
+        val closeSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.2
+                longitude = closeBusStop.longitude + 0.2
+            }
+        val farSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.3
+                longitude = closeBusStop.longitude + 0.3
+            }
+
+        val closeBusRoute =
+            objects.route {
+                type = RouteType.BUS
+                sortOrder = 4
+            }
+        val farBusRoute =
+            objects.route {
+                type = RouteType.BUS
+                sortOrder = 3
+            }
+        val closeSubwayRoute =
+            objects.route {
+                type = RouteType.LIGHT_RAIL
+                sortOrder = 2
+            }
+        val farSubwayRoute =
+            objects.route {
+                type = RouteType.LIGHT_RAIL
+                sortOrder = 1
+            }
+
+        val closeSubwayPattern =
+            objects.routePattern(closeSubwayRoute) { representativeTrip { headsign = "Alewife" } }
+        val farSubwayPattern =
+            objects.routePattern(farSubwayRoute) { representativeTrip { headsign = "Oak Grove" } }
+        val closeBusPattern =
+            objects.routePattern(closeBusRoute) { representativeTrip { headsign = "Nubian" } }
+        val farBusPattern =
+            objects.routePattern(farBusRoute) { representativeTrip { headsign = "Malden Center" } }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(farBusRoute) {
+                    stop(farBusStop) { headsign("Malden Center", listOf(farBusPattern)) }
+                }
+                route(closeBusRoute) {
+                    stop(closeBusStop) { headsign("Nubian", listOf(closeBusPattern)) }
+                }
+                route(farSubwayRoute) {
+                    stop(farSubwayStop) { headsign("Oak Grove", listOf(farSubwayPattern)) }
+                }
+                route(closeSubwayRoute) {
+                    stop(closeSubwayStop) { headsign("Alewife", listOf(closeSubwayPattern)) }
+                }
+            }
+
+        val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+        // close subway prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = closeSubwayRoute.id
+            stopId = closeSubwayStop.id
+            tripId = closeSubwayPattern.representativeTripId
+        }
+
+        // far subway prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = farSubwayRoute.id
+            stopId = farSubwayStop.id
+            tripId = farSubwayPattern.representativeTripId
+        }
+
+        // close bus prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = closeBusRoute.id
+            stopId = closeBusStop.id
+            tripId = closeBusPattern.representativeTripId
+        }
+
+        // far bus prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = farBusRoute.id
+            stopId = farBusStop.id
+            tripId = farBusPattern.representativeTripId
+        }
+
+        val realtimeRoutesSorted =
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = closeBusStop.position,
+                predictions = PredictionsStreamDataResponse(objects),
+                schedules = ScheduleResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        assertEquals(
+            listOf(closeSubwayRoute, farSubwayRoute, closeBusRoute, farBusRoute),
+            checkNotNull(realtimeRoutesSorted).flatMap {
+                when (it) {
+                    is StopsAssociated.WithRoute -> listOf(it.route)
+                    is StopsAssociated.WithLine -> it.routes
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips sorts pinned routes to the top`()  {
+        val objects = ObjectCollectionBuilder()
+
+        val closeBusStop = objects.stop()
+        val farBusStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.1
+                longitude = closeBusStop.longitude + 0.1
+            }
+        val closeSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.2
+                longitude = closeBusStop.longitude + 0.2
+            }
+        val farSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.3
+                longitude = closeBusStop.longitude + 0.3
+            }
+
+        val closeBusRoute = objects.route { type = RouteType.BUS }
+        val farBusRoute = objects.route { type = RouteType.BUS }
+        val closeSubwayRoute = objects.route { type = RouteType.LIGHT_RAIL }
+        val farSubwayRoute = objects.route { type = RouteType.LIGHT_RAIL }
+
+        val closeSubwayPattern =
+            objects.routePattern(closeSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Alewife" }
+            }
+        val farSubwayPattern =
+            objects.routePattern(farSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Oak Grove" }
+            }
+        val closeBusPattern =
+            objects.routePattern(closeBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Nubian" }
+            }
+        val farBusPattern =
+            objects.routePattern(farBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Malden Center" }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(farBusRoute) {
+                    stop(farBusStop) { headsign("Malden Center", listOf(farBusPattern)) }
+                }
+                route(closeBusRoute) {
+                    stop(closeBusStop) { headsign("Nubian", listOf(closeBusPattern)) }
+                }
+                route(farSubwayRoute) {
+                    stop(farSubwayStop) { headsign("Oak Grove", listOf(farSubwayPattern)) }
+                }
+                route(closeSubwayRoute) {
+                    stop(closeSubwayStop) { headsign("Alewife", listOf(closeSubwayPattern)) }
+                }
+            }
+
+        val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+        // close subway prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = closeSubwayRoute.id
+            stopId = closeSubwayStop.id
+            tripId = closeSubwayPattern.representativeTripId
+        }
+
+        // far subway prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = farSubwayRoute.id
+            stopId = farSubwayStop.id
+            tripId = farSubwayPattern.representativeTripId
+        }
+
+        // close bus prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = closeBusRoute.id
+            stopId = closeBusStop.id
+            tripId = closeBusPattern.representativeTripId
+        }
+
+        // far bus prediction
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = farBusRoute.id
+            stopId = farBusStop.id
+            tripId = farBusPattern.representativeTripId
+        }
+
+        val realtimeRoutesSorted =
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = closeBusStop.position,
+                predictions = PredictionsStreamDataResponse(objects),
+                schedules = ScheduleResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),)
+        assertEquals(
+            listOf(farSubwayRoute, farBusRoute, closeSubwayRoute, closeBusRoute),
+            checkNotNull(realtimeRoutesSorted).flatMap {
+                when (it) {
+                    is StopsAssociated.WithRoute -> listOf(it.route)
+                    is StopsAssociated.WithLine -> it.routes
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips sorts routes with no service today to the bottom`()  {
+        val objects = ObjectCollectionBuilder()
+
+        val closeBusStop = objects.stop()
+        val midBusStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.2
+                longitude = closeBusStop.longitude + 0.2
+            }
+        val farBusStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.4
+                longitude = closeBusStop.longitude + 0.4
+            }
+        val closeSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.1
+                longitude = closeBusStop.longitude + 0.1
+            }
+        val midSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.3
+                longitude = closeBusStop.longitude + 0.3
+            }
+        val farSubwayStop =
+            objects.stop {
+                latitude = closeBusStop.latitude + 0.5
+                longitude = closeBusStop.longitude + 0.5
+            }
+
+        // Unpinned, no schedules
+        val closeBusRoute =
+            objects.route {
+                id = "close-bus"
+                type = RouteType.BUS
+            }
+        // Unpinned, with schedules
+        val midBusRoute =
+            objects.route {
+                id = "mid-bus"
+                type = RouteType.BUS
+            }
+        // Unpinned, no schedules
+        val farBusRoute =
+            objects.route {
+                id = "far-bus"
+                type = RouteType.BUS
+            }
+        // Unpinned, no schedules
+        val closeSubwayRoute =
+            objects.route {
+                id = "close-subway"
+                type = RouteType.HEAVY_RAIL
+            }
+        // Pinned, no schedules
+        val midSubwayRoute =
+            objects.route {
+                id = "mid-subway"
+                type = RouteType.LIGHT_RAIL
+            }
+        // Pinned, with schedules
+        val farSubwayRoute =
+            objects.route {
+                id = "far-subway"
+                type = RouteType.HEAVY_RAIL
+            }
+
+        val closeBusPattern =
+            objects.routePattern(closeBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Lincoln Lab" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val midBusPattern1 =
+            objects.routePattern(midBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Nubian" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val midBusPattern2 =
+            objects.routePattern(midBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Nubian" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val farBusPattern1 =
+            objects.routePattern(farBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Malden Center" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val farBusPattern2 =
+            objects.routePattern(farBusRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Malden Center" }
+                typicality = RoutePattern.Typicality.Atypical
+            }
+        val closeSubwayPattern =
+            objects.routePattern(closeSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Alewife" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val midSubwayPattern =
+            objects.routePattern(midSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Medford/Tufts" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val farSubwayPattern =
+            objects.routePattern(farSubwayRoute) {
+                sortOrder = 1
+                representativeTrip { headsign = "Oak Grove" }
+                typicality = RoutePattern.Typicality.Typical
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(farBusRoute) {
+                    stop(farBusStop) {
+                        headsign("Malden Center", listOf(farBusPattern1, farBusPattern2))
+                    }
+                }
+                route(midBusRoute) {
+                    stop(midBusStop) { headsign("Nubian", listOf(midBusPattern1, midBusPattern2)) }
+                }
+                route(closeBusRoute) {
+                    stop(closeBusStop) { headsign("Lincoln Lab", listOf(closeBusPattern)) }
+                }
+                route(farSubwayRoute) {
+                    stop(farSubwayStop) { headsign("Oak Grove", listOf(farSubwayPattern)) }
+                }
+                route(midSubwayRoute) {
+                    stop(midSubwayStop) { headsign("Medford/Tufts", listOf(midSubwayPattern)) }
+                }
+                route(closeSubwayRoute) {
+                    stop(closeSubwayStop) { headsign("Alewife", listOf(closeSubwayPattern)) }
+                }
+            }
+
+        val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+        objects.prediction {
+            arrivalTime = time
+            departureTime = time
+            routeId = midBusRoute.id
+            stopId = midBusStop.id
+            tripId = midBusPattern1.representativeTripId
+        }
+
+        objects.schedule {
+            routeId = midBusRoute.id
+            tripId = midBusPattern1.representativeTripId
+        }
+
+        objects.schedule {
+            routeId = farSubwayRoute.id
+            tripId = farSubwayPattern.representativeTripId
+        }
+
+        val realtimeRoutesSorted =
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = closeBusStop.position,
+                predictions = PredictionsStreamDataResponse(objects),
+                schedules = ScheduleResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),)
+
+        // Routes with no service today should sort below all routes with any service today,
+        // unless they are a pinned route, in which case we want them to sort beneath all other
+        // pinned routes, but above any unpinned ones. Here, the far and mid subway routes are both
+        // pinned, but mid has no scheduled service, so it's sorted below the farther pinned route.
+        // For unpinned routes, mid bus is the only one with any schedules, so it's sorted above all
+        // the other unpinned routes, then the remaining  are ordered with the usual nearby transit
+        // sort order, subway first, then by distance.
+        assertEquals(
+            listOf(
+                farSubwayRoute,
+                midSubwayRoute,
+                midBusRoute,
+                closeSubwayRoute,
+                closeBusRoute,
+                farBusRoute
+            ),
+            checkNotNull(realtimeRoutesSorted).flatMap {
+                when (it) {
+                    is StopsAssociated.WithRoute -> listOf(it.route)
+                    is StopsAssociated.WithLine -> it.routes
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips doesn't sort unscheduled routes to the bottom if they are disrupted`() =
+        parametricTest {
+            val objects = ObjectCollectionBuilder()
+
+            val closeSubwayStop = objects.stop()
+            val midSubwayStop =
+                objects.stop {
+                    latitude = closeSubwayStop.latitude + 0.3
+                    longitude = closeSubwayStop.longitude + 0.3
+                }
+            val farSubwayStop =
+                objects.stop {
+                    latitude = closeSubwayStop.latitude + 0.5
+                    longitude = closeSubwayStop.longitude + 0.5
+                }
+
+            // No alerts, no schedules
+            val closeSubwayRoute =
+                objects.route {
+                    id = "close-subway"
+                    type = RouteType.HEAVY_RAIL
+                }
+            // Some alerts, no schedules
+            val midSubwayRoute =
+                objects.route {
+                    id = "mid-subway"
+                    type = RouteType.LIGHT_RAIL
+                }
+            // No alerts, some schedules
+            val farSubwayRoute =
+                objects.route {
+                    id = "far-subway"
+                    type = RouteType.HEAVY_RAIL
+                }
+
+            val closeSubwayPattern =
+                objects.routePattern(closeSubwayRoute) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Alewife" }
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val midSubwayPattern =
+                objects.routePattern(midSubwayRoute) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Medford/Tufts" }
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val farSubwayPattern =
+                objects.routePattern(farSubwayRoute) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Oak Grove" }
+                    typicality = RoutePattern.Typicality.Typical
+                }
+
+            val staticData =
+                NearbyStaticData.build {
+                    route(farSubwayRoute) {
+                        stop(farSubwayStop) { headsign("Oak Grove", listOf(farSubwayPattern)) }
+                    }
+                    route(midSubwayRoute) {
+                        stop(midSubwayStop) { headsign("Medford/Tufts", listOf(midSubwayPattern)) }
+                    }
+                    route(closeSubwayRoute) {
+                        stop(closeSubwayStop) { headsign("Alewife", listOf(closeSubwayPattern)) }
+                    }
+                }
+
+            val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+            objects.schedule {
+                routeId = farSubwayRoute.id
+                tripId = farSubwayPattern.representativeTripId
+            }
+
+            objects.alert {
+                activePeriod(time.minus(2.days), time.plus(2.days))
+                effect = Alert.Effect.Suspension
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board,
+                        Alert.InformedEntity.Activity.Exit,
+                        Alert.InformedEntity.Activity.Ride
+                    ),
+                    route = midSubwayRoute.id,
+                    routeType = midSubwayRoute.type,
+                    stop = midSubwayStop.id
+                )
+            }
+
+            val realtimeRoutesSorted =
+                staticData.withRealtimeInfo(
+                    globalData = GlobalResponse(objects),
+                    sortByDistanceFrom = closeSubwayStop.position,
+                    predictions = PredictionsStreamDataResponse(objects),
+                    schedules = ScheduleResponse(objects),
+                    alerts = AlertsStreamDataResponse(objects),
+                    filterAtTime = time,
+                    pinnedRoutes = setOf(),
+
+                    )
+
+            // If a route has major disruptions and doesn't have any scheduled trips, it should
+            // still
+            // be sorted as it normally would be.
+            assertEquals(
+                listOf(
+                    midSubwayRoute,
+                    farSubwayRoute,
+                    closeSubwayRoute,
+                ),
+                checkNotNull(realtimeRoutesSorted).flatMap {
+                    when (it) {
+                        is StopsAssociated.WithRoute -> listOf(it.route)
+                        is StopsAssociated.WithLine -> it.routes
+                    }
+                }
+            )
+        }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips handles parent stops`()  {
+        val objects = ObjectCollectionBuilder()
+        val parentStop = objects.stop()
+        val childStop = objects.stop { parentStationId = parentStop.id }
+        val route1 = objects.route()
+        val pattern1 = objects.routePattern(route1) { representativeTrip { headsign = "Harvard" } }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) {
+                    stop(parentStop, listOf(childStop.id)) { headsign("Harvard", listOf(pattern1)) }
+                }
+            }
+
+        val time = Instant.parse("2024-02-26T10:45:38-05:00")
+
+        val prediction1 =
+            objects.prediction {
+                departureTime = time
+                routeId = route1.id
+                stopId = childStop.id
+                tripId = pattern1.representativeTripId
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            parentStop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "Harvard",
+                                    null,
+                                    listOf(pattern1),
+                                    listOf(objects.upcomingTrip(prediction1)),
+                                    allDataLoaded = false
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = parentStop.position,
+                schedules = null,
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips incorporates schedules`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route()
+        val routePattern = objects.routePattern(route) { representativeTrip { headsign = "A" } }
+        val trip1 = objects.trip(routePattern)
+        val trip2 = objects.trip(routePattern)
+
+        val time = Instant.parse("2024-03-14T12:23:44-04:00")
+
+        val sched1 =
+            objects.schedule {
+                trip = trip1
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 1.minutes
+            }
+        val sched2 =
+            objects.schedule {
+                trip = trip2
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 2.minutes
+            }
+
+        val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
+        val pred2 = objects.prediction(sched2) { departureTime = null }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route) { stop(stop) { headsign("A", listOf(routePattern)) } }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePattern),
+                                    listOf(
+                                        objects.upcomingTrip(sched1, pred1),
+                                        objects.upcomingTrip(sched2, pred2)
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips checks if any trips are scheduled all day`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route()
+        val routePatternA =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+        val routePatternB =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "B" }
+            }
+        val routePatternC =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "C" }
+            }
+        val trip1 = objects.trip(routePatternA)
+
+        val time = Instant.parse("2024-03-14T12:23:44-04:00")
+
+        objects.schedule {
+            trip = trip1
+            stopId = stop.id
+            stopSequence = 90
+            departureTime = time - 2.hours
+        }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route) {
+                    stop(stop) {
+                        headsign("A", listOf(routePatternA))
+                        headsign("B", listOf(routePatternB))
+                        headsign("C", listOf(routePatternC))
+                    }
+                }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePatternA),
+                                    emptyList()
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "B",
+                                    null,
+                                    listOf(routePatternB),
+                                    emptyList(),
+                                    hasSchedulesToday = false
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips checks route along with route pattern and stop`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route1 = objects.route { sortOrder = 1 }
+        val routePattern1 = objects.routePattern(route1) { representativeTrip { headsign = "A" } }
+        val trip1 = objects.trip(routePattern1)
+
+        val route2 = objects.route { sortOrder = 2 }
+        val routePattern2 = objects.routePattern(route2) { representativeTrip { headsign = "B" } }
+        val trip2 = objects.trip(routePattern2)
+
+        // Should not be included
+        val trip3 = objects.trip(routePattern2) { routePatternId = "not the right id" }
+
+        val time = Instant.parse("2024-03-18T10:41:13-04:00")
+
+        val sched1 =
+            objects.schedule {
+                trip = trip1
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 1.minutes
+            }
+        val sched2 =
+            objects.schedule {
+                trip = trip2
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 2.minutes
+            }
+        val sched3 =
+            objects.schedule {
+                trip = trip3
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 3.minutes
+            }
+
+        val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
+        val pred2 = objects.prediction(sched2) { departureTime = time + 2.3.minutes }
+        val pred3 = objects.prediction(sched3) { departureTime = time + 3.4.minutes }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route1) { stop(stop) { headsign("A", listOf(routePattern1)) } }
+                route(route2) { stop(stop) { headsign("B", listOf(routePattern2)) } }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route1,
+                    listOf(
+                        PatternsByStop(
+                            route1,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route1,
+                                    "A",
+                                    null,
+                                    listOf(routePattern1),
+                                    listOf(objects.upcomingTrip(sched1, pred1))
+                                )
+                            )
+                        )
+                    )
+                ),
+                StopsAssociated.WithRoute(
+                    route2,
+                    listOf(
+                        PatternsByStop(
+                            route2,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route2,
+                                    "B",
+                                    null,
+                                    listOf(routePattern2),
+                                    listOf(objects.upcomingTrip(sched2, pred2))
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips picks out alerts`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route { sortOrder = 1 }
+        val routePattern =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+        objects.schedule {
+            this.trip = objects.trip(routePattern)
+            stopId = stop.id
+            departureTime = time.minus(1.hours)
+        }
+
+        val alert =
+            objects.alert {
+                activePeriod(
+                    Instant.parse("2024-03-18T04:30:00-04:00"),
+                    Instant.parse("2024-03-22T02:30:00-04:00")
+                )
+                effect = Alert.Effect.Suspension
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board,
+                        Alert.InformedEntity.Activity.Exit,
+                        Alert.InformedEntity.Activity.Ride
+                    ),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = stop.id
+                )
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route) { stop(stop) { headsign("A", listOf(routePattern)) } }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePattern),
+                                    emptyList(),
+                                    alertsHere = listOf(alert),
+                                    alertsDownstream = listOf()
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips ignores minor alerts`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route { sortOrder = 1 }
+        val routePattern =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+
+        val time = Instant.parse("2024-03-19T14:16:17-04:00")
+        objects.schedule {
+            this.trip = objects.trip(routePattern)
+            stopId = stop.id
+            departureTime = time.minus(1.hours)
+        }
+
+        val alert =
+            objects.alert {
+                activePeriod(
+                    Instant.parse("2024-03-18T04:30:00-04:00"),
+                    Instant.parse("2024-03-22T02:30:00-04:00")
+                )
+                effect = Alert.Effect.TrackChange
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board,
+                        Alert.InformedEntity.Activity.Exit,
+                        Alert.InformedEntity.Activity.Ride
+                    ),
+                    route = route.id,
+                    routeType = route.type,
+                    stop = stop.id
+                )
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(route) { stop(stop) { headsign("A", listOf(routePattern)) } }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    route,
+                    listOf(
+                        PatternsByStop(
+                            route,
+                            stop,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    route,
+                                    "A",
+                                    null,
+                                    listOf(routePattern),
+                                    emptyList(),
+                                    alertsHere = listOf(),
+                                    alertsDownstream = listOf()
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips groups lines by direction`()  {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val line = objects.line { id = "line-Green" }
+        val routeB =
+            objects.route {
+                id = "B"
+                sortOrder = 1
+                lineId = "line-Green"
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Kenmore & West", "Park St & North")
+            }
+        val routePatternB1 =
+            objects.routePattern(routeB) {
+                representativeTrip { headsign = "B" }
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val routePatternB2 =
+            objects.routePattern(routeB) {
+                representativeTrip { headsign = "B" }
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val tripB1 = objects.trip(routePatternB1)
+        val tripB2 = objects.trip(routePatternB2)
+
+        val routeC =
+            objects.route {
+                id = "C"
+                sortOrder = 2
+                lineId = "line-Green"
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Kenmore & West", "Park St & North")
+            }
+        val routePatternC1 =
+            objects.routePattern(routeC) {
+                representativeTrip { headsign = "C" }
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val routePatternC2 =
+            objects.routePattern(routeC) {
+                representativeTrip { headsign = "C" }
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val tripC1 = objects.trip(routePatternC1)
+        val tripC2 = objects.trip(routePatternC2)
+
+        val routeE =
+            objects.route {
+                id = "E"
+                sortOrder = 3
+                lineId = "line-Green"
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Heath Street", "Park St & North")
+            }
+        val routePatternE1 =
+            objects.routePattern(routeE) {
+                id = "test-hs"
+                representativeTrip { headsign = "Heath Street" }
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val routePatternE2 =
+            objects.routePattern(routeE) {
+                representativeTrip { headsign = "Medford/Tufts" }
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val tripE1 = objects.trip(routePatternE1)
+        val tripE2 = objects.trip(routePatternE2)
+
+        val time = Instant.parse("2024-03-18T10:41:13-04:00")
+
+        val schedB1 =
+            objects.schedule {
+                trip = tripB1
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 1.minutes
+            }
+        val schedB2 =
+            objects.schedule {
+                trip = tripB2
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 4.minutes
+            }
+        val schedC1 =
+            objects.schedule {
+                trip = tripC1
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 2.minutes
+            }
+        val schedC2 =
+            objects.schedule {
+                trip = tripC2
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 5.minutes
+            }
+        val schedE1 =
+            objects.schedule {
+                trip = tripE1
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 3.minutes
+            }
+        val schedE2 =
+            objects.schedule {
+                trip = tripE2
+                stopId = stop.id
+                stopSequence = 90
+                departureTime = time + 6.minutes
+            }
+
+        val predB1 = objects.prediction(schedB1) { departureTime = time + 1.5.minutes }
+        val predB2 = objects.prediction(schedB2) { departureTime = time + 4.5.minutes }
+        val predC1 = objects.prediction(schedC1) { departureTime = time + 2.3.minutes }
+        val predC2 = objects.prediction(schedC2) { departureTime = time + 5.3.minutes }
+        val predE1 = objects.prediction(schedE1) { departureTime = time + 2.3.minutes }
+        val predE2 = objects.prediction(schedE2) { departureTime = time + 6.3.minutes }
+
+        val directionWest = Direction("West", "Kenmore & West", 0)
+        val directionEast = Direction("East", "Park St & North", 1)
+
+        val staticData =
+            NearbyStaticData.build {
+                line(line, listOf(routeB, routeC, routeE)) {
+                    stop(stop, listOf(routeB, routeC, routeE)) {
+                        direction(
+                            directionWest,
+                            listOf(routeB, routeC),
+                            listOf(routePatternB1, routePatternC1)
+                        )
+                        headsign(routeE, "Heath Street", listOf(routePatternE1))
+                        direction(
+                            directionEast,
+                            listOf(routeB, routeC, routeE),
+                            listOf(routePatternB2, routePatternC2, routePatternE2)
+                        )
+                    }
+                }
+            }
+
+        val expected =
+            StopsAssociated.WithLine(
+                line,
+                listOf(routeB, routeC, routeE),
+                listOf(
+                    PatternsByStop(
+                        listOf(routeB, routeC, routeE),
+                        line,
+                        stop,
+                        listOf(
+                            RealtimePatterns.ByDirection(
+                                line,
+                                listOf(routeB, routeC),
+                                directionWest,
+                                listOf(routePatternB1, routePatternC1),
+                                listOf(
+                                    objects.upcomingTrip(schedB1, predB1),
+                                    objects.upcomingTrip(schedC1, predC1),
+                                )
+                            ),
+                            RealtimePatterns.ByHeadsign(
+                                routeE,
+                                "Heath Street",
+                                line,
+                                listOf(routePatternE1),
+                                listOf(objects.upcomingTrip(schedE1, predE1))
+                            ),
+                            RealtimePatterns.ByDirection(
+                                line,
+                                listOf(routeB, routeC, routeE),
+                                directionEast,
+                                listOf(routePatternB2, routePatternC2, routePatternE2),
+                                listOf(
+                                    objects.upcomingTrip(schedB2, predB2),
+                                    objects.upcomingTrip(schedC2, predC2),
+                                    objects.upcomingTrip(schedE2, predE2),
+                                )
+                            ),
+                        ),
+                        listOf(directionWest, directionEast),
+                        emptyList()
+                    )
+                )
+            )
+
+        assertEquals(
+            listOf(expected),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = stop.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
+    }
+
+    @Test
+    fun `NearbyStaticData getSchedulesTodayByPattern determines which patterns have service today`() {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop()
+        val route = objects.route()
+        val routePatternA =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "A" }
+            }
+        val routePatternB =
+            objects.routePattern(route) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "B" }
+            }
+        val trip1 = objects.trip(routePatternA)
+
+        val time = Instant.parse("2024-03-14T12:23:44-04:00")
+
+        objects.schedule {
+            trip = trip1
+            stopId = stop.id
+            stopSequence = 90
+            departureTime = time - 2.hours
+        }
+
+        assertNull(NearbyStaticData.getSchedulesTodayByPattern(null))
+
+        val hasSchedulesToday =
+            NearbyStaticData.getSchedulesTodayByPattern(ScheduleResponse(objects))
+
+        assertTrue(hasSchedulesToday?.get(routePatternA.id)!!)
+        assertNull(hasSchedulesToday[routePatternB.id])
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips north station disruption case`() {
+        val objects = ObjectCollectionBuilder()
+        val northStation =
+            objects.stop {
+                id = "place-north"
+                locationType = LocationType.STATION
+                childStopIds = listOf("70027", "70026")
+            }
+
+        val northStationNorthboundPlatform =
+            objects.stop {
+                id = "70027"
+                locationType = LocationType.STOP
+                parentStationId = "place-north"
+            }
+
+        val northStationSouthboundPlatform =
+            objects.stop {
+                id = "70026"
+                locationType = LocationType.STOP
+                parentStationId = "place-north"
+            }
+
+        val oakGrove =
+            objects.stop {
+                id = "place-ogmnl"
+                locationType = LocationType.STATION
+                childStopIds = listOf("70036")
+            }
+
+        val oakGrovePlatform =
+            objects.stop {
+                id = "70036"
+                locationType = LocationType.STOP
+                parentStationId = "place-ogmnl"
+            }
+
+        val forestHills =
+            objects.stop {
+                id = "place-forhl"
+                locationType = LocationType.STATION
+                childStopIds = listOf("70001")
+            }
+
+        val forestHillsPlatform =
+            objects.stop {
+                id = "70001"
+                locationType = LocationType.STOP
+                parentStationId = "place-forhl"
+            }
+
+        val orangeRoute = objects.route { id = "Orange" }
+        val orangeNorthboundTypical =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-3-1"
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+                representativeTrip {
+                    id = "canonical-Orange-C1-1"
+                    headsign = "Oak Grove"
+                    directionId = 1
+                    stopIds = listOf("70001", "70027", "70036")
+                }
+            }
+
+
+        val orangeNorthboundDiversion =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-6-1"
+                typicality = RoutePattern.Typicality.Diversion
+                directionId = 1
+                representativeTrip {
+                    id = "65686489"
+                    headsign = "North Station"
+                    directionId = 1
+                    stopIds = listOf("70001", "70027")
+                }
+            }
+
+        val orangeSouthboundTypical =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-3-0"
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+                representativeTrip {
+                    id = "canonical-Orange-C1-0"
+                    headsign = "Forest Hills"
+                    directionId = 0
+                    stopIds = listOf("70036", "70026", "70001")
+                }
+            }
+
+        val orangeSouthboundDiversion =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-6-0"
+                typicality = RoutePattern.Typicality.Diversion
+                directionId = 0
+                representativeTrip {
+                    id = "65743311"
+                    headsign = "Forest Hills"
+                    directionId = 0
+                    stopIds = listOf("70026", "70001")
+                }
+            }
+
+        val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
+
+        val orangeNorthboundDiversionTrip = objects.trip(orangeNorthboundDiversion)
+
+        val orangeSouthboundDiversionTrip = objects.trip(orangeSouthboundDiversion)
+
+        val time = Instant.parse("2024-10-30T16:40:00-04:00")
+
+        // Scheduled northbound arrivals with North station as last stop
+        val northboundSchedule =
+            objects.schedule {
+                trip = orangeNorthboundDiversionTrip
+                stopId = northStationNorthboundPlatform.id
+                stopSequence = 130
+                arrivalTime = time + 4.minutes
+                departureTime = null
+            }
+
+        val northboundPrediction =
+            objects.prediction {
+                trip = orangeNorthboundTypicalTrip
+                stopId = northStationNorthboundPlatform.id
+                stopSequence = 130
+                arrivalTime = time + 8.minutes
+                departureTime = null
+            }
+
+        // Scheduled southbound departures
+        val southboundSchedule =
+            objects.schedule {
+                trip = orangeSouthboundDiversionTrip
+                stopId = northStationSouthboundPlatform.id
+                stopSequence = 60
+                arrivalTime = null
+                departureTime = time + 6.minutes
+            }
+
+        val alert =
+            objects.alert {
+                id = "601685"
+                activePeriod(
+                    Instant.parse("2024-10-28T03:00:00-04:00"),
+                    Instant.parse("2024-11-02T03:00:00-04:00")
+                )
+                cause = Alert.Cause.Maintenance
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        // North station entities
+                        Alert.InformedEntity(
+                            activities =
+                            listOf(
+                                Alert.InformedEntity.Activity.Exit,
+                                Alert.InformedEntity.Activity.Ride
+                            ),
+                            route = orangeRoute.id,
+                            routeType = RouteType.HEAVY_RAIL,
+                            stop = northStationSouthboundPlatform.id
+                        ),
+                        Alert.InformedEntity(
+                            activities =
+                            listOf(
+                                Alert.InformedEntity.Activity.Board,
+                                Alert.InformedEntity.Activity.Ride
+                            ),
+                            route = orangeRoute.id,
+                            routeType = RouteType.HEAVY_RAIL,
+                            stop = northStationNorthboundPlatform.id
+                        ),
+                        Alert.InformedEntity(
+                            activities =
+                            listOf(
+                                Alert.InformedEntity.Activity.Board,
+                                Alert.InformedEntity.Activity.Exit,
+                                Alert.InformedEntity.Activity.Ride
+                            ),
+                            route = orangeRoute.id,
+                            routeType = RouteType.HEAVY_RAIL,
+                            stop = northStation.id
+                        ),
+                        Alert.InformedEntity(
+                            activities =
+                            listOf(
+                                Alert.InformedEntity.Activity.Board,
+                                Alert.InformedEntity.Activity.Exit,
+                                Alert.InformedEntity.Activity.Ride
+                            ),
+                            route = orangeRoute.id,
+                            routeType = RouteType.HEAVY_RAIL,
+                            stop = oakGrove.id
+                        ),
+                        Alert.InformedEntity(
+                            activities =
+                            listOf(
+                                Alert.InformedEntity.Activity.Board,
+                                Alert.InformedEntity.Activity.Exit,
+                                Alert.InformedEntity.Activity.Ride
+                            ),
+                            route = orangeRoute.id,
+                            routeType = RouteType.HEAVY_RAIL,
+                            stop = oakGrovePlatform.id
+                        )
+                    )
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(orangeRoute) {
+                    stop(northStation) {
+                        headsign(
+                            "Forest Hills",
+                            listOf(orangeSouthboundTypical, orangeSouthboundDiversion)
+                        )
+                        headsign("Oak Grove", listOf(orangeNorthboundTypical))
+                        headsign("North Station", listOf(orangeNorthboundDiversion))
+                    }
+                }
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    orangeRoute,
+                    listOf(
+                        PatternsByStop(
+                            orangeRoute,
+                            northStation,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    orangeRoute,
+                                    "Forest Hills",
+                                    null,
+                                    listOf(orangeSouthboundTypical, orangeSouthboundDiversion),
+                                    listOf(
+                                        UpcomingTrip(
+                                            trip = orangeSouthboundDiversionTrip,
+                                            schedule = southboundSchedule
+                                        )
+                                    ),
+                                    alertsHere = listOf(alert),
+                                    hasSchedulesToday = true
+                                ),
+                                RealtimePatterns.ByHeadsign(
+                                    orangeRoute,
+                                    "Oak Grove",
+                                    null,
+                                    listOf(orangeNorthboundTypical),
+                                    listOf(
+                                        UpcomingTrip(
+                                            trip = orangeNorthboundTypicalTrip,
+                                            prediction = northboundPrediction,
+                                            predictionStop = northStationNorthboundPlatform
+                                        )
+                                    ),
+                                    alertsHere = listOf(alert),
+                                    alertsDownstream = emptyList(),
+                                    hasSchedulesToday = false
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = northStation.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(mapOf(alert.id to alert)),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),
+            )
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips filters out headsign if it is the last stop of route pattern`() {
+        val objects = ObjectCollectionBuilder()
+
+        val oakGrove =
+            objects.stop {
+                id = "place-ogmnl"
+                locationType = LocationType.STATION
+                childStopIds = listOf("70036")
+            }
+
+        val orangeRoute = objects.route { id = "Orange" }
+        val orangeNorthboundTypical =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-3-1"
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+                representativeTrip {
+                    id = "canonical-Orange-C1-1"
+                    headsign = "Oak Grove"
+                    directionId = 1
+                    stopIds = listOf("70001", "70027", "70036")
+                }
+            }
+
+        val orangeSouthboundTypical =
+            objects.routePattern(orangeRoute) {
+                id = "Orange-3-0"
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+                representativeTrip {
+                    id = "canonical-Orange-C1-0"
+                    headsign = "Forest Hills"
+                    directionId = 0
+                    stopIds = listOf("70036", "70026", "70001")
+                }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(orangeRoute) {
+                    stop(oakGrove) {
+                        headsign("Forest Hills", listOf(orangeSouthboundTypical))
+                        headsign("Oak Grove", listOf(orangeNorthboundTypical))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-10-30T16:40:00-04:00")
+
+        val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
+        val orangeSouthboundTypicalTrip = objects.trip(orangeSouthboundTypical)
+
+        val sched1 =
+            objects.schedule {
+                trip = orangeSouthboundTypicalTrip
+                stopId = oakGrove.id
+                stopSequence = 90
+                departureTime = time + 1.minutes
+            }
+        val sched2 =
+            objects.schedule {
+                trip = orangeNorthboundTypicalTrip
+                stopId = oakGrove.id
+                stopSequence = 90
+                arrivalTime = time + 2.minutes
+                departureTime = null
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    orangeRoute,
+                    listOf(
+                        PatternsByStop(
+                            orangeRoute,
+                            oakGrove,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    orangeRoute,
+                                    "Forest Hills",
+                                    null,
+                                    listOf(orangeSouthboundTypical),
+                                    listOf(objects.upcomingTrip(sched1)),
+                                    hasSchedulesToday = true
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = oakGrove.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),
+            )
+        )
+    }
+
+    @Test
+    fun `ListBuilder addUpcomingTrips filters out any arrival only for non-subway routes`() {
+        val objects = ObjectCollectionBuilder()
+
+        val longWharf =
+            objects.stop {
+                id = "Boat-Long"
+            }
+
+        val ferryRoute = objects.route {
+            id = "Boat-F1"
+            type = RouteType.FERRY
+        }
+        val ferryInboundToLongWharf =
+            objects.routePattern(ferryRoute) {
+                id = "Boat-F1-3-1"
+                routeId = ferryRoute.id
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+                representativeTrip {
+                    id = "Boat-F1-0730-Hull-BF2H-01-Weekday-Fall-24"
+                    headsign = "Long Wharf"
+                    directionId = 1
+                    stopIds = listOf("Boat-Hull", "Boat-Long")
+                }
+            }
+
+        val ferryOutboundToHingham =
+            objects.routePattern(ferryRoute) {
+                id = "Boat-F1-0-0"
+                routeId = ferryRoute.id
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+                representativeTrip {
+                    id = "Boat-F1-1100-Long-BF2H-01-Weekday-Fall-24"
+                    headsign = "Hingham"
+                    directionId = 0
+                    stopIds = listOf("Boat-Long", "Boat-Logan", "Boat-Hull", "Boat-Hingham")
+                }
+            }
+
+        val staticData =
+            NearbyStaticData.build {
+                route(ferryRoute) {
+                    stop(longWharf) {
+                        headsign("Hingham", listOf(ferryOutboundToHingham))
+                        headsign("Long Wharf", listOf(ferryInboundToLongWharf))
+                    }
+                }
+            }
+
+        val time = Instant.parse("2024-10-30T16:40:00-04:00")
+
+        val ferryInboundTrip = objects.trip(ferryInboundToLongWharf)
+        val ferryOutboundTrip = objects.trip(ferryOutboundToHingham)
+
+        val schedInbound =
+            objects.schedule {
+                trip = ferryInboundTrip
+                stopId = longWharf.id
+                stopSequence = 90
+                arrivalTime = time + 2.minutes
+                departureTime = null            }
+        val schedOutbound =
+            objects.schedule {
+                trip = ferryOutboundTrip
+                stopId = longWharf.id
+                stopSequence = 90
+                departureTime = time + 2.minutes
+
+            }
+
+        assertEquals(
+            listOf(
+                StopsAssociated.WithRoute(
+                    ferryRoute,
+                    listOf(
+                        PatternsByStop(
+                            ferryRoute,
+                            longWharf,
+                            listOf(
+                                RealtimePatterns.ByHeadsign(
+                                    ferryRoute,
+                                    "Hingham",
+                                    null,
+                                    listOf(ferryOutboundToHingham),
+                                    listOf(objects.upcomingTrip(schedOutbound)),
+                                    hasSchedulesToday = true
+                                ),
+                            )
+                        )
+                    )
+                )
+            ),
+            staticData.withRealtimeInfo(
+                globalData = GlobalResponse(objects),
+                sortByDistanceFrom = longWharf.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                filterAtTime = time,
+                pinnedRoutes = setOf(),)
+        )
     }
 
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -54,6 +54,7 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(route1rp1),
                                             stopIds = setOf(stop1.id)
                                         )
@@ -109,6 +110,7 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(route1rp1),
                                             stopIds = setOf(stop1.id)
                                         )
@@ -117,6 +119,7 @@ class RouteCardDataTest {
                                 stop2.id to RouteCardData.RouteStopDataBuilder(
                                     stop2, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(
                                                 route1rp1,
                                                 route1rp2
@@ -175,6 +178,7 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(
                                                 route1rp1,
                                                 route1rp2
@@ -183,6 +187,7 @@ class RouteCardDataTest {
                                             stopIds = setOf(stop1.id)
                                         ),
                                         1 to RouteCardData.LeafBuilder(
+                                            directionId = 1,
                                             routePatterns = listOf(
                                                 route1rp3
                                             ),
@@ -237,6 +242,7 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(route1rp1),
                                             stopIds = setOf(stop1.id)
                                         )
@@ -251,6 +257,7 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(route2rp1),
                                             stopIds = setOf(stop1.id)
                                         )
@@ -319,6 +326,7 @@ class RouteCardDataTest {
                                 station1.id to RouteCardData.RouteStopDataBuilder(
                                     station1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(
                                                 route1rp1, route1rp2
                                             ),
@@ -330,6 +338,7 @@ class RouteCardDataTest {
                                 stop2.id to RouteCardData.RouteStopDataBuilder(
                                     stop2, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(
                                                 route1rp3
                                             ),
@@ -387,6 +396,7 @@ class RouteCardDataTest {
                                 parentStation.id to RouteCardData.RouteStopDataBuilder(
                                     parentStation, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(routePattern ),
                                             stopIds = setOf(parentStation.id, logicalPlatform.id, physicalPlatform.id)
                                         )
@@ -452,6 +462,7 @@ class RouteCardDataTest {
                                 stop.id to RouteCardData.RouteStopDataBuilder(
                                     stop, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(railPattern ),
                                             stopIds = setOf(stop.id)
                                         )
@@ -463,6 +474,7 @@ class RouteCardDataTest {
                 RouteCardData.Builder(RouteCardData.LineOrRoute.Route(shuttleRoute), mapOf(
                     stop.id to RouteCardData.RouteStopDataBuilder(stop, emptyList(), mapOf(
                         0 to RouteCardData.LeafBuilder(
+                            directionId = 0,
                             routePatterns = listOf(shuttlePattern ),
                             stopIds = setOf(stop.id)
                         )
@@ -636,10 +648,12 @@ class RouteCardDataTest {
                                 stopGov.id to RouteCardData.RouteStopDataBuilder(
                                     stopGov, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(routeDrp1, routeBrp1, routeCrp1 ),
                                             stopIds = setOf(stopGov.id)
                                         ),
                                         1 to RouteCardData.LeafBuilder(
+                                            directionId = 1,
                                             routePatterns = listOf(routeDrp2, routeCrp3 ),
                                             stopIds = setOf(stopGov.id)
                                         )
@@ -733,24 +747,28 @@ class RouteCardDataTest {
                                 stop1.id to RouteCardData.RouteStopDataBuilder(
                                     stop1, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(pattern1, pattern2),
                                             stopIds = setOf(stop1.id),
                                             upcomingTrips = listOf(
                                                 objects.upcomingTrip(stop1Pattern2Prediction),
                                                 objects.upcomingTrip(stop1Pattern1Prediction)
                                             ),
+                                            allDataLoaded = false
                                         )
                                     )
                                 ),
                                 stop2.id to RouteCardData.RouteStopDataBuilder(
                                     stop2, emptyList(), mapOf(
                                         0 to RouteCardData.LeafBuilder(
+                                            directionId = 0,
                                             routePatterns = listOf(pattern3),
                                             stopIds = setOf(stop2.id),
                                             upcomingTrips = listOf(
                                                 objects.upcomingTrip(stop2Pattern1Prediction),
                                                 objects.upcomingTrip(stop2Pattern3Prediction),
                                             ),
+                                            allDataLoaded = false
                                         )
                                     )
                                 )
@@ -763,7 +781,7 @@ class RouteCardDataTest {
         }
 
     @Test
-    fun `ListBuilder addUpcomingTrips hides rare patterns with no predictions`() {
+    fun `RouteCardData routeCardsForStopList hides rare direction with no predictions in next 120 min`() {
         val objects = ObjectCollectionBuilder()
 
         val stop1 = objects.stop()
@@ -778,23 +796,7 @@ class RouteCardDataTest {
                 typicality = RoutePattern.Typicality.Typical
                 representativeTrip { headsign = "Typical Out" }
             }
-        // should be included because typical
-        val typicalInbound =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 2
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Typical In" }
-            }
-        // should be included because prediction within 90 minutes
-        val deviationOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 3
-                typicality = RoutePattern.Typicality.Deviation
-                representativeTrip { headsign = "Deviation Out" }
-            }
-        // should be included because prediction beyond 90 minutes
+        // should not be included because not typical and prediction beyond 120 minutes
         val deviationInbound =
             objects.routePattern(route1) {
                 directionId = 1
@@ -802,36 +804,9 @@ class RouteCardDataTest {
                 typicality = RoutePattern.Typicality.Deviation
                 representativeTrip { headsign = "Deviation In" }
             }
-        // should be included because prediction
-        val atypicalOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 5
-                typicality = RoutePattern.Typicality.Atypical
-                representativeTrip { headsign = "Atypical Out" }
-            }
-        // should be excluded because no prediction
-        val atypicalInbound =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 6
-                typicality = RoutePattern.Typicality.Atypical
-                representativeTrip { headsign = "Atypical In" }
-            }
 
-        val staticData =
-            NearbyStaticData.build {
-                route(route1) {
-                    stop(stop1) {
-                        headsign("Typical Out", listOf(typicalOutbound))
-                        headsign("Typical In", listOf(typicalInbound))
-                        headsign("Deviation Out", listOf(deviationOutbound))
-                        headsign("Deviation In", listOf(deviationInbound))
-                        headsign("Atypical Out", listOf(atypicalOutbound))
-                        headsign("Atypical In", listOf(atypicalInbound))
-                    }
-                }
-            }
+        val global = GlobalResponse(objects, patternIdsByStop = mapOf(stop1.id to listOf(typicalOutbound.id,
+           deviationInbound.id)))
 
         val time = Instant.parse("2024-02-22T12:08:19-05:00")
 
@@ -842,13 +817,7 @@ class RouteCardDataTest {
                 stopId = stop1.id
                 tripId = typicalOutbound.representativeTripId
             }
-        val deviationOutboundPrediction =
-            objects.prediction {
-                departureTime = time + 119.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = deviationOutbound.representativeTripId
-            }
+
         val deviationInboundPrediction =
             objects.prediction {
                 departureTime = time + 121.minutes
@@ -856,71 +825,127 @@ class RouteCardDataTest {
                 stopId = stop1.id
                 tripId = deviationInbound.representativeTripId
             }
-        val atypicalInboundPrediction =
-            objects.prediction {
-                departureTime = time + 1.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = atypicalInbound.representativeTripId
-            }
-
         assertEquals(
-            listOf(
-                StopsAssociated.WithRoute(
-                    route1,
-                    listOf(
-                        PatternsByStop(
-                            route1,
-                            stop1,
-                            listOf(
-                                RealtimePatterns.ByHeadsign(
-                                    route1,
-                                    "Typical Out",
-                                    null,
-                                    listOf(typicalOutbound),
-                                    listOf(objects.upcomingTrip(typicalOutboundPrediction)),
-                                    allDataLoaded = false
-                                ),
-                                RealtimePatterns.ByHeadsign(
-                                    route1,
-                                    "Deviation Out",
-                                    null,
-                                    listOf(deviationOutbound),
-                                    listOf(objects.upcomingTrip(deviationOutboundPrediction)),
-                                    allDataLoaded = false
-                                ),
-                                // since this has trips it's sorted earlier than typical in
-                                RealtimePatterns.ByHeadsign(
-                                    route1,
-                                    "Atypical In",
-                                    null,
-                                    listOf(atypicalInbound),
-                                    listOf(objects.upcomingTrip(atypicalInboundPrediction)),
-                                    allDataLoaded = false
-                                ),
-                                RealtimePatterns.ByHeadsign(
-                                    route1,
-                                    "Typical In",
-                                    null,
-                                    listOf(typicalInbound),
-                                    emptyList(),
-                                    allDataLoaded = false
-                                ),
-                            )
-                        )
-                    )
-                )
-            ),
-            staticData.withRealtimeInfo(
-                globalData = GlobalResponse(objects),
-                sortByDistanceFrom = stop1.position,
+            listOf(RouteCardData(
+                lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                stopData = listOf(
+                    RouteCardData.RouteStopData(stop1, emptyList(), listOf(RouteCardData.Leaf(
+                        directionId = 0,
+                        routePatterns = listOf(typicalOutbound),
+                        stopIds = setOf(stop1.id),
+                        upcomingTrips = listOf(
+                            objects.upcomingTrip(typicalOutboundPrediction),
+                        ),
+                        allDataLoaded = false,
+                        alertsHere = emptyList()
+                    ))))
+            )),
+
+            RouteCardData.routeCardsForStopList(listOf(stop1.id), global,
+                filterAtTime = time,
+                sortByDistanceFrom = null,
                 schedules = null,
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
-                filterAtTime = time,
-                pinnedRoutes = setOf(),)
-        )
+                pinnedRoutes = setOf(),
+                context = RouteCardData.Context.NearbyTransit))
     }
+
+    @Test
+    fun `RouteCardData routeCardsForStopList shows rare direction with predictions in next 120 min`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop()
+
+        val route1 = objects.route()
+
+        // should be included because typical and has prediction < 120 minutes
+        val typicalOutbound =
+            objects.routePattern(route1) {
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { headsign = "Typical Out" }
+            }
+        // should also be included even though > 120 minutes because above prediction < 120
+        val deviationInbound =
+            objects.routePattern(route1) {
+                directionId = 1
+                sortOrder = 4
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip { headsign = "Deviation In" }
+            }
+
+        val deviationInboundTrip2 = objects.trip {
+            directionId = 1
+            routePatternId = deviationInbound.id
+            routeId = route1.id
+        }
+
+        val global = GlobalResponse(objects, patternIdsByStop = mapOf(stop1.id to listOf(typicalOutbound.id,
+            deviationInbound.id)))
+
+        val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+        val typicalOutboundPrediction =
+            objects.prediction {
+                departureTime = time
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = typicalOutbound.representativeTripId
+            }
+
+        val deviationInboundPrediction =
+            objects.prediction {
+                departureTime = time + 119.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = deviationInbound.representativeTripId
+            }
+
+        val deviationInboundPredictionLater =
+            objects.prediction {
+                departureTime = time + 121.minutes
+                routeId = route1.id
+                stopId = stop1.id
+                tripId = deviationInboundTrip2.id
+            }
+        assertEquals(
+            listOf(RouteCardData(
+                lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                stopData = listOf(
+                    RouteCardData.RouteStopData(stop1, emptyList(), listOf(RouteCardData.Leaf(
+                        directionId = 0,
+                        routePatterns = listOf(typicalOutbound),
+                        stopIds = setOf(stop1.id),
+                        upcomingTrips = listOf(
+                            objects.upcomingTrip(typicalOutboundPrediction),
+                        ),
+                        allDataLoaded = false,
+                        alertsHere = emptyList()
+                    ),
+                        RouteCardData.Leaf(
+                            directionId = 1,
+                            routePatterns = listOf(typicalOutbound),
+                            stopIds = setOf(stop1.id),
+                            upcomingTrips = listOf(
+                                objects.upcomingTrip(deviationInboundPrediction),
+                                objects.upcomingTrip(deviationInboundPredictionLater),
+                                ),
+                            allDataLoaded = false,
+                            alertsHere = emptyList()
+                        )),
+            )))),
+            RouteCardData.routeCardsForStopList(listOf(stop1.id), global,
+                filterAtTime = time,
+                sortByDistanceFrom = null,
+                schedules = null,
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(objects),
+                pinnedRoutes = setOf(),
+                context = RouteCardData.Context.NearbyTransit))
+    }
+
 
     @Test
     fun `ListBuilder addUpcomingTrips handles schedule and predictions edge cases`()  {


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | Foundational data structure](https://app.asana.com/0/1205732265579288/1209536961544699)

What is this PR for?
This PR adds upcoming trips to the RouteCardData structure and filters using the same rules as `NearbyStaticData.withRealtimeInfo` (filter cancellations, non-typical w/out upcoming trips, arrival only).

There are a few minor adjustments to this logic based on filtering by direction, I'll add specific comments where that is the case.

Still remaining work:
* Adding directions
* Sorting
* Adding equivalent of `hasSchedulesToday` (thinking of punting this entirely to the special service states ticket to unblock the barebones UX work)


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

What testing have you done?
* Ported tests of `NearbyStaticData.withRealtimeInfo` from `NearbyResponseTests` to the new `RouteCard` data type. Made some minor adjustments, will call out where so.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
