### PR TITLE
fix(Android): Fix recentering to the current location

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -112,7 +112,7 @@ fun HomeMapView(
             currentNavEntry is SheetRoutes.StopDetails
         }
     val previousSelectedVehicleId = rememberPrevious(current = selectedVehicle?.id)
-    val currentLocation = locationDataManager.currentLocation.collectAsState(initial = null).value
+    val currentLocation by locationDataManager.currentLocation.collectAsState(initial = null)
     val now = timer(updateInterval = 300.seconds)
     val globalMapData by viewModel.globalMapData.collectAsState(null)
     val isDarkMode = isSystemInDarkTheme()
@@ -388,6 +388,9 @@ fun HomeMapView(
                             locationProvider.sendLocation(
                                 Point.fromLngLat(location.longitude, location.latitude)
                             )
+                            if (viewportProvider.isFollowingPuck) {
+                                viewportProvider.follow()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Android recenter button bug](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209802459425032?focus=true)

The user's current location was not being updated when the map wasn't visible, either because the sheet was expanded to max height, or the app was backgrounded. It was being caused by the nearby transit location being updated only by the camera state, which would stop sending updates when the map wasn't shown. 

This PR switches the nearby data to consume locations directly from the phone location stream, so that it doesn't matter what the map camera is doing. It also explicitly calls `follow` for the viewport every time the location updates, which prevents the map from getting stuck on an old location with no recenter button to reposition the map.

I'm hoping to figure out a solution for clearing the manually centered location after the app has been backgrounded for a certain period of time in a follow up PR.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Existing tests pass
