### PR TITLE
refactor: Check start/end of service in shared

### DIFF
--- a/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
@@ -26,25 +26,19 @@ extension Shared.Alert.ActivePeriod {
         var formattedDate = date.formatted(dateFormat)
         var formattedTime = date.formatted(date: .omitted, time: .shortened)
 
-        let comp: DateComponents? = if let eastern = TimeZone(identifier: "America/New_York") {
-            Calendar.current.dateComponents(in: eastern, from: date)
-        } else { nil }
-        let hour = comp?.hour
-        let minute = comp?.minute
-
-        if isStart, hour == 3, minute == 0 {
+        if isStart, fromStartOfService {
             formattedTime = NSLocalizedString(
                 "start of service",
                 comment: "Used when an alert begins at the start of a service day"
             )
-        } else if !isStart, hour == 2, minute == 59 {
+        } else if !isStart, toEndOfService {
             formattedTime = NSLocalizedString(
                 "end of service",
                 comment: "Used when an alert ends at the end of a service day"
             )
             let previousDate = date - (60 * 60 * 24)
             formattedDate = previousDate.formatted(dateFormat)
-        } else if !isStart, durationCertainty == .estimated {
+        } else if !isStart, endingLaterToday {
             formattedTime = NSLocalizedString(
                 "later today",
                 comment: "Used when an alert ends at an indeterminite time later the same day"

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.model
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -77,6 +79,23 @@ data class Alert(
             }
             return instant in start..end
         }
+
+        val fromStartOfService: Boolean
+            get() {
+                val localTime = start.toLocalDateTime(TimeZone.of("America/New_York"))
+                return localTime.hour == 3 && localTime.minute == 0
+            }
+
+        val toEndOfService: Boolean
+            get() {
+                val end = end ?: return false
+                val localTime = end.toLocalDateTime(TimeZone.of("America/New_York"))
+                return (localTime.hour == 3 && localTime.minute == 0) ||
+                    (localTime.hour == 2 && localTime.minute == 59)
+            }
+
+        val endingLaterToday: Boolean
+            get() = durationCertainty == Alert.DurationCertainty.Estimated
     }
 
     @Serializable


### PR DESCRIPTION
### Summary

_Ticket:_ Precursor to [Include affected stop bounds in downstream disruption summary](https://app.asana.com/0/1205732265579288/1209527076283980/f)

Splitting this out from the alert templating changes because it can stand on its own, I didn't realize when I did this initially that it was possible to do entirely within Kotlin.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Existing tests should cover all of this