### PR TITLE
fix: Make the cache not erase unknown backend fields

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
@@ -36,6 +36,10 @@ class ResponseCache<T : Any>(
     private val cacheKey: String,
     val maxAge: Duration,
     private val serializer: KSerializer<T>,
+    // The invalidation key is written to the cache metadata on disk, if a loaded key doesn't match
+    // the key provided on cache creation, the data will be reloaded from the backend. This can be
+    // set to any arbitrary string value, but should only be changed if you want to wipe the cached
+    // data after an update, even when the etag matches the backend.
     private val invalidationKey: String? = null
 ) : KoinComponent {
     companion object {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -22,7 +22,8 @@ interface IGlobalRepository {
 }
 
 class GlobalRepository(
-    val cache: ResponseCache<GlobalResponse> = ResponseCache.create(cacheKey = "global")
+    val cache: ResponseCache<GlobalResponse> =
+        ResponseCache.create(cacheKey = "global", invalidationKey = "2025-03-18")
 ) : IGlobalRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
     override val state = cache.state

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -23,7 +23,7 @@ interface IGlobalRepository {
 
 class GlobalRepository(
     val cache: ResponseCache<GlobalResponse> =
-        ResponseCache.create(cacheKey = "global", invalidationKey = "2025-03-18")
+        ResponseCache.create(cacheKey = "global", invalidationKey = "2025-03-19")
 ) : IGlobalRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
     override val state = cache.state

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepository.kt
@@ -23,7 +23,7 @@ interface IRailRouteShapeRepository {
 
 class RailRouteShapeRepository(
     val cache: ResponseCache<MapFriendlyRouteResponse> =
-        ResponseCache.create(cacheKey = "rail-route-shapes")
+        ResponseCache.create(cacheKey = "rail-route-shapes", invalidationKey = "2025-03-19")
 ) : IRailRouteShapeRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
     override val state = cache.state

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/cache/ResponseCacheTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/cache/ResponseCacheTest.kt
@@ -29,7 +29,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.encodeToString
+import kotlinx.serialization.Serializable
 import okio.FileSystem
 import okio.fakefilesystem.FakeFileSystem
 import org.koin.core.context.startKoin
@@ -493,5 +493,158 @@ class ResponseCacheTest {
                 }
             )
         )
+    }
+
+    @Test
+    fun `writes full json even when some of it isn't parsed`() = runBlocking {
+        @Serializable data class PartialObject(val a: String,  val b: Int)
+        @Serializable data class CompleteObject(val a: String, val b: Int, val c: Double)
+        @Serializable data class FutureObject(val a: String, val b: Int, val c: Double, val d: String)
+
+        val partial = PartialObject("a", 1)
+        val complete = CompleteObject("a", 1, 2.0)
+        val future = FutureObject("a", 1, 2.0, "d")
+
+        val responseEtag = "etag"
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(json.encodeToString(future)),
+                status = HttpStatusCode.OK,
+                headers =
+                    headersOf(
+                        Pair(HttpHeaders.ContentType, listOf("application/json")),
+                        Pair(HttpHeaders.ETag, listOf(responseEtag))
+                    )
+            )
+        }
+
+        val client = MobileBackendClient(mockEngine, AppVariant.Staging)
+
+        val partialCache = ResponseCache.create<PartialObject>(cacheKey = "test")
+
+        val mockPaths = MockSystemPaths(data = "data", cache = "cache")
+        val fileSystem = FakeFileSystem()
+
+        startKoin {
+            modules(
+                module {
+                    single<SystemPaths> { mockPaths }
+                    single<FileSystem> { fileSystem }
+                }
+            )
+        }
+
+        var didFetch = false
+
+        assertEquals(
+            ApiResult.Ok(partial),
+            partialCache.getOrFetch {
+                didFetch = true
+                client.get { url { path("api/global") } }
+            }
+        )
+        assertTrue(didFetch)
+
+        assertEquals(
+            future,
+            json.decodeFromString(
+                fileSystem.read(mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY / "test.json") {
+                    readUtf8()
+                }
+            )
+        )
+
+        val completeCache = ResponseCache.create<CompleteObject>(cacheKey = "test")
+        assertEquals(
+            ApiResult.Ok(complete),
+            completeCache.getOrFetch { fail("Should not fetch again") }
+        )
+    }
+
+    @Test
+    fun `cache is invalidated by changing the invalidation key`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        objects.stop()
+        objects.stop()
+        objects.route()
+        val globalData = GlobalResponse(objects, emptyMap())
+
+        val responseEtag = "etag"
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(json.encodeToString(globalData)),
+                status = HttpStatusCode.OK,
+                headers =
+                    headersOf(
+                        Pair(HttpHeaders.ContentType, listOf("application/json")),
+                        Pair(HttpHeaders.ETag, listOf(responseEtag))
+                    )
+            )
+        }
+
+        val client = MobileBackendClient(mockEngine, AppVariant.Staging)
+
+        val cache = ResponseCache.create<GlobalResponse>(cacheKey = "test")
+
+        val mockPaths = MockSystemPaths(data = "data", cache = "cache")
+        val fileSystem = FakeFileSystem()
+        val directory = mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY
+        fileSystem.createDirectories(directory)
+
+        startKoin {
+            modules(
+                module {
+                    single<SystemPaths> { mockPaths }
+                    single<FileSystem> { fileSystem }
+                }
+            )
+        }
+
+        var fetchCount = 0
+        suspend fun fetch(): HttpResponse {
+            fetchCount++
+            return client.get { url { path("api/global") } }
+        }
+
+        assertEquals(
+            ApiResult.Ok(globalData),
+            cache.getOrFetch { fetch() }
+        )
+        assertEquals(1, fetchCount)
+        assertEquals(ApiResult.Ok(globalData), cache.getOrFetch { fail() })
+
+        fun metadataFromDisk() = json
+            .decodeFromString<ResponseMetadata>(
+                fileSystem.read(
+                    mockPaths.cache / ResponseCache.CACHE_SUBDIRECTORY / "test-meta.json"
+                ) {
+                    readUtf8()
+                }
+            )
+
+        assertEquals(responseEtag, metadataFromDisk().etag)
+        assertNull(cache.data!!.metadata.invalidationKey)
+
+        val firstInvalidationKey = "key1"
+        val invalidatedCache = ResponseCache.create<GlobalResponse>(cacheKey = "test", invalidationKey = firstInvalidationKey)
+        assertEquals(
+            ApiResult.Ok(globalData),
+            invalidatedCache.getOrFetch { fetch() }
+        )
+        assertEquals(2, fetchCount)
+        assertEquals(responseEtag, metadataFromDisk().etag)
+        assertEquals(firstInvalidationKey, metadataFromDisk().invalidationKey)
+        assertEquals(ApiResult.Ok(globalData), cache.getOrFetch { fail() })
+
+        val secondInvalidationKey = "key2"
+        val otherInvalidatedCache = ResponseCache.create<GlobalResponse>(cacheKey = "test", invalidationKey = secondInvalidationKey)
+        assertEquals(
+            ApiResult.Ok(globalData),
+            otherInvalidatedCache.getOrFetch { fetch() }
+        )
+        assertEquals(3, fetchCount)
+        assertEquals(responseEtag, metadataFromDisk().etag)
+        assertEquals(secondInvalidationKey, metadataFromDisk().invalidationKey)
+        assertEquals(ApiResult.Ok(globalData), cache.getOrFetch { fail() })
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix stale parsed cache data](https://app.asana.com/0/1205732265579288/1209717539725073/f)

Fixes a couple related issues with the cache, the first was that all data was being parsed into the cache object type before being written to disk, which means that any data which existed in the response but was not included in the object would be erased, while leaving the etag the same, which resulted in the missing fields never being reloaded even if they were added to the object type. Now we write the response body directly to the disk cache without parsing it into an object first (though a parse does still happen prior to the write, so if the parse fails, nothing will be written).

Then, even with that fixed, we needed a way for the client to know that it was possible for the current cache to be invalid, even if the etag matches the backend, so I added a hardcoded `invalidationKey`, which is an arbitrary string which gets written to disk along with the data. If the loaded invalidation key doesn't match the one that the cache expects, it clears the data and reloads from the backend.

### Testing

Added unit tests for the new behavior. Manually tested locally by loading the data on the 1.2.1 build, then switching to this branch and verifying that it was re-requesting and displaying the added fields properly.