### PR TITLE
fix(android): stop details background crash

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -184,7 +183,7 @@ fun StopDetailsFilteredDeparturesView(
     val bringIntoViewRequesters = remember { mutableStateMapOf<String, BringIntoViewRequester>() }
 
     val patternsHere =
-        rememberSaveable(data) {
+        remember(data) {
             when (data) {
                     is FilteredDeparturesData.PreGroupByDirection ->
                         data.patternsByStop.patterns.flatMap { it.patterns }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 Stop details crashes on background](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209965272304294?focus=true)

Just using `remember` seems to work just fine!

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manually tested that state is preserved when backgrounding the app on filtered stop details.