### PR TITLE
refactor: move some List<T>.foo to T.foo and add ObjectCollectionBuilder.clone

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -20,17 +20,46 @@ import kotlinx.datetime.Instant
  * - Objects which need to be referenced directly but descend inherently from a parent (e.g. route
  *   patterns from routes) are built with a required parent argument
  */
-class ObjectCollectionBuilder {
-    val alerts = mutableMapOf<String, Alert>()
-    val lines = mutableMapOf<String, Line>()
-    val predictions = mutableMapOf<String, Prediction>()
-    val routes = mutableMapOf<String, Route>()
-    val routePatterns = mutableMapOf<String, RoutePattern>()
-    val schedules = mutableMapOf<String, Schedule>()
-    val stops = mutableMapOf<String, Stop>()
-    val trips = mutableMapOf<String, Trip>()
-    val shapes = mutableMapOf<String, Shape>()
-    val vehicles = mutableMapOf<String, Vehicle>()
+class ObjectCollectionBuilder
+private constructor(
+    val alerts: MutableMap<String, Alert>,
+    val lines: MutableMap<String, Line>,
+    val predictions: MutableMap<String, Prediction>,
+    val routes: MutableMap<String, Route>,
+    val routePatterns: MutableMap<String, RoutePattern>,
+    val schedules: MutableMap<String, Schedule>,
+    val stops: MutableMap<String, Stop>,
+    val trips: MutableMap<String, Trip>,
+    val shapes: MutableMap<String, Shape>,
+    val vehicles: MutableMap<String, Vehicle>,
+) {
+    constructor() :
+        this(
+            alerts = mutableMapOf(),
+            lines = mutableMapOf(),
+            predictions = mutableMapOf(),
+            routes = mutableMapOf(),
+            routePatterns = mutableMapOf(),
+            schedules = mutableMapOf(),
+            stops = mutableMapOf(),
+            trips = mutableMapOf(),
+            shapes = mutableMapOf(),
+            vehicles = mutableMapOf(),
+        )
+
+    fun clone() =
+        ObjectCollectionBuilder(
+            alerts = alerts.toMutableMap(),
+            lines = lines.toMutableMap(),
+            predictions = predictions.toMutableMap(),
+            routes = routes.toMutableMap(),
+            routePatterns = routePatterns.toMutableMap(),
+            schedules = schedules.toMutableMap(),
+            stops = stops.toMutableMap(),
+            trips = trips.toMutableMap(),
+            shapes = shapes.toMutableMap(),
+            vehicles = vehicles.toMutableMap(),
+        )
 
     interface ObjectBuilder<Built : BackendObject> {
         fun built(): Built

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RealtimePatterns.kt
@@ -296,8 +296,7 @@ sealed class RealtimePatterns : ILeafData {
      *
      * If any typicality is unknown, the route should be shown, and so this will return true.
      */
-    fun isTypical() =
-        patterns.any { it?.typicality == null || it.typicality == RoutePattern.Typicality.Typical }
+    fun isTypical() = patterns.any { it?.isTypical() ?: true }
 
     /**
      * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet
@@ -307,10 +306,10 @@ sealed class RealtimePatterns : ILeafData {
      * should be hidden until data is available.
      */
     fun isUpcomingWithin(currentTime: Instant, cutoffTime: Instant) =
-        upcomingTrips.isUpcomingWithin(currentTime, cutoffTime)
+        upcomingTrips.any { it.isUpcomingWithin(currentTime, cutoffTime) }
 
     /** Checks if a trip exists. */
-    fun isUpcoming() = upcomingTrips.isUpcoming()
+    fun isUpcoming() = upcomingTrips.any { it.isUpcoming() }
 
     /**
      * Checks if this headsign ends at this stop, i.e. all trips are arrival-only.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -714,9 +714,11 @@ data class RouteCardData(
             if (this.allDataLoaded == false && showAllPatternsWhileLoading) return true
             val isUpcoming =
                 when (cutoffTime) {
-                    null -> this.upcomingTrips?.isUpcoming() ?: false
-                    else -> this.upcomingTrips?.isUpcomingWithin(filterAtTime, cutoffTime) ?: false
+                    null -> this.upcomingTrips?.any { it.isUpcoming() }
+                    else ->
+                        this.upcomingTrips?.any { it.isUpcomingWithin(filterAtTime, cutoffTime) }
                 }
+                    ?: false
 
             val shouldBeFilteredAsArrivalOnly =
                 if (isSubway) {
@@ -730,7 +732,7 @@ data class RouteCardData(
                     this.upcomingTrips?.isArrivalOnly() ?: false
                 }
 
-            val isTypical = routePatterns?.isTypical() ?: false
+            val isTypical = routePatterns?.any { it.isTypical() } ?: false
 
             return (isTypical || isUpcoming) && !(shouldBeFilteredAsArrivalOnly)
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -22,12 +22,12 @@ data class RoutePattern(
         @SerialName("canonical_only") CanonicalOnly
     }
 
+    /**
+     * Checks if this pattern is [Typicality.Typical].
+     *
+     * If any typicality is unknown, the route should be shown, and so this will return true.
+     */
+    fun isTypical() = typicality == null || typicality == Typicality.Typical
+
     override fun compareTo(other: RoutePattern) = sortOrder.compareTo(other.sortOrder)
 }
-/**
- * Checks if any pattern under this headsign is [RoutePattern.Typicality.Typical].
- *
- * If any typicality is unknown, the route should be shown, and so this will return true.
- */
-fun List<RoutePattern>.isTypical() =
-    this.any { it.typicality == null || it.typicality == RoutePattern.Typicality.Typical }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -67,6 +67,18 @@ constructor(
     val trackNumber: String? =
         if (predictionStop?.shouldShowTrackNumber == true) predictionStop.platformCode else null
 
+    /** Checks if a trip has a time */
+    fun isUpcoming() = time != null
+
+    /**
+     * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet
+     * left this stop.
+     */
+    fun isUpcomingWithin(currentTime: Instant, cutoffTime: Instant): Boolean =
+        time != null &&
+            time < cutoffTime &&
+            (time >= currentTime || (prediction != null && prediction.stopId == vehicle?.stopId))
+
     override fun compareTo(other: UpcomingTrip) = nullsLast<Instant>().compare(time, other.time)
 
     /**
@@ -200,27 +212,6 @@ constructor(
                     scheduleTime >= filterAtTime
                 }
         }
-    }
-}
-
-/**
- * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet left
- * this stop.
- */
-fun List<UpcomingTrip>.isUpcomingWithin(currentTime: Instant, cutoffTime: Instant): Boolean {
-    return this.any {
-        val tripTime = it.time
-        tripTime != null &&
-            tripTime < cutoffTime &&
-            (tripTime >= currentTime ||
-                (it.prediction != null && it.prediction.stopId == it.vehicle?.stopId))
-    }
-}
-/** Checks if a trip has a time */
-fun List<UpcomingTrip>.isUpcoming(): Boolean {
-    return this.any {
-        val tripTime = it.time
-        tripTime != null
     }
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | 🤖 Handle branching vs non-branching](https://app.asana.com/0/1205732265579288/1209536961544722/f)

I needed `isUpcomingWithin` and `isTypical` on the individual objects as part of branching handling, and that PR has too many tests, so this is as large of a piece as can be reasonably split out.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the shared tests all still compile and pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
