### PR TITLE
test(Android): fix some flaky tests, hopefully

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapHttpInterceptorTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapHttpInterceptorTests.kt
@@ -10,7 +10,6 @@ import com.mapbox.common.HttpResponseData
 import com.mapbox.common.SdkInformation
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 class MapHttpInterceptorTests {
@@ -23,7 +22,7 @@ class MapHttpInterceptorTests {
             .build()
 
     @Test
-    fun testOnRequestUnchanged() = runTest {
+    fun testOnRequestUnchanged() {
         var requestUnchanged = false
         val interceptor = MapHttpInterceptor {}
         interceptor.onRequest(fakeRequest) { requstOrResponse ->
@@ -36,7 +35,7 @@ class MapHttpInterceptorTests {
     }
 
     @Test
-    fun testOnResponse200DoesNothing() = runTest {
+    fun testOnResponse200DoesNothing() {
         val fakeResponse: HttpResponse =
             HttpResponse(
                 1,
@@ -58,7 +57,7 @@ class MapHttpInterceptorTests {
     }
 
     @Test
-    fun testOn401UpdatesLastError() = runTest {
+    fun testOn401UpdatesLastError() {
         val fakeResponse =
             HttpResponse(
                 1,
@@ -80,7 +79,7 @@ class MapHttpInterceptorTests {
     }
 
     @Test
-    fun testOnRequsetCancelledDoesNothing() = runTest {
+    fun testOnRequsetCancelledDoesNothing() {
         val fakeResponse =
             HttpResponse(
                 1,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapViewModelTests.kt
@@ -8,13 +8,13 @@ import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import junit.framework.TestCase.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class MapViewModelTests {
 
     @Test
-    fun testWhenLoadConfigSuccessTokenSet() = runTest {
+    fun testWhenLoadConfigSuccessTokenSet() = runBlocking {
         var configuredToken: String? = null
         val mapViewModel =
             MapViewModel(
@@ -33,7 +33,7 @@ class MapViewModelTests {
     }
 
     @Test
-    fun testWhenLoadConfigErrorTokenNotSet() = runTest {
+    fun testWhenLoadConfigErrorTokenNotSet() = runBlocking {
         var configureTokenCalled = false
         val mapViewModel =
             MapViewModel(
@@ -52,7 +52,7 @@ class MapViewModelTests {
     }
 
     @Test
-    fun testInterceptorSetOnInit() = runTest {
+    fun testInterceptorSetOnInit() {
         var httpInterceptorSet = false
         val mapViewModel =
             MapViewModel(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -9,7 +9,6 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -18,7 +17,7 @@ class MoreViewModelTests {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testToggleSetting() = runTest {
+    fun testToggleSetting() {
         var toggledHideMaps = false
 
         val settingsRepository =
@@ -36,9 +35,9 @@ class MoreViewModelTests {
             vm = MoreViewModel(LocalContext.current, {}, settingsRepository)
         }
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         vm!!.toggleSetting(Settings.HideMaps)
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil { toggledHideMaps }
 
         assertTrue { toggledHideMaps }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -28,6 +28,7 @@ class MorePageTests : KoinTest {
     fun testNearbyTransitPageDisplaysCorrectly() {
         composeTestRule.setContent { MorePage(bottomBar = {}) }
 
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("MBTA Go").assertIsDisplayed()
     }
 
@@ -55,6 +56,7 @@ class MorePageTests : KoinTest {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }
 
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExists(hasText("Settings"))
         composeTestRule.onNodeWithText("Settings").performScrollTo()
         composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
@@ -80,6 +82,7 @@ class MorePageTests : KoinTest {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }
 
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExists(hasText("Send app feedback"))
         composeTestRule.onNodeWithText("Send app feedback").assertIsDisplayed()
         composeTestRule.onNodeWithText("Trip Planner").assertIsDisplayed()
@@ -114,6 +117,7 @@ class MorePageTests : KoinTest {
 
         val dependencies = Dependency.getAllDependencies()
         val dependency = dependencies.first()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExists(hasText("Send app feedback"))
         composeTestRule.onNodeWithText("Software Licenses").performScrollTo()
         composeTestRule.onNodeWithText("Software Licenses").performClick()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -25,7 +25,6 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.koin.androidx.compose.koinViewModel
@@ -77,7 +76,7 @@ class SearchBarOverlayTest : KoinTest {
     @get:Rule var composeTestRule = createComposeRule()
 
     @Test
-    fun testSearchBarOverlayBehavesCorrectly() = runTest {
+    fun testSearchBarOverlayBehavesCorrectly() {
         val navigated = mutableStateOf(false)
         var expanded = mutableStateOf(false)
 
@@ -110,7 +109,7 @@ class SearchBarOverlayTest : KoinTest {
 
         currentNavEntry.value = SheetRoutes.StopDetails(visitedStop.id, null, null)
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         currentNavEntry.value = null
 
@@ -118,7 +117,7 @@ class SearchBarOverlayTest : KoinTest {
         val searchNode = composeTestRule.onNodeWithText("Stops")
         searchNode.assertExists()
         searchNode.requestFocus()
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Recently Viewed").assertExists()
         composeTestRule.waitUntilAtLeastOneExists(hasText(visitedStop.name))
         composeTestRule.onNodeWithText(visitedStop.name).assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/StopResultsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/StopResultsViewTest.kt
@@ -12,7 +12,6 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopResult
 import kotlin.test.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -20,7 +19,7 @@ class StopResultsViewTest {
     @get:Rule var composeTestRule = createComposeRule()
 
     @Test
-    fun testStationResultWithMultipleRoutes() = runTest {
+    fun testStationResultWithMultipleRoutes() {
         val objects = ObjectCollectionBuilder()
         val station =
             objects.stop {
@@ -101,7 +100,7 @@ class StopResultsViewTest {
     }
 
     @Test
-    fun testStandaloneStopShowsAllRoutesResultWithMultipleRoutes() = runTest {
+    fun testStandaloneStopShowsAllRoutesResultWithMultipleRoutes() {
         val objects = ObjectCollectionBuilder()
         val stop =
             objects.stop {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
@@ -22,7 +22,7 @@ class GetGlobalDataTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testGlobal() = runTest {
+    fun testGlobal() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop()
         val route = objects.route()
@@ -54,7 +54,7 @@ class GetGlobalDataTest {
     }
 
     @Test
-    fun testApiError() = runTest {
+    fun testApiError() {
         val globalRepo = MockGlobalRepository(ApiResult.Error(500, "oops"))
 
         val errorRepo = MockErrorBannerStateRepository()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
@@ -9,7 +9,6 @@ import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -17,7 +16,7 @@ class GetRailRouteShapesTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testRailRouteShapes() = runTest {
+    fun testRailRouteShapes() {
         val builder = ObjectCollectionBuilder()
         val route = builder.route()
         val routePattern = builder.routePattern(route)
@@ -56,7 +55,7 @@ class GetRailRouteShapesTest {
             actualRailRouteShapes = getRailRouteShapes(railRouteShapeRepository)
         }
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil { mapFriendlyRouteResponse == actualRailRouteShapes }
         assertEquals(mapFriendlyRouteResponse, actualRailRouteShapes)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
@@ -12,7 +12,6 @@ import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import kotlin.test.assertNotNull
-import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -22,7 +21,7 @@ class GetScheduleTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testSchedule() = runTest {
+    fun testSchedule() {
         fun buildSomeSchedules(): ScheduleResponse {
             val objects = ObjectCollectionBuilder()
             objects.schedule()
@@ -58,11 +57,11 @@ class GetScheduleTest {
             actualSchedules = getSchedule(stopIds = stopIds, "errorKey", schedulesRepo)
         }
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         assertEquals(expectedSchedules1, actualSchedules)
 
         stopIds = stops2
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         assertEquals(expectedSchedules2, actualSchedules)
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetSearchResultTest.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -52,7 +51,7 @@ class GetSearchResultTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testSearchResults() = runTest {
+    fun testSearchResults() {
         var actualSearchResultsViewModel: SearchResultsViewModel? = null
         val mockVisitHistoryRepository = MockVisitHistoryRepository()
         val visitHistory = VisitHistory()
@@ -78,7 +77,7 @@ class GetSearchResultTest {
         }
 
         composeTestRule.waitUntil { actualSearchResultsViewModel != null }
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         actualSearchResultsViewModel?.getSearchResults(
             "",

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
@@ -5,7 +5,6 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import com.mbta.tid.mbta_app.repositories.IStopRepository
-import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -14,7 +13,7 @@ class GetStopMapDataTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testStopMapData() = runTest {
+    fun testStopMapData() {
         val builder = ObjectCollectionBuilder()
         val stop = builder.stop()
         val stopMapResponse = StopMapResponse(listOf(), mapOf(stop.id to stop))
@@ -31,7 +30,7 @@ class GetStopMapDataTest {
             actualStopMapResponse = getStopMapData(stop.id, stopRepository)
         }
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil { stopMapResponse == actualStopMapResponse }
         assertEquals(stopMapResponse, actualStopMapResponse)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
@@ -11,7 +11,6 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import kotlin.test.assertEquals
-import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
@@ -20,7 +19,7 @@ class SubscribeToAlertsTest {
     @get:Rule val composeRule = createComposeRule()
 
     @Test
-    fun testAlerts() = runTest {
+    fun testAlerts() {
         val builder = ObjectCollectionBuilder()
         builder.alert {
             id = "1"
@@ -40,7 +39,7 @@ class SubscribeToAlertsTest {
     }
 
     @Test
-    fun testDisconnectsOnPause() = runTest {
+    fun testDisconnectsOnPause() {
         val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
 
         var connectCount = 0

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -21,7 +21,6 @@ import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -31,7 +30,7 @@ class SubscribeToPredictionsTest {
     @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun testPredictions() = runTest {
+    fun testPredictions() {
         val objects = ObjectCollectionBuilder()
         objects.prediction()
         objects.prediction()
@@ -84,7 +83,7 @@ class SubscribeToPredictionsTest {
     }
 
     @Test
-    fun testDisconnectsOnPause() = runTest {
+    fun testDisconnectsOnPause() {
         val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
 
         var connectCount = 0
@@ -169,7 +168,7 @@ class SubscribeToPredictionsTest {
     }
 
     @Test
-    fun testCheckPredictionsStaleCalled() = runTest {
+    fun testCheckPredictionsStaleCalled() {
         val objects = ObjectCollectionBuilder()
         objects.prediction()
         val predictionsOnJoin = PredictionsByStopJoinResponse(objects)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -33,7 +33,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.junit.Rule
@@ -258,7 +257,7 @@ class StopDetailsFilteredDeparturesViewTest {
     }
 
     @Test
-    fun testShowsCancelledTripCard() = runTest {
+    fun testShowsCancelledTripCard() {
         val objects = ObjectCollectionBuilder()
         val now = Instant.fromEpochMilliseconds(System.currentTimeMillis())
         val route =

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
@@ -28,7 +27,7 @@ class StopDetailsPageTest : KoinTest {
     val koinApplication = testKoinApplication()
 
     @Test
-    fun testCallsUpdateDepartures() = runTest {
+    fun testCallsUpdateDepartures() {
         val viewModel = StopDetailsViewModel.mocked()
         val filters = mutableStateOf(StopDetailsPageFilters("stop", null, null))
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -1322,6 +1322,8 @@ class StopDetailsViewModelTest {
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
 
+        composeTestRule.waitForIdle()
+
         composeTestRule.waitUntil(2_000) { newTripFilter == expectedTripFilter }
         kotlin.test.assertEquals(expectedTripFilter, newTripFilter)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -40,9 +40,6 @@ import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
@@ -52,7 +49,7 @@ class StopDetailsViewModelTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testLoadStopDetailsLoadsSchedulesAndPredictions() = runTest {
+    fun testLoadStopDetailsLoadsSchedulesAndPredictions() {
         val objects = ObjectCollectionBuilder()
         objects.prediction {}
         objects.trip {}
@@ -72,7 +69,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testRejoinStopPredictionsWhenStopDataSet() = runTest {
+    fun testRejoinStopPredictionsWhenStopDataSet() {
         val objects = ObjectCollectionBuilder()
         objects.prediction {}
         objects.trip {}
@@ -98,14 +95,14 @@ class StopDetailsViewModelTest {
         assertNotNull(viewModel.stopData?.value?.predictionsByStop)
         assertEquals(1, connectCount)
         viewModel.rejoinStopPredictions()
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         composeTestRule.waitUntil { connectCount == 2 }
         assertEquals(2, connectCount)
     }
 
     @Test
-    fun testRejoinStopPredictionsWhenNoStop() = runTest {
+    fun testRejoinStopPredictionsWhenNoStop() {
         val objects = ObjectCollectionBuilder()
         objects.prediction {}
         objects.trip {}
@@ -132,7 +129,7 @@ class StopDetailsViewModelTest {
         assertEquals(1, connectCount)
 
         viewModel.handleStopChange(null)
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         assertNull(viewModel.stopData?.value)
         viewModel.rejoinStopPredictions()
@@ -141,7 +138,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testLeaveStopPredictions() = runTest {
+    fun testLeaveStopPredictions() {
         val objects = ObjectCollectionBuilder()
         objects.prediction {}
         objects.trip {}
@@ -163,7 +160,7 @@ class StopDetailsViewModelTest {
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewModel.loadStopDetails("stop") } }
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         assertEquals(viewModel.stopData.value?.stopId, "stop")
         assertNotNull(viewModel.stopData?.value?.predictionsByStop)
@@ -188,7 +185,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testHandleStopChange() = runTest {
+    fun testHandleStopChange() {
         val objects = ObjectCollectionBuilder()
 
         var connectCount = 0
@@ -210,6 +207,7 @@ class StopDetailsViewModelTest {
             }
         }
 
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil { connectCount == 2 }
 
         assertEquals(1, disconnectCount)
@@ -220,7 +218,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testLoadTripData() = runTest {
+    fun testLoadTripData() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -306,7 +304,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testSkipLoadingTripData() = runTest {
+    fun testSkipLoadingTripData() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -399,7 +397,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testSkipLoadingRedundantVehicleData() = runTest {
+    fun testSkipLoadingRedundantVehicleData() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -492,7 +490,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testSkipLoadingRedundantTripData() = runTest {
+    fun testSkipLoadingRedundantTripData() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -590,7 +588,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testNullTripFilter() = runTest {
+    fun testNullTripFilter() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -669,8 +667,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testManagerHandlesStopChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerHandlesStopChange() {
         val objects = ObjectCollectionBuilder()
 
         var connectCount = 0
@@ -683,12 +680,7 @@ class StopDetailsViewModelTest {
                 onDisconnect = { disconnectCount += 1 }
             )
 
-        val viewModel =
-            StopDetailsViewModel.mocked(
-                objects,
-                predictionsRepo = predictionsRepo,
-                coroutineDispatcher = dispatcher
-            )
+        val viewModel = StopDetailsViewModel.mocked(objects, predictionsRepo = predictionsRepo)
 
         val stopFilters =
             mutableStateOf<StopDetailsPageFilters?>(StopDetailsPageFilters("stop1", null, null))
@@ -706,12 +698,10 @@ class StopDetailsViewModelTest {
                     pinnedRoutes = setOf(),
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
-                    setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
+                    setMapSelectedVehicle = {}
                 )
             }
         }
-        advanceUntilIdle()
 
         composeTestRule.waitUntil { connectCount == 1 }
 
@@ -721,8 +711,6 @@ class StopDetailsViewModelTest {
 
         stopFilters.value = StopDetailsPageFilters("stop2", null, null)
 
-        advanceUntilIdle()
-
         composeTestRule.waitUntil { connectCount == 2 }
 
         assertEquals(2, connectCount)
@@ -731,8 +719,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testManagerHandlesTripFilterChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerHandlesTripFilterChange() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -769,8 +756,7 @@ class StopDetailsViewModelTest {
                         tripResponse = TripResponse(trip1)
                     ),
                 vehicleRepo =
-                    MockVehicleRepository({}, {}, ApiResult.Ok(VehicleStreamDataResponse(vehicle))),
-                coroutineDispatcher = dispatcher
+                    MockVehicleRepository({}, {}, ApiResult.Ok(VehicleStreamDataResponse(vehicle)))
             )
 
         val newTripFilter = TripDetailsFilter(trip1.id, vehicle.id, 0, false)
@@ -793,30 +779,26 @@ class StopDetailsViewModelTest {
                     pinnedRoutes = setOf(),
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
-                    setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
+                    setMapSelectedVehicle = {}
                 )
             }
         }
 
-        advanceUntilIdle()
         composeTestRule.waitUntil { viewModel.stopData.value != null }
         assertNull(viewModel.tripData.value)
 
         composeTestRule.runOnIdle {
             stopFilters.value = stopFilters.value?.copy(tripFilter = newTripFilter)
         }
-        advanceUntilIdle()
         // This test reliably fails without also using `awaitIdle`.
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
 
         composeTestRule.waitUntil { viewModel.tripData.value != null }
         assertNotNull(viewModel.tripData.value)
     }
 
     @Test
-    fun testManagerHandlesBackgrounding() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerHandlesBackgrounding() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route()
@@ -876,8 +858,7 @@ class StopDetailsViewModelTest {
                 objects,
                 predictionsRepo = predictionsRepo,
                 tripPredictionsRepo = tripPredictionsRepo,
-                vehicleRepo = vehicleRepo,
-                coroutineDispatcher = dispatcher
+                vehicleRepo = vehicleRepo
             )
 
         val stopFilters =
@@ -902,24 +883,21 @@ class StopDetailsViewModelTest {
                     pinnedRoutes = setOf(),
                     updateStopFilter = { _, _ -> },
                     updateTripFilter = { _, _ -> },
-                    setMapSelectedVehicle = {},
-                    coroutineDispatcher = dispatcher
+                    setMapSelectedVehicle = {}
                 )
             }
         }
 
-        advanceUntilIdle()
+        composeTestRule.waitForIdle()
 
         composeTestRule.waitUntil {
-            // In resumed state, so joined 1 time for stop, 1 time for resume.
-            // Need to start with lifecycle resumed in order to test pause
-            stopPredictionsConnectCount == 2
-
-            // Trip channels rejoin is no-op because tripData hasn't been set yet
-            && tripPredictionsConnectCount == 1 && vehicleConnectCount == 1
+            // resume rejoin will have been skipped
+            stopPredictionsConnectCount == 1 &&
+                tripPredictionsConnectCount == 1 &&
+                vehicleConnectCount == 1
         }
 
-        assertEquals(2, stopPredictionsConnectCount)
+        assertEquals(1, stopPredictionsConnectCount)
         assertEquals(1, stopPredictionsDisconnectCount)
 
         assertEquals(1, tripPredictionsConnectCount)
@@ -931,7 +909,6 @@ class StopDetailsViewModelTest {
         assertEquals("stop1", viewModel.stopData.value?.stopId)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
-        advanceUntilIdle()
 
         composeTestRule.waitUntil {
             stopPredictionsDisconnectCount == 2 &&
@@ -939,33 +916,31 @@ class StopDetailsViewModelTest {
                 vehicleDisconnectCount == 3
         }
 
-        assertEquals(2, stopPredictionsConnectCount)
+        assertEquals(1, stopPredictionsConnectCount)
         assertEquals(2, stopPredictionsDisconnectCount)
         assertEquals(3, tripPredictionsDisconnectCount)
         assertEquals(3, vehicleDisconnectCount)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        advanceUntilIdle()
         composeTestRule.waitUntil {
-            stopPredictionsConnectCount == 3 &&
+            stopPredictionsConnectCount == 2 &&
                 tripPredictionsConnectCount == 2 &&
                 vehicleConnectCount == 2
         }
 
-        assertEquals(3, stopPredictionsConnectCount)
+        assertEquals(2, stopPredictionsConnectCount)
         assertEquals(2, stopPredictionsDisconnectCount)
         assertEquals(2, tripPredictionsConnectCount)
         assertEquals(2, vehicleConnectCount)
     }
 
     @Test
-    fun testManagerSetsDeparturesOnChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerSetsDeparturesOnChange() {
         val objects = ObjectCollectionBuilder()
         objects.stop { id = "stop1" }
 
-        val viewModel = StopDetailsViewModel.mocked(objects, coroutineDispatcher = dispatcher)
+        val viewModel = StopDetailsViewModel.mocked(objects)
 
         val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
 
@@ -981,15 +956,12 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
         }
 
-        advanceUntilIdle()
-
         while (viewModel.stopDepartures.value == null) {
-            composeTestRule.awaitIdle()
+            composeTestRule.waitForIdle()
         }
 
         composeTestRule.waitUntil { viewModel.stopDepartures.value != null }
@@ -999,8 +971,7 @@ class StopDetailsViewModelTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testManagerDoesNotSetDeparturesWhenNothingLoaded() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerDoesNotSetDeparturesWhenNothingLoaded() {
         val objects = ObjectCollectionBuilder()
         objects.stop { id = "stop1" }
 
@@ -1008,11 +979,7 @@ class StopDetailsViewModelTest {
 
         val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
 
-        val viewModelNothingLoaded =
-            StopDetailsViewModel.mocked(
-                schedulesRepo = emptySchedulesRepo,
-                coroutineDispatcher = dispatcher
-            )
+        val viewModelNothingLoaded = StopDetailsViewModel.mocked(schedulesRepo = emptySchedulesRepo)
 
         assertNull(viewModelNothingLoaded.stopDepartures.value)
 
@@ -1026,20 +993,16 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
         }
-
-        advanceUntilIdle()
 
         assertNull(viewModelNothingLoaded.stopDepartures.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testManagerDoesNotSetDeparturesWhenOnlySchedulesLoaded() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerDoesNotSetDeparturesWhenOnlySchedulesLoaded() {
         val objects = ObjectCollectionBuilder()
         objects.stop { id = "stop1" }
 
@@ -1048,11 +1011,7 @@ class StopDetailsViewModelTest {
         val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
 
         val viewModelSchedulesLoaded =
-            StopDetailsViewModel.mocked(
-                objects,
-                predictionsRepo = emptyPredictionsRepo,
-                coroutineDispatcher = dispatcher
-            )
+            StopDetailsViewModel.mocked(objects, predictionsRepo = emptyPredictionsRepo)
 
         assertNull(viewModelSchedulesLoaded.stopDepartures.value)
 
@@ -1066,20 +1025,16 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
         }
-
-        advanceUntilIdle()
 
         assertNull(viewModelSchedulesLoaded.stopDepartures.value)
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun testManagerDoesNotSetDeparturesWhenOnlyPredictionsLoaded() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerDoesNotSetDeparturesWhenOnlyPredictionsLoaded() {
         val objects = ObjectCollectionBuilder()
         objects.stop { id = "stop1" }
 
@@ -1088,11 +1043,7 @@ class StopDetailsViewModelTest {
         val stopFilters = mutableStateOf(StopDetailsPageFilters("stop1", null, null))
 
         val viewModelPredictionsLoaded =
-            StopDetailsViewModel.mocked(
-                objects,
-                schedulesRepo = emptySchedulesRepo,
-                coroutineDispatcher = dispatcher
-            )
+            StopDetailsViewModel.mocked(objects, schedulesRepo = emptySchedulesRepo)
 
         assertNull(viewModelPredictionsLoaded.stopDepartures.value)
 
@@ -1106,19 +1057,15 @@ class StopDetailsViewModelTest {
                 pinnedRoutes = setOf(),
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
         }
-
-        advanceUntilIdle()
 
         assertNull(viewModelPredictionsLoaded.stopDepartures.value)
     }
 
     @Test
-    fun testManagerChecksPredictionsStale() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerChecksPredictionsStale() {
         val objects = ObjectCollectionBuilder()
         objects.prediction()
 
@@ -1139,8 +1086,7 @@ class StopDetailsViewModelTest {
             StopDetailsViewModel.mocked(
                 objects,
                 errorBannerRepo = errorBannerRepo,
-                predictionsRepo = predictionsRepo,
-                coroutineDispatcher = dispatcher
+                predictionsRepo = predictionsRepo
             )
 
         composeTestRule.setContent {
@@ -1154,19 +1100,15 @@ class StopDetailsViewModelTest {
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
         }
-
-        advanceUntilIdle()
 
         composeTestRule.waitUntil(timeoutMillis = 3000) { checkPredictionsStaleCount >= 2 }
     }
 
     @Test
-    fun testManagersAppliesStopFilterAutomaticallyOnDepartureChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagersAppliesStopFilterAutomaticallyOnDepartureChange() {
 
         val objects = ObjectCollectionBuilder()
 
@@ -1196,7 +1138,7 @@ class StopDetailsViewModelTest {
 
         val stopFilters = mutableStateOf(StopDetailsPageFilters(stop.id, null, null))
 
-        val viewModel = StopDetailsViewModel.mocked(objects, coroutineDispatcher = dispatcher)
+        val viewModel = StopDetailsViewModel.mocked(objects)
 
         var newStopFilter: StopDetailsFilter? = null
 
@@ -1211,8 +1153,7 @@ class StopDetailsViewModelTest {
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, filter -> newStopFilter = filter },
                 updateTripFilter = { _, _ -> },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
 
             LaunchedEffect(null) {
@@ -1230,8 +1171,6 @@ class StopDetailsViewModelTest {
             }
         }
 
-        advanceUntilIdle()
-
         composeTestRule.waitUntil {
             newStopFilter == StopDetailsFilter(route.id, routePattern.directionId, true)
         }
@@ -1240,8 +1179,7 @@ class StopDetailsViewModelTest {
     }
 
     @Test
-    fun testManagerAppliesTripFilterAutomaticallyOnDepartureChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerAppliesTripFilterAutomaticallyOnDepartureChange() {
 
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
@@ -1270,7 +1208,7 @@ class StopDetailsViewModelTest {
 
         objects.prediction(schedule) { departureTime = now.plus(10.minutes) }
 
-        val viewModel = StopDetailsViewModel.mocked(coroutineDispatcher = dispatcher)
+        val viewModel = StopDetailsViewModel.mocked()
 
         val stopFilters =
             mutableStateOf(StopDetailsPageFilters(stop.id, StopDetailsFilter(route.id, 0), null))
@@ -1288,8 +1226,7 @@ class StopDetailsViewModelTest {
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
 
             LaunchedEffect(null) {
@@ -1306,17 +1243,16 @@ class StopDetailsViewModelTest {
                 )
             }
         }
-        advanceUntilIdle()
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
 
+        composeTestRule.waitForIdle()
         composeTestRule.waitUntil(2000) { newTripFilter == expectedTripFilter }
         kotlin.test.assertEquals(expectedTripFilter, newTripFilter)
     }
 
     @Test
-    fun testManagerAppliesTripFilterAutomaticallyOnFilterChange() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
+    fun testManagerAppliesTripFilterAutomaticallyOnFilterChange() {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
 
@@ -1344,7 +1280,7 @@ class StopDetailsViewModelTest {
 
         objects.prediction(schedule) { departureTime = now.plus(10.minutes) }
 
-        val viewModel = StopDetailsViewModel.mocked(coroutineDispatcher = dispatcher)
+        val viewModel = StopDetailsViewModel.mocked()
 
         // There are no trips in direction 1
         val stopFilters =
@@ -1363,8 +1299,7 @@ class StopDetailsViewModelTest {
                 checkPredictionsStaleInterval = 1.seconds,
                 updateStopFilter = { _, _ -> },
                 updateTripFilter = { _, tripFilter -> newTripFilter = tripFilter },
-                setMapSelectedVehicle = {},
-                coroutineDispatcher = dispatcher
+                setMapSelectedVehicle = {}
             )
 
             LaunchedEffect(null) {
@@ -1386,8 +1321,6 @@ class StopDetailsViewModelTest {
         }
 
         val expectedTripFilter = TripDetailsFilter(trip1.id, null, 0, false)
-
-        advanceUntilIdle()
 
         composeTestRule.waitUntil(2_000) { newTripFilter == expectedTripFilter }
         kotlin.test.assertEquals(expectedTripFilter, newTripFilter)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -14,7 +14,6 @@ import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.junit.Rule
@@ -50,7 +49,7 @@ class TripHeaderCardTest {
     }
 
     @Test
-    fun testDisplaysStatusDescription() = runTest {
+    fun testDisplaysStatusDescription() {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
@@ -84,7 +83,7 @@ class TripHeaderCardTest {
             }
 
         vehicleState.value = incomingVehicle
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Approaching", useUnmergedTree = true).assertIsDisplayed()
 
         val stoppedVehicle =
@@ -95,7 +94,7 @@ class TripHeaderCardTest {
 
         vehicleState.value = stoppedVehicle
 
-        composeTestRule.awaitIdle()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Now at", useUnmergedTree = true).assertIsDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManagePinnedRoutesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManagePinnedRoutesTest.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -16,7 +16,7 @@ class ManagePinnedRoutesTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testPinnedRoutes() = runTest {
+    fun testPinnedRoutes() = runBlocking {
         val getSync = Channel<Unit>(Channel.RENDEZVOUS)
         val pinnedRoutesRepo =
             object : IPinnedRoutesRepository {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -537,7 +537,7 @@ fun stopDetailsManagedVM(
     val groupByDirection by viewModel.groupByDirection.collectAsState()
     val departures by viewModel.stopDepartures.collectAsState()
 
-    var wasInBackground by remember { mutableStateOf(false) }
+    var wasInBackground by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(stopId) { viewModel.handleStopChange(stopId) }
     LaunchedEffect(filters?.tripFilter) { viewModel.handleTripFilterChange(filters?.tripFilter) }


### PR DESCRIPTION
### Summary

_Ticket:_ [[flaky android tests again]](https://app.asana.com/0/1205732265579288/1209645505139426/f)

I’m choosing to blame the StopDetailsViewModelTest failures on runTest - runTest is [suggested in the Android docs](https://developer.android.com/kotlin/coroutines/test), but not in a UI test context, and since we have access to `composeTestRule.waitForIdle()` instead, I think it’s a more realistic test if we don’t mess with the dispatchers at all. I’ve banished `runTest` throughout the tests so we never run into this issue again.

The MorePageTests failures don’t make a ton of sense to me, and I was having trouble reproducing them, so I’m just tossing in an extra `waitForIdle` and hoping that’s enough.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Ran the problematic tests a few times and never saw failures.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
