### PR TITLE
chore: fix shared test formatting with spotless

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -113,10 +113,10 @@ skie {
 
 spotless {
     kotlin {
-        target("src/*Main/**/*.kt")
         custom(
             "ban getValue outside tests",
             FormatterFunc.NeedsFile { text, file ->
+                if (file.path.contains("commonTest")) return@NeedsFile text
                 val lines = text.lines()
                 for (line in lines.withIndex()) {
                     val column = line.value.indexOf("getValue(")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -339,7 +339,7 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `stop features have routes`()  = runBlocking {
+    fun `stop features have routes`() = runBlocking {
         val stops =
             mapOf(
                 MapTestDataHelper.stopAssembly.id to MapTestDataHelper.mapStopAssembly,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -3,6 +3,10 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.serviceDate
 import com.mbta.tid.mbta_app.utils.toBostonTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.Instant
@@ -11,21 +15,18 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
 import kotlinx.datetime.plus
 import kotlinx.datetime.toInstant
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.time.Duration.Companion.hours
 
 class AlertSummaryTest {
     @Test
     fun `summary is null when there is no timeframe or location`() {
         val objects = ObjectCollectionBuilder()
         val now = Clock.System.now()
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
-            durationCertainty = Alert.DurationCertainty.Estimated
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), now.plus(1.hours))
+                durationCertainty = Alert.DurationCertainty.Estimated
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -37,10 +38,11 @@ class AlertSummaryTest {
         val objects = ObjectCollectionBuilder()
         val now = Clock.System.now()
         val endTime = now.plus(1.hours)
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -59,10 +61,11 @@ class AlertSummaryTest {
         val serviceEndTime = LocalTime(hour = 2, minute = 59)
         val endTime = tomorrow.atTime(serviceEndTime).toInstant(TimeZone.of("America/New_York"))
 
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -81,10 +84,11 @@ class AlertSummaryTest {
         val serviceEndTime = LocalTime(hour = 3, minute = 0)
         val endTime = tomorrow.atTime(serviceEndTime).toInstant(TimeZone.of("America/New_York"))
 
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -104,10 +108,11 @@ class AlertSummaryTest {
         val serviceEndTime = LocalTime(hour = 3, minute = 0)
         val endTime = tomorrow.atTime(serviceEndTime).toInstant(TimeZone.of("America/New_York"))
 
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -127,10 +132,11 @@ class AlertSummaryTest {
         val serviceEndTime = LocalTime(hour = 5, minute = 0)
         val endTime = saturday.atTime(serviceEndTime).toInstant(TimeZone.of("America/New_York"))
 
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 
@@ -150,10 +156,11 @@ class AlertSummaryTest {
         val serviceEndTime = LocalTime(hour = 5, minute = 0)
         val endTime = monday.atTime(serviceEndTime).toInstant(TimeZone.of("America/New_York"))
 
-        val alert = objects.alert {
-            effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), endTime)
-        }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                activePeriod(now.minus(1.hours), endTime)
+            }
 
         val alertSummary = AlertSummary.summarizing(alert, now, GlobalResponse(objects))
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -21,29 +21,38 @@ class AlertTest {
     @Test
     fun `alert significance is set properly`() {
         for (effect in Alert.Effect.entries) {
-            val inherentlyStopSpecific = when (effect) {
-                Alert.Effect.DockClosure, Alert.Effect.DockIssue -> true
-                Alert.Effect.StationClosure, Alert.Effect.StationIssue -> true
-                Alert.Effect.StopClosure -> true
-                else -> false
-            }
-            for (specifiedStops in listOfNotNull(false.takeUnless { inherentlyStopSpecific }, true)) {
-                val alert = ObjectCollectionBuilder.Single.alert {
-                    this.effect = effect
-                    informedEntity(emptyList(), stop = "stop".takeIf { specifiedStops })
+            val inherentlyStopSpecific =
+                when (effect) {
+                    Alert.Effect.DockClosure,
+                    Alert.Effect.DockIssue -> true
+                    Alert.Effect.StationClosure,
+                    Alert.Effect.StationIssue -> true
+                    Alert.Effect.StopClosure -> true
+                    else -> false
                 }
-                val expectedSignificance = when (effect) {
-                    Alert.Effect.Detour, Alert.Effect.SnowRoute -> if (specifiedStops) AlertSignificance.Major else AlertSignificance.Secondary
-                    Alert.Effect.DockClosure -> AlertSignificance.Major
-                    Alert.Effect.ElevatorClosure -> AlertSignificance.Accessibility
-                    Alert.Effect.ServiceChange -> AlertSignificance.Secondary
-                    Alert.Effect.Shuttle -> AlertSignificance.Major
-                    Alert.Effect.StationClosure -> AlertSignificance.Major
-                    Alert.Effect.StopClosure -> AlertSignificance.Major
-                    Alert.Effect.Suspension -> AlertSignificance.Major
-                    Alert.Effect.TrackChange -> AlertSignificance.Minor
-                    else -> AlertSignificance.None
-                }
+            for (specifiedStops in
+                listOfNotNull(false.takeUnless { inherentlyStopSpecific }, true)) {
+                val alert =
+                    ObjectCollectionBuilder.Single.alert {
+                        this.effect = effect
+                        informedEntity(emptyList(), stop = "stop".takeIf { specifiedStops })
+                    }
+                val expectedSignificance =
+                    when (effect) {
+                        Alert.Effect.Detour,
+                        Alert.Effect.SnowRoute ->
+                            if (specifiedStops) AlertSignificance.Major
+                            else AlertSignificance.Secondary
+                        Alert.Effect.DockClosure -> AlertSignificance.Major
+                        Alert.Effect.ElevatorClosure -> AlertSignificance.Accessibility
+                        Alert.Effect.ServiceChange -> AlertSignificance.Secondary
+                        Alert.Effect.Shuttle -> AlertSignificance.Major
+                        Alert.Effect.StationClosure -> AlertSignificance.Major
+                        Alert.Effect.StopClosure -> AlertSignificance.Major
+                        Alert.Effect.Suspension -> AlertSignificance.Major
+                        Alert.Effect.TrackChange -> AlertSignificance.Minor
+                        else -> AlertSignificance.None
+                    }
                 assertEquals(
                     expectedSignificance,
                     alert.significance,
@@ -55,23 +64,26 @@ class AlertTest {
 
     @Test
     fun `alert significance for delay alerts`() {
-                val subwayDelaySevere = ObjectCollectionBuilder.Single.alert {
-                    effect = Alert.Effect.Delay
-                    severity = 10
-                    informedEntity(emptyList(), stop = "stop", routeType = RouteType.LIGHT_RAIL)
-                }
+        val subwayDelaySevere =
+            ObjectCollectionBuilder.Single.alert {
+                effect = Alert.Effect.Delay
+                severity = 10
+                informedEntity(emptyList(), stop = "stop", routeType = RouteType.LIGHT_RAIL)
+            }
 
-        val subwayDelayNotSevere = ObjectCollectionBuilder.Single.alert {
-            this.effect = Alert.Effect.Delay
-            severity = 0
-            informedEntity(emptyList(), stop = "stop", routeType = RouteType.LIGHT_RAIL)
-        }
+        val subwayDelayNotSevere =
+            ObjectCollectionBuilder.Single.alert {
+                this.effect = Alert.Effect.Delay
+                severity = 0
+                informedEntity(emptyList(), stop = "stop", routeType = RouteType.LIGHT_RAIL)
+            }
 
-        val busDelaySevere = ObjectCollectionBuilder.Single.alert {
-            this.effect = Alert.Effect.Delay
-            severity = 10
-            informedEntity(emptyList(), stop = "stop", routeType = RouteType.BUS)
-        }
+        val busDelaySevere =
+            ObjectCollectionBuilder.Single.alert {
+                this.effect = Alert.Effect.Delay
+                severity = 10
+                informedEntity(emptyList(), stop = "stop", routeType = RouteType.BUS)
+            }
 
         assertEquals(subwayDelaySevere.significance, AlertSignificance.Minor)
         assertEquals(subwayDelayNotSevere.significance, AlertSignificance.None)
@@ -147,7 +159,6 @@ class AlertTest {
         assertEquals(listOf(alertMatch, alertMatchNoDirection), filteredList)
     }
 
-
     @Test
     fun `filters applicable alerts`() {
         val objects = ObjectCollectionBuilder()
@@ -210,7 +221,7 @@ class AlertTest {
             Alert.applicableAlerts(
                 listOf(alert),
                 null,
-                        listOf(route.id),
+                listOf(route.id),
                 setOf(stop.id),
                 tripId = null,
             ),
@@ -303,7 +314,8 @@ class AlertTest {
             }
         assertEquals(
             listOf(alert),
-            Alert.applicableAlerts(   listOf(alert, otherAlert),
+            Alert.applicableAlerts(
+                listOf(alert, otherAlert),
                 directionId = null,
                 listOf(route.id),
                 stopIds = null,
@@ -387,7 +399,6 @@ class AlertTest {
         assertEquals(listOf(firstRideAlert), downstreamAlerts)
     }
 
-
     @Test
     fun `downstreamAlerts excludes alerts affecting the target stop`() {
         val objects = ObjectCollectionBuilder()
@@ -452,8 +463,6 @@ class AlertTest {
         assertEquals(listOf(alertDownstream2Only), downstreamAlerts)
     }
 
-
-
     @Test
     fun `downstreamAlerts ignores alert without stops specified`() {
         val objects = ObjectCollectionBuilder()
@@ -482,12 +491,7 @@ class AlertTest {
                     )
             }
 
-        val downstreamAlerts =
-            Alert.downstreamAlerts(
-                listOf(alert),
-                trip,
-                setOf(targetStop.id)
-            )
+        val downstreamAlerts = Alert.downstreamAlerts(listOf(alert), trip, setOf(targetStop.id))
 
         assertEquals(listOf(), downstreamAlerts)
     }
@@ -508,17 +512,10 @@ class AlertTest {
         val serviceAlert =
             objects.alert {
                 effect = Alert.Effect.NoService
-                informedEntity(
-                    listOf(Alert.InformedEntity.Activity.Board),
-                    stop = stop.id
-                )
+                informedEntity(listOf(Alert.InformedEntity.Activity.Board), stop = stop.id)
             }
 
-        val alerts =
-            Alert.elevatorAlerts(
-                listOf(serviceAlert, elevatorAlert),
-                setOf(stop.id)
-            )
+        val alerts = Alert.elevatorAlerts(listOf(serviceAlert, elevatorAlert), setOf(stop.id))
 
         assertEquals(listOf(elevatorAlert), alerts)
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DirectionTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DirectionTest.kt
@@ -222,7 +222,8 @@ class DirectionTest {
         assertEquals("Gov Ctr & North", directionRp3.destination)
     }
 
-    @Test fun `getDirectionsForLine at different stops along the GL`() {
+    @Test
+    fun `getDirectionsForLine at different stops along the GL`() {
         val objects = ObjectCollectionBuilder()
 
         // B West
@@ -235,9 +236,8 @@ class DirectionTest {
         // Shared Trunk
         val hynes = objects.stop { id = "place-hymnl" }
         val arlington = objects.stop { id = "place-armnl" }
-        val boylston = objects.stop {id = "place-boyls"}
+        val boylston = objects.stop { id = "place-boyls" }
         val gov = objects.stop { id = "place-gover" }
-
 
         // E East / North
         val haymarket = objects.stop { id = "place-haecl" }
@@ -255,16 +255,18 @@ class DirectionTest {
             }
         val routePatternB1 =
             objects.routePattern(routeB) {
-                representativeTrip { headsign = "B"
-                    stopIds = listOf(gov.id, boylston.id, arlington.id, hynes.id, southSt.id,  bc.id)
+                representativeTrip {
+                    headsign = "B"
+                    stopIds = listOf(gov.id, boylston.id, arlington.id, hynes.id, southSt.id, bc.id)
                 }
                 directionId = 0
                 typicality = RoutePattern.Typicality.Typical
             }
         val routePatternB2 =
             objects.routePattern(routeB) {
-                representativeTrip { headsign = "B"
-                    stopIds = listOf(bc.id, southSt.id, hynes.id, arlington.id,  boylston.id, gov.id)
+                representativeTrip {
+                    headsign = "B"
+                    stopIds = listOf(bc.id, southSt.id, hynes.id, arlington.id, boylston.id, gov.id)
                 }
                 directionId = 1
                 typicality = RoutePattern.Typicality.Typical
@@ -281,17 +283,38 @@ class DirectionTest {
         val routePatternE1 =
             objects.routePattern(routeE) {
                 id = "test-hs"
-                representativeTrip { headsign = "Heath Street"
-                    stopIds = listOf(magoun.id, lechmere.id, haymarket.id, gov.id, boylston.id, arlington.id, hynes.id, heath.id)
-
+                representativeTrip {
+                    headsign = "Heath Street"
+                    stopIds =
+                        listOf(
+                            magoun.id,
+                            lechmere.id,
+                            haymarket.id,
+                            gov.id,
+                            boylston.id,
+                            arlington.id,
+                            hynes.id,
+                            heath.id
+                        )
                 }
                 directionId = 0
                 typicality = RoutePattern.Typicality.Typical
             }
         val routePatternE2 =
             objects.routePattern(routeE) {
-                representativeTrip { headsign = "Medford/Tufts"
-                    stopIds = listOf(heath.id, hynes.id, arlington.id, boylston.id, gov.id, haymarket.id, lechmere.id, magoun.id)
+                representativeTrip {
+                    headsign = "Medford/Tufts"
+                    stopIds =
+                        listOf(
+                            heath.id,
+                            hynes.id,
+                            arlington.id,
+                            boylston.id,
+                            gov.id,
+                            haymarket.id,
+                            lechmere.id,
+                            magoun.id
+                        )
                 }
                 directionId = 1
                 typicality = RoutePattern.Typicality.Typical
@@ -300,19 +323,38 @@ class DirectionTest {
         val global = GlobalResponse(objects)
 
         // on Western branch
-        assertEquals(listOf(Direction("West", "Boston College", 0), Direction("East", "Park St & North", 1)),
-            Direction.getDirectionsForLine(global, southSt, listOf(routePatternB1, routePatternB2)))
+        assertEquals(
+            listOf(Direction("West", "Boston College", 0), Direction("East", "Park St & North", 1)),
+            Direction.getDirectionsForLine(global, southSt, listOf(routePatternB1, routePatternB2))
+        )
 
         // on shard trunk
-        assertEquals(listOf(Direction("West", "Kenmore & West", 0), Direction("East", "Park St & North", 1)),
-            Direction.getDirectionsForLine(global, hynes, listOf(routePatternB1, routePatternB2, routePatternE1, routePatternE2)))
+        assertEquals(
+            listOf(Direction("West", "Kenmore & West", 0), Direction("East", "Park St & North", 1)),
+            Direction.getDirectionsForLine(
+                global,
+                hynes,
+                listOf(routePatternB1, routePatternB2, routePatternE1, routePatternE2)
+            )
+        )
 
         // gov center extra special case
-        assertEquals(listOf(Direction("West", "Copley & West", 0), Direction("East", "North Station & North", 1)),
-            Direction.getDirectionsForLine(global, gov, listOf(routePatternB1, routePatternB2, routePatternE1, routePatternE2)))
+        assertEquals(
+            listOf(
+                Direction("West", "Copley & West", 0),
+                Direction("East", "North Station & North", 1)
+            ),
+            Direction.getDirectionsForLine(
+                global,
+                gov,
+                listOf(routePatternB1, routePatternB2, routePatternE1, routePatternE2)
+            )
+        )
 
         // eastern branch
-        assertEquals(listOf(Direction("West", "Copley & West", 0), Direction("East", "Medford/Tufts", 1)),
-            Direction.getDirectionsForLine(global, magoun, listOf(routePatternE1, routePatternE2)))
+        assertEquals(
+            listOf(Direction("West", "Copley & West", 0), Direction("East", "Medford/Tufts", 1)),
+            Direction.getDirectionsForLine(global, magoun, listOf(routePatternE1, routePatternE2))
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalResponseTest.kt
@@ -375,12 +375,8 @@ class GlobalResponseTest {
 
         val route = objects.route()
         lateinit var childStop: Stop
-        val parentStation = objects.stop {
-            childStop = childStop()
-        }
-        val alert = objects.alert {
-            informedEntity(listOf(), stop = childStop.id)
-        }
+        val parentStation = objects.stop { childStop = childStop() }
+        val alert = objects.alert { informedEntity(listOf(), stop = childStop.id) }
 
         val affectedStops = GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route))
         assertEquals(affectedStops, listOf(parentStation))
@@ -395,11 +391,12 @@ class GlobalResponseTest {
         val stop1 = objects.stop()
         val stop2 = objects.stop()
         val stop3 = objects.stop()
-        val alert = objects.alert {
-            informedEntity(listOf(), stop = stop1.id)
-            informedEntity(listOf(), route = route1.id, stop = stop2.id)
-            informedEntity(listOf(), route = route2.id, stop = stop3.id)
-        }
+        val alert =
+            objects.alert {
+                informedEntity(listOf(), stop = stop1.id)
+                informedEntity(listOf(), route = route1.id, stop = stop2.id)
+                informedEntity(listOf(), route = route2.id, stop = stop3.id)
+            }
 
         val affectedStops = GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route1))
         assertEquals(affectedStops, listOf(stop1, stop2))
@@ -413,14 +410,16 @@ class GlobalResponseTest {
         val route2 = objects.route()
         val stop1 = objects.stop()
         val stop2 = objects.stop()
-        val alert = objects.alert {
-            informedEntity(listOf(), route = route1.id, stop = stop1.id)
-            informedEntity(listOf(), route = route1.id, stop = stop2.id)
-            informedEntity(listOf(), route = route2.id, stop = stop1.id)
-            informedEntity(listOf(), route = route2.id, stop = stop2.id)
-        }
+        val alert =
+            objects.alert {
+                informedEntity(listOf(), route = route1.id, stop = stop1.id)
+                informedEntity(listOf(), route = route1.id, stop = stop2.id)
+                informedEntity(listOf(), route = route2.id, stop = stop1.id)
+                informedEntity(listOf(), route = route2.id, stop = stop2.id)
+            }
 
-        val affectedStops = GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route1, route2))
+        val affectedStops =
+            GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route1, route2))
         assertEquals(affectedStops, listOf(stop1, stop2))
     }
 
@@ -430,20 +429,17 @@ class GlobalResponseTest {
 
         val line = objects.line()
 
-        val route = objects.route {
-            lineId = line.id
-        }
+        val route = objects.route { lineId = line.id }
 
-        val shuttleRoute = objects.route {
-            id = "Shuttle-1"
-            lineId = line.id
-        }
+        val shuttleRoute =
+            objects.route {
+                id = "Shuttle-1"
+                lineId = line.id
+            }
 
         // not included b/c no line
         val otherRoute = objects.route()
 
         assertEquals(mapOf(line.id to listOf(route)), GlobalResponse(objects).routesByLineId)
-
-
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/NearbyResponseTest.kt
@@ -535,12 +535,12 @@ class NearbyResponseTest {
                 lineId = line.id
             }
 
-        val railPattern = objects.routePattern(railRoute) {
-            representativeTrip { headsign = "Boston College" }
-        }
-        val shuttlePattern = objects.routePattern(shuttleRoute) {
-            representativeTrip { headsign = "Boston College" }
-        }
+        val railPattern =
+            objects.routePattern(railRoute) { representativeTrip { headsign = "Boston College" } }
+        val shuttlePattern =
+            objects.routePattern(shuttleRoute) {
+                representativeTrip { headsign = "Boston College" }
+            }
 
         val global =
             GlobalResponse(
@@ -556,13 +556,16 @@ class NearbyResponseTest {
             NearbyStaticData.build {
                 line(line, listOf(railRoute)) {
                     stop(stop, routes = listOf(railRoute), directions = listOf(westDir, eastDir)) {
-                        headsign(railRoute, "Boston College", listOf(railPattern), direction = westDir)
+                        headsign(
+                            railRoute,
+                            "Boston College",
+                            listOf(railPattern),
+                            direction = westDir
+                        )
                     }
                 }
                 route(shuttleRoute) {
-                    stop(stop) {
-                        headsign("Boston College", listOf(shuttlePattern))
-                    }
+                    stop(stop) { headsign("Boston College", listOf(shuttlePattern)) }
                 }
             },
             NearbyStaticData(global, nearby)
@@ -980,7 +983,6 @@ class NearbyResponseTest {
                     alerts = AlertsStreamDataResponse(emptyMap()),
                     filterAtTime = time,
                     pinnedRoutes = setOf(),
-
                 )
             )
         }
@@ -1141,7 +1143,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -1313,7 +1316,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -1427,7 +1431,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(emptyMap(), emptyMap(), emptyMap()),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -1727,7 +1732,8 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         assertEquals(
             listOf(closeSubwayRoute, farSubwayRoute, closeBusRoute, farBusRoute),
             checkNotNull(realtimeRoutesSorted).flatMap {
@@ -1848,7 +1854,8 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),)
+                pinnedRoutes = setOf(farBusRoute.id, farSubwayRoute.id),
+            )
         assertEquals(
             listOf(farSubwayRoute, farBusRoute, closeSubwayRoute, closeBusRoute),
             checkNotNull(realtimeRoutesSorted).flatMap {
@@ -2029,7 +2036,8 @@ class NearbyResponseTest {
                 schedules = ScheduleResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),)
+                pinnedRoutes = setOf(midSubwayRoute.id, farSubwayRoute.id),
+            )
 
         // Routes with no service today should sort below all routes with any service today,
         // unless they are a pinned route, in which case we want them to sort beneath all other
@@ -2155,7 +2163,6 @@ class NearbyResponseTest {
                     alerts = AlertsStreamDataResponse(objects),
                     filterAtTime = time,
                     pinnedRoutes = setOf(),
-
                 )
 
             // If a route has major disruptions and doesn't have any scheduled trips, it should
@@ -2230,7 +2237,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2299,7 +2307,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2381,7 +2390,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2480,7 +2490,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2556,7 +2567,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2632,7 +2644,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(objects),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2839,7 +2852,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 
@@ -2944,7 +2958,6 @@ class NearbyResponseTest {
                 }
             }
 
-
         val orangeNorthboundDiversion =
             objects.routePattern(orangeRoute) {
                 id = "Orange-6-1"
@@ -3035,53 +3048,53 @@ class NearbyResponseTest {
                         // North station entities
                         Alert.InformedEntity(
                             activities =
-                            listOf(
-                                Alert.InformedEntity.Activity.Exit,
-                                Alert.InformedEntity.Activity.Ride
-                            ),
+                                listOf(
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride
+                                ),
                             route = orangeRoute.id,
                             routeType = RouteType.HEAVY_RAIL,
                             stop = northStationSouthboundPlatform.id
                         ),
                         Alert.InformedEntity(
                             activities =
-                            listOf(
-                                Alert.InformedEntity.Activity.Board,
-                                Alert.InformedEntity.Activity.Ride
-                            ),
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Ride
+                                ),
                             route = orangeRoute.id,
                             routeType = RouteType.HEAVY_RAIL,
                             stop = northStationNorthboundPlatform.id
                         ),
                         Alert.InformedEntity(
                             activities =
-                            listOf(
-                                Alert.InformedEntity.Activity.Board,
-                                Alert.InformedEntity.Activity.Exit,
-                                Alert.InformedEntity.Activity.Ride
-                            ),
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride
+                                ),
                             route = orangeRoute.id,
                             routeType = RouteType.HEAVY_RAIL,
                             stop = northStation.id
                         ),
                         Alert.InformedEntity(
                             activities =
-                            listOf(
-                                Alert.InformedEntity.Activity.Board,
-                                Alert.InformedEntity.Activity.Exit,
-                                Alert.InformedEntity.Activity.Ride
-                            ),
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride
+                                ),
                             route = orangeRoute.id,
                             routeType = RouteType.HEAVY_RAIL,
                             stop = oakGrove.id
                         ),
                         Alert.InformedEntity(
                             activities =
-                            listOf(
-                                Alert.InformedEntity.Activity.Board,
-                                Alert.InformedEntity.Activity.Exit,
-                                Alert.InformedEntity.Activity.Ride
-                            ),
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride
+                                ),
                             route = orangeRoute.id,
                             routeType = RouteType.HEAVY_RAIL,
                             stop = oakGrovePlatform.id
@@ -3160,121 +3173,120 @@ class NearbyResponseTest {
     }
 
     @Test
-    fun `withRealtimeInfo filters out headsign if it is the last stop of route pattern`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `withRealtimeInfo filters out headsign if it is the last stop of route pattern`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val oakGrove =
-            objects.stop {
-                id = "place-ogmnl"
-                locationType = LocationType.STATION
-                childStopIds = listOf("70036")
-            }
+            val oakGrove =
+                objects.stop {
+                    id = "place-ogmnl"
+                    locationType = LocationType.STATION
+                    childStopIds = listOf("70036")
+                }
 
-        val orangeRoute = objects.route { id = "Orange" }
-        val orangeNorthboundTypical =
-            objects.routePattern(orangeRoute) {
-                id = "Orange-3-1"
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 1
-                representativeTrip {
-                    id = "canonical-Orange-C1-1"
-                    headsign = "Oak Grove"
+            val orangeRoute = objects.route { id = "Orange" }
+            val orangeNorthboundTypical =
+                objects.routePattern(orangeRoute) {
+                    id = "Orange-3-1"
+                    typicality = RoutePattern.Typicality.Typical
                     directionId = 1
-                    stopIds = listOf("70001", "70027", "70036")
-                }
-            }
-
-        val orangeSouthboundTypical =
-            objects.routePattern(orangeRoute) {
-                id = "Orange-3-0"
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 0
-                representativeTrip {
-                    id = "canonical-Orange-C1-0"
-                    headsign = "Forest Hills"
-                    directionId = 0
-                    stopIds = listOf("70036", "70026", "70001")
-                }
-            }
-
-        val staticData =
-            NearbyStaticData.build {
-                route(orangeRoute) {
-                    stop(oakGrove) {
-                        headsign("Forest Hills", listOf(orangeSouthboundTypical))
-                        headsign("Oak Grove", listOf(orangeNorthboundTypical))
+                    representativeTrip {
+                        id = "canonical-Orange-C1-1"
+                        headsign = "Oak Grove"
+                        directionId = 1
+                        stopIds = listOf("70001", "70027", "70036")
                     }
                 }
-            }
 
-        val time = Instant.parse("2024-10-30T16:40:00-04:00")
+            val orangeSouthboundTypical =
+                objects.routePattern(orangeRoute) {
+                    id = "Orange-3-0"
+                    typicality = RoutePattern.Typicality.Typical
+                    directionId = 0
+                    representativeTrip {
+                        id = "canonical-Orange-C1-0"
+                        headsign = "Forest Hills"
+                        directionId = 0
+                        stopIds = listOf("70036", "70026", "70001")
+                    }
+                }
 
-        val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
-        val orangeSouthboundTypicalTrip = objects.trip(orangeSouthboundTypical)
+            val staticData =
+                NearbyStaticData.build {
+                    route(orangeRoute) {
+                        stop(oakGrove) {
+                            headsign("Forest Hills", listOf(orangeSouthboundTypical))
+                            headsign("Oak Grove", listOf(orangeNorthboundTypical))
+                        }
+                    }
+                }
 
-        val sched1 =
-            objects.schedule {
-                trip = orangeSouthboundTypicalTrip
-                stopId = oakGrove.id
-                stopSequence = 90
-                departureTime = time + 1.minutes
-            }
-        val sched2 =
-            objects.schedule {
-                trip = orangeNorthboundTypicalTrip
-                stopId = oakGrove.id
-                stopSequence = 90
-                arrivalTime = time + 2.minutes
-                departureTime = null
-            }
+            val time = Instant.parse("2024-10-30T16:40:00-04:00")
 
-        assertEquals(
-            listOf(
-                StopsAssociated.WithRoute(
-                    orangeRoute,
-                    listOf(
-                        PatternsByStop(
-                            orangeRoute,
-                            oakGrove,
-                            listOf(
-                                RealtimePatterns.ByHeadsign(
-                                    orangeRoute,
-                                    "Forest Hills",
-                                    null,
-                                    listOf(orangeSouthboundTypical),
-                                    listOf(objects.upcomingTrip(sched1)),
-                                    hasSchedulesToday = true
-                                ),
+            val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
+            val orangeSouthboundTypicalTrip = objects.trip(orangeSouthboundTypical)
+
+            val sched1 =
+                objects.schedule {
+                    trip = orangeSouthboundTypicalTrip
+                    stopId = oakGrove.id
+                    stopSequence = 90
+                    departureTime = time + 1.minutes
+                }
+            val sched2 =
+                objects.schedule {
+                    trip = orangeNorthboundTypicalTrip
+                    stopId = oakGrove.id
+                    stopSequence = 90
+                    arrivalTime = time + 2.minutes
+                    departureTime = null
+                }
+
+            assertEquals(
+                listOf(
+                    StopsAssociated.WithRoute(
+                        orangeRoute,
+                        listOf(
+                            PatternsByStop(
+                                orangeRoute,
+                                oakGrove,
+                                listOf(
+                                    RealtimePatterns.ByHeadsign(
+                                        orangeRoute,
+                                        "Forest Hills",
+                                        null,
+                                        listOf(orangeSouthboundTypical),
+                                        listOf(objects.upcomingTrip(sched1)),
+                                        hasSchedulesToday = true
+                                    ),
+                                )
                             )
                         )
                     )
+                ),
+                staticData.withRealtimeInfo(
+                    globalData = GlobalResponse(objects),
+                    sortByDistanceFrom = oakGrove.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    filterAtTime = time,
+                    pinnedRoutes = setOf(),
                 )
-            ),
-            staticData.withRealtimeInfo(
-                globalData = GlobalResponse(objects),
-                sortByDistanceFrom = oakGrove.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                filterAtTime = time,
-                pinnedRoutes = setOf(),
             )
-        )
-    }
+        }
 
     @Test
     fun `withRealtimeInfo filters out any arrival only for non-subway routes`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
-        val longWharf =
-            objects.stop {
-                id = "Boat-Long"
-            }
+        val longWharf = objects.stop { id = "Boat-Long" }
 
-        val ferryRoute = objects.route {
-            id = "Boat-F1"
-            type = RouteType.FERRY
-        }
+        val ferryRoute =
+            objects.route {
+                id = "Boat-F1"
+                type = RouteType.FERRY
+            }
         val ferryInboundToLongWharf =
             objects.routePattern(ferryRoute) {
                 id = "Boat-F1-3-1"
@@ -3324,14 +3336,14 @@ class NearbyResponseTest {
                 stopId = longWharf.id
                 stopSequence = 90
                 arrivalTime = time + 2.minutes
-                departureTime = null            }
+                departureTime = null
+            }
         val schedOutbound =
             objects.schedule {
                 trip = ferryOutboundTrip
                 stopId = longWharf.id
                 stopSequence = 90
                 departureTime = time + 2.minutes
-
             }
 
         assertEquals(
@@ -3363,7 +3375,8 @@ class NearbyResponseTest {
                 predictions = PredictionsStreamDataResponse(objects),
                 alerts = AlertsStreamDataResponse(emptyMap()),
                 filterAtTime = time,
-                pinnedRoutes = setOf(),)
+                pinnedRoutes = setOf(),
+            )
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternsByStopTest.kt
@@ -3,11 +3,11 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class PatternsByStopTest {
     @Test
@@ -204,7 +204,8 @@ class PatternsByStopTest {
 
         val route = objects.route()
         val stop = objects.stop()
-        val pattern = objects.routePattern(route) { representativeTrip { stopIds = listOf(stop.id) }}
+        val pattern =
+            objects.routePattern(route) { representativeTrip { stopIds = listOf(stop.id) } }
 
         val time = Clock.System.now()
 
@@ -644,10 +645,7 @@ class PatternsByStopTest {
                 representativeTripId = "trip_1"
             }
 
-        val stop =
-            objects.stop {
-                id = "stop_1"
-            }
+        val stop = objects.stop { id = "stop_1" }
         val trip =
             objects.trip {
                 id = "trip_1"
@@ -656,12 +654,12 @@ class PatternsByStopTest {
                 routePatternId = "pattern_1"
             }
 
-        val schedule = objects.schedule {
-            tripId = "trip_1"
-            stopId = "stop_1"
-            departureTime = now.plus(10.minutes)
-
-        }
+        val schedule =
+            objects.schedule {
+                tripId = "trip_1"
+                stopId = "stop_1"
+                departureTime = now.plus(10.minutes)
+            }
         val prediction =
             objects.prediction {
                 id = "prediction_1"
@@ -683,13 +681,39 @@ class PatternsByStopTest {
                 scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
             }
 
-        assertTrue(PatternsByStop(route, stop,
-            listOf(RealtimePatterns.ByHeadsign(route, trip.headsign, null, listOf(routePattern), listOf(
-                UpcomingTrip(trip, schedule, predictionCancelled))))).tripIsCancelled(trip.id))
+        assertTrue(
+            PatternsByStop(
+                    route,
+                    stop,
+                    listOf(
+                        RealtimePatterns.ByHeadsign(
+                            route,
+                            trip.headsign,
+                            null,
+                            listOf(routePattern),
+                            listOf(UpcomingTrip(trip, schedule, predictionCancelled))
+                        )
+                    )
+                )
+                .tripIsCancelled(trip.id)
+        )
 
-        assertFalse(PatternsByStop(route, stop,
-            listOf(RealtimePatterns.ByHeadsign(route, trip.headsign, null, listOf(routePattern), listOf(
-                UpcomingTrip(trip, schedule, prediction))))).tripIsCancelled(trip.id))
+        assertFalse(
+            PatternsByStop(
+                    route,
+                    stop,
+                    listOf(
+                        RealtimePatterns.ByHeadsign(
+                            route,
+                            trip.headsign,
+                            null,
+                            listOf(routePattern),
+                            listOf(UpcomingTrip(trip, schedule, prediction))
+                        )
+                    )
+                )
+                .tripIsCancelled(trip.id)
+        )
     }
 
     object GroupedGLTestPatterns {
@@ -754,7 +778,11 @@ class PatternsByStopTest {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
             }
         val upcomingTripCCleveland1 =
-            objects.upcomingTrip(scheduleCCleveland1, predictionCCleveland1, vehicle = vehicleCCleveland1)
+            objects.upcomingTrip(
+                scheduleCCleveland1,
+                predictionCCleveland1,
+                vehicle = vehicleCCleveland1
+            )
         val upcomingTripScheduledCCleveland1 = objects.upcomingTrip(scheduleCCleveland1)
 
         val tripEMedford1 = objects.trip(routePatternEMedford)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -20,150 +20,152 @@ import kotlinx.datetime.Instant
 class RouteCardDataTest {
 
     @Test
-    fun `ListBuilder addStaticStopsData when there are no new patterns for a stop then it is omitted`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `ListBuilder addStaticStopsData when there are no new patterns for a stop then it is omitted`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
-        val stop2 = objects.stop()
+            val stop1 = objects.stop()
+            val stop2 = objects.stop()
 
-        val route1 = objects.route()
+            val route1 = objects.route()
 
-        val route1rp1 =
-            objects.routePattern(route1) {
-                representativeTrip {
-                    headsign = "Harvard"
-                    directionId = 0
+            val route1rp1 =
+                objects.routePattern(route1) {
+                    representativeTrip {
+                        headsign = "Harvard"
+                        directionId = 0
+                    }
                 }
-            }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        stop1.id to listOf(route1rp1.id),
-                        stop2.id to listOf(route1rp1.id),
-                    ),
-            )
-        val nearby = NearbyResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val now = Clock.System.now()
-
-        assertEquals(
-            mapOf(
-                route1.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
                         mapOf(
-                            stop1.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop1,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(route1rp1),
-                                                stopIds = setOf(stop1.id),
-                                                allDataLoaded = false,
-                                            )
-                                    ),
-                                    global
-                                )
+                            stop1.id to listOf(route1rp1.id),
+                            stop2.id to listOf(route1rp1.id),
                         ),
-                        context,
-                        now,
-                    )
-            ),
-            RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global)
-                .data
-        )
-    }
+                )
+            val nearby = NearbyResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val now = Clock.System.now()
+
+            assertEquals(
+                mapOf(
+                    route1.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route1),
+                            mapOf(
+                                stop1.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop1,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(route1rp1),
+                                                    stopIds = setOf(stop1.id),
+                                                    allDataLoaded = false,
+                                                )
+                                        ),
+                                        global
+                                    )
+                            ),
+                            context,
+                            now,
+                        )
+                ),
+                RouteCardData.ListBuilder(false, context, now)
+                    .addStaticStopsData(nearby.stopIds, global)
+                    .data
+            )
+        }
 
     @Test
-    fun `ListBuilder addStaticStopsData when second stop serves a new rp for route served by previous stop then include all rps at second stop`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `ListBuilder addStaticStopsData when second stop serves a new rp for route served by previous stop then include all rps at second stop`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
-        val stop2 = objects.stop()
+            val stop1 = objects.stop()
+            val stop2 = objects.stop()
 
-        val route1 = objects.route()
+            val route1 = objects.route()
 
-        val route1rp1 =
-            objects.routePattern(route1) {
-                representativeTrip {
-                    headsign = "Harvard"
-                    directionId = 0
+            val route1rp1 =
+                objects.routePattern(route1) {
+                    representativeTrip {
+                        headsign = "Harvard"
+                        directionId = 0
+                    }
                 }
-            }
-        val route1rp2 =
-            objects.routePattern(route1) {
-                representativeTrip {
-                    headsign = "Nubian"
-                    directionId = 0
+            val route1rp2 =
+                objects.routePattern(route1) {
+                    representativeTrip {
+                        headsign = "Nubian"
+                        directionId = 0
+                    }
                 }
-            }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        stop1.id to listOf(route1rp1.id),
-                        stop2.id to listOf(route1rp1.id, route1rp2.id),
-                    ),
-            )
-        val nearby = NearbyResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val now = Clock.System.now()
-
-        assertEquals(
-            mapOf(
-                route1.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
                         mapOf(
-                            stop1.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop1,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(route1rp1),
-                                                stopIds = setOf(stop1.id),
-                                                allDataLoaded = true,
-                                            )
-                                    ),
-                                    global
-                                ),
-                            stop2.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop2,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(route1rp1, route1rp2),
-                                                stopIds = setOf(stop2.id),
-                                                allDataLoaded = true,
-                                            )
-                                    ),
-                                    global
-                                )
+                            stop1.id to listOf(route1rp1.id),
+                            stop2.id to listOf(route1rp1.id, route1rp2.id),
                         ),
-                        context,
-                        now
-                    )
-            ),
-            RouteCardData.ListBuilder(true, context, now)
-                .addStaticStopsData(nearby.stopIds, global)
-                .data
-        )
-    }
+                )
+            val nearby = NearbyResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val now = Clock.System.now()
+
+            assertEquals(
+                mapOf(
+                    route1.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route1),
+                            mapOf(
+                                stop1.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop1,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(route1rp1),
+                                                    stopIds = setOf(stop1.id),
+                                                    allDataLoaded = true,
+                                                )
+                                        ),
+                                        global
+                                    ),
+                                stop2.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop2,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(route1rp1, route1rp2),
+                                                    stopIds = setOf(stop2.id),
+                                                    allDataLoaded = true,
+                                                )
+                                        ),
+                                        global
+                                    )
+                            ),
+                            context,
+                            now
+                        )
+                ),
+                RouteCardData.ListBuilder(true, context, now)
+                    .addStaticStopsData(nearby.stopIds, global)
+                    .data
+            )
+        }
 
     @Test
     fun `ListBuilder addStaticStopsData groups patterns by direction`() = runBlocking {
@@ -241,88 +243,89 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `ListBuilder addStaticStopsData when a stop is served by multiple routes it is included for each route`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `ListBuilder addStaticStopsData when a stop is served by multiple routes it is included for each route`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
+            val stop1 = objects.stop()
 
-        val route1 = objects.route()
-        val route2 = objects.route()
+            val route1 = objects.route()
+            val route2 = objects.route()
 
-        val route1rp1 =
-            objects.routePattern(route1) {
-                representativeTrip { headsign = "Harvard" }
-                directionId = 0
-            }
-        val route2rp1 =
-            objects.routePattern(route2) {
-                representativeTrip { headsign = "Kenmore" }
-                directionId = 0
-            }
+            val route1rp1 =
+                objects.routePattern(route1) {
+                    representativeTrip { headsign = "Harvard" }
+                    directionId = 0
+                }
+            val route2rp1 =
+                objects.routePattern(route2) {
+                    representativeTrip { headsign = "Kenmore" }
+                    directionId = 0
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop = mapOf(stop1.id to listOf(route1rp1.id, route2rp1.id)),
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop = mapOf(stop1.id to listOf(route1rp1.id, route2rp1.id)),
+                )
+            val nearby = NearbyResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val now = Clock.System.now()
+
+            assertEquals(
+                mapOf(
+                    route1.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route1),
+                            mapOf(
+                                stop1.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop1,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(route1rp1),
+                                                    stopIds = setOf(stop1.id),
+                                                    allDataLoaded = false,
+                                                )
+                                        ),
+                                        global
+                                    ),
+                            ),
+                            context,
+                            now
+                        ),
+                    route2.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route2),
+                            mapOf(
+                                stop1.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop1,
+                                        route2,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(route2rp1),
+                                                    stopIds = setOf(stop1.id),
+                                                    allDataLoaded = false,
+                                                )
+                                        ),
+                                        global
+                                    )
+                            ),
+                            context,
+                            now
+                        )
+                ),
+                RouteCardData.ListBuilder(false, context, now)
+                    .addStaticStopsData(nearby.stopIds, global)
+                    .data
             )
-        val nearby = NearbyResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val now = Clock.System.now()
-
-        assertEquals(
-            mapOf(
-                route1.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
-                        mapOf(
-                            stop1.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop1,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(route1rp1),
-                                                stopIds = setOf(stop1.id),
-                                                allDataLoaded = false,
-                                            )
-                                    ),
-                                    global
-                                ),
-                        ),
-                        context,
-                        now
-                    ),
-                route2.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route2),
-                        mapOf(
-                            stop1.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop1,
-                                    route2,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(route2rp1),
-                                                stopIds = setOf(stop1.id),
-                                                allDataLoaded = false,
-                                            )
-                                    ),
-                                    global
-                                )
-                        ),
-                        context,
-                        now
-                    )
-            ),
-            RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global)
-                .data
-        )
-    }
+        }
 
     @Test
     fun `ListBuilder addStaticStopsData groups by parent station`() = runBlocking {
@@ -502,101 +505,104 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `ListBuilder addStaticStopsData Green Line shuttles are not grouped together`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `ListBuilder addStaticStopsData Green Line shuttles are not grouped together`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop = objects.stop()
+            val stop = objects.stop()
 
-        val line =
-            objects.line {
-                id = "line-Green"
-                sortOrder = 0
-            }
+            val line =
+                objects.line {
+                    id = "line-Green"
+                    sortOrder = 0
+                }
 
-        val railRoute =
-            objects.route {
-                lineId = line.id
-                directionNames = listOf("West", "East")
-                directionDestinations = listOf("Boston College", "Government Center")
-            }
-        val shuttleRoute =
-            objects.route {
-                id = "Shuttle-$id"
-                lineId = line.id
-            }
+            val railRoute =
+                objects.route {
+                    lineId = line.id
+                    directionNames = listOf("West", "East")
+                    directionDestinations = listOf("Boston College", "Government Center")
+                }
+            val shuttleRoute =
+                objects.route {
+                    id = "Shuttle-$id"
+                    lineId = line.id
+                }
 
-        val railPattern =
-            objects.routePattern(railRoute) { representativeTrip { headsign = "Boston College" } }
-        val shuttlePattern =
-            objects.routePattern(shuttleRoute) {
-                representativeTrip { headsign = "Boston College" }
-            }
+            val railPattern =
+                objects.routePattern(railRoute) {
+                    representativeTrip { headsign = "Boston College" }
+                }
+            val shuttlePattern =
+                objects.routePattern(shuttleRoute) {
+                    representativeTrip { headsign = "Boston College" }
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop = mapOf(stop.id to listOf(railPattern.id, shuttlePattern.id)),
-            )
-        val nearby = NearbyResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val now = Clock.System.now()
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop = mapOf(stop.id to listOf(railPattern.id, shuttlePattern.id)),
+                )
+            val nearby = NearbyResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val now = Clock.System.now()
 
-        val westDir = Direction("West", "Boston College", 0)
-        val eastDir = Direction("East", "Government Center", 1)
+            val westDir = Direction("West", "Boston College", 0)
+            val eastDir = Direction("East", "Government Center", 1)
 
-        assertEquals(
-            mapOf(
-                line.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Line(line, setOf(railRoute)),
-                        mapOf(
-                            stop.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop,
-                                    listOf(westDir, eastDir),
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(railPattern),
-                                                stopIds = setOf(stop.id),
-                                                allDataLoaded = false,
-                                            )
+            assertEquals(
+                mapOf(
+                    line.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Line(line, setOf(railRoute)),
+                            mapOf(
+                                stop.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop,
+                                        listOf(westDir, eastDir),
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(railPattern),
+                                                    stopIds = setOf(stop.id),
+                                                    allDataLoaded = false,
+                                                )
+                                        )
                                     )
-                                )
+                            ),
+                            context,
+                            now
                         ),
-                        context,
-                        now
-                    ),
-                shuttleRoute.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(shuttleRoute),
-                        mapOf(
-                            stop.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop,
-                                    shuttleRoute,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(shuttlePattern),
-                                                stopIds = setOf(stop.id),
-                                                allDataLoaded = false
-                                            )
-                                    ),
-                                    global
-                                )
-                        ),
-                        context,
-                        now
-                    )
-            ),
-            RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global)
-                .data
-        )
-    }
+                    shuttleRoute.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(shuttleRoute),
+                            mapOf(
+                                stop.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop,
+                                        shuttleRoute,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(shuttlePattern),
+                                                    stopIds = setOf(stop.id),
+                                                    allDataLoaded = false
+                                                )
+                                        ),
+                                        global
+                                    )
+                            ),
+                            context,
+                            now
+                        )
+                ),
+                RouteCardData.ListBuilder(false, context, now)
+                    .addStaticStopsData(nearby.stopIds, global)
+                    .data
+            )
+        }
 
     @Test
     fun `ListBuilder addStaticStopsData Green Line routes all grouped by direction when different child stops`() {
@@ -607,7 +613,7 @@ class RouteCardDataTest {
         val bWestPlatform = objects.stop { parentStationId = parkSt.id }
         val cWestPlatform = objects.stop { parentStationId = parkSt.id }
         val dWestPlatform = objects.stop { parentStationId = parkSt.id }
-        val  eastPlatform = objects.stop { parentStationId = parkSt.id }
+        val eastPlatform = objects.stop { parentStationId = parkSt.id }
 
         val line =
             objects.line {
@@ -636,9 +642,8 @@ class RouteCardDataTest {
                 directionDestinations = listOf("Riverside", "Union Sq")
             }
 
-
         val bWestPattern = objects.routePattern(bRoute) {}
-        val bEastPattern = objects.routePattern(bRoute){ directionId = 1 }
+        val bEastPattern = objects.routePattern(bRoute) { directionId = 1 }
         val cWestPattern = objects.routePattern(cRoute) {}
         val cEastPattern = objects.routePattern(cRoute) { directionId = 1 }
         val dWestPattern = objects.routePattern(dRoute) {}
@@ -646,10 +651,13 @@ class RouteCardDataTest {
         val global =
             GlobalResponse(
                 objects,
-                patternIdsByStop = mapOf(eastPlatform.id to listOf(bEastPattern.id, cEastPattern.id),
-                    bWestPlatform.id to listOf(bWestPattern.id),
-                    cWestPlatform.id to listOf(cWestPattern.id),
-                    dWestPlatform.id to listOf(dWestPattern.id)),
+                patternIdsByStop =
+                    mapOf(
+                        eastPlatform.id to listOf(bEastPattern.id, cEastPattern.id),
+                        bWestPlatform.id to listOf(bWestPattern.id),
+                        cWestPlatform.id to listOf(cWestPattern.id),
+                        dWestPlatform.id to listOf(dWestPattern.id)
+                    ),
             )
         val nearby = NearbyResponse(objects)
         val context = RouteCardData.Context.NearbyTransit
@@ -658,229 +666,55 @@ class RouteCardDataTest {
         assertEquals(
             mapOf(
                 line.id to
-                        RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute)),
-                            mapOf(
-                                parkSt.id to
-                                        RouteCardData.RouteStopDataBuilder(
-                                            parkSt,
-                                            line,
-                                            setOf(bRoute, cRoute, dRoute),
-                                            mapOf(
-                                                0 to
-                                                        RouteCardData.LeafBuilder(
-                                                            directionId = 0,
-                                                            routePatterns = listOf(bWestPattern, cWestPattern, dWestPattern),
-                                                            stopIds = setOf(parkSt.id, eastPlatform.id, bWestPlatform.id, cWestPlatform.id, dWestPlatform.id),
-                                                            allDataLoaded = false,
-                                                        ),
-                                                1 to
-                                                        RouteCardData.LeafBuilder(
-                                                            directionId = 1,
-                                                            routePatterns = listOf(bEastPattern, cEastPattern),
-                                                            stopIds = setOf(parkSt.id, eastPlatform.id, bWestPlatform.id, cWestPlatform.id, dWestPlatform.id),
-                                                            allDataLoaded = false,
-                                                        )), global
-                            )),
-                            context,
-                            now
-                        ),
-            ),
-            RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global)
-                .data
-        )
-    }
-
-    @Test
-    fun `ListBuilder addStaticStopsData Green Line routes are grouped together without Government Center direction`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-
-        val stopGov = objects.stop { id = "place-gover" }
-        // Only get nearby results at Government Center
-        val nearby = NearbyResponse(objects)
-
-        // These stops are included because they're thresholds in Direction.specialCases
-        val stopArlington = objects.stop { id = "place-armnl" }
-        val stopHaymarket = objects.stop { id = "place-haecl" }
-
-        val stop1 = objects.stop { id = "place-lake" }
-        val stop2 = objects.stop { id = "place-clmnl" }
-        val stop3 = objects.stop { id = "place-river" }
-        val stop4 = objects.stop { id = "place-pktrm" }
-        val stop5 = objects.stop { id = "place-mgngl" }
-
-        val line = objects.line { id = "line-Green" }
-
-        val routeB =
-            objects.route {
-                id = "Green-B"
-                lineId = line.id
-                directionNames = listOf("West", "East")
-                directionDestinations = listOf("Boston College", "Government Center")
-            }
-        val routeC =
-            objects.route {
-                id = "Green-C"
-                lineId = line.id
-                directionNames = listOf("West", "East")
-                directionDestinations = listOf("Cleveland Circle", "Government Center")
-            }
-        val routeD =
-            objects.route {
-                id = "Green-D"
-                lineId = line.id
-                directionNames = listOf("West", "East")
-                directionDestinations = listOf("Riverside", "Union Square")
-            }
-
-        val routeBrp1 =
-            objects.routePattern(routeB) {
-                representativeTrip {
-                    headsign = "Boston College"
-                    stopIds = listOf(stopGov.id, stop4.id, stopArlington.id, stop1.id)
-                }
-                id = "routeBrp1"
-                directionId = 0
-                sortOrder = 3
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routeBrp2 =
-            objects.routePattern(routeB) {
-                representativeTrip {
-                    headsign = "Government Center"
-                    stopIds = listOf(stop1.id, stopArlington.id, stop4.id, stopGov.id)
-                }
-                id = "routeBrp2"
-                directionId = 1
-                sortOrder = 4
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routeCrp1 =
-            objects.routePattern(routeC) {
-                representativeTrip {
-                    headsign = "Cleveland Circle"
-                    stopIds = listOf(stopGov.id, stop4.id, stopArlington.id, stop2.id)
-                }
-                id = "routeCrp1"
-                directionId = 0
-                sortOrder = 3
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routeCrp2 =
-            objects.routePattern(routeC) {
-                representativeTrip {
-                    headsign = "Government Center"
-                    stopIds = listOf(stop2.id, stopArlington.id, stop4.id, stopGov.id)
-                }
-                id = "routeCrp2"
-                directionId = 1
-                sortOrder = 4
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routeCrp3 =
-            objects.routePattern(routeC) {
-                representativeTrip {
-                    headsign = "Union Square"
-                    stopIds =
-                        listOf(
-                            stop2.id,
-                            stopArlington.id,
-                            stop4.id,
-                            stopGov.id,
-                            stopHaymarket.id,
-                            stop5.id
-                        )
-                }
-                id = "routeCrp3"
-                directionId = 1
-                sortOrder = 5
-                typicality = RoutePattern.Typicality.Atypical
-            }
-        val routeDrp1 =
-            objects.routePattern(routeD) {
-                representativeTrip {
-                    headsign = "Riverside"
-                    stopIds =
-                        listOf(
-                            stop5.id,
-                            stopHaymarket.id,
-                            stopGov.id,
-                            stop4.id,
-                            stopArlington.id,
-                            stop3.id
-                        )
-                }
-                id = "routeDrp1"
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routeDrp2 =
-            objects.routePattern(routeD) {
-                representativeTrip {
-                    headsign = "Union Square"
-                    stopIds =
-                        listOf(
-                            stop3.id,
-                            stopArlington.id,
-                            stop4.id,
-                            stopGov.id,
-                            stopHaymarket.id,
-                            stop5.id
-                        )
-                }
-                id = "routeDrp2"
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 1
-                sortOrder = 2
-            }
-
-        val global = GlobalResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val now = Clock.System.now()
-
-        val westDir = Direction("West", "Copley & West", 0)
-        val northDir = Direction("East", "North Station & North", 1)
-
-        assertEquals(
-            mapOf(
-                line.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeD)),
+                        RouteCardData.LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute)),
                         mapOf(
-                            stopGov.id to
+                            parkSt.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stopGov,
-                                    listOf(westDir, northDir),
+                                    parkSt,
+                                    line,
+                                    setOf(bRoute, cRoute, dRoute),
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
                                                 directionId = 0,
                                                 routePatterns =
-                                                    listOf(routeBrp1, routeCrp1, routeDrp1),
-                                                stopIds = setOf(stopGov.id),
+                                                    listOf(
+                                                        bWestPattern,
+                                                        cWestPattern,
+                                                        dWestPattern
+                                                    ),
+                                                stopIds =
+                                                    setOf(
+                                                        parkSt.id,
+                                                        eastPlatform.id,
+                                                        bWestPlatform.id,
+                                                        cWestPlatform.id,
+                                                        dWestPlatform.id
+                                                    ),
                                                 allDataLoaded = false,
                                             ),
                                         1 to
                                             RouteCardData.LeafBuilder(
                                                 directionId = 1,
-                                                routePatterns =
-                                                    listOf(
-                                                        routeBrp2,
-                                                        routeCrp2,
-                                                        routeCrp3,
-                                                        routeDrp2
+                                                routePatterns = listOf(bEastPattern, cEastPattern),
+                                                stopIds =
+                                                    setOf(
+                                                        parkSt.id,
+                                                        eastPlatform.id,
+                                                        bWestPlatform.id,
+                                                        cWestPlatform.id,
+                                                        dWestPlatform.id
                                                     ),
-                                                stopIds = setOf(stopGov.id),
                                                 allDataLoaded = false,
                                             )
-                                    )
+                                    ),
+                                    global
                                 )
                         ),
                         context,
                         now
-                    )
+                    ),
             ),
             RouteCardData.ListBuilder(false, context, now)
                 .addStaticStopsData(nearby.stopIds, global)
@@ -889,151 +723,349 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `ListBuilder addUpcomingTrips includes predictions filtered to the correct stop and direction`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `ListBuilder addStaticStopsData Green Line routes are grouped together without Government Center direction`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
-        val stop2 = objects.stop()
+            val stopGov = objects.stop { id = "place-gover" }
+            // Only get nearby results at Government Center
+            val nearby = NearbyResponse(objects)
 
-        val route1 = objects.route()
+            // These stops are included because they're thresholds in Direction.specialCases
+            val stopArlington = objects.stop { id = "place-armnl" }
+            val stopHaymarket = objects.stop { id = "place-haecl" }
 
-        val pattern1 =
-            objects.routePattern(route1) {
-                sortOrder = 1
-                representativeTrip { headsign = "Harvard" }
-            }
-        val trip1 = objects.trip(pattern1)
-        val pattern2 =
-            objects.routePattern(route1) {
-                sortOrder = 2
-                representativeTrip { headsign = "Harvard" }
-            }
-        val trip2 = objects.trip(pattern2)
-        val pattern3 =
-            objects.routePattern(route1) {
-                sortOrder = 3
-                representativeTrip { headsign = "Nubian" }
-            }
-        val trip3 = objects.trip(pattern3)
+            val stop1 = objects.stop { id = "place-lake" }
+            val stop2 = objects.stop { id = "place-clmnl" }
+            val stop3 = objects.stop { id = "place-river" }
+            val stop4 = objects.stop { id = "place-pktrm" }
+            val stop5 = objects.stop { id = "place-mgngl" }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        stop1.id to listOf(pattern1.id, pattern2.id),
-                        stop2.id to listOf(pattern3.id)
-                    )
+            val line = objects.line { id = "line-Green" }
+
+            val routeB =
+                objects.route {
+                    id = "Green-B"
+                    lineId = line.id
+                    directionNames = listOf("West", "East")
+                    directionDestinations = listOf("Boston College", "Government Center")
+                }
+            val routeC =
+                objects.route {
+                    id = "Green-C"
+                    lineId = line.id
+                    directionNames = listOf("West", "East")
+                    directionDestinations = listOf("Cleveland Circle", "Government Center")
+                }
+            val routeD =
+                objects.route {
+                    id = "Green-D"
+                    lineId = line.id
+                    directionNames = listOf("West", "East")
+                    directionDestinations = listOf("Riverside", "Union Square")
+                }
+
+            val routeBrp1 =
+                objects.routePattern(routeB) {
+                    representativeTrip {
+                        headsign = "Boston College"
+                        stopIds = listOf(stopGov.id, stop4.id, stopArlington.id, stop1.id)
+                    }
+                    id = "routeBrp1"
+                    directionId = 0
+                    sortOrder = 3
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val routeBrp2 =
+                objects.routePattern(routeB) {
+                    representativeTrip {
+                        headsign = "Government Center"
+                        stopIds = listOf(stop1.id, stopArlington.id, stop4.id, stopGov.id)
+                    }
+                    id = "routeBrp2"
+                    directionId = 1
+                    sortOrder = 4
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val routeCrp1 =
+                objects.routePattern(routeC) {
+                    representativeTrip {
+                        headsign = "Cleveland Circle"
+                        stopIds = listOf(stopGov.id, stop4.id, stopArlington.id, stop2.id)
+                    }
+                    id = "routeCrp1"
+                    directionId = 0
+                    sortOrder = 3
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val routeCrp2 =
+                objects.routePattern(routeC) {
+                    representativeTrip {
+                        headsign = "Government Center"
+                        stopIds = listOf(stop2.id, stopArlington.id, stop4.id, stopGov.id)
+                    }
+                    id = "routeCrp2"
+                    directionId = 1
+                    sortOrder = 4
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val routeCrp3 =
+                objects.routePattern(routeC) {
+                    representativeTrip {
+                        headsign = "Union Square"
+                        stopIds =
+                            listOf(
+                                stop2.id,
+                                stopArlington.id,
+                                stop4.id,
+                                stopGov.id,
+                                stopHaymarket.id,
+                                stop5.id
+                            )
+                    }
+                    id = "routeCrp3"
+                    directionId = 1
+                    sortOrder = 5
+                    typicality = RoutePattern.Typicality.Atypical
+                }
+            val routeDrp1 =
+                objects.routePattern(routeD) {
+                    representativeTrip {
+                        headsign = "Riverside"
+                        stopIds =
+                            listOf(
+                                stop5.id,
+                                stopHaymarket.id,
+                                stopGov.id,
+                                stop4.id,
+                                stopArlington.id,
+                                stop3.id
+                            )
+                    }
+                    id = "routeDrp1"
+                    directionId = 0
+                    sortOrder = 1
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val routeDrp2 =
+                objects.routePattern(routeD) {
+                    representativeTrip {
+                        headsign = "Union Square"
+                        stopIds =
+                            listOf(
+                                stop3.id,
+                                stopArlington.id,
+                                stop4.id,
+                                stopGov.id,
+                                stopHaymarket.id,
+                                stop5.id
+                            )
+                    }
+                    id = "routeDrp2"
+                    typicality = RoutePattern.Typicality.Typical
+                    directionId = 1
+                    sortOrder = 2
+                }
+
+            val global = GlobalResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val now = Clock.System.now()
+
+            val westDir = Direction("West", "Copley & West", 0)
+            val northDir = Direction("East", "North Station & North", 1)
+
+            assertEquals(
+                mapOf(
+                    line.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeD)),
+                            mapOf(
+                                stopGov.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stopGov,
+                                        listOf(westDir, northDir),
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns =
+                                                        listOf(routeBrp1, routeCrp1, routeDrp1),
+                                                    stopIds = setOf(stopGov.id),
+                                                    allDataLoaded = false,
+                                                ),
+                                            1 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 1,
+                                                    routePatterns =
+                                                        listOf(
+                                                            routeBrp2,
+                                                            routeCrp2,
+                                                            routeCrp3,
+                                                            routeDrp2
+                                                        ),
+                                                    stopIds = setOf(stopGov.id),
+                                                    allDataLoaded = false,
+                                                )
+                                        )
+                                    )
+                            ),
+                            context,
+                            now
+                        )
+                ),
+                RouteCardData.ListBuilder(false, context, now)
+                    .addStaticStopsData(nearby.stopIds, global)
+                    .data
             )
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-02-21T09:30:08-05:00")
+        }
 
-        // should be sorted before the pattern 1 prediction under Harvard
-        val stop1Pattern2Prediction =
-            objects.prediction {
-                arrivalTime = time
-                departureTime = time + 10.seconds
-                stopId = stop1.id
-                trip = trip2
-            }
+    @Test
+    fun `ListBuilder addUpcomingTrips includes predictions filtered to the correct stop and direction`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        // should be sorted after the pattern 2 prediction under Harvard
-        val stop1Pattern1Prediction =
-            objects.prediction {
-                arrivalTime = time + 5.seconds
-                departureTime = time + 15.seconds
-                stopId = stop1.id
-                trip = trip1
-            }
+            val stop1 = objects.stop()
+            val stop2 = objects.stop()
 
-        // should *not* be ignored since pattern 1 shows at stop, but pattern 3 does not
-        val stop2Pattern1Prediction =
-            objects.prediction {
-                arrivalTime = time + 10.seconds
-                departureTime = time + 20.seconds
-                stopId = stop2.id
-                trip = trip1
-            }
+            val route1 = objects.route()
 
-        // should be shown under Nubian
-        val stop2Pattern3Prediction =
-            objects.prediction {
-                arrivalTime = time + 20.seconds
-                departureTime = time + 30.seconds
-                stopId = stop2.id
-                trip = trip3
-            }
+            val pattern1 =
+                objects.routePattern(route1) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Harvard" }
+                }
+            val trip1 = objects.trip(pattern1)
+            val pattern2 =
+                objects.routePattern(route1) {
+                    sortOrder = 2
+                    representativeTrip { headsign = "Harvard" }
+                }
+            val trip2 = objects.trip(pattern2)
+            val pattern3 =
+                objects.routePattern(route1) {
+                    sortOrder = 3
+                    representativeTrip { headsign = "Nubian" }
+                }
+            val trip3 = objects.trip(pattern3)
 
-        assertEquals(
-            mapOf(
-                route1.id to
-                    RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
                         mapOf(
-                            stop1.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop1,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(pattern1, pattern2),
-                                                stopIds = setOf(stop1.id),
-                                                upcomingTrips =
-                                                    listOf(
-                                                        objects.upcomingTrip(
-                                                            stop1Pattern2Prediction
-                                                        ),
-                                                        objects.upcomingTrip(
-                                                            stop1Pattern1Prediction
-                                                        )
-                                                    ),
-                                                allDataLoaded = false
-                                            )
-                                    ),
-                                    global
-                                ),
-                            stop2.id to
-                                RouteCardData.RouteStopDataBuilder(
-                                    stop2,
-                                    route1,
-                                    mapOf(
-                                        0 to
-                                            RouteCardData.LeafBuilder(
-                                                directionId = 0,
-                                                routePatterns = listOf(pattern3),
-                                                stopIds = setOf(stop2.id),
-                                                upcomingTrips =
-                                                    listOf(
-                                                        objects.upcomingTrip(
-                                                            stop2Pattern1Prediction
-                                                        ),
-                                                        objects.upcomingTrip(
-                                                            stop2Pattern3Prediction
-                                                        ),
-                                                    ),
-                                                allDataLoaded = false
-                                            )
-                                    ),
-                                    global
-                                )
-                        ),
-                        context,
-                        time
-                    )
-            ),
-            RouteCardData.ListBuilder(true, context, time)
-                .addStaticStopsData(listOf(stop1.id, stop2.id), global)
-                .addUpcomingTrips(
-                    null,
-                    PredictionsStreamDataResponse(objects),
-                    filterAtTime = time,
-                    globalData = global
+                            stop1.id to listOf(pattern1.id, pattern2.id),
+                            stop2.id to listOf(pattern3.id)
+                        )
                 )
-                .data
-        )
-    }
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-02-21T09:30:08-05:00")
+
+            // should be sorted before the pattern 1 prediction under Harvard
+            val stop1Pattern2Prediction =
+                objects.prediction {
+                    arrivalTime = time
+                    departureTime = time + 10.seconds
+                    stopId = stop1.id
+                    trip = trip2
+                }
+
+            // should be sorted after the pattern 2 prediction under Harvard
+            val stop1Pattern1Prediction =
+                objects.prediction {
+                    arrivalTime = time + 5.seconds
+                    departureTime = time + 15.seconds
+                    stopId = stop1.id
+                    trip = trip1
+                }
+
+            // should *not* be ignored since pattern 1 shows at stop, but pattern 3 does not
+            val stop2Pattern1Prediction =
+                objects.prediction {
+                    arrivalTime = time + 10.seconds
+                    departureTime = time + 20.seconds
+                    stopId = stop2.id
+                    trip = trip1
+                }
+
+            // should be shown under Nubian
+            val stop2Pattern3Prediction =
+                objects.prediction {
+                    arrivalTime = time + 20.seconds
+                    departureTime = time + 30.seconds
+                    stopId = stop2.id
+                    trip = trip3
+                }
+
+            assertEquals(
+                mapOf(
+                    route1.id to
+                        RouteCardData.Builder(
+                            RouteCardData.LineOrRoute.Route(route1),
+                            mapOf(
+                                stop1.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop1,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(pattern1, pattern2),
+                                                    stopIds = setOf(stop1.id),
+                                                    upcomingTrips =
+                                                        listOf(
+                                                            objects.upcomingTrip(
+                                                                stop1Pattern2Prediction
+                                                            ),
+                                                            objects.upcomingTrip(
+                                                                stop1Pattern1Prediction
+                                                            )
+                                                        ),
+                                                    allDataLoaded = false
+                                                )
+                                        ),
+                                        global
+                                    ),
+                                stop2.id to
+                                    RouteCardData.RouteStopDataBuilder(
+                                        stop2,
+                                        route1,
+                                        mapOf(
+                                            0 to
+                                                RouteCardData.LeafBuilder(
+                                                    directionId = 0,
+                                                    routePatterns = listOf(pattern3),
+                                                    stopIds = setOf(stop2.id),
+                                                    upcomingTrips =
+                                                        listOf(
+                                                            objects.upcomingTrip(
+                                                                stop2Pattern1Prediction
+                                                            ),
+                                                            objects.upcomingTrip(
+                                                                stop2Pattern3Prediction
+                                                            ),
+                                                        ),
+                                                    allDataLoaded = false
+                                                )
+                                        ),
+                                        global
+                                    )
+                            ),
+                            context,
+                            time
+                        )
+                ),
+                RouteCardData.ListBuilder(true, context, time)
+                    .addStaticStopsData(listOf(stop1.id, stop2.id), global)
+                    .addUpcomingTrips(
+                        null,
+                        PredictionsStreamDataResponse(objects),
+                        filterAtTime = time,
+                        globalData = global
+                    )
+                    .data
+            )
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList sorts subway routes first`() = runBlocking {
@@ -1138,105 +1170,106 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `RouteCardData routeCardsForStopList preserves original stop ordering among subway routes`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForStopList preserves original stop ordering among subway routes`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val closerStop = objects.stop()
-        val furtherStop = objects.stop()
+            val closerStop = objects.stop()
+            val furtherStop = objects.stop()
 
-        val subwayRoute1 = objects.route { type = RouteType.LIGHT_RAIL }
-        val subwayRoute2 = objects.route { type = RouteType.LIGHT_RAIL }
+            val subwayRoute1 = objects.route { type = RouteType.LIGHT_RAIL }
+            val subwayRoute2 = objects.route { type = RouteType.LIGHT_RAIL }
 
-        val subway1Rp1 =
-            objects.routePattern(subwayRoute1) {
-                sortOrder = 2
-                representativeTrip { headsign = "Alewife" }
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val subway2Rp1 =
-            objects.routePattern(subwayRoute2) {
-                sortOrder = 1
-                representativeTrip { headsign = "Braintree" }
-                typicality = RoutePattern.Typicality.Typical
-            }
+            val subway1Rp1 =
+                objects.routePattern(subwayRoute1) {
+                    sortOrder = 2
+                    representativeTrip { headsign = "Alewife" }
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val subway2Rp1 =
+                objects.routePattern(subwayRoute2) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Braintree" }
+                    typicality = RoutePattern.Typicality.Typical
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        closerStop.id to listOf(subway2Rp1.id),
-                        furtherStop.id to listOf(subway1Rp1.id),
-                    ),
-            )
-        val nearby = NearbyResponse(objects)
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-02-22T12:08:19-05:00")
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute2),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                closerStop,
-                                subwayRoute2,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(subway2Rp1),
-                                        stopIds = setOf(closerStop.id),
-                                        upcomingTrips = listOf(),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(
+                            closerStop.id to listOf(subway2Rp1.id),
+                            furtherStop.id to listOf(subway1Rp1.id),
                         ),
-                    context,
-                    time
-                ),
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                furtherStop,
-                                subwayRoute1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(subway1Rp1),
-                                        stopIds = setOf(furtherStop.id),
-                                        upcomingTrips = listOf(),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                nearby.stopIds,
-                global,
-                sortByDistanceFrom = null,
-                schedules = null,
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(objects),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val nearby = NearbyResponse(objects)
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute2),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    closerStop,
+                                    subwayRoute2,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(subway2Rp1),
+                                            stopIds = setOf(closerStop.id),
+                                            upcomingTrips = listOf(),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    ),
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    furtherStop,
+                                    subwayRoute1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(subway1Rp1),
+                                            stopIds = setOf(furtherStop.id),
+                                            upcomingTrips = listOf(),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    nearby.stopIds,
+                    global,
+                    sortByDistanceFrom = null,
+                    schedules = null,
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(objects),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList sorts subway first then by distance`() = runBlocking {
@@ -1806,438 +1839,443 @@ class RouteCardDataTest {
         }
 
     @Test
-    fun `RouteCardData routeCardsForStopList hides rare direction with no predictions in next 120 min`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForStopList hides rare direction with no predictions in next 120 min`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
+            val stop1 = objects.stop()
 
-        val route1 = objects.route()
+            val route1 = objects.route()
 
-        // should be included because typical and has prediction
-        val typicalOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Typical Out" }
-            }
-        // should not be included because not typical and prediction beyond 120 minutes
-        val deviationInbound =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 4
-                typicality = RoutePattern.Typicality.Deviation
-                representativeTrip { headsign = "Deviation In" }
-            }
+            // should be included because typical and has prediction
+            val typicalOutbound =
+                objects.routePattern(route1) {
+                    directionId = 0
+                    sortOrder = 1
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "Typical Out" }
+                }
+            // should not be included because not typical and prediction beyond 120 minutes
+            val deviationInbound =
+                objects.routePattern(route1) {
+                    directionId = 1
+                    sortOrder = 4
+                    typicality = RoutePattern.Typicality.Deviation
+                    representativeTrip { headsign = "Deviation In" }
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
-            )
-
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-02-22T12:08:19-05:00")
-
-        val typicalOutboundPrediction =
-            objects.prediction {
-                departureTime = time
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = typicalOutbound.representativeTripId
-            }
-
-        val deviationInboundPrediction =
-            objects.prediction {
-                departureTime = time + 121.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = deviationInbound.representativeTripId
-            }
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(typicalOutbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(typicalOutboundPrediction),
-                                            ),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                listOf(stop1.id),
-                global,
-                sortByDistanceFrom = null,
-                schedules = null,
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(objects),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
-            )
-        )
-    }
 
-    @Test
-    fun `RouteCardData routeCardsForStopList shows rare direction with predictions in next 120 min`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-02-22T12:08:19-05:00")
 
-        val stop1 = objects.stop()
+            val typicalOutboundPrediction =
+                objects.prediction {
+                    departureTime = time
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = typicalOutbound.representativeTripId
+                }
 
-        val route1 = objects.route()
-
-        // should be included because typical and has prediction < 120 minutes
-        val typicalOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Typical Out" }
-            }
-        // should also be included even though > 120 minutes because above prediction < 120
-        val deviationInbound =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 4
-                typicality = RoutePattern.Typicality.Deviation
-                representativeTrip { headsign = "Deviation In" }
-            }
-
-        val deviationInboundTrip2 =
-            objects.trip {
-                directionId = 1
-                routePatternId = deviationInbound.id
-                routeId = route1.id
-            }
-
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
-            )
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-02-22T12:08:19-05:00")
-
-        val typicalOutboundPrediction =
-            objects.prediction {
-                departureTime = time
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = typicalOutbound.representativeTripId
-            }
-
-        val deviationInboundPrediction =
-            objects.prediction {
-                departureTime = time + 119.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = deviationInbound.representativeTripId
-            }
-
-        val deviationInboundPredictionLater =
-            objects.prediction {
-                departureTime = time + 121.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = deviationInboundTrip2.id
-            }
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(typicalOutbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(typicalOutboundPrediction),
-                                            ),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    ),
-                                    RouteCardData.Leaf(
-                                        directionId = 1,
-                                        routePatterns = listOf(deviationInbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(deviationInboundPrediction),
-                                                objects.upcomingTrip(
-                                                    deviationInboundPredictionLater
-                                                ),
-                                            ),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
-                )
-            ),
-            RouteCardData.routeCardsForStopList(
-                listOf(stop1.id),
-                global,
-                sortByDistanceFrom = null,
-                schedules = null,
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(objects),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
-            )
-        )
-    }
-
-    @Test
-    fun `RouteCardData routeCardsForStopList handles schedule and predictions edge cases`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-
-        val stop1 = objects.stop()
-
-        val route1 = objects.route()
-        val route2 = objects.route()
-        val route3 = objects.route()
-        val route4 = objects.route()
-
-        // assigning each route pattern to a unique route + direction to more easily test filtering
-        // with one upcoming trip for each
-
-        // exclude, schedule in past
-        val schedulePast =
-            objects.routePattern(route1) {
-                sortOrder = 1
-                representativeTrip { headsign = "Schedule Past" }
-            }
-        // include, schedule upcoming
-        val scheduleSoon =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 2
-                representativeTrip { headsign = "Schedule Soon" }
-            }
-        // exclude, schedule too late
-        val scheduleLater =
-            objects.routePattern(route2) {
-                sortOrder = 3
-                representativeTrip { headsign = "Schedule Later" }
-            }
-        // exclude, prediction in past
-        val predictionPast =
-            objects.routePattern(route2) {
-                directionId = 1
-                sortOrder = 4
-                representativeTrip { headsign = "Prediction Past" }
-            }
-        // include, prediction in past but BRD
-        val predictionBrd =
-            objects.routePattern(route3) {
-                sortOrder = 5
-                representativeTrip { headsign = "Prediction BRD" }
-            }
-        // include, prediction upcoming
-        val predictionSoon =
-            objects.routePattern(route3) {
-                directionId = 1
-                sortOrder = 6
-                representativeTrip { headsign = "Prediction Soon" }
-            }
-        // exclude, prediction later
-        val predictionLater =
-            objects.routePattern(route4) {
-                sortOrder = 7
-                representativeTrip { headsign = "Prediction Later" }
-            }
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        stop1.id to
+            val deviationInboundPrediction =
+                objects.prediction {
+                    departureTime = time + 121.minutes
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = deviationInbound.representativeTripId
+                }
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
                             listOf(
-                                schedulePast.id,
-                                scheduleSoon.id,
-                                scheduleLater.id,
-                                predictionPast.id,
-                                predictionBrd.id,
-                                predictionSoon.id,
-                                predictionLater.id
-                            )
-                    )
-            )
-
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-09-19T13:43:19-04:00")
-
-        val schedulePastSchedule =
-            objects.schedule {
-                stopId = stop1.id
-                trip = objects.trip(schedulePast)
-                departureTime = time - 1.minutes
-            }
-        val scheduleSoonSchedule =
-            objects.schedule {
-                stopId = stop1.id
-                trip = objects.trip(scheduleSoon)
-                departureTime = time + 5.minutes
-            }
-        val scheduleLaterSchedule =
-            objects.schedule {
-                stopId = stop1.id
-                trip = objects.trip(scheduleLater)
-                departureTime = time + 121.minutes
-            }
-        val predictionPastPrediction =
-            objects.prediction {
-                stopId = stop1.id
-                trip = objects.trip(predictionPast)
-                departureTime = time - 1.minutes
-            }
-        val predictionBrdTrip = objects.trip(predictionBrd)
-        val predictionBrdVehicle =
-            objects.vehicle {
-                stopId = stop1.id
-                tripId = predictionBrdTrip.id
-                currentStatus = Vehicle.CurrentStatus.StoppedAt
-            }
-        val predictionBrdPrediction =
-            objects.prediction {
-                stopId = stop1.id
-                trip = predictionBrdTrip
-                departureTime = time - 1.minutes
-                vehicleId = predictionBrdVehicle.id
-            }
-        val predictionSoonPrediction =
-            objects.prediction {
-                stopId = stop1.id
-                trip = objects.trip(predictionSoon)
-                departureTime = time + 5.minutes
-            }
-        val predictionLaterPrediction =
-            objects.prediction {
-                stopId = stop1.id
-                trip = objects.trip(predictionLater)
-                departureTime = time + 121.minutes
-            }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 1,
-                                        routePatterns = listOf(scheduleSoon),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(scheduleSoonSchedule),
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            ),
-                        ),
-                    context,
-                    time
-                ),
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route3),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route3,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(predictionBrd),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = predictionBrdPrediction,
-                                                    vehicle = predictionBrdVehicle
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(typicalOutbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(typicalOutboundPrediction),
                                                 ),
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
                                     ),
-                                    RouteCardData.Leaf(
-                                        directionId = 1,
-                                        routePatterns = listOf(predictionSoon),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(predictionSoonPrediction),
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    listOf(stop1.id),
+                    global,
+                    sortByDistanceFrom = null,
+                    schedules = null,
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(objects),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(stop1.id),
-                globalData = global,
-                sortByDistanceFrom = stop1.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
             )
-        )
-    }
+        }
+
+    @Test
+    fun `RouteCardData routeCardsForStopList shows rare direction with predictions in next 120 min`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
+
+            val stop1 = objects.stop()
+
+            val route1 = objects.route()
+
+            // should be included because typical and has prediction < 120 minutes
+            val typicalOutbound =
+                objects.routePattern(route1) {
+                    directionId = 0
+                    sortOrder = 1
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "Typical Out" }
+                }
+            // should also be included even though > 120 minutes because above prediction < 120
+            val deviationInbound =
+                objects.routePattern(route1) {
+                    directionId = 1
+                    sortOrder = 4
+                    typicality = RoutePattern.Typicality.Deviation
+                    representativeTrip { headsign = "Deviation In" }
+                }
+
+            val deviationInboundTrip2 =
+                objects.trip {
+                    directionId = 1
+                    routePatternId = deviationInbound.id
+                    routeId = route1.id
+                }
+
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
+                )
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+            val typicalOutboundPrediction =
+                objects.prediction {
+                    departureTime = time
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = typicalOutbound.representativeTripId
+                }
+
+            val deviationInboundPrediction =
+                objects.prediction {
+                    departureTime = time + 119.minutes
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = deviationInbound.representativeTripId
+                }
+
+            val deviationInboundPredictionLater =
+                objects.prediction {
+                    departureTime = time + 121.minutes
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = deviationInboundTrip2.id
+                }
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(typicalOutbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(typicalOutboundPrediction),
+                                                ),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        ),
+                                        RouteCardData.Leaf(
+                                            directionId = 1,
+                                            routePatterns = listOf(deviationInbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        deviationInboundPrediction
+                                                    ),
+                                                    objects.upcomingTrip(
+                                                        deviationInboundPredictionLater
+                                                    ),
+                                                ),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    listOf(stop1.id),
+                    global,
+                    sortByDistanceFrom = null,
+                    schedules = null,
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(objects),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
+            )
+        }
+
+    @Test
+    fun `RouteCardData routeCardsForStopList handles schedule and predictions edge cases`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
+
+            val stop1 = objects.stop()
+
+            val route1 = objects.route()
+            val route2 = objects.route()
+            val route3 = objects.route()
+            val route4 = objects.route()
+
+            // assigning each route pattern to a unique route + direction to more easily test
+            // filtering with one upcoming trip for each
+
+            // exclude, schedule in past
+            val schedulePast =
+                objects.routePattern(route1) {
+                    sortOrder = 1
+                    representativeTrip { headsign = "Schedule Past" }
+                }
+            // include, schedule upcoming
+            val scheduleSoon =
+                objects.routePattern(route1) {
+                    directionId = 1
+                    sortOrder = 2
+                    representativeTrip { headsign = "Schedule Soon" }
+                }
+            // exclude, schedule too late
+            val scheduleLater =
+                objects.routePattern(route2) {
+                    sortOrder = 3
+                    representativeTrip { headsign = "Schedule Later" }
+                }
+            // exclude, prediction in past
+            val predictionPast =
+                objects.routePattern(route2) {
+                    directionId = 1
+                    sortOrder = 4
+                    representativeTrip { headsign = "Prediction Past" }
+                }
+            // include, prediction in past but BRD
+            val predictionBrd =
+                objects.routePattern(route3) {
+                    sortOrder = 5
+                    representativeTrip { headsign = "Prediction BRD" }
+                }
+            // include, prediction upcoming
+            val predictionSoon =
+                objects.routePattern(route3) {
+                    directionId = 1
+                    sortOrder = 6
+                    representativeTrip { headsign = "Prediction Soon" }
+                }
+            // exclude, prediction later
+            val predictionLater =
+                objects.routePattern(route4) {
+                    sortOrder = 7
+                    representativeTrip { headsign = "Prediction Later" }
+                }
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(
+                            stop1.id to
+                                listOf(
+                                    schedulePast.id,
+                                    scheduleSoon.id,
+                                    scheduleLater.id,
+                                    predictionPast.id,
+                                    predictionBrd.id,
+                                    predictionSoon.id,
+                                    predictionLater.id
+                                )
+                        )
+                )
+
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-09-19T13:43:19-04:00")
+
+            val schedulePastSchedule =
+                objects.schedule {
+                    stopId = stop1.id
+                    trip = objects.trip(schedulePast)
+                    departureTime = time - 1.minutes
+                }
+            val scheduleSoonSchedule =
+                objects.schedule {
+                    stopId = stop1.id
+                    trip = objects.trip(scheduleSoon)
+                    departureTime = time + 5.minutes
+                }
+            val scheduleLaterSchedule =
+                objects.schedule {
+                    stopId = stop1.id
+                    trip = objects.trip(scheduleLater)
+                    departureTime = time + 121.minutes
+                }
+            val predictionPastPrediction =
+                objects.prediction {
+                    stopId = stop1.id
+                    trip = objects.trip(predictionPast)
+                    departureTime = time - 1.minutes
+                }
+            val predictionBrdTrip = objects.trip(predictionBrd)
+            val predictionBrdVehicle =
+                objects.vehicle {
+                    stopId = stop1.id
+                    tripId = predictionBrdTrip.id
+                    currentStatus = Vehicle.CurrentStatus.StoppedAt
+                }
+            val predictionBrdPrediction =
+                objects.prediction {
+                    stopId = stop1.id
+                    trip = predictionBrdTrip
+                    departureTime = time - 1.minutes
+                    vehicleId = predictionBrdVehicle.id
+                }
+            val predictionSoonPrediction =
+                objects.prediction {
+                    stopId = stop1.id
+                    trip = objects.trip(predictionSoon)
+                    departureTime = time + 5.minutes
+                }
+            val predictionLaterPrediction =
+                objects.prediction {
+                    stopId = stop1.id
+                    trip = objects.trip(predictionLater)
+                    departureTime = time + 121.minutes
+                }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 1,
+                                            routePatterns = listOf(scheduleSoon),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(scheduleSoonSchedule),
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                ),
+                            ),
+                        context,
+                        time
+                    ),
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route3),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route3,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(predictionBrd),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = predictionBrdPrediction,
+                                                        vehicle = predictionBrdVehicle
+                                                    ),
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        ),
+                                        RouteCardData.Leaf(
+                                            directionId = 1,
+                                            routePatterns = listOf(predictionSoon),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(predictionSoonPrediction),
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(stop1.id),
+                    globalData = global,
+                    sortByDistanceFrom = stop1.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
+            )
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList hides rare patterns while loading`() = runBlocking {
@@ -2316,197 +2354,201 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `RouteCardData routCardsForStopList doesn't filter future trips in filtered stop details`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routCardsForStopList doesn't filter future trips in filtered stop details`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val stop1 = objects.stop()
+            val stop1 = objects.stop()
 
-        val route1 = objects.route()
+            val route1 = objects.route()
 
-        // should be included because typical and has prediction
-        val typicalOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Typical Out" }
-            }
+            // should be included because typical and has prediction
+            val typicalOutbound =
+                objects.routePattern(route1) {
+                    directionId = 0
+                    sortOrder = 1
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "Typical Out" }
+                }
 
-        // should be included because all trips should be visible in filtered stop details
-        val deviationInbound =
-            objects.routePattern(route1) {
-                directionId = 1
-                sortOrder = 4
-                typicality = RoutePattern.Typicality.Deviation
-                representativeTrip { headsign = "Deviation In" }
-            }
+            // should be included because all trips should be visible in filtered stop details
+            val deviationInbound =
+                objects.routePattern(route1) {
+                    directionId = 1
+                    sortOrder = 4
+                    typicality = RoutePattern.Typicality.Deviation
+                    representativeTrip { headsign = "Deviation In" }
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
-            )
-        val context = RouteCardData.Context.StopDetailsFiltered
-        val time = Instant.parse("2024-02-22T12:08:19-05:00")
-
-        val typicalOutboundPrediction =
-            objects.prediction {
-                departureTime = time
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = typicalOutbound.representativeTripId
-            }
-
-        val deviationInboundPrediction =
-            objects.prediction {
-                departureTime = time + 400.minutes
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = deviationInbound.representativeTripId
-            }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(typicalOutbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(objects.upcomingTrip(typicalOutboundPrediction)),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    ),
-                                    RouteCardData.Leaf(
-                                        directionId = 1,
-                                        routePatterns = listOf(deviationInbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(deviationInboundPrediction)
-                                            ),
-                                        allDataLoaded = false,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(stop1.id to listOf(typicalOutbound.id, deviationInbound.id))
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(stop1.id),
-                globalData = global,
-                sortByDistanceFrom = stop1.position,
-                schedules = null,
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val context = RouteCardData.Context.StopDetailsFiltered
+            val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+            val typicalOutboundPrediction =
+                objects.prediction {
+                    departureTime = time
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = typicalOutbound.representativeTripId
+                }
+
+            val deviationInboundPrediction =
+                objects.prediction {
+                    departureTime = time + 400.minutes
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = deviationInbound.representativeTripId
+                }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(typicalOutbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(typicalOutboundPrediction)
+                                                ),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        ),
+                                        RouteCardData.Leaf(
+                                            directionId = 1,
+                                            routePatterns = listOf(deviationInbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(deviationInboundPrediction)
+                                                ),
+                                            allDataLoaded = false,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(stop1.id),
+                    globalData = global,
+                    sortByDistanceFrom = stop1.position,
+                    schedules = null,
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 
     @Test
-    fun `RouteCardData routeCardsForStopList includes cancellations in filtered stop details context`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val stop1 = objects.stop()
-        val route1 = objects.route { type = RouteType.BUS }
+    fun `RouteCardData routeCardsForStopList includes cancellations in filtered stop details context`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
+            val stop1 = objects.stop()
+            val route1 = objects.route { type = RouteType.BUS }
 
-        // should be included because typical and has cancelled prediction
-        val typicalOutbound =
-            objects.routePattern(route1) {
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Typical Out" }
-            }
+            // should be included because typical and has cancelled prediction
+            val typicalOutbound =
+                objects.routePattern(route1) {
+                    directionId = 0
+                    sortOrder = 1
+                    typicality = RoutePattern.Typicality.Typical
+                    representativeTrip { headsign = "Typical Out" }
+                }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop = mapOf(stop1.id to listOf(typicalOutbound.id))
-            )
-        val context = RouteCardData.Context.StopDetailsFiltered
-        val time = Instant.parse("2024-02-22T12:08:19-05:00")
-
-        val typicalOutboundSchedule =
-            objects.schedule {
-                routeId = route1.id
-                tripId = typicalOutbound.representativeTripId
-                stopId = stop1.id
-                arrivalTime = time
-                departureTime = time
-            }
-
-        val typicalOutboundPrediction =
-            objects.prediction {
-                departureTime = null
-                routeId = route1.id
-                stopId = stop1.id
-                tripId = typicalOutbound.representativeTripId
-                scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
-            }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop1,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(typicalOutbound),
-                                        stopIds = setOf(stop1.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = typicalOutboundPrediction,
-                                                    schedule = typicalOutboundSchedule
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop = mapOf(stop1.id to listOf(typicalOutbound.id))
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(stop1.id),
-                globalData = global,
-                sortByDistanceFrom = stop1.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val context = RouteCardData.Context.StopDetailsFiltered
+            val time = Instant.parse("2024-02-22T12:08:19-05:00")
+
+            val typicalOutboundSchedule =
+                objects.schedule {
+                    routeId = route1.id
+                    tripId = typicalOutbound.representativeTripId
+                    stopId = stop1.id
+                    arrivalTime = time
+                    departureTime = time
+                }
+
+            val typicalOutboundPrediction =
+                objects.prediction {
+                    departureTime = null
+                    routeId = route1.id
+                    stopId = stop1.id
+                    tripId = typicalOutbound.representativeTripId
+                    scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
+                }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop1,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(typicalOutbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = typicalOutboundPrediction,
+                                                        schedule = typicalOutboundSchedule
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(stop1.id),
+                    globalData = global,
+                    sortByDistanceFrom = stop1.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList handles parent stops`() = runBlocking {
@@ -2742,135 +2784,138 @@ class RouteCardDataTest {
         }
 
     @Test
-    fun `RouteCardData routeCardsForStopList checks route along with route pattern and stop`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val stop = objects.stop()
-        val route1 = objects.route { sortOrder = 1 }
-        val routePattern1 = objects.routePattern(route1) { representativeTrip { headsign = "A" } }
-        val trip1 = objects.trip(routePattern1)
+    fun `RouteCardData routeCardsForStopList checks route along with route pattern and stop`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 = objects.route { sortOrder = 1 }
+            val routePattern1 =
+                objects.routePattern(route1) { representativeTrip { headsign = "A" } }
+            val trip1 = objects.trip(routePattern1)
 
-        val route2 = objects.route { sortOrder = 2 }
-        val routePattern2 = objects.routePattern(route2) { representativeTrip { headsign = "B" } }
-        val trip2 = objects.trip(routePattern2)
+            val route2 = objects.route { sortOrder = 2 }
+            val routePattern2 =
+                objects.routePattern(route2) { representativeTrip { headsign = "B" } }
+            val trip2 = objects.trip(routePattern2)
 
-        // change from before: this will be included because it has a matching
-        // route & direction, even if it is an unexpected route pattern.
-        val trip3 = objects.trip(routePattern2) { routePatternId = "not the right id" }
+            // change from before: this will be included because it has a matching
+            // route & direction, even if it is an unexpected route pattern.
+            val trip3 = objects.trip(routePattern2) { routePatternId = "not the right id" }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop = mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
-            )
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-03-18T10:41:13-04:00")
-
-        val sched1 =
-            objects.schedule {
-                trip = trip1
-                stopId = stop.id
-                stopSequence = 90
-                departureTime = time + 1.minutes
-            }
-        val sched2 =
-            objects.schedule {
-                trip = trip2
-                stopId = stop.id
-                stopSequence = 90
-                departureTime = time + 2.minutes
-            }
-        val sched3 =
-            objects.schedule {
-                trip = trip3
-                stopId = stop.id
-                stopSequence = 90
-                departureTime = time + 3.minutes
-            }
-
-        val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
-        val pred2 = objects.prediction(sched2) { departureTime = time + 2.3.minutes }
-        val pred3 = objects.prediction(sched3) { departureTime = time + 3.4.minutes }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop,
-                                route1,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(routePattern1),
-                                        stopIds = setOf(stop.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = pred1,
-                                                    schedule = sched1
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
-                ),
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route2),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop,
-                                route2,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(routePattern2),
-                                        stopIds = setOf(stop.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = pred2,
-                                                    schedule = sched2
-                                                ),
-                                                objects.upcomingTrip(
-                                                    prediction = pred3,
-                                                    schedule = sched3
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop = mapOf(stop.id to listOf(routePattern1.id, routePattern2.id))
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(stop.id),
-                globalData = global,
-                sortByDistanceFrom = stop.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-03-18T10:41:13-04:00")
+
+            val sched1 =
+                objects.schedule {
+                    trip = trip1
+                    stopId = stop.id
+                    stopSequence = 90
+                    departureTime = time + 1.minutes
+                }
+            val sched2 =
+                objects.schedule {
+                    trip = trip2
+                    stopId = stop.id
+                    stopSequence = 90
+                    departureTime = time + 2.minutes
+                }
+            val sched3 =
+                objects.schedule {
+                    trip = trip3
+                    stopId = stop.id
+                    stopSequence = 90
+                    departureTime = time + 3.minutes
+                }
+
+            val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
+            val pred2 = objects.prediction(sched2) { departureTime = time + 2.3.minutes }
+            val pred3 = objects.prediction(sched3) { departureTime = time + 3.4.minutes }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop,
+                                    route1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(routePattern1),
+                                            stopIds = setOf(stop.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = pred1,
+                                                        schedule = sched1
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    ),
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route2),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop,
+                                    route2,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(routePattern2),
+                                            stopIds = setOf(stop.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = pred2,
+                                                        schedule = sched2
+                                                    ),
+                                                    objects.upcomingTrip(
+                                                        prediction = pred3,
+                                                        schedule = sched3
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(stop.id),
+                    globalData = global,
+                    sortByDistanceFrom = stop.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList groups lines by direction`() = runBlocking {
@@ -3153,227 +3198,235 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `RouteCardData routeCardsForStopList for line on branch uses branch direction name`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForStopList for line on branch uses branch direction name`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val bc = objects.stop { id = "place-lake" }
+            val bc = objects.stop { id = "place-lake" }
 
-        val southSt = objects.stop { id = "place-sougr" }
+            val southSt = objects.stop { id = "place-sougr" }
 
-        val arlington = objects.stop { id = "place-armnl" }
-        val boylston = objects.stop { id = "place-boyls" }
-        val gov = objects.stop { id = "place-gover" }
-        val haymarket = objects.stop { id = "place-haecl" }
+            val arlington = objects.stop { id = "place-armnl" }
+            val boylston = objects.stop { id = "place-boyls" }
+            val gov = objects.stop { id = "place-gover" }
+            val haymarket = objects.stop { id = "place-haecl" }
 
-        val line = objects.line { id = "line-Green" }
-        val routeB =
-            objects.route {
-                id = "Green-B"
-                sortOrder = 1
-                lineId = "line-Green"
-                directionNames = listOf("West", "East")
-                directionDestinations = listOf("Real B West", "Real B East")
-            }
-        val routePatternB1 =
-            objects.routePattern(routeB) {
-                representativeTrip {
-                    headsign = "B"
-                    stopIds = listOf(gov.id, boylston.id, arlington.id, southSt.id, bc.id)
+            val line = objects.line { id = "line-Green" }
+            val routeB =
+                objects.route {
+                    id = "Green-B"
+                    sortOrder = 1
+                    lineId = "line-Green"
+                    directionNames = listOf("West", "East")
+                    directionDestinations = listOf("Real B West", "Real B East")
                 }
-                directionId = 0
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val routePatternB2 =
-            objects.routePattern(routeB) {
-                representativeTrip {
-                    headsign = "B"
-                    stopIds = listOf(bc.id, southSt.id, arlington.id, boylston.id, gov.id)
+            val routePatternB1 =
+                objects.routePattern(routeB) {
+                    representativeTrip {
+                        headsign = "B"
+                        stopIds = listOf(gov.id, boylston.id, arlington.id, southSt.id, bc.id)
+                    }
+                    directionId = 0
+                    typicality = RoutePattern.Typicality.Typical
                 }
-                directionId = 1
-                typicality = RoutePattern.Typicality.Typical
-            }
-        val tripB1 = objects.trip(routePatternB1)
-        val tripB2 = objects.trip(routePatternB2)
+            val routePatternB2 =
+                objects.routePattern(routeB) {
+                    representativeTrip {
+                        headsign = "B"
+                        stopIds = listOf(bc.id, southSt.id, arlington.id, boylston.id, gov.id)
+                    }
+                    directionId = 1
+                    typicality = RoutePattern.Typicality.Typical
+                }
+            val tripB1 = objects.trip(routePatternB1)
+            val tripB2 = objects.trip(routePatternB2)
 
-        val time = Instant.parse("2024-03-18T10:41:13-04:00")
+            val time = Instant.parse("2024-03-18T10:41:13-04:00")
 
-        val schedB1 =
-            objects.schedule {
-                trip = tripB1
-                stopId = southSt.id
-                stopSequence = 90
-                departureTime = time + 1.minutes
-            }
-        val schedB2 =
-            objects.schedule {
-                trip = tripB2
-                stopId = southSt.id
-                stopSequence = 90
-                departureTime = time + 4.minutes
-            }
+            val schedB1 =
+                objects.schedule {
+                    trip = tripB1
+                    stopId = southSt.id
+                    stopSequence = 90
+                    departureTime = time + 1.minutes
+                }
+            val schedB2 =
+                objects.schedule {
+                    trip = tripB2
+                    stopId = southSt.id
+                    stopSequence = 90
+                    departureTime = time + 4.minutes
+                }
 
-        val predB1 = objects.prediction(schedB1) { departureTime = time + 1.5.minutes }
-        val predB2 = objects.prediction(schedB2) { departureTime = time + 4.5.minutes }
-        val directionWest = Direction("West", routeB.directionDestinations[0], 0)
-        val directionEast = Direction("East", "Park St & North", 1)
+            val predB1 = objects.prediction(schedB1) { departureTime = time + 1.5.minutes }
+            val predB2 = objects.prediction(schedB2) { departureTime = time + 4.5.minutes }
+            val directionWest = Direction("West", routeB.directionDestinations[0], 0)
+            val directionEast = Direction("East", "Park St & North", 1)
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop = mapOf(southSt.id to listOf(routePatternB1.id, routePatternB2.id))
-            )
-        val context = RouteCardData.Context.NearbyTransit
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(southSt.id to listOf(routePatternB1.id, routePatternB2.id))
+                )
+            val context = RouteCardData.Context.NearbyTransit
 
-        val expected =
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB)),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                southSt,
-                                listOf(directionWest, directionEast),
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(routePatternB1),
-                                        stopIds = setOf(southSt.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = predB1,
-                                                    schedule = schedB1
+            val expected =
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB)),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    southSt,
+                                    listOf(directionWest, directionEast),
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(routePatternB1),
+                                            stopIds = setOf(southSt.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = predB1,
+                                                        schedule = schedB1
+                                                    ),
                                                 ),
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    ),
-                                    RouteCardData.Leaf(
-                                        directionId = 1,
-                                        routePatterns = listOf(routePatternB2),
-                                        stopIds = setOf(southSt.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = predB2,
-                                                    schedule = schedB2
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        ),
+                                        RouteCardData.Leaf(
+                                            directionId = 1,
+                                            routePatterns = listOf(routePatternB2),
+                                            stopIds = setOf(southSt.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = predB2,
+                                                        schedule = schedB2
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
                                     )
                                 )
-                            )
-                        ),
-                    context,
-                    time
+                            ),
+                        context,
+                        time
+                    )
+                )
+
+            assertEquals(
+                expected,
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(southSt.id),
+                    globalData = global,
+                    sortByDistanceFrom = southSt.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
                 )
             )
-
-        assertEquals(
-            expected,
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(southSt.id),
-                globalData = global,
-                sortByDistanceFrom = southSt.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
-            )
-        )
-    }
+        }
 
     @Test
-    fun `RouteCardData routeCardsForStopList direction names for regular route pulled from route data`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val stop = objects.stop()
-        val route1 =
-            objects.route {
-                sortOrder = 1
-                directionNames = listOf("Direction 0", "Direction 1")
-                directionDestinations = listOf("Direction 0 destination", "Direction 1 destination")
-            }
+    fun `RouteCardData routeCardsForStopList direction names for regular route pulled from route data`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
+            val stop = objects.stop()
+            val route1 =
+                objects.route {
+                    sortOrder = 1
+                    directionNames = listOf("Direction 0", "Direction 1")
+                    directionDestinations =
+                        listOf("Direction 0 destination", "Direction 1 destination")
+                }
 
-        val routePattern1 = objects.routePattern(route1) { representativeTrip { headsign = "A" } }
-        val trip1 = objects.trip(routePattern1)
+            val routePattern1 =
+                objects.routePattern(route1) { representativeTrip { headsign = "A" } }
+            val trip1 = objects.trip(routePattern1)
 
-        val time = Instant.parse("2024-03-18T10:41:13-04:00")
+            val time = Instant.parse("2024-03-18T10:41:13-04:00")
 
-        val sched1 =
-            objects.schedule {
-                trip = trip1
-                stopId = stop.id
-                stopSequence = 90
-                departureTime = time + 1.minutes
-            }
+            val sched1 =
+                objects.schedule {
+                    trip = trip1
+                    stopId = stop.id
+                    stopSequence = 90
+                    departureTime = time + 1.minutes
+                }
 
-        val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
+            val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
 
-        val global =
-            GlobalResponse(objects, patternIdsByStop = mapOf(stop.id to listOf(routePattern1.id)))
-        val context = RouteCardData.Context.NearbyTransit
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop = mapOf(stop.id to listOf(routePattern1.id))
+                )
+            val context = RouteCardData.Context.NearbyTransit
 
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                stop,
-                                listOf(
-                                    Direction(
-                                        id = 0,
-                                        name = "Direction 0",
-                                        destination = "Direction 0 destination"
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    stop,
+                                    listOf(
+                                        Direction(
+                                            id = 0,
+                                            name = "Direction 0",
+                                            destination = "Direction 0 destination"
+                                        ),
+                                        Direction(
+                                            id = 1,
+                                            name = "Direction 1",
+                                            destination = "Direction 1 destination"
+                                        )
                                     ),
-                                    Direction(
-                                        id = 1,
-                                        name = "Direction 1",
-                                        destination = "Direction 1 destination"
-                                    )
-                                ),
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(routePattern1),
-                                        stopIds = setOf(stop.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                objects.upcomingTrip(
-                                                    prediction = pred1,
-                                                    schedule = sched1
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(routePattern1),
+                                            stopIds = setOf(stop.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(
+                                                        prediction = pred1,
+                                                        schedule = sched1
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
                                     )
                                 )
-                            )
-                        ),
-                    context,
-                    time
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(stop.id),
+                    globalData = global,
+                    sortByDistanceFrom = stop.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(stop.id),
-                globalData = global,
-                sortByDistanceFrom = stop.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
             )
-        )
-    }
+        }
 
     @Test
     fun `RouteCardData routeCardsForStopList north station disruption case`() = runBlocking {
@@ -3670,229 +3723,232 @@ class RouteCardDataTest {
     }
 
     @Test
-    fun `RouteCardData routeCardsForList filters out direction if it is the typical last stop of subway`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForList filters out direction if it is the typical last stop of subway`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val oakGrove =
-            objects.stop {
-                id = "place-ogmnl"
-                locationType = LocationType.STATION
-                childStopIds = listOf("70036")
-            }
+            val oakGrove =
+                objects.stop {
+                    id = "place-ogmnl"
+                    locationType = LocationType.STATION
+                    childStopIds = listOf("70036")
+                }
 
-        val orangeRoute = objects.route { id = "Orange" }
-        val orangeNorthboundTypical =
-            objects.routePattern(orangeRoute) {
-                id = "Orange-3-1"
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 1
-                representativeTrip {
-                    id = "canonical-Orange-C1-1"
-                    headsign = "Oak Grove"
+            val orangeRoute = objects.route { id = "Orange" }
+            val orangeNorthboundTypical =
+                objects.routePattern(orangeRoute) {
+                    id = "Orange-3-1"
+                    typicality = RoutePattern.Typicality.Typical
                     directionId = 1
-                    stopIds = listOf("70001", "70027", "70036")
+                    representativeTrip {
+                        id = "canonical-Orange-C1-1"
+                        headsign = "Oak Grove"
+                        directionId = 1
+                        stopIds = listOf("70001", "70027", "70036")
+                    }
                 }
-            }
 
-        val orangeSouthboundTypical =
-            objects.routePattern(orangeRoute) {
-                id = "Orange-3-0"
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 0
-                representativeTrip {
-                    id = "canonical-Orange-C1-0"
-                    headsign = "Forest Hills"
+            val orangeSouthboundTypical =
+                objects.routePattern(orangeRoute) {
+                    id = "Orange-3-0"
+                    typicality = RoutePattern.Typicality.Typical
                     directionId = 0
-                    stopIds = listOf("70036", "70026", "70001")
+                    representativeTrip {
+                        id = "canonical-Orange-C1-0"
+                        headsign = "Forest Hills"
+                        directionId = 0
+                        stopIds = listOf("70036", "70026", "70001")
+                    }
                 }
-            }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        oakGrove.id to
-                            listOf(orangeSouthboundTypical.id, orangeNorthboundTypical.id)
-                    )
-            )
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-10-30T16:40:00-04:00")
-
-        val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
-        val orangeSouthboundTypicalTrip = objects.trip(orangeSouthboundTypical)
-
-        val sched1 =
-            objects.schedule {
-                trip = orangeSouthboundTypicalTrip
-                stopId = oakGrove.id
-                stopSequence = 90
-                departureTime = time + 1.minutes
-            }
-        val sched2 =
-            objects.schedule {
-                trip = orangeNorthboundTypicalTrip
-                stopId = oakGrove.id
-                stopSequence = 90
-                arrivalTime = time + 2.minutes
-                departureTime = null
-            }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                oakGrove,
-                                orangeRoute,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(orangeSouthboundTypical),
-                                        stopIds = setOf(oakGrove.id),
-                                        upcomingTrips =
-                                            listOf(
-                                                UpcomingTrip(
-                                                    trip = orangeSouthboundTypicalTrip,
-                                                    schedule = sched1
-                                                )
-                                            ),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(
+                            oakGrove.id to
+                                listOf(orangeSouthboundTypical.id, orangeNorthboundTypical.id)
+                        )
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(oakGrove.id),
-                globalData = global,
-                sortByDistanceFrom = oakGrove.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-10-30T16:40:00-04:00")
+
+            val orangeNorthboundTypicalTrip = objects.trip(orangeNorthboundTypical)
+            val orangeSouthboundTypicalTrip = objects.trip(orangeSouthboundTypical)
+
+            val sched1 =
+                objects.schedule {
+                    trip = orangeSouthboundTypicalTrip
+                    stopId = oakGrove.id
+                    stopSequence = 90
+                    departureTime = time + 1.minutes
+                }
+            val sched2 =
+                objects.schedule {
+                    trip = orangeNorthboundTypicalTrip
+                    stopId = oakGrove.id
+                    stopSequence = 90
+                    arrivalTime = time + 2.minutes
+                    departureTime = null
+                }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    oakGrove,
+                                    orangeRoute,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(orangeSouthboundTypical),
+                                            stopIds = setOf(oakGrove.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    UpcomingTrip(
+                                                        trip = orangeSouthboundTypicalTrip,
+                                                        schedule = sched1
+                                                    )
+                                                ),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(oakGrove.id),
+                    globalData = global,
+                    sortByDistanceFrom = oakGrove.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 
     @Test
-    fun `RouteCardData routeCardsForStopList filters out any arrival only for non-subway routes`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForStopList filters out any arrival only for non-subway routes`() =
+        runBlocking {
+            val objects = ObjectCollectionBuilder()
 
-        val longWharf = objects.stop { id = "Boat-Long" }
+            val longWharf = objects.stop { id = "Boat-Long" }
 
-        val ferryRoute =
-            objects.route {
-                id = "Boat-F1"
-                type = RouteType.FERRY
-            }
-        val ferryInboundToLongWharf =
-            objects.routePattern(ferryRoute) {
-                id = "Boat-F1-3-1"
-                routeId = ferryRoute.id
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 1
-                representativeTrip {
-                    id = "Boat-F1-0730-Hull-BF2H-01-Weekday-Fall-24"
-                    headsign = "Long Wharf"
+            val ferryRoute =
+                objects.route {
+                    id = "Boat-F1"
+                    type = RouteType.FERRY
+                }
+            val ferryInboundToLongWharf =
+                objects.routePattern(ferryRoute) {
+                    id = "Boat-F1-3-1"
+                    routeId = ferryRoute.id
+                    typicality = RoutePattern.Typicality.Typical
                     directionId = 1
-                    stopIds = listOf("Boat-Hull", "Boat-Long")
+                    representativeTrip {
+                        id = "Boat-F1-0730-Hull-BF2H-01-Weekday-Fall-24"
+                        headsign = "Long Wharf"
+                        directionId = 1
+                        stopIds = listOf("Boat-Hull", "Boat-Long")
+                    }
                 }
-            }
 
-        val ferryOutboundToHingham =
-            objects.routePattern(ferryRoute) {
-                id = "Boat-F1-0-0"
-                routeId = ferryRoute.id
-                typicality = RoutePattern.Typicality.Typical
-                directionId = 0
-                representativeTrip {
-                    id = "Boat-F1-1100-Long-BF2H-01-Weekday-Fall-24"
-                    headsign = "Hingham"
+            val ferryOutboundToHingham =
+                objects.routePattern(ferryRoute) {
+                    id = "Boat-F1-0-0"
+                    routeId = ferryRoute.id
+                    typicality = RoutePattern.Typicality.Typical
                     directionId = 0
-                    stopIds = listOf("Boat-Long", "Boat-Logan", "Boat-Hull", "Boat-Hingham")
+                    representativeTrip {
+                        id = "Boat-F1-1100-Long-BF2H-01-Weekday-Fall-24"
+                        headsign = "Hingham"
+                        directionId = 0
+                        stopIds = listOf("Boat-Long", "Boat-Logan", "Boat-Hull", "Boat-Hingham")
+                    }
                 }
-            }
 
-        val global =
-            GlobalResponse(
-                objects,
-                patternIdsByStop =
-                    mapOf(
-                        longWharf.id to
-                            listOf(ferryInboundToLongWharf.id, ferryOutboundToHingham.id)
-                    )
-            )
-        val context = RouteCardData.Context.NearbyTransit
-        val time = Instant.parse("2024-10-30T16:40:00-04:00")
-
-        val ferryInboundTrip = objects.trip(ferryInboundToLongWharf)
-        val ferryOutboundTrip = objects.trip(ferryOutboundToHingham)
-
-        val schedInbound =
-            objects.schedule {
-                trip = ferryInboundTrip
-                stopId = longWharf.id
-                stopSequence = 90
-                arrivalTime = time + 2.minutes
-                departureTime = null
-            }
-        val schedOutbound =
-            objects.schedule {
-                trip = ferryOutboundTrip
-                stopId = longWharf.id
-                stopSequence = 90
-                departureTime = time + 2.minutes
-            }
-
-        assertEquals(
-            listOf(
-                RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(ferryRoute),
-                    stopData =
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                longWharf,
-                                ferryRoute,
-                                listOf(
-                                    RouteCardData.Leaf(
-                                        directionId = 0,
-                                        routePatterns = listOf(ferryOutboundToHingham),
-                                        stopIds = setOf(longWharf.id),
-                                        upcomingTrips = listOf(objects.upcomingTrip(schedOutbound)),
-                                        allDataLoaded = true,
-                                        alertsHere = emptyList(),
-                                        hasSchedulesToday = false
-                                    )
-                                ),
-                                global
-                            )
-                        ),
-                    context,
-                    time
+            val global =
+                GlobalResponse(
+                    objects,
+                    patternIdsByStop =
+                        mapOf(
+                            longWharf.id to
+                                listOf(ferryInboundToLongWharf.id, ferryOutboundToHingham.id)
+                        )
                 )
-            ),
-            RouteCardData.routeCardsForStopList(
-                stopIds = listOf(longWharf.id),
-                globalData = global,
-                sortByDistanceFrom = longWharf.position,
-                schedules = ScheduleResponse(objects),
-                predictions = PredictionsStreamDataResponse(objects),
-                alerts = AlertsStreamDataResponse(emptyMap()),
-                now = time,
-                pinnedRoutes = setOf(),
-                context = context
+            val context = RouteCardData.Context.NearbyTransit
+            val time = Instant.parse("2024-10-30T16:40:00-04:00")
+
+            val ferryInboundTrip = objects.trip(ferryInboundToLongWharf)
+            val ferryOutboundTrip = objects.trip(ferryOutboundToHingham)
+
+            val schedInbound =
+                objects.schedule {
+                    trip = ferryInboundTrip
+                    stopId = longWharf.id
+                    stopSequence = 90
+                    arrivalTime = time + 2.minutes
+                    departureTime = null
+                }
+            val schedOutbound =
+                objects.schedule {
+                    trip = ferryOutboundTrip
+                    stopId = longWharf.id
+                    stopSequence = 90
+                    departureTime = time + 2.minutes
+                }
+
+            assertEquals(
+                listOf(
+                    RouteCardData(
+                        lineOrRoute = RouteCardData.LineOrRoute.Route(ferryRoute),
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    longWharf,
+                                    ferryRoute,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            directionId = 0,
+                                            routePatterns = listOf(ferryOutboundToHingham),
+                                            stopIds = setOf(longWharf.id),
+                                            upcomingTrips =
+                                                listOf(objects.upcomingTrip(schedOutbound)),
+                                            allDataLoaded = true,
+                                            alertsHere = emptyList(),
+                                            hasSchedulesToday = false
+                                        )
+                                    ),
+                                    global
+                                )
+                            ),
+                        context,
+                        time
+                    )
+                ),
+                RouteCardData.routeCardsForStopList(
+                    stopIds = listOf(longWharf.id),
+                    globalData = global,
+                    sortByDistanceFrom = longWharf.position,
+                    schedules = ScheduleResponse(objects),
+                    predictions = PredictionsStreamDataResponse(objects),
+                    alerts = AlertsStreamDataResponse(emptyMap()),
+                    now = time,
+                    pinnedRoutes = setOf(),
+                    context = context
+                )
             )
-        )
-    }
+        }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -87,7 +87,11 @@ class TripDetailsStopListTest {
                 block()
             }
 
-        fun stopListOf(vararg stops: TripDetailsStopList.Entry, terminalStop: TripDetailsStopList.Entry? = null, tripId: String? = null) =
+        fun stopListOf(
+            vararg stops: TripDetailsStopList.Entry,
+            terminalStop: TripDetailsStopList.Entry? = null,
+            tripId: String? = null
+        ) =
             TripDetailsStopList(
                 tripId ?: if (this@TestBuilder::_trip.isInitialized) _trip.id else "",
                 stops.asList(),
@@ -125,8 +129,9 @@ class TripDetailsStopListTest {
             patternIdsByStop: Map<String, List<String>> = emptyMap(),
             trip: Trip? = null
         ): TripDetailsStopList? {
-            val actualTrip = trip ?: if (this@TestBuilder::_trip.isInitialized) _trip
-            else Trip("trip", 0, "", "")
+            val actualTrip =
+                trip
+                    ?: if (this@TestBuilder::_trip.isInitialized) _trip else Trip("trip", 0, "", "")
             return TripDetailsStopList.fromPieces(
                 actualTrip.id,
                 actualTrip.directionId,
@@ -165,7 +170,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns schedules when there are no predictions`() = test {
-        trip{}
+        trip {}
         val sched1 = schedule("A", 10)
         val sched2 = schedule("B", 20)
         val sched3 = schedule("C", 30)
@@ -181,7 +186,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns null with scheduled IDs and no predictions`() = test {
-        trip{}
+        trip {}
         val sched1 = schedule("A", 10)
         val sched2 = schedule("B", 20)
         val sched3 = schedule("C", 30)
@@ -193,7 +198,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns null with unavailable schedules and no predictions`() = test {
-        val trip = trip{}
+        val trip = trip {}
         assertEquals(
             TripDetailsStopList(trip.id, stops = emptyList()),
             fromPieces(TripSchedulesResponse.Unknown, null)
@@ -202,7 +207,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces preserves predictions with no schedules`() = test {
-        trip{}
+        trip {}
         val pred1 = prediction("A", 10)
         val pred2 = prediction("B", 20)
         val pred3 = prediction("C", 30)
@@ -218,7 +223,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces matches full set of predictions to full set of schedules`() = test {
-        trip{}
+        trip {}
         val sched1 = schedule("A", 10)
         val sched2 = schedule("B", 20)
         val sched3 = schedule("C", 30)
@@ -237,7 +242,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces aligns scheduled stop IDs with existing predictions`() = test {
-        trip{}
+        trip {}
         val pred1 = prediction("A", 10)
         val pred2 = prediction("B", 20)
         val pred3 = prediction("C", 30)
@@ -253,7 +258,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces extrapolates stop sequences before current predictions`() = test {
-        trip{}
+        trip {}
         val pred2 = prediction("B", 20)
         val pred3 = prediction("C", 30)
         assertEquals(
@@ -420,8 +425,26 @@ class TripDetailsStopListTest {
             TripDetailsStopList(
                 trip.id,
                 listOf(
-                    TripDetailsStopList.Entry(boylston, 590, null, null, null, null, null, listOf()),
-                    TripDetailsStopList.Entry(parkStreet, 600, null, null, p1, parkStreet, null, listOf()),
+                    TripDetailsStopList.Entry(
+                        boylston,
+                        590,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        listOf()
+                    ),
+                    TripDetailsStopList.Entry(
+                        parkStreet,
+                        600,
+                        null,
+                        null,
+                        p1,
+                        parkStreet,
+                        null,
+                        listOf()
+                    ),
                     TripDetailsStopList.Entry(
                         governmentCenter,
                         610,
@@ -539,7 +562,6 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces includes all transfer routes`() = test {
-
         stop("A", listOf("A1", "A2"), listOf("A3"))
         stop("B", listOf("B1"))
         val stopC = stop("C", listOf("C1"))
@@ -551,7 +573,7 @@ class TripDetailsStopListTest {
         val stopC1 = stop("C1")
 
         val routeCurrent = objects.route { id = "V" }
-        val trip = trip{ routeId = routeCurrent.id }
+        val trip = trip { routeId = routeCurrent.id }
         val routeW =
             objects.route {
                 id = "W"
@@ -648,13 +670,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces resolves current route from available data`() = test {
-
         val stopA = stop("A")
         val stopB = stop("B")
 
         val routeCurrent = objects.route { id = "X" }
         val routeOther = objects.route { id = "Y" }
-
 
         val patternCurrent = pattern("X1", routeCurrent)
         val patternOther = pattern("Y1", routeOther)
@@ -688,7 +708,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces discards stops vehicle has passed`() = test {
-        trip{}
+        trip {}
         val pred1 = prediction("A", 10)
         val pred2 = prediction("B", 20)
         val pred3 = prediction("C", 30)
@@ -712,7 +732,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces discards stops vehicle is currently at`() = test {
-        val trip =  trip{}
+        val trip = trip {}
         val pred1 = prediction("A", 10)
         prediction("B", 20)
         val pred3 = prediction("C", 30)
@@ -770,7 +790,13 @@ class TripDetailsStopListTest {
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
-                entry("B", 20, disruption = UpcomingFormat.Disruption(alert, iconName = "alert-large-red-issue"), prediction = pred2),
+                entry(
+                    "B",
+                    20,
+                    disruption =
+                        UpcomingFormat.Disruption(alert, iconName = "alert-large-red-issue"),
+                    prediction = pred2
+                ),
                 entry("C", 30, prediction = pred3)
             ),
             fromPieces(null, predictions())
@@ -804,7 +830,7 @@ class TripDetailsStopListTest {
         assertEquals(
             TripDetailsStopList.TargetSplit(
                 firstStop = entry("A", 10),
-                collapsedStops = listOf( entry("B", 20), entry("C", 30)),
+                collapsedStops = listOf(entry("B", 20), entry("C", 30)),
                 targetStop = entry("A", 40),
                 followingStops = emptyList()
             ),
@@ -845,12 +871,7 @@ class TripDetailsStopListTest {
 
     @Test
     fun `splitForTarget removes first stop from collapsed when no vehicle exists`() = test {
-        val list = stopListOf(
-            entry("A", 10),
-            entry("B", 20),
-            entry("C", 30),
-            entry("D", 40)
-        )
+        val list = stopListOf(entry("A", 10), entry("B", 20), entry("C", 30), entry("D", 40))
 
         assertEquals(
             TripDetailsStopList.TargetSplit(
@@ -865,19 +886,20 @@ class TripDetailsStopListTest {
 
     @Test
     fun `splitForTarget removes first stop from collapsed when vehicle trip is different`() = test {
-        trip{}
+        trip {}
         val vehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
                 currentStopSequence = 20
                 tripId = "different"
             }
-        val list = stopListOf(
-            entry("A", 10, vehicle = vehicle),
-            entry("B", 20, vehicle = vehicle),
-            entry("C", 30, vehicle = vehicle),
-            entry("D", 40, vehicle = vehicle)
-        )
+        val list =
+            stopListOf(
+                entry("A", 10, vehicle = vehicle),
+                entry("B", 20, vehicle = vehicle),
+                entry("C", 30, vehicle = vehicle),
+                entry("D", 40, vehicle = vehicle)
+            )
 
         assertEquals(
             TripDetailsStopList.TargetSplit(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -343,13 +343,13 @@ class TripInstantDisplayTest {
                 TripInstantDisplay.Boarding,
                 TripInstantDisplay.from(
                     prediction =
-                    ObjectCollectionBuilder.Single.prediction {
-                        arrivalTime = now.minus(5.seconds)
-                        departureTime = now.plus(95.seconds)
-                        stopId = "12345"
-                        tripId = "trip1"
-                        vehicleId = vehicle.id
-                    },
+                        ObjectCollectionBuilder.Single.prediction {
+                            arrivalTime = now.minus(5.seconds)
+                            departureTime = now.plus(95.seconds)
+                            stopId = "12345"
+                            tripId = "trip1"
+                            vehicleId = vehicle.id
+                        },
                     schedule = null,
                     vehicle = vehicle,
                     routeType = subway(),
@@ -471,24 +471,25 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `arriving when prediction arrival in the past and departure more than 30 seconds away`() = parametricTest {
-        val now = Clock.System.now()
-        assertEquals(
-            TripInstantDisplay.Arriving,
-            TripInstantDisplay.from(
-                prediction =
-                ObjectCollectionBuilder.Single.prediction {
-                    arrivalTime = now.minus(10.seconds)
-                    departureTime = now.plus(40.seconds)
-                },
-                schedule = null,
-                vehicle = null,
-                routeType = null,
-                now = now,
-                context = nonTripDetails()
+    fun `arriving when prediction arrival in the past and departure more than 30 seconds away`() =
+        parametricTest {
+            val now = Clock.System.now()
+            assertEquals(
+                TripInstantDisplay.Arriving,
+                TripInstantDisplay.from(
+                    prediction =
+                        ObjectCollectionBuilder.Single.prediction {
+                            arrivalTime = now.minus(10.seconds)
+                            departureTime = now.plus(40.seconds)
+                        },
+                    schedule = null,
+                    vehicle = null,
+                    routeType = null,
+                    now = now,
+                    context = nonTripDetails()
+                )
             )
-        )
-    }
+        }
 
     @Test
     fun `seconds less than 60 outside trip details`() = parametricTest {
@@ -615,10 +616,11 @@ class TripInstantDisplayTest {
     fun `time with status`() = parametricTest {
         val now = Clock.System.now()
         val predictionTime = now + 2.minutes
-        val prediction = ObjectCollectionBuilder.Single.prediction {
-            status = "All aboard"
-            departureTime = predictionTime
-        }
+        val prediction =
+            ObjectCollectionBuilder.Single.prediction {
+                status = "All aboard"
+                departureTime = predictionTime
+            }
 
         assertEquals(
             TripInstantDisplay.TimeWithStatus(predictionTime, "All aboard", true),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -163,12 +163,13 @@ class UpcomingTripTest {
                 TripInstantDisplay.Boarding,
                 UpcomingTrip(
                         trip {},
-                        prediction = prediction {
-                            departureTime = now.plus(10.seconds)
-                            stopId = "12345"
-                            tripId = "trip1"
-                            vehicleId = vehicle.id
-                        },
+                        prediction =
+                            prediction {
+                                departureTime = now.plus(10.seconds)
+                                stopId = "12345"
+                                tripId = "trip1"
+                                vehicleId = vehicle.id
+                            },
                         vehicle = vehicle
                     )
                     .format(now, subway(), anyContext())
@@ -188,13 +189,14 @@ class UpcomingTripTest {
                     TripInstantDisplay.Minutes(2),
                     UpcomingTrip(
                             trip {},
-                        prediction = prediction {
-                                departureTime = now.plus(95.seconds)
-                                stopId = "12345"
-                                tripId = "trip1"
-                                vehicleId = vehicle.id
-                            },
-                        vehicle = vehicle
+                            prediction =
+                                prediction {
+                                    departureTime = now.plus(95.seconds)
+                                    stopId = "12345"
+                                    tripId = "trip1"
+                                    vehicleId = vehicle.id
+                                },
+                            vehicle = vehicle
                         )
                         .format(now, subway(), anyContext())
                 )
@@ -213,13 +215,14 @@ class UpcomingTripTest {
                 TripInstantDisplay.Boarding,
                 UpcomingTrip(
                         trip {},
-                        prediction = prediction {
-                            departureTime = now.plus(10.seconds)
-                            stopId = "12345"
-                            tripId = "trip1"
-                            vehicleId = vehicle.id
-                        },
-                    vehicle = vehicle
+                        prediction =
+                            prediction {
+                                departureTime = now.plus(10.seconds)
+                                stopId = "12345"
+                                tripId = "trip1"
+                                vehicleId = vehicle.id
+                            },
+                        vehicle = vehicle
                     )
                     .format(now, subway(), anyContext())
             )
@@ -233,13 +236,14 @@ class UpcomingTripTest {
                 TripInstantDisplay.Boarding,
                 UpcomingTrip(
                         trip {},
-                    prediction = prediction {
-                            departureTime = now.plus(10.seconds)
-                            stopId = "12345"
-                            tripId = "trip1"
-                            vehicleId = vehicle.id
-                        },
-                    vehicle = vehicle
+                        prediction =
+                            prediction {
+                                departureTime = now.plus(10.seconds)
+                                stopId = "12345"
+                                tripId = "trip1"
+                                vehicleId = vehicle.id
+                            },
+                        vehicle = vehicle
                     )
                     .format(now, subway(), anyContext())
             )
@@ -253,13 +257,14 @@ class UpcomingTripTest {
                 TripInstantDisplay.Boarding,
                 UpcomingTrip(
                         trip {},
-                    prediction = prediction {
-                            departureTime = now.plus(10.seconds)
-                            stopId = "12345"
-                            tripId = "trip1"
-                            vehicleId = vehicle.id
-                        },
-                    vehicle = vehicle
+                        prediction =
+                            prediction {
+                                departureTime = now.plus(10.seconds)
+                                stopId = "12345"
+                                tripId = "trip1"
+                                vehicleId = vehicle.id
+                            },
+                        vehicle = vehicle
                     )
                     .format(now, subway(), anyContext())
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
@@ -6,43 +6,42 @@ import kotlin.test.assertEquals
 class LocalizedFeedbackFormUrlTest {
     @Test
     fun testEN() {
-        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl","en"))
+        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl", "en"))
     }
 
     @Test
     fun testES() {
-        assertEquals("baseUrl?lang=es-US", localizedFeedbackFormUrl("baseUrl","es"))
+        assertEquals("baseUrl?lang=es-US", localizedFeedbackFormUrl("baseUrl", "es"))
     }
 
     @Test
     fun testHT() {
         assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl", "ht"))
         assertEquals("baseUrl-ht", localizedFeedbackFormUrl("baseUrl", "ht", true))
-
     }
 
     @Test
     fun testPTBR() {
-        assertEquals("baseUrl?lang=pt-BR", localizedFeedbackFormUrl("baseUrl","pt-BR"))
+        assertEquals("baseUrl?lang=pt-BR", localizedFeedbackFormUrl("baseUrl", "pt-BR"))
     }
 
     @Test
     fun testVI() {
-        assertEquals("baseUrl?lang=vi", localizedFeedbackFormUrl("baseUrl","vi"))
+        assertEquals("baseUrl?lang=vi", localizedFeedbackFormUrl("baseUrl", "vi"))
     }
 
     @Test
     fun testZHHans() {
-        assertEquals("baseUrl?lang=zh-Hans", localizedFeedbackFormUrl("baseUrl","zh-Hans-CN"))
+        assertEquals("baseUrl?lang=zh-Hans", localizedFeedbackFormUrl("baseUrl", "zh-Hans-CN"))
     }
 
     @Test
     fun testZHHant() {
-        assertEquals("baseUrl?lang=zh-Hant", localizedFeedbackFormUrl("baseUrl","zh-Hant-TW"))
+        assertEquals("baseUrl?lang=zh-Hant", localizedFeedbackFormUrl("baseUrl", "zh-Hant-TW"))
     }
 
     @Test
     fun testUnknown() {
-        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl","tok"))
+        assertEquals("baseUrl", localizedFeedbackFormUrl("baseUrl", "tok"))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
@@ -144,29 +144,29 @@ class AlertsChannelTest {
             AlertsStreamDataResponse(
                 mapOf(
                     "501047" to
-                            Alert(
-                                "501047",
-                                listOf(
-                                    Alert.ActivePeriod(Instant.parse("2023-05-26T16:46:13-04:00"), null)
+                        Alert(
+                            "501047",
+                            listOf(
+                                Alert.ActivePeriod(Instant.parse("2023-05-26T16:46:13-04:00"), null)
+                            ),
+                            Alert.Cause.UnknownCause,
+                            "Description",
+                            Alert.DurationCertainty.Unknown,
+                            Alert.Effect.UnknownEffect,
+                            null,
+                            "Header",
+                            listOf(
+                                Alert.InformedEntity(
+                                    listOf(Alert.InformedEntity.Activity.Board),
+                                    route = "Red",
+                                    routeType = RouteType.HEAVY_RAIL,
+                                    stop = "place-pktrm"
                                 ),
-                                Alert.Cause.UnknownCause,
-                                "Description",
-                                Alert.DurationCertainty.Unknown,
-                                Alert.Effect.UnknownEffect,
-                                null,
-                                "Header",
-                                listOf(
-                                    Alert.InformedEntity(
-                                        listOf(Alert.InformedEntity.Activity.Board),
-                                        route = "Red",
-                                        routeType = RouteType.HEAVY_RAIL,
-                                        stop = "place-pktrm"
-                                    ),
-                                ),
-                                Alert.Lifecycle.Ongoing,
-                                10,
-                                Instant.parse("2023-05-26T16:46:13-04:00")
-                            )
+                            ),
+                            Alert.Lifecycle.Ongoing,
+                            10,
+                            Instant.parse("2023-05-26T16:46:13-04:00")
+                        )
                 )
             ),
             parsed

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
@@ -46,7 +46,7 @@ class AlertsRepositoryTests {
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
-        alertsRepo.connect(onReceive = { })
+        alertsRepo.connect(onReceive = {})
         verify { alertsRepo.disconnect() }
         verify { channel.detach() }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
@@ -70,13 +70,13 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val stopIds = runBlocking {
-            repo.getStopIdsNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
+            repo.getStopIdsNearby(
+                globalData,
+                Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude)
+            )
         }
 
-        assertEquals(
-            listOf(nearbySubwayStop.id, nearbyCRStop.id),
-            stopIds
-        )
+        assertEquals(listOf(nearbySubwayStop.id, nearbyCRStop.id), stopIds)
     }
 
     @Test
@@ -104,13 +104,13 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val stopIds = runBlocking {
-            repo.getStopIdsNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
+            repo.getStopIdsNearby(
+                globalData,
+                Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude)
+            )
         }
 
-        assertEquals(
-            listOf(nearbySubwayStop.id, nearbyCRStop.id),
-            stopIds
-        )
+        assertEquals(listOf(nearbySubwayStop.id, nearbyCRStop.id), stopIds)
     }
 
     @Test
@@ -129,7 +129,10 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val stopIds = runBlocking {
-            repo.getStopIdsNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
+            repo.getStopIdsNearby(
+                globalData,
+                Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude)
+            )
         }
 
         assertEquals(emptyList(), stopIds)
@@ -160,7 +163,10 @@ class NearbyRepositoryTest {
 
         val repo = NearbyRepository()
         val staticData = runBlocking {
-            repo.getNearby(globalData, Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude))
+            repo.getNearby(
+                globalData,
+                Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude)
+            )
         }
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/OnboardingRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/OnboardingRepositoryTest.kt
@@ -44,7 +44,12 @@ class OnboardingRepositoryTest : KoinTest {
         startKoin(isScreenReaderEnabled = true)
         val repo = OnboardingRepository()
         assertEquals(
-            listOf(OnboardingScreen.Location, OnboardingScreen.StationAccessibility, OnboardingScreen.HideMaps, OnboardingScreen.Feedback),
+            listOf(
+                OnboardingScreen.Location,
+                OnboardingScreen.StationAccessibility,
+                OnboardingScreen.HideMaps,
+                OnboardingScreen.Feedback
+            ),
             repo.getPendingOnboarding()
         )
     }
@@ -75,7 +80,11 @@ class OnboardingRepositoryTest : KoinTest {
         startKoin(isScreenReaderEnabled = true, storage)
         val repo = OnboardingRepository()
         assertEquals(
-            listOf(OnboardingScreen.StationAccessibility, OnboardingScreen.HideMaps, OnboardingScreen.Feedback),
+            listOf(
+                OnboardingScreen.StationAccessibility,
+                OnboardingScreen.HideMaps,
+                OnboardingScreen.Feedback
+            ),
             repo.getPendingOnboarding()
         )
     }
@@ -85,7 +94,11 @@ class OnboardingRepositoryTest : KoinTest {
         startKoin(isScreenReaderEnabled = false)
         val repo = OnboardingRepository()
         assertEquals(
-            listOf(OnboardingScreen.Location, OnboardingScreen.StationAccessibility, OnboardingScreen.Feedback),
+            listOf(
+                OnboardingScreen.Location,
+                OnboardingScreen.StationAccessibility,
+                OnboardingScreen.Feedback
+            ),
             repo.getPendingOnboarding()
         )
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -53,7 +53,7 @@ class PredictionsRepositoryTests : KoinTest {
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
-        predictionsRepo.connect(stopIds = listOf("Test"), onReceive = { })
+        predictionsRepo.connect(stopIds = listOf("Test"), onReceive = {})
         verify { predictionsRepo.disconnect() }
         verify { channel.detach() }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
@@ -22,9 +22,8 @@ class TripPredictionsRepositoryTests {
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
-        tripPredictionsRepo.connect(tripId = "Test", onReceive = { })
+        tripPredictionsRepo.connect(tripId = "Test", onReceive = {})
         verify { tripPredictionsRepo.disconnect() }
         verify { channel.detach() }
     }
-
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
@@ -22,9 +22,8 @@ class VehicleRepositoryTests {
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
-        vehicleRepo.connect(vehicleId = "Test", onReceive = { })
+        vehicleRepo.connect(vehicleId = "Test", onReceive = {})
         verify { vehicleRepo.disconnect() }
         verify { channel.detach() }
     }
-
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
@@ -61,7 +61,7 @@ class VehiclesRepositoryTest : KoinTest {
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
-        vehiclesRepo.connect(routeId = "Test", directionId = 0, onReceive = { })
+        vehiclesRepo.connect(routeId = "Test", directionId = 0, onReceive = {})
         verify { vehiclesRepo.disconnect() }
         verify { channel.detach() }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUsecaseTest.kt
@@ -13,20 +13,22 @@ import kotlinx.coroutines.runBlocking
 class FeaturePromoUsecaseTest {
     @Test
     fun `empty when no current version`() = runBlocking {
-        val useCase = FeaturePromoUseCase(
-            MockCurrentAppVersionRepository(null),
-            MockLastLaunchedAppVersionRepository(AppVersion(0u, 1u, 0u), onSet = { fail() })
-        )
+        val useCase =
+            FeaturePromoUseCase(
+                MockCurrentAppVersionRepository(null),
+                MockLastLaunchedAppVersionRepository(AppVersion(0u, 1u, 0u), onSet = { fail() })
+            )
         assertEquals(emptyList(), useCase.getFeaturePromos())
     }
 
     @Test
     fun `writes current and returns empty when no last launched version`() = runBlocking {
         var savedVersion: AppVersion? = null
-        val useCase = FeaturePromoUseCase(
-            MockCurrentAppVersionRepository(AppVersion(0u, 1u, 0u)),
-            MockLastLaunchedAppVersionRepository(null, onSet = { savedVersion = it })
-        )
+        val useCase =
+            FeaturePromoUseCase(
+                MockCurrentAppVersionRepository(AppVersion(0u, 1u, 0u)),
+                MockLastLaunchedAppVersionRepository(null, onSet = { savedVersion = it })
+            )
         assertEquals(emptyList(), useCase.getFeaturePromos())
         assertEquals(AppVersion(0u, 1u, 0u), savedVersion)
     }
@@ -34,11 +36,13 @@ class FeaturePromoUsecaseTest {
     @Test
     fun `returns new features when version bumped`() = runBlocking {
         // instead of an @Ignore we may forget, skip the test if there are no features
-        if (FeaturePromo.entries.all { it.addedInVersion == AppVersion(0u, 0u, 0u) }) return@runBlocking
-        val useCase = FeaturePromoUseCase(
-            MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
-            MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
-        )
+        if (FeaturePromo.entries.all { it.addedInVersion == AppVersion(0u, 0u, 0u) })
+            return@runBlocking
+        val useCase =
+            FeaturePromoUseCase(
+                MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
+                MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
+            )
         assertEquals(listOf(FeaturePromo.CombinedStopAndTrip), useCase.getFeaturePromos())
     }
 
@@ -46,10 +50,11 @@ class FeaturePromoUsecaseTest {
     fun `skips promos when too many`() = runBlocking {
         // instead of an @Ignore we may forget, skip the test if there aren't enough features
         if (FeaturePromo.entries.size <= FeaturePromoUseCase.MAX_PROMOS) return@runBlocking
-        val useCase = FeaturePromoUseCase(
-            MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
-            MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
-        )
+        val useCase =
+            FeaturePromoUseCase(
+                MockCurrentAppVersionRepository(AppVersion(999u, 999u, 999u)),
+                MockLastLaunchedAppVersionRepository(AppVersion(0u, 0u, 0u))
+            )
         assertEquals(listOf(FeaturePromo.CombinedStopAndTrip), useCase.getFeaturePromos())
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none

This has been broken since November. Oops.

Review this with ignore whitespace turned on.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the shared tests all still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
