### PR TITLE
fix(iOS): widen focus area for stop and route names in nearby transit

### DIFF
--- a/iosApp/iosApp/ComponentViews/TransitHeader.swift
+++ b/iosApp/iosApp/ComponentViews/TransitHeader.swift
@@ -27,7 +27,7 @@ struct TransitHeader<Content: View>: View {
                 .foregroundStyle(textColor)
                 .textCase(.none)
                 .frame(maxWidth: .infinity, maxHeight: modeIconHeight, alignment: .leading)
-                .contentShape(.rect)
+                .fullFocusSize()
                 .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h2)
                 .accessibilityLabel(Text("\(name) \(routeType.typeText(isOnly: true))"))

--- a/iosApp/iosApp/ComponentViews/TransitHeader.swift
+++ b/iosApp/iosApp/ComponentViews/TransitHeader.swift
@@ -27,6 +27,7 @@ struct TransitHeader<Content: View>: View {
                 .foregroundStyle(textColor)
                 .textCase(.none)
                 .frame(maxWidth: .infinity, maxHeight: modeIconHeight, alignment: .leading)
+                .contentShape(.rect)
                 .accessibilityAddTraits(.isHeader)
                 .accessibilityHeading(.h2)
                 .accessibilityLabel(Text("\(name) \(routeType.typeText(isOnly: true))"))

--- a/iosApp/iosApp/Pages/More/MorePhone.swift
+++ b/iosApp/iosApp/Pages/More/MorePhone.swift
@@ -30,7 +30,7 @@ struct MorePhone: View {
                 .fontWeight(.semibold)
                 .accessibilityHidden(true)
         }
-        .contentShape(Rectangle())
+        .fullFocusSize()
         .padding(.vertical, 10)
         .padding(.horizontal, 16)
         .frame(minHeight: 44)

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
@@ -56,7 +56,7 @@ struct NearbyStopView: View {
                     .foregroundStyle(Color.text)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(.rect)
+            .fullFocusSize()
             .accessibilityElement(children: .combine)
             if showInaccessible || showElevatorAlerts {
                 Group {
@@ -70,7 +70,7 @@ struct NearbyStopView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(.rect)
+                .fullFocusSize()
                 .multilineTextAlignment(.leading)
                 .font(Typography.footnoteSemibold)
                 .foregroundColor(Color.text.opacity(0.5))

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyStopView.swift
@@ -55,6 +55,9 @@ struct NearbyStopView: View {
                     .font(Typography.callout)
                     .foregroundStyle(Color.text)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(.rect)
+            .accessibilityElement(children: .combine)
             if showInaccessible || showElevatorAlerts {
                 Group {
                     if showInaccessible {
@@ -67,6 +70,7 @@ struct NearbyStopView: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(.rect)
                 .multilineTextAlignment(.leading)
                 .font(Typography.footnoteSemibold)
                 .foregroundColor(Color.text.opacity(0.5))

--- a/iosApp/iosApp/Utils/ViewModifier.swift
+++ b/iosApp/iosApp/Utils/ViewModifier.swift
@@ -1,0 +1,16 @@
+//
+//  ViewModifier.swift
+//  iosApp
+//
+//  Created by Melody Horn on 4/7/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+public extension View {
+    /// Sets this view’s focus size to be the entire size of the view including any preceding `.frame()` calls.
+    func fullFocusSize() -> some View {
+        contentShape(.rect)
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: VoiceOver bugs from research session](https://app.asana.com/0/1205732265579288/1209584641001346/f)

Makes the full width available to these text fields tappable to focus them.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Manually verified that the full available width is now tappable.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
