### PR TITLE
perf: move expensive calculations to background in shared code

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ iOS
 
 android
 - [ ] All user-facing strings added to strings resource in alphabetical order
-- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible
+- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)
 
 ### Testing
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -31,6 +31,7 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -137,7 +138,7 @@ class StopDetailsFilteredDeparturesViewTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testStopDetailsRouteViewDisplaysCorrectly() {
+    fun testStopDetailsRouteViewDisplaysCorrectly(): Unit = runBlocking {
         val departures =
             checkNotNull(
                 StopDetailsDepartures.fromData(
@@ -194,7 +195,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testTappingTripSetsFilter() {
+    fun testTappingTripSetsFilter() = runBlocking {
         var tripFilter: TripDetailsFilter? = null
 
         val departures =
@@ -410,7 +411,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testShowsSuspension() {
+    fun testShowsSuspension(): Unit = runBlocking {
         val now = Clock.System.now()
         val alert =
             builder.alert {
@@ -488,7 +489,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testShowsDownstreamAlert() {
+    fun testShowsDownstreamAlert(): Unit = runBlocking {
         val alert =
             builder.alert {
                 activePeriod(now - 5.seconds, now + 5.seconds)
@@ -561,7 +562,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testShowsElevatorAlert() {
+    fun testShowsElevatorAlert(): Unit = runBlocking {
         val alert =
             builder.alert {
                 effect = Alert.Effect.ElevatorClosure
@@ -625,7 +626,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testShowsNotAccessibleAlert() {
+    fun testShowsNotAccessibleAlert(): Unit = runBlocking {
         val departures =
             checkNotNull(
                 StopDetailsDepartures.fromData(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
@@ -101,8 +102,7 @@ class StopDetailsUnfilteredRoutesViewTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testStopDetailsRoutesViewDisplaysCorrectly() {
-
+    fun testStopDetailsRoutesViewDisplaysCorrectly(): Unit = runBlocking {
         val departures =
             checkNotNull(
                 StopDetailsDepartures.fromData(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -742,7 +742,6 @@ class StopDetailsViewModelTest {
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
                     setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
                 )
             }
         }
@@ -829,7 +828,6 @@ class StopDetailsViewModelTest {
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
                     setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
                 )
             }
         }
@@ -943,7 +941,6 @@ class StopDetailsViewModelTest {
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
                     setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
                 )
             }
         }
@@ -1037,7 +1034,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
         }
 
@@ -1083,7 +1079,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
         }
 
@@ -1127,7 +1122,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
         }
 
@@ -1172,7 +1166,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
         }
 
@@ -1222,7 +1215,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
         }
 
@@ -1291,7 +1283,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, filter -> newStopFilter = filter },
                 updateTripFilter = { _, _ -> },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {
@@ -1368,7 +1359,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {
@@ -1443,7 +1433,6 @@ class StopDetailsViewModelTest {
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
                 setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
             )
 
             LaunchedEffect(null) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapLayerManager.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapLayerManager.kt
@@ -46,10 +46,8 @@ class MapLayerManager(val map: MapboxMap, context: Context) {
 
     suspend fun addLayers(colorPalette: ColorPalette) {
         val layers: List<MapboxLayer> =
-            withContext(Dispatchers.Default) {
-                RouteLayerGenerator.createAllRouteLayers(colorPalette).map { it.toMapbox() } +
-                    StopLayerGenerator.createStopLayers(colorPalette).map { it.toMapbox() }
-            }
+            RouteLayerGenerator.createAllRouteLayers(colorPalette).map { it.toMapbox() } +
+                StopLayerGenerator.createStopLayers(colorPalette).map { it.toMapbox() }
         withContext(Dispatchers.Main) {
             for (layer in layers) {
                 if (map.styleLayerExists(checkNotNull(layer.layerId))) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -158,30 +158,26 @@ open class MapViewModel(
     }
 
     override suspend fun refreshRouteLineData(globalMapData: GlobalMapData?) {
-        withContext(Dispatchers.Default) {
-            val globalResponse = globalResponse.first() ?: return@withContext
-            val railRouteShapes = railRouteShapes.first() ?: return@withContext
-            _railRouteLineData.value =
-                RouteFeaturesBuilder.generateRouteLines(
-                    railRouteShapes.routesWithSegmentedShapes,
-                    globalResponse.routes,
-                    globalResponse.stops,
-                    globalMapData?.alertsByStop
-                )
-        }
+        val globalResponse = globalResponse.first() ?: return
+        val railRouteShapes = railRouteShapes.first() ?: return
+        _railRouteLineData.value =
+            RouteFeaturesBuilder.generateRouteLines(
+                railRouteShapes.routesWithSegmentedShapes,
+                globalResponse.routes,
+                globalResponse.stops,
+                globalMapData?.alertsByStop
+            )
     }
 
     override suspend fun refreshStopFeatures(selectedStop: Stop?, globalMapData: GlobalMapData?) {
-        withContext(Dispatchers.Default) {
-            val routeLineData = railRouteLineData.first() ?: return@withContext
-            _stopSourceData.value =
-                StopFeaturesBuilder.buildCollection(
-                        StopSourceData(selectedStopId = selectedStop?.id),
-                        globalMapData?.mapStops.orEmpty(),
-                        routeLineData
-                    )
-                    .toMapbox()
-        }
+        val routeLineData = railRouteLineData.first() ?: return
+        _stopSourceData.value =
+            StopFeaturesBuilder.buildCollection(
+                    StopSourceData(selectedStopId = selectedStop?.id),
+                    globalMapData?.mapStops.orEmpty(),
+                    routeLineData
+                )
+                .toMapbox()
     }
 
     override suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -40,9 +40,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.withRealtimeInfo
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -104,20 +102,18 @@ fun NearbyTransitView(
             now,
             pinnedRoutes
         ) {
-            withContext(Dispatchers.Default) {
-                if (targetLocation != null) {
-                    nearbyVM.nearby?.withRealtimeInfo(
-                        globalData = globalResponse,
-                        sortByDistanceFrom = targetLocation,
-                        schedules,
-                        predictions,
-                        alertData,
-                        now,
-                        pinnedRoutes.orEmpty(),
-                    )
-                } else {
-                    null
-                }
+            if (targetLocation != null) {
+                nearbyVM.nearby?.withRealtimeInfo(
+                    globalData = globalResponse,
+                    sortByDistanceFrom = targetLocation,
+                    schedules,
+                    predictions,
+                    alertData,
+                    now,
+                    pinnedRoutes.orEmpty(),
+                )
+            } else {
+                null
             }
         }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -277,28 +277,26 @@ class StopDetailsViewModel(
     ): StateFlow<TripDetailsStopList?> {
         val tripData = this.tripData.collectAsState().value
         LaunchedEffect(tripFilter, tripData, allAlerts, globalResponse) {
-            withContext(Dispatchers.Default) {
-                _tripDetailsStopList.value =
-                    if (
-                        tripFilter != null &&
-                            tripData != null &&
-                            tripData.tripFilter == tripFilter &&
-                            tripData.tripPredictionsLoaded &&
-                            globalResponse != null
-                    ) {
-                        TripDetailsStopList.fromPieces(
-                            tripFilter.tripId,
-                            tripData.trip.directionId,
-                            tripData.tripSchedules,
-                            tripData.tripPredictions,
-                            tripData.vehicle,
-                            allAlerts,
-                            globalResponse
-                        )
-                    } else {
-                        null
-                    }
-            }
+            _tripDetailsStopList.value =
+                if (
+                    tripFilter != null &&
+                        tripData != null &&
+                        tripData.tripFilter == tripFilter &&
+                        tripData.tripPredictionsLoaded &&
+                        globalResponse != null
+                ) {
+                    TripDetailsStopList.fromPieces(
+                        tripFilter.tripId,
+                        tripData.trip.directionId,
+                        tripData.tripSchedules,
+                        tripData.tripPredictions,
+                        tripData.vehicle,
+                        allAlerts,
+                        globalResponse
+                    )
+                } else {
+                    null
+                }
         }
         return this._tripDetailsStopList.asStateFlow()
     }
@@ -488,8 +486,7 @@ fun stopDetailsManagedVM(
     setMapSelectedVehicle: (Vehicle?) -> Unit,
     now: Instant = Clock.System.now(),
     viewModel: StopDetailsViewModel = koinViewModel(),
-    checkPredictionsStaleInterval: Duration = 5.seconds,
-    coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default
+    checkPredictionsStaleInterval: Duration = 5.seconds
 ): StopDetailsViewModel {
     val stopId = filters?.stopId
     val timer = timer(checkPredictionsStaleInterval)
@@ -513,28 +510,26 @@ fun stopDetailsManagedVM(
     }
 
     LaunchedEffect(stopId, globalResponse, stopData, filters, alertData, pinnedRoutes, now) {
-        withContext(coroutineDispatcher) {
-            val schedules = stopData.value?.schedules
-            viewModel.setDepartures(
-                if (
-                    globalResponse != null &&
-                        stopId != null &&
-                        stopId == stopData.value?.stopId &&
-                        schedules != null &&
-                        stopData.value?.predictionsLoaded == true
-                ) {
-                    StopDetailsDepartures.fromData(
-                        stopId,
-                        globalResponse,
-                        schedules,
-                        stopData.value?.predictionsByStop?.toPredictionsStreamDataResponse(),
-                        alertData,
-                        pinnedRoutes,
-                        now,
-                    )
-                } else null
-            )
-        }
+        val schedules = stopData.value?.schedules
+        viewModel.setDepartures(
+            if (
+                globalResponse != null &&
+                    stopId != null &&
+                    stopId == stopData.value?.stopId &&
+                    schedules != null &&
+                    stopData.value?.predictionsLoaded == true
+            ) {
+                StopDetailsDepartures.fromData(
+                    stopId,
+                    globalResponse,
+                    schedules,
+                    stopData.value?.predictionsByStop?.toPredictionsStreamDataResponse(),
+                    alertData,
+                    pinnedRoutes,
+                    now,
+                )
+            } else null
+        )
     }
 
     LaunchedEffect(key1 = timer) { viewModel.checkStopPredictionsStale() }

--- a/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewLayerExtension.swift
@@ -44,14 +44,16 @@ extension HomeMapView {
     }
 
     func handleSetStopSources() {
-        let snappedStopRouteLines = RouteFeaturesBuilder.shared.generateRouteLines(
-            routeData: mapVM.allRailSourceData,
-            routesById: mapVM.globalData?.routes,
-            stopsById: mapVM.globalData?.stops,
-            alertsByStop: globalMapData?.alertsByStop
-        )
-        mapVM.snappedStopRouteLines = snappedStopRouteLines
-        mapVM.stopSourceData = .init(selectedStopId: lastNavEntry?.stopId())
+        Task {
+            let snappedStopRouteLines = try await RouteFeaturesBuilder.shared.generateRouteLines(
+                routeData: mapVM.allRailSourceData,
+                routesById: mapVM.globalData?.routes,
+                stopsById: mapVM.globalData?.stops,
+                alertsByStop: globalMapData?.alertsByStop
+            )
+            mapVM.snappedStopRouteLines = snappedStopRouteLines
+            mapVM.stopSourceData = .init(selectedStopId: lastNavEntry?.stopId())
+        }
     }
 
     func initializeLayers(_ layerManager: IMapLayerManager) {

--- a/iosApp/iosApp/Pages/Map/MapLayerManager.swift
+++ b/iosApp/iosApp/Pages/Map/MapLayerManager.swift
@@ -76,10 +76,11 @@ class MapLayerManager: IMapLayerManager {
         Task {
             let colorPalette = getColorPalette(colorScheme: colorScheme)
             currentScheme = colorScheme
-            let layers: [MapboxMaps.Layer] = RouteLayerGenerator.shared.createAllRouteLayers(colorPalette: colorPalette)
-                .map { $0.toMapbox() } + StopLayerGenerator.shared.createStopLayers(
-                    colorPalette: colorPalette
-                ).map { $0.toMapbox() }
+            let routeLayers = try await RouteLayerGenerator.shared.createAllRouteLayers(colorPalette: colorPalette)
+                .map { $0.toMapbox() }
+            let stopLayers = try await StopLayerGenerator.shared.createStopLayers(colorPalette: colorPalette)
+                .map { $0.toMapbox() }
+            let layers: [MapboxMaps.Layer] = routeLayers + stopLayers
 
             for layer in layers {
                 DispatchQueue.main.async { [weak self] in

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -329,13 +329,15 @@ struct NearbyTransitView: View {
     ) {
         let fallbackPredictions = predictionsByStop?.toPredictionsStreamDataResponse()
 
-        nearbyWithRealtimeInfo = withRealtimeInfo(
-            schedules: scheduleResponse ?? self.scheduleResponse,
-            predictions: predictions ?? fallbackPredictions,
-            alerts: alerts ?? nearbyVM.alerts,
-            filterAtTime: now.toKotlinInstant(),
-            pinnedRoutes: pinnedRoutes ?? self.pinnedRoutes
-        )
+        Task {
+            nearbyWithRealtimeInfo = await withRealtimeInfo(
+                schedules: scheduleResponse ?? self.scheduleResponse,
+                predictions: predictions ?? fallbackPredictions,
+                alerts: alerts ?? nearbyVM.alerts,
+                filterAtTime: now.toKotlinInstant(),
+                pinnedRoutes: pinnedRoutes ?? self.pinnedRoutes
+            )
+        }
     }
 
     private func withRealtimeInfo(
@@ -344,9 +346,9 @@ struct NearbyTransitView: View {
         alerts: AlertsStreamDataResponse?,
         filterAtTime: Instant,
         pinnedRoutes: Set<String>
-    ) -> [StopsAssociated]? {
+    ) async -> [StopsAssociated]? {
         guard let loadedLocation = state.loadedLocation else { return nil }
-        return state.nearbyByRouteAndStop?.withRealtimeInfo(
+        return try? await state.nearbyByRouteAndStop?.withRealtimeInfo(
             globalData: globalData,
             sortByDistanceFrom: .init(longitude: loadedLocation.longitude, latitude: loadedLocation.latitude),
             schedules: schedules,

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -179,7 +179,7 @@ struct StopDetailsPage: View {
     func updateDepartures() {
         Task {
             if stopId != stopDetailsVM.stopData?.stopId { return }
-            let nextDepartures = stopDetailsVM.getDepartures(
+            let nextDepartures = await stopDetailsVM.getDepartures(
                 stopId: stopId,
                 alerts: nearbyVM.alerts,
                 now: now

--- a/iosApp/iosApp/ViewModels/MapViewModel.swift
+++ b/iosApp/iosApp/ViewModels/MapViewModel.swift
@@ -57,9 +57,9 @@ class MapViewModel: ObservableObject {
         updateRouteSource(globalData: globalData, globalMapData: globalMapData)
     }
 
-    private func getLineFeatures(globalData: GlobalResponse?, globalMapData: GlobalMapData?) -> MapboxMaps
+    private func getLineFeatures(globalData: GlobalResponse?, globalMapData: GlobalMapData?) async throws -> MapboxMaps
         .FeatureCollection {
-        RouteFeaturesBuilder.shared.buildCollection(
+        try await RouteFeaturesBuilder.shared.buildCollection(
             routeLines: RouteFeaturesBuilder.shared.generateRouteLines(
                 routeData: routeSourceData,
                 routesById: globalData?.routes,
@@ -76,14 +76,14 @@ class MapViewModel: ObservableObject {
         }
         routeUpdateTask = Task(priority: .high) {
             try Task.checkCancellation()
-            let routeFeatures = self.getLineFeatures(globalData: globalData, globalMapData: globalMapData)
+            let routeFeatures = try await self.getLineFeatures(globalData: globalData, globalMapData: globalMapData)
             try Task.checkCancellation()
             layerManager.updateSourceData(routeData: routeFeatures)
         }
     }
 
-    private func getStopFeatures(globalMapData: GlobalMapData) -> MapboxMaps.FeatureCollection {
-        StopFeaturesBuilder.shared.buildCollection(
+    private func getStopFeatures(globalMapData: GlobalMapData) async throws -> MapboxMaps.FeatureCollection {
+        try await StopFeaturesBuilder.shared.buildCollection(
             stopData: stopSourceData,
             stops: globalMapData.mapStops,
             linesToSnap: snappedStopRouteLines
@@ -97,7 +97,7 @@ class MapViewModel: ObservableObject {
         }
         stopUpdateTask = Task(priority: .high) {
             try Task.checkCancellation()
-            let stopFeatures = self.getStopFeatures(globalMapData: globalMapData)
+            let stopFeatures = try await self.getStopFeatures(globalMapData: globalMapData)
             try Task.checkCancellation()
             layerManager.updateSourceData(stopData: stopFeatures)
         }

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -143,9 +143,9 @@ class StopDetailsViewModel: ObservableObject {
         stopId: String,
         alerts: AlertsStreamDataResponse?,
         now: Date
-    ) -> StopDetailsDepartures? {
+    ) async -> StopDetailsDepartures? {
         if let global, let schedules = stopData?.schedules {
-            StopDetailsDepartures.companion.fromData(
+            try? await StopDetailsDepartures.companion.fromData(
                 stopId: stopId,
                 global: global,
                 schedules: schedules,

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -72,7 +72,7 @@ final class TripDetailsViewTests: XCTestCase {
             vehicle: vehicle
         )
 
-        let sut = TripDetailsView(
+        var sut = TripDetailsView(
             tripFilter: stopDetailsVM.tripData?.tripFilter,
             stopId: targetStop.id,
             now: now,
@@ -82,8 +82,12 @@ final class TripDetailsViewTests: XCTestCase {
             stopDetailsVM: stopDetailsVM
         )
 
-        XCTAssertNotNil(try sut.inspect().find(TripHeaderCard.self).find(text: "Next stop"))
-        XCTAssertNotNil(try sut.inspect().find(TripHeaderCard.self).find(text: vehicleStop.name))
+        let exp = sut.on(\.didLoadData) { view in
+            XCTAssertNotNil(try view.find(TripHeaderCard.self).find(text: "Next stop"))
+            XCTAssertNotNil(try view.find(TripHeaderCard.self).find(text: vehicleStop.name))
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 1)
     }
 
     func testDisplaysScheduleCard() throws {
@@ -133,7 +137,7 @@ final class TripDetailsViewTests: XCTestCase {
             vehicle: nil
         )
 
-        let sut = TripDetailsView(
+        var sut = TripDetailsView(
             tripFilter: stopDetailsVM.tripData?.tripFilter,
             stopId: targetStop.id,
             now: now,
@@ -143,8 +147,14 @@ final class TripDetailsViewTests: XCTestCase {
             stopDetailsVM: stopDetailsVM
         )
 
-        XCTAssertNotNil(try sut.inspect().find(TripHeaderCard.self).find(text: "Scheduled to depart"))
-        XCTAssertNotNil(try sut.inspect().find(TripHeaderCard.self).find(text: targetStop.name))
+        let exp = sut.on(\.didLoadData) { view in
+            let card = try view.find(TripHeaderCard.self)
+            try debugPrint(card.findAll(ViewType.Text.self).map { try $0.string() })
+            XCTAssertNotNil(try view.find(TripHeaderCard.self).find(text: "Scheduled to depart"))
+            XCTAssertNotNil(try view.find(TripHeaderCard.self).find(text: targetStop.name))
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 1)
     }
 
     func testDisplaysStopList() throws {
@@ -207,7 +217,7 @@ final class TripDetailsViewTests: XCTestCase {
             vehicle: vehicle
         )
 
-        let sut = TripDetailsView(
+        var sut = TripDetailsView(
             tripFilter: stopDetailsVM.tripData?.tripFilter,
             stopId: targetStop.id,
             now: now,
@@ -217,7 +227,11 @@ final class TripDetailsViewTests: XCTestCase {
             stopDetailsVM: stopDetailsVM
         )
 
-        XCTAssertNotNil(try sut.inspect().find(TripStops.self).find(text: targetStop.name))
+        let exp = sut.on(\.didLoadData) { view in
+            XCTAssertNotNil(try view.find(TripStops.self).find(text: targetStop.name))
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 1)
     }
 
     func testTappingDownstreamStopAppendsToNavStack() throws {

--- a/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
+++ b/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
@@ -159,7 +159,7 @@ final class StopDetailsViewModelTests: XCTestCase {
             predictionsLoaded: true
         )
 
-        let departures = stopDetailsVM.getDepartures(
+        let departures = await stopDetailsVM.getDepartures(
             stopId: stop.id,
             alerts: .init(objects: objects),
             now: now

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
@@ -5,6 +5,8 @@ import com.mbta.tid.mbta_app.map.style.LineJoin
 import com.mbta.tid.mbta_app.map.style.LineLayer
 import com.mbta.tid.mbta_app.map.style.downcastToColor
 import com.mbta.tid.mbta_app.model.SegmentAlertState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object RouteLayerGenerator {
     val routeLayerId = "route-layer"
@@ -15,11 +17,13 @@ object RouteLayerGenerator {
 
     fun getRouteLayerId(routeId: String) = "$routeLayerId-$routeId"
 
-    fun createAllRouteLayers(colorPalette: ColorPalette): List<LineLayer> =
-        listOf(createRouteLayer()) +
-            // Draw all alerting layers on top so they are not covered by any overlapping route
-            // shape
-            createAlertingRouteLayers(colorPalette)
+    suspend fun createAllRouteLayers(colorPalette: ColorPalette): List<LineLayer> =
+        withContext(Dispatchers.Default) {
+            listOf(createRouteLayer()) +
+                // Draw all alerting layers on top so they are not covered by any overlapping route
+                // shape
+                createAlertingRouteLayers(colorPalette)
+        }
 
     fun createRouteLayer(): LineLayer {
         val layer = baseRouteLayer(routeLayerId)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
@@ -11,6 +11,8 @@ import io.github.dellisd.spatialk.geojson.Point
 import io.github.dellisd.spatialk.geojson.Position
 import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
 import io.github.dellisd.spatialk.turf.nearestPointOnLine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 data class StopFeatureData(val stop: MapStop, val feature: Feature)
 
@@ -32,20 +34,21 @@ object StopFeaturesBuilder {
     val propServiceStatusKey = FeatureProperty<Map<String, String>>("serviceStatus")
     val propSortOrderKey = FeatureProperty<Number>("sortOrder")
 
-    fun buildCollection(
+    suspend fun buildCollection(
         stopData: StopSourceData,
         stops: Map<String, MapStop>,
         linesToSnap: List<RouteLineData>
-    ): FeatureCollection {
-        val filteredStops =
-            if (stopData.filteredStopIds != null) {
-                stops.filter { stopData.filteredStopIds.contains(it.key) }
-            } else {
-                stops
-            }
-        val stopFeatures = generateStopFeatures(stopData, filteredStops, linesToSnap)
-        return buildCollection(stopFeatures = stopFeatures)
-    }
+    ): FeatureCollection =
+        withContext(Dispatchers.Default) {
+            val filteredStops =
+                if (stopData.filteredStopIds != null) {
+                    stops.filter { stopData.filteredStopIds.contains(it.key) }
+                } else {
+                    stops
+                }
+            val stopFeatures = generateStopFeatures(stopData, filteredStops, linesToSnap)
+            buildCollection(stopFeatures = stopFeatures)
+        }
 
     fun buildCollection(stopFeatures: List<StopFeatureData>): FeatureCollection {
         return FeatureCollection(features = stopFeatures.map { it.feature })

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -11,6 +11,8 @@ import com.mbta.tid.mbta_app.utils.resolveParentId
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 
 /**
@@ -795,7 +797,7 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
         .sortedWith(PatternSorting.compareStopsAssociated(pinnedRoutes, sortByDistanceFrom))
 }
 
-fun NearbyStaticData.withRealtimeInfo(
+suspend fun NearbyStaticData.withRealtimeInfo(
     globalData: GlobalResponse?,
     sortByDistanceFrom: Position,
     schedules: ScheduleResponse?,
@@ -804,19 +806,21 @@ fun NearbyStaticData.withRealtimeInfo(
     filterAtTime: Instant,
     pinnedRoutes: Set<String>,
 ): List<StopsAssociated>? {
-    return this.withRealtimeInfoWithoutTripHeadsigns(
-        globalData,
-        sortByDistanceFrom,
-        schedules,
-        predictions,
-        alerts,
-        filterAtTime,
-        showAllPatternsWhileLoading = false,
-        hideNonTypicalPatternsBeyondNext = 120.minutes,
-        filterCancellations = true,
-        includeMinorAlerts = false,
-        pinnedRoutes
-    )
+    return withContext(Dispatchers.Default) {
+        this@withRealtimeInfo.withRealtimeInfoWithoutTripHeadsigns(
+            globalData,
+            sortByDistanceFrom,
+            schedules,
+            predictions,
+            alerts,
+            filterAtTime,
+            showAllPatternsWhileLoading = false,
+            hideNonTypicalPatternsBeyondNext = 120.minutes,
+            filterCancellations = true,
+            includeMinorAlerts = false,
+            pinnedRoutes
+        )
+    }
 }
 
 class NearbyStaticDataBuilder {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -5,6 +5,8 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
 
 data class TripDetailsStopList
@@ -144,7 +146,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             }
         }
 
-        fun fromPieces(
+        suspend fun fromPieces(
             tripId: String,
             directionId: Int,
             tripSchedules: TripSchedulesResponse?,
@@ -152,83 +154,85 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             vehicle: Vehicle?,
             alertsData: AlertsStreamDataResponse?,
             globalData: GlobalResponse,
-        ): TripDetailsStopList? {
-            if (alertsData == null) return null
-            val entries = mutableMapOf<Int, WorkingEntry>()
-            val routeId =
-                tripPredictions?.trips?.values?.singleOrNull()?.routeId ?: tripSchedules?.routeId()
-            val route = globalData.routes[routeId]
+        ): TripDetailsStopList? =
+            withContext(Dispatchers.Default) {
+                if (alertsData == null) return@withContext null
+                val entries = mutableMapOf<Int, WorkingEntry>()
+                val routeId =
+                    tripPredictions?.trips?.values?.singleOrNull()?.routeId
+                        ?: tripSchedules?.routeId()
+                val route = globalData.routes[routeId]
 
-            var predictions = emptyList<Prediction>()
-            if (tripPredictions != null) {
-                val tripPredictionsWithCorrectRoute =
-                    tripPredictions.predictions.values.filter {
-                        routeId == null || it.routeId == routeId
-                    }
-                predictions =
-                    deduplicatePredictionsByStopSequence(
-                        tripPredictionsWithCorrectRoute,
-                        tripSchedules,
-                        globalData
+                var predictions = emptyList<Prediction>()
+                if (tripPredictions != null) {
+                    val tripPredictionsWithCorrectRoute =
+                        tripPredictions.predictions.values.filter {
+                            routeId == null || it.routeId == routeId
+                        }
+                    predictions =
+                        deduplicatePredictionsByStopSequence(
+                            tripPredictionsWithCorrectRoute,
+                            tripSchedules,
+                            globalData
+                        )
+
+                    predictions.forEach { prediction -> entries.putPrediction(prediction, vehicle) }
+                }
+                if (tripSchedules is TripSchedulesResponse.Schedules) {
+                    tripSchedules.schedules.forEach { entries.putSchedule(it) }
+                } else if (tripSchedules is TripSchedulesResponse.StopIds) {
+                    val aligner =
+                        ScheduleStopSequenceAligner(
+                            tripSchedules.stopIds,
+                            predictions,
+                            globalData,
+                            entries
+                        )
+                    aligner.run()
+                }
+
+                if (entries.isEmpty()) {
+                    return@withContext TripDetailsStopList(tripId, emptyList())
+                }
+
+                val sortedEntries = entries.entries.sortedBy { it.key }
+
+                fun getEntry(optionalWorking: WorkingEntry?): Entry? {
+                    val working = optionalWorking ?: return null
+                    val stop = globalData.stops[working.stopId] ?: return null
+                    return Entry(
+                        stop,
+                        working.stopSequence,
+                        getDisruption(working, alertsData, route, tripId, directionId),
+                        working.schedule,
+                        working.prediction,
+                        globalData.stops[working.prediction?.stopId],
+                        working.vehicle,
+                        getTransferRoutes(working, globalData)
                     )
+                }
 
-                predictions.forEach { prediction -> entries.putPrediction(prediction, vehicle) }
-            }
-            if (tripSchedules is TripSchedulesResponse.Schedules) {
-                tripSchedules.schedules.forEach { entries.putSchedule(it) }
-            } else if (tripSchedules is TripSchedulesResponse.StopIds) {
-                val aligner =
-                    ScheduleStopSequenceAligner(
-                        tripSchedules.stopIds,
-                        predictions,
-                        globalData,
-                        entries
-                    )
-                aligner.run()
-            }
-
-            if (entries.isEmpty()) {
-                return TripDetailsStopList(tripId, emptyList())
-            }
-
-            val sortedEntries = entries.entries.sortedBy { it.key }
-
-            fun getEntry(optionalWorking: WorkingEntry?): Entry? {
-                val working = optionalWorking ?: return null
-                val stop = globalData.stops[working.stopId] ?: return null
-                return Entry(
-                    stop,
-                    working.stopSequence,
-                    getDisruption(working, alertsData, route, tripId, directionId),
-                    working.schedule,
-                    working.prediction,
-                    globalData.stops[working.prediction?.stopId],
-                    working.vehicle,
-                    getTransferRoutes(working, globalData)
+                val startTerminalEntry = getEntry(sortedEntries.firstOrNull()?.value)
+                TripDetailsStopList(
+                    tripId,
+                    sortedEntries
+                        .dropWhile {
+                            if (
+                                vehicle == null ||
+                                    vehicle.tripId != tripId ||
+                                    vehicle.currentStopSequence == null
+                            ) {
+                                false
+                            } else {
+                                it.value.stopSequence < vehicle.currentStopSequence ||
+                                    (it.value.stopSequence == vehicle.currentStopSequence &&
+                                        vehicle.currentStatus == Vehicle.CurrentStatus.StoppedAt)
+                            }
+                        }
+                        .mapNotNull { getEntry(it.value) },
+                    startTerminalEntry
                 )
             }
-
-            val startTerminalEntry = getEntry(sortedEntries.firstOrNull()?.value)
-            return TripDetailsStopList(
-                tripId,
-                sortedEntries
-                    .dropWhile {
-                        if (
-                            vehicle == null ||
-                                vehicle.tripId != tripId ||
-                                vehicle.currentStopSequence == null
-                        ) {
-                            false
-                        } else {
-                            it.value.stopSequence < vehicle.currentStopSequence ||
-                                (it.value.stopSequence == vehicle.currentStopSequence &&
-                                    vehicle.currentStatus == Vehicle.CurrentStatus.StoppedAt)
-                        }
-                    }
-                    .mapNotNull { getEntry(it.value) },
-                startTerminalEntry
-            )
-        }
 
         // unfortunately, stop sequence is not always actually unique
         // conveniently, it seems like duplicates are rare

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
@@ -1,5 +1,7 @@
 package com.mbta.tid.mbta_app.model.response
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Prediction
 import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.Vehicle
@@ -12,4 +14,10 @@ data class PredictionsByStopMessageResponse(
     val predictions: Map<String, Prediction>,
     val trips: Map<String, Trip>,
     val vehicles: Map<String, Vehicle>
-) {}
+) {
+    @DefaultArgumentInterop.Enabled
+    constructor(
+        objects: ObjectCollectionBuilder,
+        stopId: String = objects.stops.keys.single()
+    ) : this(stopId, objects.predictions, objects.trips, objects.vehicles)
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -225,6 +225,13 @@ constructor(
         if (connectV2Outcome != null) {
             onJoin(connectV2Outcome)
         }
+        this.onMessage = onMessage
+    }
+
+    var onMessage: ((ApiResult<PredictionsByStopMessageResponse>) -> Unit)? = null
+
+    fun sendMessage(message: PredictionsByStopMessageResponse) {
+        onMessage?.invoke(ApiResult.Ok(message))
     }
 
     override var lastUpdated: Instant? = null

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -20,12 +20,13 @@ import io.github.dellisd.spatialk.turf.lineSlice
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 
 @OptIn(ExperimentalTurfApi::class)
 class RouteFeaturesBuilderTest {
     @Test
-    fun `creates route feature collection`() {
+    fun `creates route feature collection`() = runBlocking {
         val collection =
             RouteFeaturesBuilder.buildCollection(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
@@ -91,7 +92,7 @@ class RouteFeaturesBuilderTest {
     }
 
     @Test
-    fun `preserves route properties`() {
+    fun `preserves route properties`() = runBlocking {
         val collection =
             RouteFeaturesBuilder.buildCollection(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
@@ -121,7 +122,7 @@ class RouteFeaturesBuilderTest {
     }
 
     @Test
-    fun `splits for alerts`() {
+    fun `splits for alerts`() = runBlocking {
         val now = Clock.System.now()
 
         val objects = ObjectCollectionBuilder()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGeneratorTest.kt
@@ -3,13 +3,14 @@ package com.mbta.tid.mbta_app.map
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 
 class RouteLayerGeneratorTest {
     @Test
-    fun `route layers are created`() {
+    fun `route layers are created`(): Unit = runBlocking {
         val routeLayers = RouteLayerGenerator.createAllRouteLayers(ColorPalette.light)
 
         assertEquals(4, routeLayers.size)
@@ -27,7 +28,7 @@ class RouteLayerGeneratorTest {
     }
 
     @Test
-    fun `layers have offset`() {
+    fun `layers have offset`(): Unit = runBlocking {
         val routeLayers = RouteLayerGenerator.createAllRouteLayers(ColorPalette.light)
 
         assertEquals(4, routeLayers.size)
@@ -45,7 +46,7 @@ class RouteLayerGeneratorTest {
     }
 
     @Test
-    fun `base layer color comes from data`() {
+    fun `base layer color comes from data`() = runBlocking {
         val routeLayers = RouteLayerGenerator.createAllRouteLayers(ColorPalette.light)
 
         val baseRouteLayer = routeLayers[0]
@@ -59,7 +60,7 @@ class RouteLayerGeneratorTest {
     }
 
     @Test
-    fun `sort key comes from data`() {
+    fun `sort key comes from data`() = runBlocking {
         val routeLayers = RouteLayerGenerator.createAllRouteLayers(ColorPalette.light)
 
         val baseRouteLayer = routeLayers[0]
@@ -73,8 +74,8 @@ class RouteLayerGeneratorTest {
     }
 
     @Test
-    fun `uses provided colors`() {
-        fun checkColorsMatch(colorPalette: ColorPalette) {
+    fun `uses provided colors`() = runBlocking {
+        suspend fun checkColorsMatch(colorPalette: ColorPalette) {
             val routeLayers = RouteLayerGenerator.createAllRouteLayers(colorPalette)
 
             val suspendedLayer =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -12,10 +12,11 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 
 class StopFeaturesBuilderTest {
     @Test
-    fun `stop sources are created`() {
+    fun `stop sources are created`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val stop1 =
@@ -135,7 +136,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stops are snapped to routes`() {
+    fun `stops are snapped to routes`() = runBlocking {
         val stops =
             mapOf(
                 MapTestDataHelper.stopAssembly.id to MapTestDataHelper.mapStopAssembly,
@@ -168,7 +169,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `selected stop has prop set`() {
+    fun `selected stop has prop set`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val selectedStop =
             objects.stop {
@@ -216,7 +217,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `filtered stop ids`() {
+    fun `filtered stop ids`(): Unit = runBlocking {
         val collection =
             StopFeaturesBuilder.buildCollection(
                 stopData =
@@ -248,7 +249,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stops features have service status`() {
+    fun `stops features have service status`() = runBlocking {
         val objects = MapTestDataHelper.objects
 
         val stops =
@@ -338,7 +339,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stop features have routes`() {
+    fun `stop features have routes`()  = runBlocking {
         val stops =
             mapOf(
                 MapTestDataHelper.stopAssembly.id to MapTestDataHelper.mapStopAssembly,
@@ -383,7 +384,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stop features have names`() {
+    fun `stop features have names`() = runBlocking {
         val stops =
             mapOf(
                 MapTestDataHelper.stopAssembly.id to MapTestDataHelper.mapStopAssembly,
@@ -411,7 +412,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stop features have terminals`() {
+    fun `stop features have terminals`() = runBlocking {
         val stops =
             mapOf(
                 MapTestDataHelper.stopAlewife.id to MapTestDataHelper.mapStopAlewife,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
@@ -10,10 +10,11 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopAlertState
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
 
 class StopLayerGeneratorTest {
     @Test
-    fun `stop layers are created`() {
+    fun `stop layers are created`() = runBlocking {
         val stopLayers = StopLayerGenerator.createStopLayers(ColorPalette.light)
 
         assertEquals(11, stopLayers.size)
@@ -31,7 +32,7 @@ class StopLayerGeneratorTest {
     }
 
     @Test
-    fun `North Station with alerts has correct properties`() {
+    fun `North Station with alerts has correct properties`() = runBlocking {
         val northStation =
             Stop(
                 id = "place-north",

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -14,6 +14,7 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 
 class NearbyResponseTest {
@@ -2878,7 +2879,7 @@ class NearbyResponseTest {
     }
 
     @Test
-    fun `withRealtimeInfo north station disruption case`() {
+    fun `withRealtimeInfo north station disruption case`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val northStation =
             objects.stop {
@@ -3159,7 +3160,7 @@ class NearbyResponseTest {
     }
 
     @Test
-    fun `withRealtimeInfo filters out headsign if it is the last stop of route pattern`() {
+    fun `withRealtimeInfo filters out headsign if it is the last stop of route pattern`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val oakGrove =
@@ -3262,7 +3263,7 @@ class NearbyResponseTest {
     }
 
     @Test
-    fun `withRealtimeInfo filters out any arrival only for non-subway routes`() {
+    fun `withRealtimeInfo filters out any arrival only for non-subway routes`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val longWharf =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RealtimePatternsTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -594,7 +595,7 @@ class RealtimePatternsTest {
     }
 
     @Test
-    fun `properly applies platform alerts by pattern`() {
+    fun `properly applies platform alerts by pattern`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         lateinit var platform1: Stop
         lateinit var platform2: Stop
@@ -694,7 +695,7 @@ class RealtimePatternsTest {
     }
 
     @Test
-    fun `handles logical vs physical platforms`() {
+    fun `handles logical vs physical platforms`() = runBlocking {
         // at Union Sq, North/South Station, and some others, the platforms don't map one-to-one to
         // the directions, and the schedules are by direction but the predictions are by physical
         // platform

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
 
 class RouteCardDataTest {
 
@@ -2139,7 +2140,7 @@ class RouteCardDataTest {
 
     @Test
     @Ignore // TODO: Add hasSchedules functionality as part of special service dates
-    fun `RouteCardData routeCardsForStopList checks if any trips are scheduled all day`()  {
+    fun `RouteCardData routeCardsForStopList checks if any trips are scheduled all day`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop()
         val route = objects.route()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsDeparturesTest.kt
@@ -553,7 +553,7 @@ class StopDetailsDeparturesTest {
         fun expected(vararg pattern: RealtimePatterns.ByHeadsign): StopDetailsDepartures =
             StopDetailsDepartures(listOf(PatternsByStop(route, stop, pattern.toList())))
 
-        fun actual(includeSchedules: Boolean = true, includePredictions: Boolean = true) =
+        suspend fun actual(includeSchedules: Boolean = true, includePredictions: Boolean = true) =
             StopDetailsDepartures.fromData(
                 stop,
                 GlobalResponse(objects, mapOf(stop.id to objects.routePatterns.keys.toList())),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TemporaryTerminalTest.kt
@@ -10,6 +10,7 @@ import kotlin.properties.PropertyDelegateProvider
 import kotlin.properties.ReadOnlyProperty
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -325,7 +326,7 @@ class TemporaryTerminalTest {
         )
 
     @Test
-    fun `shows only regular terminals when outside shuttle`() {
+    fun `shows only regular terminals when outside shuttle`() = runBlocking {
         val expected =
             expected(
                 harvard.station,
@@ -392,7 +393,7 @@ class TemporaryTerminalTest {
     }
 
     @Test
-    fun `shows only regular terminals when inside shuttle`() {
+    fun `shows only regular terminals when inside shuttle`() = runBlocking {
         val expected =
             expected(
                 parkStreet.station,
@@ -452,7 +453,7 @@ class TemporaryTerminalTest {
     }
 
     @Test
-    fun `shows only regular terminals when at boundary of shuttle`() {
+    fun `shows only regular terminals when at boundary of shuttle`() = runBlocking {
         val expected =
             expected(
                 jfkUmass.station,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -117,7 +118,7 @@ class TripDetailsStopListTest {
         fun globalData(patternIdsByStop: Map<String, List<String>> = emptyMap()) =
             GlobalResponse(objects, patternIdsByStop)
 
-        fun fromPieces(
+        suspend fun fromPieces(
             tripSchedules: TripSchedulesResponse?,
             tripPredictions: PredictionsStreamDataResponse?,
             vehicle: Vehicle? = null,
@@ -146,7 +147,7 @@ class TripDetailsStopListTest {
         fun predictions() = PredictionsStreamDataResponse(objects)
     }
 
-    private fun test(block: TestBuilder.() -> Unit) {
+    private fun test(block: suspend TestBuilder.() -> Unit) = runBlocking {
         val builder = TestBuilder()
         builder.block()
     }
@@ -346,7 +347,7 @@ class TripDetailsStopListTest {
     }
 
     @Test
-    fun `fromPieces can deduplicate predictions by stop sequence from real data`() {
+    fun `fromPieces can deduplicate predictions by stop sequence from real data`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val p1 =
@@ -439,7 +440,7 @@ class TripDetailsStopListTest {
     }
 
     @Test
-    fun `fromPieces handles happy path with schedules and vehicles`() {
+    fun `fromPieces handles happy path with schedules and vehicles`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.InTransitTo }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTest.kt
@@ -2,12 +2,13 @@ package com.mbta.tid.mbta_app.parametric
 
 import kotlin.enums.enumEntries
 import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
 
 /**
  * Sometimes there are values that don't matter in your individual test, and you want to run the
  * test with all those values without having to write for loops yourself.
  */
-class ParametricTest(val block: ParametricTest.() -> Unit) {
+class ParametricTest(val block: suspend ParametricTest.() -> Unit) {
     var state: State = State.Gathering
     var parameterSpace = mutableListOf<List<Any>>()
 
@@ -44,13 +45,13 @@ class ParametricTest(val block: ParametricTest.() -> Unit) {
             is State.Executing -> state.nextParameter()
         }
 
-    internal fun gatherParameters() {
+    internal suspend fun gatherParameters() {
         state = State.Gathering
         parameterSpace.clear()
         block()
     }
 
-    internal fun executeAll() {
+    internal suspend fun executeAll() {
         // constructing all these partial lists will be inefficient for more than a handful of
         // parameters
         val parameterSets =
@@ -74,8 +75,10 @@ class ParametricTest(val block: ParametricTest.() -> Unit) {
     }
 }
 
-fun parametricTest(block: ParametricTest.() -> Unit) {
-    val test = ParametricTest(block)
-    test.gatherParameters()
-    test.executeAll()
+fun parametricTest(block: suspend ParametricTest.() -> Unit) {
+    runBlocking {
+        val test = ParametricTest(block)
+        test.gatherParameters()
+        test.executeAll()
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Move expensive calculations to background thread in shared code](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209077852914470?focus=true)

I'm removing the explicit dispatchers from the Android side in the places where I'm adding them in shared code instead.

Since `runBlocking` implicitly returns the last value in its block and `assertNotNull(x)` returns x, I've had to explicitly mark some tests as returning `Unit` to make the compiler happy.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible

### Testing

Updated tests. Checked that the app isn't obviously completely broken in a way that the tests aren't catching.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
