### PR TITLE
feat(Android): Alert summary locations

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
@@ -24,7 +24,7 @@ private val localizedDirectionNames: Map<String, Int> =
     )
 
 @StringRes
-private fun directionNameFormatted(direction: Direction) =
+fun directionNameFormatted(direction: Direction) =
     localizedDirectionNames[direction.name] ?: R.string.heading
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -43,6 +43,7 @@ import com.mbta.tid.mbta_app.android.component.routeSlashIcon
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSignificance
+import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.PatternsByStop
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -175,7 +176,19 @@ fun StopDetailsFilteredDeparturesView(
                             } else {
                                 AlertCardSpec.Secondary
                             }
-                    val summary = global?.let { alert.summary(now, it) }
+                    val patternsHere =
+                        remember(patternsByStop) {
+                            patternsByStop.patterns
+                                .flatMap { it.patterns }
+                                .filterNotNull()
+                                .filter { it.directionId == stopFilter.directionId }
+                        }
+                    val summary: AlertSummary? =
+                        remember(global, alert, stopId, stopFilter.directionId, patternsHere, now) {
+                            global?.let {
+                                alert.summary(stopId, stopFilter.directionId, patternsHere, now, it)
+                            }
+                        }
                     AlertCard(
                         alert,
                         summary,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -46,7 +46,6 @@ fun StopDetailsFilteredView(
         }
 
     if (patternsByStop != null) {
-
         val tileData =
             departures
                 .stopDetailsFormattedTrips(stopFilter.routeId, stopFilter.directionId, now)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.directionNameFormatted
 import com.mbta.tid.mbta_app.android.stopDetails.AlertCardSpec
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
@@ -82,7 +83,33 @@ data class FormattedAlert(
         @Composable get() = summary ?: AnnotatedString(alert.header ?: "")
 
     private val summaryLocation
-        @Composable get() = alertSummary?.location?.let { "" } ?: ""
+        @Composable
+        get() =
+            alertSummary?.location?.let {
+                when (it) {
+                    is AlertSummary.Location.SingleStop ->
+                        stringResource(R.string.alert_summary_location_single, it.stopName)
+                    is AlertSummary.Location.SuccessiveStops ->
+                        stringResource(
+                            R.string.alert_summary_location_successive,
+                            it.startStopName,
+                            it.endStopName
+                        )
+                    is AlertSummary.Location.StopToBranch ->
+                        stringResource(
+                            R.string.alert_summary_location_stop_to_branch,
+                            it.startStopName,
+                            stringResource(directionNameFormatted(it.direction))
+                        )
+                    is AlertSummary.Location.BranchToStop ->
+                        stringResource(
+                            R.string.alert_summary_location_branch_to_stop,
+                            stringResource(directionNameFormatted(it.direction)),
+                            it.endStopName,
+                        )
+                }
+            }
+                ?: ""
 
     private val summaryTimeframe
         @Composable

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -15,8 +15,9 @@
     <string name="alert_details">Detalles de la alerta</string>
     <string name="alert_ended">La alerta ya no está vigente</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020desde &lt;b>%1$s&lt;/b> hasta paradas en &lt;b>%2$s&lt;/b></string>
+    <string name="alert_summary_location_branch_to_stop">\u0020desde paradas en &lt;b>%1$s&lt;/b> hasta &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020en &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020desde &lt;b>%1$s&lt;/b> hasta paradas en &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020hasta el final del servicio</string>
     <string name="alert_summary_timeframe_later_date">\u0020hasta el %1$s</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -15,8 +15,9 @@
     <string name="alert_details">Détails de l’alerte</string>
     <string name="alert_ended">L’alerte n’est plus en vigueur</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020de &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b> arrêts</string>
+    <string name="alert_summary_location_branch_to_stop">\u0020de &lt;b>%1$s&lt;/b> arrêts à &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020à &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020de &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b> arrêts</string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020jusqu’à la fin du service</string>
     <string name="alert_summary_timeframe_later_date">\u0020jusqu’au %1$s</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -18,8 +18,9 @@
     <string name="alert_details">Detay Avètisman</string>
     <string name="alert_ended">Avètisman an pa aplikab ankò</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020soti nan &lt;b>%1$s&lt;/b> rive nan &lt;b>%2$s&lt;/b> sispann</string>
+    <string name="alert_summary_location_branch_to_stop">\u0020soti nan &lt;b>%1$s&lt;/b> sispann rive nan &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020nan &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020soti nan &lt;b>%1$s&lt;/b> rive nan &lt;b>%2$s&lt;/b> sispann</string>
     <string name="alert_summary_location_successive">\u0020soti nan &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020jiska fen sèvis la</string>
     <string name="alert_summary_timeframe_later_date">\u0020jiska %1$s</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -15,8 +15,9 @@
     <string name="alert_details">Detalhes do alerta</string>
     <string name="alert_ended">O alerta não está mais em efeito</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020de &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b> paradas</string>
+    <string name="alert_summary_location_branch_to_stop">\u0020de &lt;b>%1$s&lt;/b> paradas a &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020em &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020de &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b> paradas</string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> para &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020até o fim do serviço</string>
     <string name="alert_summary_timeframe_later_date">\u0020até %1$s</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -13,8 +13,9 @@
     <string name="alert_details">Chi tiết cảnh báo</string>
     <string name="alert_ended">Cảnh báo không còn hiệu lực</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020từ *%1$s&lt;b> đến các điểm dừng &lt;/b>%2$s**</string>
+    <string name="alert_summary_location_branch_to_stop">\u0020từ các điểm dừng &lt;b>%1$s&lt;/b> đến &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020tại &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020từ &lt;b>%1$s&lt;/b> đến các điểm dừng &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_successive">\u0020từ &lt;b>%1$s&lt;/b> đến &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020đến cuối dịch vụ</string>
     <string name="alert_summary_timeframe_later_date">\u0020đến ngày %1$s</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -13,8 +13,9 @@
     <string name="alert_details">警报详情</string>
     <string name="alert_ended">警报已失效</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">从 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b> 站</string>
+    <string name="alert_summary_location_branch_to_stop">从 &lt;b>%1$s&lt;/b> 站到 &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">在 &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">从 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b> 站</string>
     <string name="alert_summary_location_successive">从 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">直至服务结束</string>
     <string name="alert_summary_timeframe_later_date">至%1$s</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -13,8 +13,9 @@
     <string name="alert_details">警報詳情</string>
     <string name="alert_ended">警報已失效</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">從 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b> 站</string>
+    <string name="alert_summary_location_branch_to_stop">從 &lt;b>%1$s&lt;/b> 站到 &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">在 &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">從 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b> 站</string>
     <string name="alert_summary_location_successive">從 &lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">直至禮拜結束</string>
     <string name="alert_summary_timeframe_later_date">至%1$s</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -14,8 +14,9 @@
     <string name="alert_details">Alert Details</string>
     <string name="alert_ended">Alert is no longer in effect</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
-    <string name="alert_summary_location_branching">\u0020from &lt;b>%1$s&lt;/b> to &lt;b>%2$s&lt;/b> stops</string>
+    <string name="alert_summary_location_branch_to_stop">\u0020from &lt;b>%1$s&lt;/b> stops to &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_location_single">\u0020at &lt;b>%1$s&lt;/b></string>
+    <string name="alert_summary_location_stop_to_branch">\u0020from &lt;b>%1$s&lt;/b> to &lt;b>%2$s&lt;/b> stops</string>
     <string name="alert_summary_location_successive">\u0020from &lt;b>%1$s&lt;/b> to &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_end_of_service">\u0020through end of service</string>
     <string name="alert_summary_timeframe_later_date">\u0020through %1$s</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -55,6 +55,54 @@
         }
       }
     },
+    " from **%1$@** stops to **%2$@**" : {
+      "comment" : "Alert summary location for branching routes in the format of \" from [direction] stops to [Stop name]\" ex. \" from [Westbound] stops to [Kenmore]\" or \" from [Eastbound] stops to [Government Center]\". The leading space should be retained, because this will be added in the %2 position of the \"**%1$@**%2$@%3$@\" alert summary template which may or may not include a location fragment.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : " desde paradas en **%1$@** hasta **%2$@**"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : " de **%1$@** arrêts à **%2$@**"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : " soti nan **%1$@** sispann rive nan **%2$@**"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : " de **%1$@** paradas a **%2$@**"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : " từ các điểm dừng **%1$@** đến **%2$@**"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "从 **%1$@** 站到 **%2$@**"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "從 **%1$@** 站到 **%2$@**"
+          }
+        }
+      }
+    },
     " from **%1$@** to **%2$@**" : {
       "comment" : "Alert summary location for consecutive stops in the format of \" from [Stop name] to [Other stop name]\" ex. \" from [Alewife] to [Harvard]\" or \" from [Lechmere] to [Park Street]\". The leading space should be retained, because this will be added in the %2 position of the \"**%1$@**%2$@%3$@\" alert summary template which may or may not include a location fragment.",
       "extractionState" : "manual",
@@ -146,7 +194,7 @@
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : " từ *%1$@** đến các điểm dừng **%2$@**"
+            "value" : " từ **%1$@** đến các điểm dừng **%2$@**"
           }
         },
         "zh-Hans-CN" : {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -70,8 +70,13 @@ data class Alert(
             else -> AlertSignificance.None
         }
 
-    fun summary(atTime: Instant, global: GlobalResponse) =
-        AlertSummary.summarizing(this, atTime, global)
+    fun summary(
+        stopId: String,
+        directionId: Int,
+        patterns: List<RoutePattern>,
+        atTime: Instant,
+        global: GlobalResponse
+    ) = AlertSummary.summarizing(this, stopId, directionId, patterns, atTime, global)
 
     @Serializable
     data class ActivePeriod(val start: Instant, val end: Instant?) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -16,10 +16,11 @@ data class AlertSummary(
     val timeframe: Timeframe? = null
 ) {
     sealed class Location {
-        data class BranchingStops(val startStopName: String, val directionName: String) :
-            Location()
+        data class BranchToStop(val direction: Direction, val endStopName: String) : Location()
 
         data class SingleStop(val stopName: String) : Location()
+
+        data class StopToBranch(val startStopName: String, val direction: Direction) : Location()
 
         data class SuccessiveStops(val startStopName: String, val endStopName: String) : Location()
     }
@@ -37,10 +38,17 @@ data class AlertSummary(
     }
 
     companion object {
-        fun summarizing(alert: Alert, atTime: Instant, global: GlobalResponse): AlertSummary? {
+        fun summarizing(
+            alert: Alert,
+            stopId: String,
+            directionId: Int,
+            patterns: List<RoutePattern>,
+            atTime: Instant,
+            global: GlobalResponse
+        ): AlertSummary? {
             if (alert.significance < AlertSignificance.Secondary) return null
 
-            val location = alertLocation(alert, global)
+            val location = alertLocation(alert, stopId, directionId, patterns, global)
             val timeframe = alertTimeframe(alert, atTime)
 
             if (location == null && timeframe == null) return null
@@ -71,8 +79,289 @@ data class AlertSummary(
             onDate.dayOfWeek.isoDayNumber < endDate.dayOfWeek.isoDayNumber &&
                 endDate.minus(onDate).days < 7
 
-        private fun alertLocation(alert: Alert, global: GlobalResponse): Location? {
-            return null
+        private fun alertLocation(
+            alert: Alert,
+            stopId: String,
+            directionId: Int,
+            patterns: List<RoutePattern>,
+            global: GlobalResponse
+        ): Location? {
+            val routes = patterns.mapNotNull { global.routes[it.routeId] }.distinct()
+            val affectedStops = global.getAlertAffectedStops(alert, routes) ?: return null
+
+            if (affectedStops.size == 1) {
+                return Location.SingleStop(affectedStops.first().name)
+            }
+
+            // Never show multiple stops for bus
+            if (routes.any { !it.isShuttle && it.type == RouteType.BUS }) {
+                return null
+            }
+
+            // Map each pattern to its list of stops affected by this alert
+            val affectedPatternStopsWithOverlapping =
+                patterns
+                    .mapNotNull { pattern ->
+                        if (pattern.directionId != directionId) return@mapNotNull null
+                        val trip =
+                            global.trips[pattern.representativeTripId] ?: return@mapNotNull null
+                        Pair(pattern, trip.stopIds)
+                    }
+                    .plus(
+                        // Special casing to properly show when alerts affect multiple GL branches
+                        if (routes.any { it.lineId == "line-Green" }) {
+                            val directionStops =
+                                if (directionId == 0) westboundBranches else eastboundBranches
+                            // If the provided stop is on a branch, don't take any parallel
+                            // branches into account, we only want to group downstream branches
+                            if (
+                                directionStops.any { (_, branchStops) ->
+                                    branchStops.any {
+                                        global.stops[it]?.resolveParent(global)?.id == stopId
+                                    }
+                                }
+                            )
+                                emptyList()
+                            else
+                                directionStops.map { (earlier, branched) ->
+                                    Pair(
+                                        ObjectCollectionBuilder.Single.routePattern(routes[0]) {
+                                            this.directionId = directionId
+                                        },
+                                        earlier + branched
+                                    )
+                                }
+                        } else emptyList()
+                    )
+                    .mapNotNull { (pattern, stopIds) ->
+                        val stopIdsOnPattern =
+                            stopIds
+                                ?.filter { stopOnTrip ->
+                                    alert.anyInformedEntitySatisfies {
+                                        // `affectedStops` only includes parent stops, here we check
+                                        // if the child stops on each pattern are affected
+                                        checkStop(stopOnTrip)
+                                        checkRoute(pattern.routeId)
+                                    }
+                                }
+                                ?.mapNotNull { global.stops[it]?.resolveParent(global)?.id }
+
+                        if (stopIdsOnPattern != null) pattern to stopIdsOnPattern else null
+                    }
+                    .filter { (_, affectedStopsOnPattern) -> affectedStopsOnPattern.isNotEmpty() }
+                    .toMap()
+
+            // On the D branch, there are patterns that terminate at Reservoir and Riverside, this
+            // will remove stop lists that are subsets of some other stop list so that we don't
+            // display "Westbound stops" instead of "Riverside" in this case.
+            val affectedPatternStops =
+                if (affectedPatternStopsWithOverlapping.size > 1)
+                    affectedPatternStopsWithOverlapping.filter {
+                        !affectedPatternStopsWithOverlapping.any { (otherPattern, otherStops) ->
+                            otherPattern != it.key &&
+                                otherStops.size > it.value.size &&
+                                otherStops.containsAll(it.value)
+                        }
+                    }
+                else affectedPatternStopsWithOverlapping
+
+            // Compare the first stop list to all the others to determine if all patterns share the
+            // same disrupted stops, or if multiple branches are disrupted
+            val firstStops = affectedPatternStops.values.firstOrNull { it.size > 1 } ?: return null
+            val orderedStops = firstStops.mapNotNull { global.stops[it] }
+
+            if (affectedPatternStops.all { it.value.toSet() == firstStops.toSet() }) {
+                return Location.SuccessiveStops(orderedStops.first().name, orderedStops.last().name)
+            }
+
+            // Determine if every effected stop list starts or ends at the same stop, if they do,
+            // the disruption starts on the trunk and ends on multiple branches, if not, return null
+            // because we have some kind more complicated branch to branch disruption.
+            fun locationFrom(stop: Stop, first: Boolean = true): Location? {
+                val directions =
+                    Direction.getDirectionsForLine(global, stop, affectedPatternStops.keys.toList())
+
+                val (stopName, direction) =
+                    if (affectedPatternStops.values.all { it.firstOrNull() == stop.id }) {
+                        Pair(stop.name, directions[directionId])
+                    } else if (affectedPatternStops.values.all { it.lastOrNull() == stop.id }) {
+                        Pair(stop.name, directions[1 - directionId])
+                    } else return null
+
+                return if (first) {
+                    Location.StopToBranch(stopName, direction)
+                } else {
+                    Location.BranchToStop(direction, stopName)
+                }
+            }
+
+            return locationFrom(orderedStops.first()) ?: locationFrom(orderedStops.last(), false)
         }
+
+        // The first value in these pairs is the list of trunk stops for each route, including a few
+        // minor child stop differences at some stops, like Park and Kenmore. These trunk lists
+        // start at the first trunk stop on the opposite end of the trip (Lechmere and Kenmore).
+        // The second value contains all the child stops that exist only on each branch.
+        // These are hard coded because the patterns provided to `summarizing` will only include
+        // ones served at the selected stop, they don't take other branches into account, but we
+        // always want to show when a disruption is happening on all downstream branches.
+        private val westboundBranches =
+            listOf(
+                Pair( // B Branch
+                    listOf(
+                        "70502",
+                        "70208",
+                        "70206",
+                        "70204",
+                        "70202",
+                        "70196",
+                        "70159",
+                        "70157",
+                        "70155",
+                        "70153",
+                        "71151"
+                    ),
+                    listOf(
+                        "70149",
+                        "70147",
+                        "70145",
+                        "170141",
+                        "170137",
+                        "70135",
+                        "70131",
+                        "70129",
+                        "70127",
+                        "70125",
+                        "70121",
+                        "70117",
+                        "70115",
+                        "70113",
+                        "70111",
+                        "70107"
+                    )
+                ),
+                Pair( // C Branch
+                    listOf(
+                        "70502",
+                        "70208",
+                        "70206",
+                        "70204",
+                        "70202",
+                        "70197",
+                        "70159",
+                        "70157",
+                        "70155",
+                        "70153",
+                        "70151"
+                    ),
+                    listOf(
+                        "70211",
+                        "70213",
+                        "70215",
+                        "70217",
+                        "70219",
+                        "70223",
+                        "70225",
+                        "70227",
+                        "70229",
+                        "70231",
+                        "70233",
+                        "70235",
+                        "70237"
+                    )
+                ),
+                Pair( // D Branch
+                    listOf(
+                        "70502",
+                        "70208",
+                        "70206",
+                        "70204",
+                        "70202",
+                        "70198",
+                        "70159",
+                        "70157",
+                        "70155",
+                        "70153",
+                        "70151"
+                    ),
+                    listOf(
+                        "70187",
+                        "70183",
+                        "70181",
+                        "70179",
+                        "70177",
+                        "70175",
+                        "70173",
+                        "70171",
+                        "70169",
+                        "70167",
+                        "70165",
+                        "70163",
+                        "70161"
+                    )
+                ),
+                Pair( // E Branch
+                    listOf(
+                        "70502",
+                        "70208",
+                        "70206",
+                        "70204",
+                        "70202",
+                        "70199",
+                        "70159",
+                        "70157",
+                        "70155"
+                    ),
+                    listOf(
+                        "70239",
+                        "70241",
+                        "70243",
+                        "70245",
+                        "70247",
+                        "70249",
+                        "70251",
+                        "70253",
+                        "70255",
+                        "70257",
+                        "70260"
+                    )
+                ),
+            )
+
+        private val eastboundBranches =
+            listOf(
+                Pair( // Medford/Tufts
+                    listOf(
+                        "70150",
+                        "70152",
+                        "70154",
+                        "70156",
+                        "70158",
+                        "70200",
+                        "70201",
+                        "70203",
+                        "70205",
+                        "70207",
+                        "70501"
+                    ),
+                    listOf("70513", "70505", "70507", "70509", "70511")
+                ),
+                Pair( // Union
+                    listOf(
+                        "70150",
+                        "70152",
+                        "70154",
+                        "70156",
+                        "70158",
+                        "70200",
+                        "70201",
+                        "70203",
+                        "70205",
+                        "70207",
+                        "70501"
+                    ),
+                    listOf("70503")
+                ),
+            )
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -97,8 +97,8 @@ data class GlobalResponse(
     fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
         if (alert == null || routes == null) return null
         val routeEntities =
-            alert.matchingEntities { entity ->
-                routes.any { route -> entity.route == null || entity.route == route.id }
+            routes.flatMap { route ->
+                alert.matchingEntities { entity -> entity.satisfies { checkRoute(route.id) } }
             }
         val parentStops =
             routeEntities.mapNotNull { this.stops[it.stop]?.resolveParent(this.stops) }


### PR DESCRIPTION
### Summary

_Ticket:_ [Include affected stop bounds in downstream disruption summary](https://app.asana.com/0/1205732265579288/1209527076283980/f)

Add location info to the alert summary templates shown on stop details alert cards. The bulk of the work here involved getting green line branches to display properly, I ended up hard coding the child stop IDs for all trunk and branching scenarios, because there was no generalized way to determine which other route patterns should be taken into account.

![Screenshot_20250407_143136](https://github.com/user-attachments/assets/9488f79e-df1c-488d-8e94-ca5ab3adc529) ![Screenshot_20250407_143218](https://github.com/user-attachments/assets/1ef6e7e9-162f-4f6c-b483-ca7fe2a46de7) ![Screenshot_20250407_143304](https://github.com/user-attachments/assets/86e35412-e8fd-4ab5-9b8a-d06ad15e0d81)


iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

WIP
