### PR TITLE
fix(Android): group by direction UI polish

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -38,7 +40,7 @@ fun HeadsignRowView(
 @Composable
 fun HeadsignRowViewPreview() {
     MyApplicationTheme {
-        Column {
+        Column(Modifier.background(MaterialTheme.colorScheme.background)) {
             HeadsignRowView(
                 "Some",
                 UpcomingFormat.Some(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavDrilldownRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavDrilldownRow.kt
@@ -1,0 +1,57 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun NavDrilldownRow(
+    onClick: () -> Unit,
+    onClickLabel: String,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.(Modifier) -> Unit
+) {
+    Row(
+        modifier
+            .background(color = MaterialTheme.colorScheme.background)
+            .fillMaxWidth()
+            .minimumInteractiveComponentSize()
+            .clickable(onClickLabel = onClickLabel, onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        content(Modifier.weight(1f))
+        Column(
+            modifier = Modifier.padding(start = 8.dp).widthIn(max = 8.dp),
+        ) {
+            Icon(
+                painterResource(id = R.drawable.baseline_chevron_right_24),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun NavDrilldownRowPreview() {
+    NavDrilldownRow({}, "") { modifier -> Text("ABC", modifier) }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
@@ -73,9 +71,14 @@ fun PredictionRowView(
             )
         }
 
+        // The behavior that we’d really like is for both the destination and the prediction to get
+        // their full intrinsic max width if that can be done with no text wrapping, and to only
+        // apply these weights if the text won’t just all fit on one line. Unfortunately, it’s not
+        // clear how to do this, so we’re just applying the weights and accepting the unnecessary
+        // text wrapping.
         Column(modifier = Modifier.weight(1f)) { destination() }
         Row(
-            modifier = Modifier.width(IntrinsicSize.Max),
+            modifier = Modifier.weight(0.5f),
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -4,13 +4,12 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
@@ -52,34 +51,37 @@ fun PredictionRowView(
     destination: @Composable () -> Unit
 ) {
     Row(
-        modifier
-            .fillMaxWidth()
-            .heightIn(min = 44.dp)
-            .padding(8.dp)
-            .background(color = MaterialTheme.colorScheme.background),
+        modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        if (pillDecoration is PillDecoration.OnRow) {
+            RoutePill(
+                pillDecoration.route,
+                line = null,
+                RoutePillType.Flex,
+                modifier =
+                    if (predictions.secondaryAlert == null) Modifier.padding(end = 8.dp)
+                    else Modifier
+            )
+        }
         predictions.secondaryAlert?.let { secondaryAlert ->
             Image(
                 painterResource(drawableByName(secondaryAlert.iconName)),
                 stringResource(R.string.alert),
-                modifier = Modifier.placeholderIfLoading()
+                modifier = Modifier.placeholderIfLoading().padding(end = 8.dp)
             )
         }
-        if (pillDecoration is PillDecoration.OnRow) {
-            RoutePill(pillDecoration.route, line = null, RoutePillType.Flex)
-        }
 
-        Column(modifier = Modifier.weight(1f).padding(start = 8.dp)) { destination() }
+        Column(modifier = Modifier.weight(1f)) { destination() }
         Row(
-            modifier = Modifier.weight(1f),
+            modifier = Modifier.width(IntrinsicSize.Max),
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
             ProvideTextStyle(value = Typography.callout) {
                 Column(
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f, fill = false),
                     horizontalAlignment = Alignment.End,
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
@@ -130,18 +132,6 @@ fun PredictionRowView(
                     }
                 }
             }
-
-            if (predictions !is UpcomingFormat.Disruption) {
-                Column(
-                    modifier = Modifier.padding(8.dp).widthIn(max = 8.dp),
-                ) {
-                    Icon(
-                        painterResource(id = R.drawable.baseline_chevron_right_24),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.tertiary
-                    )
-                }
-            }
         }
     }
 }
@@ -163,7 +153,7 @@ private fun PredictionRowViewPreview() {
     val trip = objects.trip()
 
     MyApplicationTheme {
-        Column {
+        Column(Modifier.background(MaterialTheme.colorScheme.background)) {
             PredictionRowView(
                 predictions =
                     UpcomingFormat.Some(
@@ -178,7 +168,7 @@ private fun PredictionRowViewPreview() {
                     ),
                 pillDecoration = PillDecoration.OnPrediction(mapOf(trip.id to greenB))
             ) {
-                Text("Destination")
+                Text("Longer Destination than That")
             }
 
             PredictionRowView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -89,10 +89,10 @@ fun UpcomingTripView(
             when (state.trip) {
                 is TripInstantDisplay.Overridden ->
                     WithRealtimeIndicator(modifier, hideRealtimeIndicators) {
-                        Text(
+                        TightWrapText(
                             state.trip.text,
                             modifier = Modifier.placeholderIfLoading(),
-                            textAlign = TextAlign.End
+                            style = Typography.footnote.merge(textAlign = TextAlign.End)
                         )
                     }
                 is TripInstantDisplay.Hidden -> {}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -390,7 +390,7 @@ fun DisruptionView(
                         }
                             ?: Modifier
                     ),
-            style = Typography.footnote
+            style = Typography.footnoteSemibold
         )
         Image(icon, null, Modifier.size(20.dp))
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/legacyRouteCard/StopDeparturesSummaryList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/legacyRouteCard/StopDeparturesSummaryList.kt
@@ -1,15 +1,17 @@
 package com.mbta.tid.mbta_app.android.component.legacyRouteCard
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionRowView
 import com.mbta.tid.mbta_app.android.component.HeadsignRowView
+import com.mbta.tid.mbta_app.android.component.NavDrilldownRow
 import com.mbta.tid.mbta_app.android.component.PillDecoration
 import com.mbta.tid.mbta_app.model.PatternsByStop
 import com.mbta.tid.mbta_app.model.RealtimePatterns
@@ -56,38 +58,42 @@ fun StopDeparturesSummaryList(
                         if (condenseHeadsignPredictions) 1 else 2,
                         context
                     )
-                HeadsignRowView(
-                    patterns.headsign,
-                    predictions,
-                    modifier =
-                        Modifier.clickable(
-                            onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
-                            onClick = {
-                                onClick(patterns)
-                                analyticsTappedDeparture(predictions)
-                            }
-                        ),
-                    pillDecoration =
-                        if (patternsAtStop.line != null) PillDecoration.OnRow(patterns.route)
-                        else null
-                )
+                NavDrilldownRow(
+                    onClick = {
+                        onClick(patterns)
+                        analyticsTappedDeparture(predictions)
+                    },
+                    onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                ) { modifier ->
+                    HeadsignRowView(
+                        patterns.headsign,
+                        predictions,
+                        modifier = modifier,
+                        pillDecoration =
+                            if (patternsAtStop.line != null) PillDecoration.OnRow(patterns.route)
+                            else null
+                    )
+                }
             }
             is RealtimePatterns.ByDirection -> {
                 val predictions =
                     patterns.format(now, patternsAtStop.representativeRoute.type, context)
-                DirectionRowView(
-                    patterns.direction,
-                    predictions,
-                    modifier =
-                        Modifier.clickable(
-                            onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
-                            onClick = {
-                                onClick(patterns)
-                                analyticsTappedDeparture(predictions)
-                            }
-                        ),
-                    pillDecoration = PillDecoration.OnPrediction(patterns.routesByTrip)
-                )
+                NavDrilldownRow(
+                    onClick = {
+                        onClick(patterns)
+                        analyticsTappedDeparture(predictions)
+                    },
+                    onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                ) { modifier ->
+                    DirectionRowView(
+                        patterns.direction,
+                        predictions,
+                        modifier = modifier,
+                        pillDecoration = PillDecoration.OnPrediction(patterns.routesByTrip)
+                    )
+                }
             }
         }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -1,25 +1,36 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionLabel
 import com.mbta.tid.mbta_app.android.component.DirectionRowView
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.HeadsignRowView
+import com.mbta.tid.mbta_app.android.component.NavDrilldownRow
 import com.mbta.tid.mbta_app.android.component.PillDecoration
 import com.mbta.tid.mbta_app.model.LeafFormat
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.UpcomingFormat
+import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
@@ -35,63 +46,189 @@ fun Departures(
 ) {
     val localContext = LocalContext.current
 
-    stopData.data.withIndex().forEach { (index, leaf) ->
-        fun analyticsTappedDeparture(leafFormat: LeafFormat) {
-            val format = (leafFormat as? LeafFormat.Single)?.format
-            val noTrips = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
-            analytics.tappedDeparture(
-                cardData.lineOrRoute.id,
-                stopData.stop.id,
-                pinned,
-                leaf.alertsHere.isNotEmpty(),
-                cardData.lineOrRoute.type,
-                noTrips
-            )
-        }
+    Column {
+        stopData.data.withIndex().forEach { (index, leaf) ->
+            fun analyticsTappedDeparture(leafFormat: LeafFormat) {
+                val format = (leafFormat as? LeafFormat.Single)?.format
+                val noTrips = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
+                analytics.tappedDeparture(
+                    cardData.lineOrRoute.id,
+                    stopData.stop.id,
+                    pinned,
+                    leaf.alertsHere.isNotEmpty(),
+                    cardData.lineOrRoute.type,
+                    noTrips
+                )
+            }
 
-        val formatted =
-            leaf.format(now, cardData.lineOrRoute.sortRoute, globalData, cardData.context)
-        val direction = stopData.directions.first { it.id == leaf.directionId }
+            val formatted =
+                leaf.format(now, cardData.lineOrRoute.sortRoute, globalData, cardData.context)
+            val direction = stopData.directions.first { it.id == leaf.directionId }
 
-        val clickModifier =
-            Modifier.clickable(
-                onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
+            NavDrilldownRow(
                 onClick = {
                     onClick(leaf)
                     analyticsTappedDeparture(formatted)
-                }
-            )
-
-        Column(
-            modifier = clickModifier,
-            horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(0.dp)
-        ) {
-            when (formatted) {
-                is LeafFormat.Single -> {
-                    DirectionRowView(
-                        direction.copy(destination = formatted.headsign ?: direction.destination),
-                        formatted.format
-                    )
-                }
-                is LeafFormat.Branched -> {
-                    DirectionLabel(
-                        direction,
-                        Modifier.padding(start = 8.dp, top = 8.dp),
-                        showDestination = false
-                    )
-                    for (branch in formatted.branches) {
-                        HeadsignRowView(
-                            branch.headsign,
-                            branch.format,
-                            pillDecoration = branch.route?.let { PillDecoration.OnRow(it) }
-                        )
+                },
+                onClickLabel = localContext.getString(R.string.open_for_more_arrivals),
+                modifier = Modifier.padding(vertical = 10.dp, horizontal = 16.dp)
+            ) { modifier ->
+                Column(
+                    modifier = modifier,
+                    horizontalAlignment = Alignment.Start,
+                    verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically)
+                ) {
+                    when (formatted) {
+                        is LeafFormat.Single -> {
+                            DirectionRowView(
+                                direction.copy(
+                                    destination = formatted.headsign ?: direction.destination
+                                ),
+                                formatted.format
+                            )
+                        }
+                        is LeafFormat.Branched -> {
+                            DirectionLabel(direction, showDestination = false)
+                            for (branch in formatted.branches) {
+                                HeadsignRowView(
+                                    branch.headsign,
+                                    branch.format,
+                                    pillDecoration = branch.route?.let { PillDecoration.OnRow(it) },
+                                )
+                            }
+                        }
                     }
                 }
             }
+
             if (index < stopData.data.lastIndex) {
                 HaloSeparator()
             }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DeparturesPreview() {
+    val now = Clock.System.now()
+    val objects = ObjectCollectionBuilder()
+    val redLine =
+        objects.route {
+            id = "Red"
+            color = "DA291C"
+            directionDestinations = listOf("Ashmont/Braintree", "Alewife")
+            directionNames = listOf("South", "North")
+            longName = "Red Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+        }
+    val redLineAshmontSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Ashmont" }
+        }
+    val redLineBraintreeSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Braintree" }
+        }
+    val redLineAshmontNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    val redLineBraintreeNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    val jfkUmass =
+        objects.stop {
+            name = "JFK/UMass"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    val global = GlobalResponse(objects)
+    val context = RouteCardData.Context.NearbyTransit
+
+    val lineOrRoute = RouteCardData.LineOrRoute.Route(redLine)
+    val stopData =
+        RouteCardData.RouteStopData(
+            jfkUmass,
+            lineOrRoute,
+            listOf(
+                RouteCardData.Leaf(
+                    0,
+                    listOf(redLineAshmontSouthbound, redLineBraintreeSouthbound),
+                    setOf(jfkUmass.id),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(redLineAshmontSouthbound)
+                                departureTime = now + 1.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(redLineBraintreeSouthbound)
+                                departureTime = now + 2.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(redLineAshmontSouthbound)
+                                departureTime = now + 9.minutes
+                            }
+                        ),
+                    ),
+                    emptyList(),
+                    true,
+                    true,
+                    emptyList()
+                ),
+                RouteCardData.Leaf(
+                    1,
+                    listOf(redLineAshmontNorthbound, redLineBraintreeNorthbound),
+                    setOf(jfkUmass.id),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(redLineAshmontNorthbound)
+                                departureTime = now + 3.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(redLineBraintreeNorthbound)
+                                departureTime = now + 12.minutes
+                            }
+                        )
+                    ),
+                    emptyList(),
+                    true,
+                    true,
+                    emptyList()
+                )
+            ),
+            global
+        )
+    val card = RouteCardData(lineOrRoute, listOf(stopData), context, now)
+
+    MyApplicationTheme {
+        Column(Modifier.background(MaterialTheme.colorScheme.background)) {
+            Departures(
+                card.stopData.single(),
+                card,
+                global,
+                now,
+                false,
+                MockAnalytics(),
+                onClick = {}
+            )
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -3,13 +3,30 @@ package com.mbta.tid.mbta_app.android.component.routeCard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.component.PinButton
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.UpcomingTrip
+import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.koin.compose.KoinContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
 
 @Composable
 fun RouteCard(
@@ -38,5 +55,501 @@ fun RouteCard(
                 )
             }
         }
+    }
+}
+
+class Previews() {
+    val now = Clock.System.now()
+    val objects = ObjectCollectionBuilder()
+    val greenLine =
+        objects.line {
+            color = "00843D"
+            longName = "Green Line"
+            textColor = "FFFFFF"
+        }
+    val orangeLine =
+        objects.route {
+            id = "Orange"
+            color = "ED8B00"
+            directionDestinations = listOf("Forest Hills", "Oak Grove")
+            directionNames = listOf("South", "North")
+            longName = "Orange Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+        }
+    val redLine =
+        objects.route {
+            id = "Red"
+            color = "DA291C"
+            directionDestinations = listOf("Ashmont/Braintree", "Alewife")
+            directionNames = listOf("South", "North")
+            longName = "Red Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+        }
+    val greenLineB =
+        objects.route {
+            id = "Green-B"
+            color = greenLine.color
+            directionDestinations = listOf("Boston College", "Government Center")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line B"
+            shortName = "B"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    val greenLineC =
+        objects.route {
+            id = "Green-C"
+            color = greenLine.color
+            directionDestinations = listOf("Cleveland Circle", "Government Center")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line C"
+            shortName = "C"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    val greenLineD =
+        objects.route {
+            id = "Green-D"
+            color = greenLine.color
+            directionDestinations = listOf("Riverside", "Union Square")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line D"
+            shortName = "D"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    val greenLineE =
+        objects.route {
+            id = "Green-E"
+            color = greenLine.color
+            directionDestinations = listOf("Heath Street", "Medford/Tufts")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line E"
+            shortName = "E"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    val orangeLineSouthbound =
+        objects.routePattern(orangeLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Forest Hills" }
+        }
+    val orangeLineNorthbound =
+        objects.routePattern(orangeLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Oak Grove" }
+        }
+    val redLineAshmontSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Ashmont" }
+        }
+    val redLineBraintreeSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Braintree" }
+        }
+    val redLineAshmontNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    val redLineBraintreeNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    val greenLineBWestbound =
+        objects.routePattern(greenLineB) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Boston College" }
+        }
+    val greenLineBEastbound =
+        objects.routePattern(greenLineB) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Government Center" }
+        }
+    val greenLineCWestbound =
+        objects.routePattern(greenLineC) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Cleveland Circle" }
+        }
+    val greenLineCEastbound =
+        objects.routePattern(greenLineC) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Government Center" }
+        }
+    val greenLineDWestbound =
+        objects.routePattern(greenLineD) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Riverside" }
+        }
+    val greenLineDEastbound =
+        objects.routePattern(greenLineD) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Union Square" }
+        }
+    val ruggles =
+        objects.stop {
+            name = "Ruggles"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    val stonyBrook =
+        objects.stop {
+            name = "Stony Brook"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    val jfkUmass =
+        objects.stop {
+            name = "JFK/UMass"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    val boylston =
+        objects.stop {
+            name = "Boylston"
+            wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
+        }
+    val shuttleAlert = objects.alert { effect = Alert.Effect.Shuttle }
+    val suspensionAlert = objects.alert { effect = Alert.Effect.Suspension }
+    val global = GlobalResponse(objects)
+    val context = RouteCardData.Context.NearbyTransit
+
+    val koin = koinApplication { modules(module { single<Analytics> { MockAnalytics() } }) }
+
+    fun card(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        stop: Stop,
+        patterns: List<RoutePattern>,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert>,
+        alertDownstream: Map<Int, Alert>
+    ) =
+        RouteCardData(
+            lineOrRoute,
+            listOf(
+                RouteCardData.RouteStopData(
+                    stop,
+                    lineOrRoute,
+                    listOf(
+                        RouteCardData.Leaf(
+                            0,
+                            patterns.filter { it.directionId == 0 },
+                            setOf(stop.id),
+                            trips.filter { it.trip.directionId == 0 },
+                            listOfNotNull(alertHere[0]),
+                            true,
+                            true,
+                            listOfNotNull(alertDownstream[0])
+                        ),
+                        RouteCardData.Leaf(
+                            1,
+                            patterns.filter { it.directionId == 1 },
+                            setOf(stop.id),
+                            trips.filter { it.trip.directionId == 1 },
+                            listOfNotNull(alertHere[1]),
+                            true,
+                            true,
+                            listOfNotNull(alertDownstream[1])
+                        )
+                    ),
+                    global
+                )
+            ),
+            context,
+            now
+        )
+
+    fun card(
+        route: Route,
+        stop: Stop,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert> = emptyMap(),
+        alertDownstream: Map<Int, Alert> = emptyMap()
+    ) =
+        card(
+            RouteCardData.LineOrRoute.Route(route),
+            stop,
+            objects.routePatterns.values.filter { it.routeId == route.id },
+            trips,
+            alertHere,
+            alertDownstream
+        )
+
+    fun card(
+        line: Line,
+        stop: Stop,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert> = emptyMap(),
+        alertDownstream: Map<Int, Alert> = emptyMap()
+    ): RouteCardData {
+        val routes = objects.routes.values.filter { it.lineId == line.id }.toSet()
+        val routeIds = routes.map { it.id }
+        val routePatterns = objects.routePatterns.values.filter { routeIds.contains(it.routeId) }
+        return card(
+            RouteCardData.LineOrRoute.Line(line, routes),
+            stop,
+            routePatterns,
+            trips,
+            alertHere,
+            alertDownstream
+        )
+    }
+
+    @Composable
+    fun CardForPreview(card: RouteCardData) {
+        KoinContext(koin.koin) { RouteCard(card, global, now, false, {}, true, { _, _ -> }) }
+    }
+
+    @Preview(group = "Orange Line disruption")
+    @Composable
+    fun DownstreamDisruption() {
+        CardForPreview(
+            card(
+                orangeLine,
+                ruggles,
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip =
+                                objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
+                            departureTime = now + 5.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip =
+                                objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
+                            departureTime = now + 16.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(orangeLineNorthbound)
+                            departureTime = now + 7.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(orangeLineNorthbound)
+                            departureTime = now + 12.minutes
+                        }
+                    )
+                ),
+                alertDownstream = mapOf(0 to shuttleAlert)
+            )
+        )
+    }
+
+    @Preview(group = "Orange Line disruption")
+    @Composable
+    fun DisruptedStop() {
+        CardForPreview(
+            card(orangeLine, stonyBrook, listOf(), mapOf(0 to shuttleAlert, 1 to shuttleAlert))
+        )
+    }
+
+    @Preview(group = "Red Line branching")
+    @Composable
+    fun NextThreeTrips() {
+        CardForPreview(
+            card(
+                redLine,
+                jfkUmass,
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontSouthbound)
+                            departureTime = now + 1.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineBraintreeSouthbound)
+                            departureTime = now + 2.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontSouthbound)
+                            departureTime = now + 9.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontNorthbound)
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineBraintreeNorthbound)
+                            departureTime = now + 12.minutes
+                        }
+                    )
+                )
+            )
+        )
+    }
+
+    @Preview(group = "Red Line branching")
+    @Composable
+    fun DisruptedDownstream() {
+        CardForPreview(
+            card(
+                redLine,
+                jfkUmass,
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontSouthbound)
+                            departureTime = now + 1.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip =
+                                objects.trip(redLineBraintreeSouthbound) { headsign = "Wollaston" }
+                            departureTime = now + 2.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontSouthbound)
+                            departureTime = now + 9.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineAshmontNorthbound)
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(redLineBraintreeNorthbound)
+                            departureTime = now + 12.minutes
+                        }
+                    )
+                ),
+                alertDownstream = mapOf(0 to suspensionAlert)
+            )
+        )
+    }
+
+    @Preview(group = "Green Line branching")
+    @Composable
+    fun BranchingInBothDirections() {
+        CardForPreview(
+            card(
+                greenLine,
+                boylston,
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineCWestbound)
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineBWestbound)
+                            departureTime = now + 5.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineDWestbound)
+                            departureTime = now + 10.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineDEastbound)
+                            departureTime = now + 1.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineBEastbound)
+                            departureTime = now + 6.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineCEastbound)
+                            departureTime = now + 12.minutes
+                        }
+                    ),
+                )
+            )
+        )
+    }
+
+    @Preview(group = "Green Line branching")
+    @Composable
+    fun GLDownstreamDisruption() {
+        CardForPreview(
+            card(
+                greenLine,
+                boylston,
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineCWestbound)
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineBWestbound)
+                            departureTime = now + 5.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineDWestbound)
+                            departureTime = now + 10.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineDEastbound)
+                            departureTime = now + 1.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineBEastbound)
+                            departureTime = now + 6.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(greenLineCEastbound)
+                            departureTime = now + 12.minutes
+                        }
+                    ),
+                ),
+                alertDownstream = mapOf(0 to suspensionAlert)
+            )
+        )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | 🤖 Polish UI](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209536961544716?focus=true)

Samples selected from the [Figma spec](https://www.figma.com/design/eFiLM8xjo9hKprg93BBCtZ/App-UI-Design?node-id=9211-340210&t=Jps9NJcHKfDpav9h-4):

|Before|After|
|------|-----|
|<img width="354" alt="Screenshot 2025-04-10 at 10 21 48 AM" src="https://github.com/user-attachments/assets/f1522b34-0e8b-40eb-8a11-dfb716fd1cd4" />|<img width="354" alt="Screenshot 2025-04-10 at 10 23 08 AM" src="https://github.com/user-attachments/assets/3a5887ec-db4b-4ceb-bd6a-bb3851dacd3e" />|
|<img width="354" alt="Screenshot 2025-04-10 at 10 22 01 AM" src="https://github.com/user-attachments/assets/3c1300ea-1e6e-489c-b44b-b956de9d7d10" />|<img width="354" alt="Screenshot 2025-04-10 at 10 23 27 AM" src="https://github.com/user-attachments/assets/6bbbe5bb-9292-49fc-b3d1-57484f35538a" />|
|<img width="354" alt="Screenshot 2025-04-10 at 10 22 13 AM" src="https://github.com/user-attachments/assets/f09f1bc7-7160-40e2-bef8-2b679b21eb72" />|<img width="354" alt="Screenshot 2025-04-10 at 10 23 37 AM" src="https://github.com/user-attachments/assets/549ae555-7d8c-4b75-8bbf-9ca48d0457ec" />|

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that things still look reasonable both with and without group by direction turned on.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
