### PR TITLE
fix(TripInstantDisplay): BRD / ARR when predicted arrival in the past

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -138,14 +138,14 @@ sealed class TripInstantDisplay {
                 vehicle?.currentStatus == Vehicle.CurrentStatus.StoppedAt &&
                     vehicle.stopId == prediction.stopId &&
                     vehicle.tripId == prediction.tripId &&
-                    timeRemaining <= BOARDING_CUTOFF
+                    (timeRemaining <= BOARDING_CUTOFF || prediction.hasArrivedButNotDeparted(now))
             ) {
                 return Boarding
             }
             if (timeRemaining.isNegative()) {
                 return Hidden
             }
-            if (timeRemaining <= ARRIVAL_CUTOFF) {
+            if (timeRemaining <= ARRIVAL_CUTOFF || prediction.hasArrivedButNotDeparted(now)) {
                 return Arriving
             }
             if (timeRemaining <= APPROACH_CUTOFF) {
@@ -154,4 +154,6 @@ sealed class TripInstantDisplay {
             return Minutes(minutes)
         }
     }
+
+    fun scheduleBasedDisplay() {}
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -154,6 +154,4 @@ sealed class TripInstantDisplay {
             return Minutes(minutes)
         }
     }
-
-    fun scheduleBasedDisplay() {}
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -11,6 +11,14 @@ interface TripStopTime : Comparable<TripStopTime> {
 
     fun stopTimeAfter(now: Instant) = arrivalTime?.takeUnless { it < now } ?: departureTime
 
+    /**
+     * Is the current time between the arrival & departure times for this prediction (inclusive)?
+     */
+    fun hasArrivedButNotDeparted(now: Instant): Boolean {
+        return (arrivalTime?.let { it <= now }
+            ?: false) && (departureTime?.let { it >= now } ?: false)
+    }
+
     override fun compareTo(other: TripStopTime): Int =
         nullsLast<Instant>().compare(stopTime, other.stopTime)
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -330,6 +330,36 @@ class TripInstantDisplayTest {
         }
 
     @Test
+    fun `boarding when subway stopped at stop but arrival is in the past and more than 90 seconds until departure`() =
+        parametricTest {
+            val now = Clock.System.now()
+            val vehicle =
+                ObjectCollectionBuilder.Single.vehicle {
+                    currentStatus = Vehicle.CurrentStatus.StoppedAt
+                    stopId = "12345"
+                    tripId = "trip1"
+                }
+            assertEquals(
+                TripInstantDisplay.Boarding,
+                TripInstantDisplay.from(
+                    prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        arrivalTime = now.minus(5.seconds)
+                        departureTime = now.plus(95.seconds)
+                        stopId = "12345"
+                        tripId = "trip1"
+                        vehicleId = vehicle.id
+                    },
+                    schedule = null,
+                    vehicle = vehicle,
+                    routeType = subway(),
+                    now = now,
+                    context = nonTripDetails()
+                )
+            )
+        }
+
+    @Test
     fun `not boarding`() = parametricTest {
         val now = Clock.System.now()
         // wrong vehicle status
@@ -431,6 +461,26 @@ class TripInstantDisplayTest {
                     ObjectCollectionBuilder.Single.prediction {
                         departureTime = now.plus(15.seconds)
                     },
+                schedule = null,
+                vehicle = null,
+                routeType = null,
+                now = now,
+                context = nonTripDetails()
+            )
+        )
+    }
+
+    @Test
+    fun `arriving when prediction arrival in the past and departure more than 30 seconds away`() = parametricTest {
+        val now = Clock.System.now()
+        assertEquals(
+            TripInstantDisplay.Arriving,
+            TripInstantDisplay.from(
+                prediction =
+                ObjectCollectionBuilder.Single.prediction {
+                    arrivalTime = now.minus(10.seconds)
+                    departureTime = now.plus(40.seconds)
+                },
                 schedule = null,
                 vehicle = null,
                 routeType = null,


### PR DESCRIPTION
### Summary

_Ticket:_ [BRD bug when train dwelling at station](https://app.asana.com/0/1205732265579288/1209702051776246/f)

What is this PR for?

When a train is dwelling at a station, show it as BRD to match in-station countown clocks. 
Similarly, if we predict that a train is already be at a station (but it doesn't have the StoppedAt boarding status), show ARR, even if departure is predicted more than 30 seconds out.

**Note:** This PR description suggested considering whether to refactor out `TripInstantDisplay.from` in conjunction with this change. I considered it but ultimately this change was so simple I don't think it is necessary to tie it to this change. After thinking more about how I would approach that refactor, I'm also not totally sure we'd want to strictly split up this logic by mode, as there is some shared logic & entangled pieces that I think worth be worth putting more thought into the refactor.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~ - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests for each new case

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
