### PR TITLE
fix(iOS): update Sentry pod to fix Xcode 16.3 issue

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Sentry (8.44.0):
-    - Sentry/Core (= 8.44.0)
-  - Sentry/Core (8.44.0)
+  - Sentry (8.46.0):
+    - Sentry/Core (= 8.46.0)
+  - Sentry/Core (8.46.0)
   - shared (1.0):
-    - Sentry (~> 8.44.0)
+    - Sentry (~> 8.46.0)
 
 DEPENDENCIES:
   - shared (from `../shared/`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../shared/"
 
 SPEC CHECKSUMS:
-  Sentry: 0f9bc9adfc0b960e7f3bb5ec67e9a3d8193f3bdb
-  shared: a9db4f0e42ae63be47641a3e618fa1df4b8b27b7
+  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
+  shared: 14f4a3356b6f68d1cb8be476a45ba66ae9c4a72e
 
 PODFILE CHECKSUM: 8b77545532cdf4b25adfa1dd92b4b893e9371c67
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -436,5 +436,9 @@ mokkery {
 
 sentryKmp {
     autoInstall.commonMain.enabled = false
-    autoInstall.cocoapods.sentryCocoaVersion.set("~> 8.46.0")
+    if (autoInstall.cocoapods.sentryCocoaVersion.getOrElse("") == "~> 8.44.0") {
+        autoInstall.cocoapods.sentryCocoaVersion.set("~> 8.46.0")
+    } else {
+        throw IllegalStateException("sentry-kmp was updated, delete explicit sentry-cocoa version")
+    }
 }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -434,4 +434,7 @@ mokkery {
     ignoreFinalMembers.set(true)
 }
 
-sentryKmp { autoInstall.commonMain.enabled = false }
+sentryKmp {
+    autoInstall.commonMain.enabled = false
+    autoInstall.cocoapods.sentryCocoaVersion.set("~> 8.46.0")
+}

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/Shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target    = '15.0'
-    spec.dependency 'Sentry', '~> 8.44.0'
+    spec.dependency 'Sentry', '~> 8.46.0'
 
     if !Dir.exist?('build/cocoapods/framework/Shared.framework') || Dir.empty?('build/cocoapods/framework/Shared.framework')
         raise "


### PR DESCRIPTION
### Summary

_Ticket:_ none

I let my Xcode install an update (rookie mistake, I know), and Sentry stopped building on iOS due to https://github.com/getsentry/sentry-cocoa/issues/4886. The fix for that is included in sentry-cocoa 8.46+.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Verified that the app now builds in Xcode 16.3.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
