### PR TITLE
fix: dash routes for full-route alerts

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
@@ -17,7 +17,6 @@ class AlertAssociatedStop(val stop: Stop) {
     ) : this(stop) {
         global.run {
             relevantAlerts = alertsByStop[stop.id]?.toList() ?: emptyList()
-            serviceAlerts = getServiceAlerts(relevantAlerts)
 
             val childStops =
                 stop.childStopIds
@@ -42,8 +41,9 @@ class AlertAssociatedStop(val stop: Stop) {
                     } + relevantAlerts
             }
 
-            stateByRoute =
-                getAlertStateByRoute(stop, getServiceAlerts(relevantAlerts), childAlerts, global)
+            serviceAlerts = getServiceAlerts(relevantAlerts)
+
+            stateByRoute = getAlertStateByRoute(stop, serviceAlerts, childAlerts, global)
         }
     }
 
@@ -123,9 +123,7 @@ private fun getAlertStateByRoute(
             }
 
             val childStates =
-                childAlerts.values.mapNotNull childState@{
-                    stopState(it.stop, mapRoute, childAlerts)
-                }
+                childAlerts.values.mapNotNull { stopState(it.stop, mapRoute, childAlerts) }
 
             val patternStates =
                 (patterns ?: emptyList()).map { statesForPattern(it, stop, serviceAlerts) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
@@ -80,16 +80,21 @@ data class RouteSegment(
                             .toSet()
                     routes = routes.plus(sourceRouteId)
 
+                    val allServiceAlerts =
+                        (alertsByStop[stopId]?.serviceAlerts.orEmpty() +
+                                alertsByStop[stopId]
+                                    ?.childAlerts
+                                    ?.values
+                                    ?.flatMap { it.serviceAlerts }
+                                    .orEmpty())
+                            .distinct()
                     val serviceAlerts =
-                        alertsByStop[stopId]
-                            ?.serviceAlerts
-                            ?.filter { alert ->
-                                alert.anyInformedEntity { informedEntity ->
-                                    informedEntity.route != null &&
-                                        routes.contains(informedEntity.route)
-                                }
+                        allServiceAlerts.filter { alert ->
+                            alert.anyInformedEntity { informedEntity ->
+                                informedEntity.route != null &&
+                                    routes.contains(informedEntity.route)
                             }
-                            .orEmpty()
+                        }
 
                     // TODO determine effects that count
                     StopAlertState(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
@@ -51,4 +51,42 @@ class AlertAssociatedStopTest {
             )
         assertEquals(mapOf(MapStopRoute.RED to StopAlertState.Shuttle), result.stateByRoute)
     }
+
+    @Test
+    fun `handles full-route shuttle`() {
+        val objects = ObjectCollectionBuilder()
+        lateinit var child1: Stop
+        lateinit var child2: Stop
+        val stop = objects.stop {
+            child1 = childStop()
+            child2 = childStop()
+        }
+        val route = objects.route {
+            id = "Mattapan"
+            type = RouteType.LIGHT_RAIL
+        }
+        objects.routePattern(route) {
+            directionId = 0
+            representativeTrip { stopIds = listOf(child1.id) }
+        }
+        objects.routePattern(route) {
+            directionId = 1
+            representativeTrip { stopIds = listOf(child2.id) }
+        }
+
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit, Alert.InformedEntity.Activity.Ride),
+                route = route.id,
+                routeType = route.type
+            )
+        }
+
+        val result = AlertAssociatedStop(stop, emptyMap(), setOf(alert), GlobalResponse(objects))
+
+        assertEquals(mapOf(MapStopRoute.MATTAPAN to StopAlertState.Shuttle), result.stateByRoute)
+        assertEquals(listOf(alert), result.childAlerts[child1.id]!!.serviceAlerts)
+        assertEquals(listOf(alert), result.childAlerts[child2.id]!!.serviceAlerts)
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
@@ -261,6 +261,50 @@ class RouteSegmentTest {
     }
 
     @Test
+    fun `alertStateByStopId includes stop when only children have service alerts`() {
+        lateinit var child1: Stop
+        lateinit var child2: Stop
+        val stop = stop {
+            id = "place-butlr"
+            child1 = childStop()
+            child2 = childStop()
+        }
+
+        val alert = alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit, Alert.InformedEntity.Activity.Ride), routeType = RouteType.LIGHT_RAIL, route = "Mattapan")
+        }
+
+        val segment =
+            RouteSegment(
+                id = "id",
+                sourceRouteId = "Mattapan",
+                sourceRoutePatternId = "sourceRoutePattern",
+                stopIds = listOf("place-butlr"),
+                otherPatternsByStopId = mapOf()
+            )
+
+        val alertsForStop =
+            AlertAssociatedStop(
+                stop = stop,
+                relevantAlerts = emptyList(),
+                childAlerts = mapOf(
+                    child1.id to AlertAssociatedStop(stop = child1, relevantAlerts = listOf(alert), stateByRoute = mapOf(MapStopRoute.MATTAPAN to StopAlertState.Shuttle)),
+                    child2.id to AlertAssociatedStop(stop = child2, relevantAlerts = listOf(alert), stateByRoute = mapOf(MapStopRoute.MATTAPAN to StopAlertState.Shuttle)),
+                ),
+                stateByRoute = mapOf(MapStopRoute.MATTAPAN to StopAlertState.Shuttle)
+            )
+
+        assertEquals(
+            mapOf(
+                "place-butlr" to
+                        RouteSegment.StopAlertState(hasSuspension = false, hasShuttle = true)
+            ),
+            segment.alertStateByStopId(mapOf("place-butlr" to alertsForStop))
+        )
+    }
+
+    @Test
     fun `alertingSegments when alerting segment in the middle splits so alert in each segment`() {
 
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1743608455909699)

I thought about hoisting the child stops’ `relevantAlerts` to the parent and removing the `childStops` field from `AlertAssociatedStop` completely, but I wasn’t confident it‘d be safe and I wanted to have something in place for this promptly.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manually verified that the current Mattapan shuttle is correctly drawn on both iOS and Android. Added unit tests that fail on `main` and pass now to prevent regressions.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
