### PR TITLE
build: let Fastlane take longer to check xcodebuild settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,15 @@ repos:
         language: script
         always_run: true
         stages: [post-checkout, post-merge]
+        pass_filenames: false
       - id: diff-xcodeproj
         name: diff xcodeproj
         entry: ./bin/diff-xcodeproj.sh
         language: script
         always_run: true
+        pass_filenames: false
       - id: rubocop
         name: rubocop
         entry: bundle exec rubocop -A
         language: system
-        types: [ruby]
+        files: '\.rb$|file$'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -89,6 +89,9 @@ platform :android do
 end
 
 platform :ios do
+  # https://github.com/fastlane/fastlane/issues/20919#issuecomment-1344976529
+  ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
+
   def app_identifier(scheme)
     case scheme
     when 'Prod'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,10 +41,9 @@ platform :android do
             package_name: package_name,
             track: 'internal'
           ).max
-        rescue Exception => e
-          unless e.message == "Google Api Error: Invalid request - Package not found: #{package_name}."
-            raise
-          end
+        rescue StandardError => e
+          raise unless e.message == "Google Api Error: Invalid request - Package not found: #{package_name}."
+
           0
         end
       end
@@ -90,7 +89,7 @@ end
 
 platform :ios do
   # https://github.com/fastlane/fastlane/issues/20919#issuecomment-1344976529
-  ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
+  ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   def app_identifier(scheme)
     case scheme


### PR DESCRIPTION
### Summary

_Ticket:_ none

The first scheduled iOS dev-orange deploy [failed](https://github.com/mbta/mobile_app/actions/runs/14176894183/job/39713864460) because this setting defaults to three seconds. It’s not clear to me what the point of the timeout is if the advice is to just raise it if you ever actually hit it, but whatever.

I also noticed that the double quotes hadn’t been rewritten to single quotes by rubocop, which looks like it’s because pre-commit doesn’t know that Fastfile is a Ruby file.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that the pre-commit hooks run, at least; this is a random failure that’s going to be hard to be certain we’ve addressed.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
