### PR TITLE
fix(Android): center stop on map

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -327,8 +327,8 @@ fun HomeMapView(
                     viewModel.refreshStopFeatures(selectedStop, globalMapData)
                 }
                 LaunchedEffect(selectedStop) {
-                    positionViewportToStop()
                     viewModel.refreshStopFeatures(selectedStop, globalMapData)
+                    positionViewportToStop()
                 }
                 LaunchedEffect(stopSourceData) { refreshStopSource() }
                 LaunchedEffect(selectedVehicle) {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 bug: selected stop not centered on map](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209845006714026?focus=true)

It feels silly that this was the fix but here it is! Since we were attempting to position the viewport and simultaneously update map layers there seemed to be somewhat of a race condition happening that would cause the map to cease centering the viewport on the stop. Calling the suspending `refreshStopFeatures` first makes sure everything takes place before attempting to position the viewport.

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manual.
