### PR TITLE
ci: run android/ios deploy when no platform prefix

### DIFF
--- a/.github/workflows/android-prod-deploy.yaml
+++ b/.github/workflows/android-prod-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - android-*
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/android-prod-deploy.yaml
+++ b/.github/workflows/android-prod-deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - android-*
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ios-prod-deploy.yaml
+++ b/.github/workflows/ios-prod-deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - ios-*
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ios-prod-deploy.yaml
+++ b/.github/workflows/ios-prod-deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - ios-*
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Summary

_Ticket:_ [Update CI to deploy both platforms when we use a certain tag format](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209633379255738?focus=true)

What is this PR for?
Adds new tag matching condition for ios + android to deploy to both platforms at once. 
Referenced this SO post and [GitHub Actions docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Have not tested, but we can give it a try for our next release & I'll come back to edit as needed.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
