### PR TITLE
fix(Android): more destination and prediction spacing tweaks

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -4,11 +4,9 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProvideTextStyle
@@ -26,6 +24,8 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.generated.drawableByName
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.containsWrappableText
+import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.MapStopRoute
@@ -73,41 +73,10 @@ fun PredictionRowView(
             )
         }
 
-        // The behavior that we’d really like is for both the destination and the prediction to get
-        // their full intrinsic max width if that can be done with no text wrapping, and to only
-        // apply these weights if the text won’t just all fit on one line. Unfortunately, it’s not
-        // clear how to do this, but we can get reasonably close by giving the predictions the full
-        // width they want as long as they don’t contain arbitrary or long fixed text.
-        val predictionContainsWrappableText =
-            when (predictions) {
-                is UpcomingFormat.Some ->
-                    predictions.trips.any {
-                        when (it.format) {
-                            is TripInstantDisplay.Overridden -> true
-                            TripInstantDisplay.Hidden -> false
-                            TripInstantDisplay.Boarding -> false
-                            TripInstantDisplay.Arriving -> false
-                            TripInstantDisplay.Approaching -> false
-                            TripInstantDisplay.Now -> false
-                            is TripInstantDisplay.Time -> false
-                            is TripInstantDisplay.TimeWithStatus -> true
-                            is TripInstantDisplay.Minutes -> false
-                            is TripInstantDisplay.ScheduleTime -> false
-                            is TripInstantDisplay.ScheduleMinutes -> false
-                            is TripInstantDisplay.Skipped -> false
-                            is TripInstantDisplay.Cancelled -> false
-                        }
-                    }
-                is UpcomingFormat.NoTrips -> true
-                is UpcomingFormat.Disruption -> false
-                is UpcomingFormat.Loading -> false
-            }
-        val predictionsWidthModifier =
-            if (predictionContainsWrappableText) Modifier.weight(0.5f)
-            else Modifier.width(IntrinsicSize.Max)
-        Column(modifier = Modifier.weight(1f)) { destination() }
+        Column(modifier = DestinationPredictionBalance.destinationWidth()) { destination() }
         Row(
-            modifier = predictionsWidthModifier,
+            modifier =
+                DestinationPredictionBalance.predictionWidth(predictions.containsWrappableText()),
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/WithRealtimeIndicator.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/WithRealtimeIndicator.kt
@@ -20,6 +20,7 @@ import com.mbta.tid.mbta_app.android.R
 fun WithRealtimeIndicator(
     modifier: Modifier = Modifier,
     hideIndicator: Boolean = false,
+    alignment: Alignment.Horizontal = Alignment.End,
     prediction: @Composable RowScope.() -> Unit
 ) {
     val subjectSpacing = 4.dp
@@ -27,7 +28,7 @@ fun WithRealtimeIndicator(
 
     Row(
         modifier,
-        horizontalArrangement = Arrangement.spacedBy(subjectSpacing),
+        horizontalArrangement = Arrangement.spacedBy(subjectSpacing, alignment),
         verticalAlignment = Alignment.CenterVertically
     ) {
         if (!hideIndicator) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,6 +53,8 @@ import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.component.routeIcon
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.containsWrappableText
+import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
@@ -114,7 +117,7 @@ fun TripHeaderCard(
                                 targetId,
                                 routeAccents,
                                 clickable,
-                                Modifier.weight(1f)
+                                DestinationPredictionBalance.destinationWidth()
                             )
                             TripIndicator(spec, routeAccents, now, clickable)
                         }
@@ -392,13 +395,20 @@ private fun VehiclePuck(
 }
 
 @Composable
-private fun TripIndicator(
+private fun RowScope.TripIndicator(
     spec: TripHeaderSpec,
     routeAccents: TripRouteAccents,
     now: Instant,
     clickable: Boolean = false
 ) {
-    Column(verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.End) {
+    val upcomingTripViewState = upcomingTripViewState(spec, routeAccents, now)
+    Column(
+        DestinationPredictionBalance.predictionWidth(
+            upcomingTripViewState?.containsWrappableText() ?: false
+        ),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.End
+    ) {
         when (spec) {
             TripHeaderSpec.FinishingAnotherTrip,
             TripHeaderSpec.NoVehicle -> {
@@ -410,7 +420,6 @@ private fun TripIndicator(
             is TripHeaderSpec.Scheduled -> {}
         }
 
-        val upcomingTripViewState = upcomingTripViewState(spec, routeAccents, now)
         if (upcomingTripViewState != null) {
             UpcomingTripView(
                 upcomingTripViewState,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -48,7 +47,9 @@ import com.mbta.tid.mbta_app.android.component.UpcomingTripView
 import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.containsWrappableText
 import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -129,7 +130,7 @@ fun TripStopRow(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         Column(
-                            Modifier.weight(1f),
+                            DestinationPredictionBalance.destinationWidth(),
                             horizontalAlignment = Alignment.Start,
                             verticalArrangement = Arrangement.spacedBy(4.dp)
                         ) {
@@ -168,11 +169,18 @@ fun TripStopRow(
                         CompositionLocalProvider(
                             LocalContentColor provides colorResource(R.color.text)
                         ) {
+                            val state = upcomingTripViewState(stop, now, routeAccents)
                             UpcomingTripView(
-                                upcomingTripViewState(stop, now, routeAccents),
-                                Modifier.alpha(0.6f).padding(end = 12.dp).width(IntrinsicSize.Min),
+                                state,
+                                Modifier.padding(end = 12.dp)
+                                    .then(
+                                        DestinationPredictionBalance.predictionWidth(
+                                            state.containsWrappableText()
+                                        )
+                                    ),
                                 routeType = routeAccents.type,
-                                hideRealtimeIndicators = true
+                                hideRealtimeIndicators = true,
+                                maxTextAlpha = 0.6f
                             )
                         }
                     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
@@ -1,0 +1,38 @@
+package com.mbta.tid.mbta_app.android.util
+
+import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
+import com.mbta.tid.mbta_app.model.TripInstantDisplay
+import com.mbta.tid.mbta_app.model.UpcomingFormat
+
+fun UpcomingFormat.containsWrappableText() =
+    when (this) {
+        is UpcomingFormat.Some -> this.trips.any { it.format.containsWrappableText() }
+        is UpcomingFormat.NoTrips -> true
+        is UpcomingFormat.Disruption -> false
+        UpcomingFormat.Loading -> false
+    }
+
+fun UpcomingTripViewState.containsWrappableText() =
+    when (this) {
+        is UpcomingTripViewState.Some -> this.trip.containsWrappableText()
+        is UpcomingTripViewState.NoTrips -> true
+        is UpcomingTripViewState.Disruption -> false
+        UpcomingTripViewState.Loading -> false
+    }
+
+fun TripInstantDisplay.containsWrappableText() =
+    when (this) {
+        is TripInstantDisplay.Overridden -> true
+        TripInstantDisplay.Hidden -> false
+        TripInstantDisplay.Boarding -> false
+        TripInstantDisplay.Arriving -> false
+        TripInstantDisplay.Approaching -> false
+        TripInstantDisplay.Now -> false
+        is TripInstantDisplay.Time -> false
+        is TripInstantDisplay.TimeWithStatus -> true
+        is TripInstantDisplay.Minutes -> false
+        is TripInstantDisplay.ScheduleTime -> false
+        is TripInstantDisplay.ScheduleMinutes -> false
+        is TripInstantDisplay.Skipped -> false
+        is TripInstantDisplay.Cancelled -> false
+    }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/modifiers/DestinationPredictionBalance.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/modifiers/DestinationPredictionBalance.kt
@@ -1,0 +1,38 @@
+package com.mbta.tid.mbta_app.android.util.modifiers
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * The behavior that we’d really like is for both the destination and the prediction to get their
+ * full intrinsic max width if that can be done with no text wrapping, and to only apply these
+ * weights if the text won’t just all fit on one line. Unfortunately, it’s not clear how to do this,
+ * but we can get reasonably close by giving the predictions the full width they want as long as
+ * they don’t contain arbitrary or long fixed text.
+ *
+ * One day, Kotlin context parameters will make a lot of this less ugly, because we can just declare
+ * `context(rowScope: RowScope) fun Modifier.destinationWidth()`.
+ */
+@SuppressLint("ModifierFactoryExtensionFunction")
+class DestinationPredictionBalance(private val rowScope: RowScope) {
+    fun destinationWidth() = with(rowScope) { Modifier.weight(1f).padding(end = 8.dp) }
+
+    fun predictionWidth(containsWrappableText: Boolean) =
+        with(rowScope) {
+            if (containsWrappableText) Modifier.weight(0.5f) else Modifier.width(IntrinsicSize.Max)
+        }
+}
+
+/**
+ * Constructs a [DestinationPredictionBalance] that refers to the current scope.
+ *
+ * I wanted to make [DestinationPredictionBalance] a top-level `object`, but then the [RowScope]
+ * would’ve had to be a parameter to each method separately, and that’s no good.
+ */
+val RowScope.DestinationPredictionBalance: DestinationPredictionBalance
+    get() = DestinationPredictionBalance(this)


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1744994138263999?thread_ts=1744923529.120979&cid=C05QMG9GS9M)

Applies the destination and prediction sizing balance from #881/#885 to trip details, adds the padding called for in [the other Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1744983130060599) between the destination and prediction, and fixes the double applied transparency in trip details for disruption predictions.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that everything looks better or at least more consistent than it used to.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
