### PR TITLE
refactor: always return a TargetSplit from splitForTarget

### DIFF
--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -199,7 +199,6 @@
     <string name="onboarding_feedback_advance">Empezar</string>
     <string name="onboarding_feedback_body">MBTA Go está en su etapa inicial. Queremos recibir sus comentarios mientras seguimos realizando mejoras y agregando nuevas características.</string>
     <string name="onboarding_feedback_header">Ayúdenos a mejorar</string>
-    <string name="onboarding_location_advance">Continuar</string>
     <string name="onboarding_location_body">Usamos su ubicación para mostrarle opciones de tráfico cercanas.</string>
     <string name="onboarding_location_footer">Puede cambiar la configuración de ubicación en la aplicación de Configuración.</string>
     <string name="onboarding_location_header">Ver tráfico cerca de usted</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -199,7 +199,6 @@
     <string name="onboarding_feedback_advance">Commencer</string>
     <string name="onboarding_feedback_body">MBTA Go est encore en développement ! Votre avis est précieux pour continuer à l’améliorer et ajouter de nouvelles fonctionnalités.</string>
     <string name="onboarding_feedback_header">Aidez-nous à nous améliorer</string>
-    <string name="onboarding_location_advance">Continuer</string>
     <string name="onboarding_location_body">Nous utilisons votre position pour afficher les options de transport à proximité.</string>
     <string name="onboarding_location_footer">Vous pourrez changer les paramètres de localisation dans les paramètres de l’application.</string>
     <string name="onboarding_location_header">Voir les transports près de votre position</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -205,7 +205,6 @@
     <string name="onboarding_feedback_advance">Kòmanse</string>
     <string name="onboarding_feedback_body">MBTA Go nan etap kòmansman yo! Nou vle kòmantè w pandan n ap kontinye fè amelyorasyon epi ajoute nouvo opsyon.</string>
     <string name="onboarding_feedback_header">Ede nou amelyore</string>
-    <string name="onboarding_location_advance">Kontinye</string>
     <string name="onboarding_location_body">Nou itilize pozisyon w pou montre w opsyon transpò piblik ki toupre yo.</string>
     <string name="onboarding_location_footer">Ou ka toujou chanje paramèt pozisyon yo apre nan paramèt aplikasyon an.</string>
     <string name="onboarding_location_header">Gade transpò piblik toupre w</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -199,7 +199,6 @@
     <string name="onboarding_feedback_advance">Comece aqui</string>
     <string name="onboarding_feedback_body">O MBTA Go está no estágio inicial! Queremos seus comentários enquanto continuamos a fazer melhorias e adicionar novos recursos.</string>
     <string name="onboarding_feedback_header">Ajude-nos a melhorar</string>
-    <string name="onboarding_location_advance">Continuar</string>
     <string name="onboarding_location_body">Usamos sua localização para lhe mostrar suas opções de transporte próximas.</string>
     <string name="onboarding_location_footer">Você sempre poderá mudar as configurações de localização mais tarde no aplicativo Configurações.</string>
     <string name="onboarding_location_header">Ver transporte perto de você</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -195,7 +195,6 @@
     <string name="onboarding_feedback_advance">Bắt đầu</string>
     <string name="onboarding_feedback_body">MBTA Go đang trong giai đoạn đầu! Chúng tôi muốn nghe ý kiến đóng góp của bạn để tiếp tục cải thiện và bổ sung các tính năng mới.</string>
     <string name="onboarding_feedback_header">Giúp chúng tôi cải thiện</string>
-    <string name="onboarding_location_advance">Tiếp tục</string>
     <string name="onboarding_location_body">Chúng tôi sử dụng vị trí của bạn để hiển thị cho bạn các lựa chọn phương tiện công cộng ở gần.</string>
     <string name="onboarding_location_footer">Bạn luôn có thể thay đổi cài đặt vị trí sau trong ứng dụng Cài đặt.</string>
     <string name="onboarding_location_header">Xem phương tiện công cộng gần bạn</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -195,7 +195,6 @@
     <string name="onboarding_feedback_advance">开始</string>
     <string name="onboarding_feedback_body">MBTA Go尚处于试运行阶段！我们希望收到您的反馈，以便我们继续改进和新增功能。</string>
     <string name="onboarding_feedback_header">帮助我们改进</string>
-    <string name="onboarding_location_advance">继续</string>
     <string name="onboarding_location_body">我们使用您的位置向您显示附近的交通选择。</string>
     <string name="onboarding_location_footer">您可以随时在“设置”应用程序中更改位置设置。</string>
     <string name="onboarding_location_header">查看您附近的交通</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -195,7 +195,6 @@
     <string name="onboarding_feedback_advance">開始</string>
     <string name="onboarding_feedback_body">MBTA Go尚處於試運行階段！我們希望收到您的回饋，以便我們繼續改進和新增功能。</string>
     <string name="onboarding_feedback_header">幫助我們改進</string>
-    <string name="onboarding_location_advance">繼續</string>
     <string name="onboarding_location_body">我們使用您的位置向您顯示附近的交通選擇。</string>
     <string name="onboarding_location_footer">您可以隨時在「設定」應用程式中變更位置設定。</string>
     <string name="onboarding_location_header">查看您附近的交通</string>

--- a/bin/filter-xcodeproj-diff.rb
+++ b/bin/filter-xcodeproj-diff.rb
@@ -30,6 +30,7 @@ module DiffCrawler
       ignore_added_file_type!(path)
       ignore_object_version!(path)
       ignore_pods_name!(path)
+      ignore_pods_frameworks!(path)
     end
 
     def ignore_added_file_type!(path)
@@ -49,6 +50,12 @@ module DiffCrawler
       if (path == '.rootObject.mainGroup.children.Pods.name') && self['dirty'].nil? && (self['generated'] == 'Pods')
         replace({})
       end
+    end
+
+    def ignore_pods_frameworks!(path)
+      return unless path.include?('Embed Pods Frameworks') && self['dirty'] == [] && self['generated'].nil?
+
+      replace({})
     end
 
     def crawl_recursive!(path)

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -18,13 +18,14 @@ struct TripStops: View {
     let onTapLink: (TripDetailsStopList.Entry) -> Void
     let routeAccents: TripRouteAccents
     let showStationAccessibility: Bool
-    let splitStops: TripDetailsStopList.TargetSplit?
+    let splitStops: TripDetailsStopList.TargetSplit
 
     @State private var stopsExpanded = false
 
     private var routeTypeText: String { routeAccents.type.typeText(isOnly: true) }
-    private var stopsAway: Int? { splitStops?.collapsedStops.count }
-    private var target: TripDetailsStopList.Entry? { splitStops?.targetStop }
+    private var collapsedStops: [TripDetailsStopList.Entry]? { splitStops.collapsedStops }
+    private var stopsAway: Int? { collapsedStops?.count }
+    private var target: TripDetailsStopList.Entry? { splitStops.targetStop }
     private var hideTarget: Bool {
         if case .scheduled = headerSpec, target != nil, target == stops.startTerminalEntry { true } else { false }
     }
@@ -49,13 +50,11 @@ struct TripStops: View {
         self.routeAccents = routeAccents
         self.showStationAccessibility = showStationAccessibility
 
-        splitStops = if let stopSequence, let global {
-            stops.splitForTarget(
-                targetStopId: targetId,
-                targetStopSequence: Int32(stopSequence),
-                globalData: global
-            )
-        } else { nil }
+        splitStops = stops.splitForTarget(
+            targetStopId: targetId,
+            targetStopSequence: KotlinInt(value: stopSequence),
+            globalData: global
+        )
     }
 
     var showFirstStopSeparately: Bool {
@@ -93,96 +92,92 @@ struct TripStops: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: 0) {
-            if let splitStops, let target {
-                if showFirstStopSeparately, let firstStop = splitStops.firstStop {
-                    TripStopRow(
-                        stop: firstStop,
-                        now: now.toKotlinInstant(),
-                        onTapLink: onTapLink,
-                        routeAccents: routeAccents,
-                        showStationAccessibility: showStationAccessibility,
-                        firstStop: true
-                    )
-                }
-                if !splitStops.collapsedStops.isEmpty, let stopsAway {
-                    DisclosureGroup(
-                        isExpanded: $stopsExpanded,
-                        content: {
-                            VStack(spacing: 0) {
-                                HaloSeparator().overlay(alignment: .leading) {
-                                    if !showFirstStopSeparately {
-                                        // Lil 1x4 pt route color bar to maintain an
-                                        // unbroken route color line over the separator
-                                        ColoredRouteLine(routeAccents.color).padding(.leading, 42)
-                                    }
-                                }
-                                stopList(list: splitStops.collapsedStops)
-                            }
-                        },
-                        label: {
-                            HStack(spacing: 0) {
-                                VStack(spacing: 0) {
-                                    if stopsExpanded {
-                                        ColoredRouteLine(routeAccents.color)
-                                    } else {
-                                        routeLineTwist
-                                    }
-                                }
-                                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
-                                .frame(minWidth: 24)
-
-                                Text(
-                                    "\(stopsAway, specifier: "%ld") stops away",
-                                    comment: "How many stops away the vehicle is from the target stop"
-                                )
-                                .foregroundStyle(Color.text)
-                                .padding(.leading, 16)
-                                .accessibilityLabel(Text(
-                                    "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
-                                    comment: """
-                                    VoiceOver label for how many stops away a vehicle is from a stop,
-                                    ex 'bus is 4 stops away from Harvard'
-                                    """
-                                ))
-                                .accessibilityHint(stopsExpanded ? Text(
-                                    "Hides remaining stops",
-                                    comment: """
-                                    Screen reader hint explaining what happens when 'x stops away'
-                                    is selected when it's already open (closes the accordion listing those stops)
-                                    """
-                                ) : Text(
-                                    "Lists remaining stops",
-                                    comment: """
-                                    Screen reader hint explaining what happens when 'x stops away'
-                                    is selected (open an accordion listing those stops)
-                                    """
-                                ))
-                                .accessibilityAddTraits(.updatesFrequently)
-                                Spacer()
-                            }
-                            .frame(maxWidth: .infinity, minHeight: 56)
-                        }
-                    )
-                    .disclosureGroupStyle(.tripDetails)
-                }
-                if !hideTarget {
-                    // If the target is the first stop and there's no vehicle,
-                    // it's already displayed in the trip header
-                    TripStopRow(
-                        stop: target,
-                        now: now.toKotlinInstant(),
-                        onTapLink: onTapLink,
-                        routeAccents: routeAccents,
-                        showStationAccessibility: showStationAccessibility,
-                        targeted: true,
-                        firstStop: showFirstStopSeparately && target == stops.startTerminalEntry
-                    )
-                    .background(Color.fill3)
-                }
-                stopList(list: splitStops.followingStops)
-            } else {
-                stopList(list: stops.stops)
+            if showFirstStopSeparately, let firstStop = splitStops.firstStop {
+                TripStopRow(
+                    stop: firstStop,
+                    now: now.toKotlinInstant(),
+                    onTapLink: onTapLink,
+                    routeAccents: routeAccents,
+                    showStationAccessibility: showStationAccessibility,
+                    firstStop: true
+                )
             }
+            if let collapsedStops, !collapsedStops.isEmpty, let stopsAway, let target {
+                DisclosureGroup(
+                    isExpanded: $stopsExpanded,
+                    content: {
+                        VStack(spacing: 0) {
+                            HaloSeparator().overlay(alignment: .leading) {
+                                if !showFirstStopSeparately {
+                                    // Lil 1x4 pt route color bar to maintain an
+                                    // unbroken route color line over the separator
+                                    ColoredRouteLine(routeAccents.color).padding(.leading, 42)
+                                }
+                            }
+                            stopList(list: collapsedStops)
+                        }
+                    },
+                    label: {
+                        HStack(spacing: 0) {
+                            VStack(spacing: 0) {
+                                if stopsExpanded {
+                                    ColoredRouteLine(routeAccents.color)
+                                } else {
+                                    routeLineTwist
+                                }
+                            }
+                            .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+                            .frame(minWidth: 24)
+
+                            Text(
+                                "\(stopsAway, specifier: "%ld") stops away",
+                                comment: "How many stops away the vehicle is from the target stop"
+                            )
+                            .foregroundStyle(Color.text)
+                            .padding(.leading, 16)
+                            .accessibilityLabel(Text(
+                                "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
+                                comment: """
+                                VoiceOver label for how many stops away a vehicle is from a stop,
+                                ex 'bus is 4 stops away from Harvard'
+                                """
+                            ))
+                            .accessibilityHint(stopsExpanded ? Text(
+                                "Hides remaining stops",
+                                comment: """
+                                Screen reader hint explaining what happens when 'x stops away'
+                                is selected when it's already open (closes the accordion listing those stops)
+                                """
+                            ) : Text(
+                                "Lists remaining stops",
+                                comment: """
+                                Screen reader hint explaining what happens when 'x stops away'
+                                is selected (open an accordion listing those stops)
+                                """
+                            ))
+                            .accessibilityAddTraits(.updatesFrequently)
+                            Spacer()
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 56)
+                    }
+                )
+                .disclosureGroupStyle(.tripDetails)
+            }
+            if let target, !hideTarget {
+                // If the target is the first stop and there's no vehicle,
+                // it's already displayed in the trip header
+                TripStopRow(
+                    stop: target,
+                    now: now.toKotlinInstant(),
+                    onTapLink: onTapLink,
+                    routeAccents: routeAccents,
+                    showStationAccessibility: showStationAccessibility,
+                    targeted: true,
+                    firstStop: showFirstStopSeparately && target == stops.startTerminalEntry
+                )
+                .background(Color.fill3)
+            }
+            stopList(list: splitStops.followingStops)
         }
         .padding(.top, 56)
         .overlay(alignment: .topLeading) {

--- a/iosApp/iosApp/Utils/KotlinIntExtension.swift
+++ b/iosApp/iosApp/Utils/KotlinIntExtension.swift
@@ -1,0 +1,16 @@
+//
+//  KotlinIntExtension.swift
+//  iosApp
+//
+//  Created by Melody Horn on 4/15/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+
+extension KotlinInt {
+    convenience init?(value: Int?) {
+        guard let value else { return nil }
+        self.init(int: Int32(value))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -6,7 +6,6 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
@@ -913,10 +912,18 @@ class TripDetailsStopListTest {
     }
 
     @Test
-    fun `splitForTarget returns null if target not found`() = test {
+    fun `splitForTarget dumps everything into followingStops if target not found`() = test {
         val list = stopListOf(entry("A", 10), entry("B", 20), entry("C", 30))
         stop("D")
 
-        assertNull(list.splitForTarget("D", 40, globalData()))
+        assertEquals(
+            TripDetailsStopList.TargetSplit(
+                firstStop = null,
+                collapsedStops = null,
+                targetStop = null,
+                followingStops = list.stops
+            ),
+            list.splitForTarget("D", 40, globalData())
+        )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display downstream shuttles & suspensions in trip details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209527076283977?focus=true)

Since we don’t know which alerts are downstream until we know what the target stop is, we can‘t truncate the stop list in `fromPieces`, only in `splitForTarget`. Since `splitForTarget` returns `null` to indicate that the target stop wasn’t found, it can’t do truncation in that case, which isn’t great; if it instead puts all the stops in the unconditionally-displayed `followingStops`, it will be able to truncate reasonably even if the target wasn’t found, and we don’t need a separate case.

I suggest reviewing with whitespace hidden.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the UI tests still pass (except on iOS where I broke everything locally by upgrading Xcode). Updated the shared test for the target not found case to expect the new behavior instead of the old behavior.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
