### PR TITLE
fix(iOS): Alerts not updating in the map

### DIFF
--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -43,7 +43,6 @@ struct HomeMapView: View {
     @State var lastNavEntry: SheetNavigationStackEntry?
 
     let inspection = Inspection<Self>()
-    let timer = Timer.publish(every: 300, on: .main, in: .common).autoconnect()
     let log = Logger()
 
     private var isNearbyNotFollowing: Bool {
@@ -149,9 +148,12 @@ struct HomeMapView: View {
                 onInactive: leaveVehiclesChannel,
                 onBackground: leaveVehiclesChannel
             )
-            .onReceive(timer) { input in
-                now = input
-                handleGlobalMapDataChange(now: now)
+            .task {
+                while !Task.isCancelled {
+                    now = Date.now
+                    handleGlobalMapDataChange(now: now)
+                    try? await Task.sleep(for: .seconds(30))
+                }
             }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: New alerts not pushed to consumers](https://app.asana.com/0/1205732265579288/1207048982201707/f)

Fixes alerts updating in nearby transit but not the map. The ticket originally pointed toward there being issues with the backend but from my testing this was solely an iOS issue.

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible~~

### Testing

Manual testing by creating short lived alerts in the dev-orange env.
