### PR TITLE
feat(iOS): show downstream alert cards in trip details

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -45,6 +45,7 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSignificance
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -75,7 +76,7 @@ fun TripStops(
 
     val splitStops: TripDetailsStopList.TargetSplit =
         remember(targetId, stops, stopSequence, global) {
-            stops.splitForTarget(targetId, stopSequence, global, truncateForDisruptions = true)
+            stops.splitForTarget(targetId, stopSequence, global)
         }
 
     var stopsExpanded by rememberSaveable { mutableStateOf(false) }
@@ -101,7 +102,16 @@ fun TripStops(
     Box {
         Box(
             Modifier.matchParentSize()
-                .padding(4.dp)
+                .padding(horizontal = 4.dp)
+                .padding(
+                    bottom =
+                        if (
+                            stops.stops.lastOrNull()?.disruption?.alert?.significance ==
+                                AlertSignificance.Major
+                        )
+                            4.dp
+                        else 0.dp
+                )
                 .haloContainer(2.dp, backgroundColor = colorResource(R.color.fill2))
         )
         Column(
@@ -238,7 +248,7 @@ fun TripStops(
             }
             StopList(
                 splitStops.followingStops,
-                lastStopSequence?.plus(if (splitStops.isTruncatedByLastAlert) 1 else 0),
+                lastStopSequence,
                 now,
                 onTapLink,
                 onOpenAlertDetails,

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -24,12 +24,31 @@ struct AlertCard: View {
     let color: Color
     let textColor: Color
     let onViewDetails: (() -> Void)?
+    let internalPadding: EdgeInsets
 
     @ScaledMetric var majorIconSize = 48
     @ScaledMetric var elevatorIconSize = 36
 
     @ScaledMetric var miniIconSize = 20
     @ScaledMetric var infoIconSize = 16
+
+    init(
+        alert: Shared.Alert,
+        alertSummary: AlertSummary?,
+        spec: AlertCardSpec,
+        color: Color,
+        textColor: Color,
+        onViewDetails: (() -> Void)?,
+        internalPadding: EdgeInsets = .init()
+    ) {
+        self.alert = alert
+        self.alertSummary = alertSummary
+        self.spec = spec
+        self.color = color
+        self.textColor = textColor
+        self.onViewDetails = onViewDetails
+        self.internalPadding = internalPadding
+    }
 
     var formattedAlert: FormattedAlert {
         FormattedAlert(alert: alert, alertSummary: alertSummary)
@@ -83,6 +102,7 @@ struct AlertCard: View {
                 }
             }
         }
+        .padding(internalPadding)
         .padding(16)
         .background(Color.fill3)
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/iosApp/iosApp/Pages/StopDetails/ColoredRouteLine.swift
+++ b/iosApp/iosApp/Pages/StopDetails/ColoredRouteLine.swift
@@ -10,14 +10,32 @@ import SwiftUI
 
 struct ColoredRouteLine: View {
     var color: Color
+    var state: State
 
-    init(_ color: Color) {
+    enum State {
+        case empty
+        case shuttle
+        case regular
+    }
+
+    init(_ color: Color, state: State = .regular) {
         self.color = color
+        self.state = state
     }
 
     var body: some View {
-        Rectangle()
-            .frame(minWidth: 4, maxWidth: 4)
-            .foregroundStyle(color)
+        Canvas { context, size in
+            let style: StrokeStyle? = switch state {
+            case .empty: nil
+            case .shuttle: .init(lineWidth: size.width, dash: [8, 8], dashPhase: 14)
+            case .regular: .init(lineWidth: size.width)
+            }
+            guard let style else { return }
+            context.stroke(Path {
+                $0.move(to: .init(x: size.width / 2, y: 0))
+                $0.addLine(to: .init(x: size.width / 2, y: size.height))
+            }, with: .color(color), style: style)
+        }
+        .frame(minWidth: 4, maxWidth: 4)
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -142,7 +142,8 @@ struct StopDetailsFilteredDepartureDetails: View {
                             errorBannerVM: errorBannerVM,
                             nearbyVM: nearbyVM,
                             mapVM: mapVM,
-                            stopDetailsVM: stopDetailsVM
+                            stopDetailsVM: stopDetailsVM,
+                            onOpenAlertDetails: { alert in getAlertDetailsHandler(alert.id, spec: .downstream)() }
                         )
                     }
                 }

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsDisclosureGroup.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsDisclosureGroup.swift
@@ -22,7 +22,7 @@ struct TripDetailsDisclosureGroup: DisclosureGroupStyle {
                             .rotationEffect(caretRotation)
                             .foregroundStyle(Color.deemphasized)
                             .frame(width: 24, height: 24)
-                            .padding(.leading, 8)
+                            .padding(.leading, 14)
                         configuration.label
                     }.frame(maxWidth: .infinity)
                 }

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -24,6 +24,8 @@ struct TripDetailsView: View {
 
     @State var stops: TripDetailsStopList?
 
+    let onOpenAlertDetails: (Shared.Alert) -> Void
+
     let analytics: Analytics
     var didLoadData: ((Self) -> Void)?
     let inspection = Inspection<Self>()
@@ -36,6 +38,7 @@ struct TripDetailsView: View {
         nearbyVM: NearbyViewModel,
         mapVM: MapViewModel,
         stopDetailsVM: StopDetailsViewModel,
+        onOpenAlertDetails: @escaping (Shared.Alert) -> Void,
         analytics: Analytics = AnalyticsProvider.shared
     ) {
         self.tripFilter = tripFilter
@@ -45,6 +48,7 @@ struct TripDetailsView: View {
         self.nearbyVM = nearbyVM
         self.mapVM = mapVM
         self.stopDetailsVM = stopDetailsVM
+        self.onOpenAlertDetails = onOpenAlertDetails
 
         self.analytics = analytics
     }
@@ -93,6 +97,7 @@ struct TripDetailsView: View {
                         Text(verbatim: "vehicle id: \(tripFilter?.vehicleId ?? "nil")")
                     }
                 }
+                .padding(.horizontal, 6)
             }
             let vehicle = stopDetailsVM.tripData?.vehicle
             if let tripFilter,
@@ -111,7 +116,6 @@ struct TripDetailsView: View {
                 loadingBody()
             }
         }
-        .padding(.horizontal, 6)
     }
 
     @ViewBuilder private func tripDetails(
@@ -151,13 +155,16 @@ struct TripDetailsView: View {
 
         VStack(spacing: 0) {
             tripHeaderCard(tripId, headerSpec, onHeaderTap, routeAccents).zIndex(1)
+                .padding(.horizontal, 6)
             TripStops(
                 targetId: stopId,
                 stops: stops,
                 stopSequence: tripFilter?.stopSequence?.intValue,
                 headerSpec: headerSpec,
                 now: now,
+                alertSummaries: stopDetailsVM.alertSummaries,
                 onTapLink: onTapStop,
+                onOpenAlertDetails: onOpenAlertDetails,
                 routeAccents: routeAccents,
                 showStationAccessibility: stopDetailsVM.showStationAccessibility,
                 global: stopDetailsVM.global

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -13,21 +13,72 @@ struct TripStopRow: View {
     var stop: TripDetailsStopList.Entry
     var now: Instant
     var onTapLink: (TripDetailsStopList.Entry) -> Void
+    var onOpenAlertDetails: (Shared.Alert) -> Void
     var routeAccents: TripRouteAccents
+    var alertSummaries: [String: AlertSummary?]
     var showStationAccessibility: Bool = false
+    var showDownstreamAlert: Bool = false
     var targeted: Bool = false
     var firstStop: Bool = false
     var lastStop: Bool = false
+    var background: Color? = nil
+
+    var disruption: UpcomingFormat.Disruption? {
+        if let disruption = stop.disruption, disruption.alert.significance == .major, showDownstreamAlert {
+            disruption
+        } else {
+            nil
+        }
+    }
+
+    var stateBefore: ColoredRouteLine.State {
+        if firstStop {
+            .empty
+        } else {
+            .regular
+        }
+    }
+
+    var stateAfter: ColoredRouteLine.State {
+        if lastStop {
+            .empty
+        } else if disruption?.alert.effect == .shuttle {
+            .shuttle
+        } else {
+            .regular
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
-            stopRow.overlay {
+            stopRow.background(background).overlay {
                 if targeted {
                     Rectangle().inset(by: -1).stroke(Color.halo, lineWidth: 2)
                 }
             }
+            if let disruption {
+                ZStack(alignment: .leading) {
+                    VStack(spacing: 0) {
+                        ColoredRouteLine(routeAccents.color, state: stateAfter)
+                        if stop.isTruncating() {
+                            ColoredRouteLine(routeAccents.color, state: .empty)
+                        }
+                    }
+                    .padding(.leading, 42)
+                    AlertCard(
+                        alert: disruption.alert,
+                        alertSummary: alertSummaries[disruption.alert.id] ?? nil,
+                        spec: .downstream,
+                        color: routeAccents.color,
+                        textColor: routeAccents.textColor,
+                        onViewDetails: { onOpenAlertDetails(disruption.alert) },
+                        internalPadding: .init(top: 0, leading: 21, bottom: 0, trailing: 0)
+                    )
+                    .padding(.horizontal, -4)
+                }
+            }
         }
-        .fixedSize(horizontal: false, vertical: true)
+        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, 6)
     }
 
     @ViewBuilder
@@ -35,7 +86,7 @@ struct TripStopRow: View {
         let activeElevatorAlerts = stop.activeElevatorAlerts(now: now)
 
         ZStack(alignment: .bottom) {
-            if !lastStop, !targeted {
+            if !lastStop, !targeted, disruption == nil {
                 HaloSeparator()
             }
             HStack(alignment: .center, spacing: 0) {
@@ -121,17 +172,8 @@ struct TripStopRow: View {
     var routeLine: some View {
         ZStack(alignment: .center) {
             VStack(spacing: 0) {
-                if firstStop {
-                    // Use a clear rectangle as a spacer, the Spacer() view doesn't
-                    // take up enough space, this is always exactly half
-                    ColoredRouteLine(Color.clear)
-                }
-                ColoredRouteLine(routeAccents.color)
-                if lastStop {
-                    // Use a clear rectangle as a spacer, the Spacer() view doesn't
-                    // take up enough space, this is always exactly half
-                    ColoredRouteLine(Color.clear)
-                }
+                ColoredRouteLine(routeAccents.color, state: stateBefore)
+                ColoredRouteLine(routeAccents.color, state: stateAfter)
             }
             StopDot(routeAccents: routeAccents, targeted: targeted)
         }
@@ -219,99 +261,208 @@ struct TripStopRow: View {
 
 #Preview {
     let objects = ObjectCollectionBuilder()
+    let now = Date.now
+    VStack {
+        TripStopRow(
+            stop: .init(
+                stop: objects.stop { stop in
+                    stop.name = "Charles/MGH"
+                    stop.wheelchairBoarding = .accessible
+                },
+                stopSequence: 10,
+                disruption: nil,
+                schedule: nil,
+                prediction: objects.prediction { $0.status = "Stopped 5 stops away" },
+                predictionStop: nil,
+                vehicle: nil,
+                routes: [
+                    objects.route { route in
+                        route.longName = "Red Line"
+                        route.color = "DA291C"
+                        route.textColor = "FFFFFF"
+                    },
+                    objects.route { route in
+                        route.longName = "Green Line"
+                        route.color = "00843D"
+                        route.textColor = "FFFFFF"
+                    },
+                ]
+            ),
+            now: now.toKotlinInstant(),
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(
+                color: Color(hex: "DA291C"),
+                type: .heavyRail,
+            ),
+            alertSummaries: [:],
+            showStationAccessibility: true,
+        )
+        TripStopRow(
+            stop: .init(
+                stop: objects.stop { $0.name = "Park Street" },
+                stopSequence: 10,
+                disruption: nil,
+                schedule: nil,
+                prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
+                predictionStop: nil,
+                vehicle: nil,
+                routes: [
+                    objects.route { route in
+                        route.longName = "Red Line"
+                        route.color = "DA291C"
+                        route.textColor = "FFFFFF"
+                    },
+                    objects.route { route in
+                        route.longName = "Green Line"
+                        route.color = "00843D"
+                        route.textColor = "FFFFFF"
+                    },
+                ]
+            ),
+            now: now.toKotlinInstant(),
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(
+                color: Color(hex: "DA291C"),
+                type: .heavyRail,
+            ),
+            alertSummaries: [:],
+            showStationAccessibility: true
+        )
+        TripStopRow(
+            stop: .init(
+                stop: objects.stop { $0.name = "South Station" },
+                stopSequence: 10,
+                disruption: nil,
+                schedule: nil,
+                prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
+                predictionStop: objects.stop { $0.platformCode = "1" },
+                vehicle: nil,
+                routes: [],
+                elevatorAlerts: [
+                    objects.alert {
+                        $0.activePeriod(
+                            start: (now - 20 * 60).toKotlinInstant(),
+                            end: (now + 20 * 60).toKotlinInstant()
+                        )
+                    },
+                ]
+            ),
+            now: now.toKotlinInstant(),
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(
+                color: Color(hex: "DA291C"),
+                type: .heavyRail,
+            ),
+            alertSummaries: [:],
+            showStationAccessibility: true
+        )
+    }
+    .font(Typography.body)
+    .background(Color.fill3)
+}
 
-    TripStopRow(
-        stop: .init(
-            stop: objects.stop {
-                $0.name = "ABC"
-                $0.wheelchairBoarding = .accessible
-            },
-            stopSequence: 10,
-            disruption: nil,
-            schedule: nil,
-            prediction: nil,
-            predictionStop: nil,
-            vehicle: nil,
-            routes: [
-                objects.route {
-                    $0.longName = "Red Line"
-                    $0.color = "#DA291C"
-                    $0.textColor = "#ffffff"
-                },
-                objects.route {
-                    $0.longName = "Green Line"
-                    $0.color = "#00843D"
-                    $0.textColor = "#ffffff"
-                },
-            ],
-            elevatorAlerts: []
-        ),
-        now: Date.now.toKotlinInstant(),
-        onTapLink: { _ in },
-        routeAccents: TripRouteAccents(type: .lightRail),
-        showStationAccessibility: true
-    ).font(Typography.body)
-
-    TripStopRow(
-        stop: .init(
-            stop: objects.stop { $0.name = "ABC" },
-            stopSequence: 10,
-            disruption: nil,
-            schedule: nil,
-            prediction: nil,
-            predictionStop: nil,
-            vehicle: nil,
-            routes: [
-                objects.route {
-                    $0.longName = "Red Line"
-                    $0.color = "#DA291C"
-                    $0.textColor = "#ffffff"
-                },
-                objects.route {
-                    $0.longName = "Green Line"
-                    $0.color = "#00843D"
-                    $0.textColor = "#ffffff"
-                },
-            ],
-            elevatorAlerts: []
-        ),
-        now: Date.now.toKotlinInstant(),
-        onTapLink: { _ in },
-        routeAccents: TripRouteAccents(type: .lightRail),
-        showStationAccessibility: true
-    ).font(Typography.body)
-
-    TripStopRow(
-        stop: .init(
-            stop: objects.stop { $0.name = "ABC" },
-            stopSequence: 10,
-            disruption: nil,
-            schedule: nil,
-            prediction: nil,
-            predictionStop: nil,
-            vehicle: nil,
-            routes: [
-                objects.route {
-                    $0.longName = "Red Line"
-                    $0.color = "#DA291C"
-                    $0.textColor = "#ffffff"
-                },
-                objects.route {
-                    $0.longName = "Green Line"
-                    $0.color = "#00843D"
-                    $0.textColor = "#ffffff"
-                },
-            ],
-            elevatorAlerts: [objects.alert {
-                $0.activePeriod(
-                    start: Date.now.addingTimeInterval(-20 * 60).toKotlinInstant(),
-                    end: Date.now.addingTimeInterval(20 * 60).toKotlinInstant()
-                )
-            }]
-        ),
-        now: Date.now.toKotlinInstant(),
-        onTapLink: { _ in },
-        routeAccents: TripRouteAccents(type: .lightRail),
-        showStationAccessibility: true
-    ).font(Typography.body)
+#Preview("Disruptions") {
+    let objects = ObjectCollectionBuilder()
+    let now = Date.now
+    ZStack {
+        Color.fill3.padding(6)
+        VStack {
+            TripStopRow(
+                stop:
+                .init(
+                    stop: objects.stop { $0.name = "Charles/MGH" },
+                    stopSequence: 10,
+                    disruption: .init(
+                        alert: objects.alert { $0.effect = .stopClosure },
+                        mapStopRoute: .red
+                    ),
+                    schedule: nil,
+                    prediction: objects.prediction { $0.status = "Stopped 5 stops away" },
+                    predictionStop: nil,
+                    vehicle: nil,
+                    routes: [
+                        objects.route { route in
+                            route.longName = "Red Line"
+                            route.color = "DA291C"
+                            route.textColor = "FFFFFF"
+                        },
+                        objects.route { route in
+                            route.longName = "Green Line"
+                            route.color = "00843D"
+                            route.textColor = "FFFFFF"
+                        },
+                    ]
+                ),
+                now: now.toKotlinInstant(),
+                onTapLink: { _ in },
+                onOpenAlertDetails: { _ in },
+                routeAccents: TripRouteAccents(
+                    color: Color(hex: "DA291C"),
+                    type: .heavyRail
+                ),
+                alertSummaries: [:],
+                showDownstreamAlert: true
+            )
+            TripStopRow(
+                stop:
+                .init(
+                    stop: objects.stop { $0.name = "Park Street" },
+                    stopSequence: 10,
+                    disruption: nil,
+                    schedule: nil,
+                    prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
+                    predictionStop: nil,
+                    vehicle: nil,
+                    routes: [
+                        objects.route { route in
+                            route.longName = "Red Line"
+                            route.color = "DA291C"
+                            route.textColor = "FFFFFF"
+                        },
+                        objects.route { route in
+                            route.longName = "Green Line"
+                            route.color = "00843D"
+                            route.textColor = "FFFFFF"
+                        },
+                    ]
+                ),
+                now: now.toKotlinInstant(),
+                onTapLink: { _ in },
+                onOpenAlertDetails: { _ in },
+                routeAccents: TripRouteAccents(
+                    color: Color(hex: "DA291C"),
+                    type: .heavyRail
+                ),
+                alertSummaries: [:],
+                showDownstreamAlert: true
+            )
+            TripStopRow(
+                stop:
+                .init(
+                    stop: objects.stop { $0.name = "South Station" },
+                    stopSequence: 10,
+                    disruption: .init(alert: objects.alert { $0.effect = .shuttle },
+                                      mapStopRoute: .red),
+                    schedule: nil,
+                    prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
+                    predictionStop: objects.stop { $0.platformCode = "1" },
+                    vehicle: nil,
+                    routes: [],
+                    elevatorAlerts: []
+                ),
+                now: now.toKotlinInstant(),
+                onTapLink: { _ in },
+                onOpenAlertDetails: { _ in },
+                routeAccents: TripRouteAccents(
+                    color: Color(hex: "DA291C"),
+                    type: .heavyRail
+                ),
+                alertSummaries: [:],
+                showDownstreamAlert: true
+            )
+        }
+    }.padding(6)
 }

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -15,7 +15,9 @@ struct TripStops: View {
     let stopSequence: Int?
     let headerSpec: TripHeaderSpec?
     let now: Date
+    let alertSummaries: [String: AlertSummary?]
     let onTapLink: (TripDetailsStopList.Entry) -> Void
+    let onOpenAlertDetails: (Shared.Alert) -> Void
     let routeAccents: TripRouteAccents
     let showStationAccessibility: Bool
     let splitStops: TripDetailsStopList.TargetSplit
@@ -36,7 +38,9 @@ struct TripStops: View {
         stopSequence: Int?,
         headerSpec: TripHeaderSpec?,
         now: Date,
+        alertSummaries: [String: AlertSummary?],
         onTapLink: @escaping (TripDetailsStopList.Entry) -> Void,
+        onOpenAlertDetails: @escaping (Shared.Alert) -> Void,
         routeAccents: TripRouteAccents,
         showStationAccessibility: Bool,
         global: GlobalResponse?
@@ -46,15 +50,16 @@ struct TripStops: View {
         self.stopSequence = stopSequence
         self.headerSpec = headerSpec
         self.now = now
+        self.alertSummaries = alertSummaries
         self.onTapLink = onTapLink
+        self.onOpenAlertDetails = onOpenAlertDetails
         self.routeAccents = routeAccents
         self.showStationAccessibility = showStationAccessibility
 
         splitStops = stops.splitForTarget(
             targetStopId: targetId,
             targetStopSequence: KotlinInt(value: stopSequence),
-            globalData: global,
-            truncateForDisruptions: false
+            globalData: global
         )
     }
 
@@ -66,14 +71,17 @@ struct TripStops: View {
     }
 
     @ViewBuilder
-    func stopList(list: [TripDetailsStopList.Entry]) -> some View {
+    func stopList(list: [TripDetailsStopList.Entry], showDownstreamAlerts: Bool = false) -> some View {
         ForEach(list, id: \.stopSequence) { stop in
             TripStopRow(
                 stop: stop,
                 now: now.toKotlinInstant(),
                 onTapLink: onTapLink,
+                onOpenAlertDetails: onOpenAlertDetails,
                 routeAccents: routeAccents,
+                alertSummaries: alertSummaries,
                 showStationAccessibility: showStationAccessibility,
+                showDownstreamAlert: showDownstreamAlerts,
                 lastStop: stop.stopSequence == stops.stops.last?.stopSequence
             )
         }
@@ -92,105 +100,168 @@ struct TripStops: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            if showFirstStopSeparately, let firstStop = splitStops.firstStop {
-                TripStopRow(
-                    stop: firstStop,
-                    now: now.toKotlinInstant(),
-                    onTapLink: onTapLink,
-                    routeAccents: routeAccents,
-                    showStationAccessibility: showStationAccessibility,
-                    firstStop: true
-                )
-            }
-            if let collapsedStops, !collapsedStops.isEmpty, let stopsAway, let target {
-                DisclosureGroup(
-                    isExpanded: $stopsExpanded,
-                    content: {
-                        VStack(spacing: 0) {
-                            HaloSeparator().overlay(alignment: .leading) {
-                                if !showFirstStopSeparately {
-                                    // Lil 1x4 pt route color bar to maintain an
-                                    // unbroken route color line over the separator
-                                    ColoredRouteLine(routeAccents.color).padding(.leading, 42)
-                                }
-                            }
-                            stopList(list: collapsedStops)
-                        }
-                    },
-                    label: {
-                        HStack(spacing: 0) {
+        ZStack {
+            Color.fill2
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .padding(1)
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
+                .padding(.horizontal, 6)
+                .padding(.bottom, stops.stops.last?.disruption?.alert.significance == .major ? 6 : 0)
+            VStack(alignment: .center, spacing: 0) {
+                if showFirstStopSeparately, let firstStop = splitStops.firstStop {
+                    TripStopRow(
+                        stop: firstStop,
+                        now: now.toKotlinInstant(),
+                        onTapLink: onTapLink,
+                        onOpenAlertDetails: onOpenAlertDetails,
+                        routeAccents: routeAccents,
+                        alertSummaries: alertSummaries,
+                        showStationAccessibility: showStationAccessibility,
+                        firstStop: true
+                    )
+                }
+                if let collapsedStops, !collapsedStops.isEmpty, let stopsAway, let target {
+                    DisclosureGroup(
+                        isExpanded: $stopsExpanded,
+                        content: {
                             VStack(spacing: 0) {
-                                if stopsExpanded {
-                                    ColoredRouteLine(routeAccents.color)
-                                } else {
-                                    routeLineTwist
+                                HaloSeparator().overlay(alignment: .leading) {
+                                    if !showFirstStopSeparately {
+                                        // Lil 1x4 pt route color bar to maintain an
+                                        // unbroken route color line over the separator
+                                        ColoredRouteLine(routeAccents.color).padding(.leading, 42)
+                                    }
                                 }
+                                stopList(list: collapsedStops)
                             }
-                            .transition(.opacity.animation(.easeInOut(duration: 0.2)))
-                            .frame(minWidth: 24)
+                        },
+                        label: {
+                            HStack(spacing: 0) {
+                                VStack(spacing: 0) {
+                                    if stopsExpanded {
+                                        ColoredRouteLine(routeAccents.color)
+                                    } else {
+                                        routeLineTwist
+                                    }
+                                }
+                                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+                                .frame(minWidth: 24)
 
-                            Text(
-                                "\(stopsAway, specifier: "%ld") stops away",
-                                comment: "How many stops away the vehicle is from the target stop"
-                            )
-                            .foregroundStyle(Color.text)
-                            .padding(.leading, 16)
-                            .accessibilityLabel(Text(
-                                "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
-                                comment: """
-                                VoiceOver label for how many stops away a vehicle is from a stop,
-                                ex 'bus is 4 stops away from Harvard'
-                                """
-                            ))
-                            .accessibilityHint(stopsExpanded ? Text(
-                                "Hides remaining stops",
-                                comment: """
-                                Screen reader hint explaining what happens when 'x stops away'
-                                is selected when it's already open (closes the accordion listing those stops)
-                                """
-                            ) : Text(
-                                "Lists remaining stops",
-                                comment: """
-                                Screen reader hint explaining what happens when 'x stops away'
-                                is selected (open an accordion listing those stops)
-                                """
-                            ))
-                            .accessibilityAddTraits(.updatesFrequently)
-                            Spacer()
+                                Text(
+                                    "\(stopsAway, specifier: "%ld") stops away",
+                                    comment: "How many stops away the vehicle is from the target stop"
+                                )
+                                .foregroundStyle(Color.text)
+                                .padding(.leading, 16)
+                                .accessibilityLabel(Text(
+                                    "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
+                                    comment: """
+                                    VoiceOver label for how many stops away a vehicle is from a stop,
+                                    ex 'bus is 4 stops away from Harvard'
+                                    """
+                                ))
+                                .accessibilityHint(stopsExpanded ? Text(
+                                    "Hides remaining stops",
+                                    comment: """
+                                    Screen reader hint explaining what happens when 'x stops away'
+                                    is selected when it's already open (closes the accordion listing those stops)
+                                    """
+                                ) : Text(
+                                    "Lists remaining stops",
+                                    comment: """
+                                    Screen reader hint explaining what happens when 'x stops away'
+                                    is selected (open an accordion listing those stops)
+                                    """
+                                ))
+                                .accessibilityAddTraits(.updatesFrequently)
+                                Spacer()
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 56)
                         }
-                        .frame(maxWidth: .infinity, minHeight: 56)
-                    }
-                )
-                .disclosureGroupStyle(.tripDetails)
+                    )
+                    .disclosureGroupStyle(.tripDetails)
+                }
+                if let target, !hideTarget {
+                    // If the target is the first stop and there's no vehicle,
+                    // it's already displayed in the trip header
+                    TripStopRow(
+                        stop: target,
+                        now: now.toKotlinInstant(),
+                        onTapLink: onTapLink,
+                        onOpenAlertDetails: onOpenAlertDetails,
+                        routeAccents: routeAccents,
+                        alertSummaries: alertSummaries,
+                        showStationAccessibility: showStationAccessibility,
+                        targeted: true,
+                        firstStop: showFirstStopSeparately && target == stops.startTerminalEntry,
+                        background: Color.fill3
+                    )
+                }
+                stopList(list: splitStops.followingStops, showDownstreamAlerts: true)
             }
-            if let target, !hideTarget {
-                // If the target is the first stop and there's no vehicle,
-                // it's already displayed in the trip header
-                TripStopRow(
-                    stop: target,
-                    now: now.toKotlinInstant(),
-                    onTapLink: onTapLink,
-                    routeAccents: routeAccents,
-                    showStationAccessibility: showStationAccessibility,
-                    targeted: true,
-                    firstStop: showFirstStopSeparately && target == stops.startTerminalEntry
-                )
-                .background(Color.fill3)
+            .padding(.top, 56)
+            .overlay(alignment: .topLeading) {
+                if !showFirstStopSeparately {
+                    ColoredRouteLine(routeAccents.color).frame(maxHeight: 56).padding(.leading, 42)
+                }
             }
-            stopList(list: splitStops.followingStops)
         }
-        .padding(.top, 56)
-        .overlay(alignment: .topLeading) {
-            if !showFirstStopSeparately {
-                ColoredRouteLine(routeAccents.color).frame(maxHeight: 56).padding(.leading, 42)
-            }
-        }
-        .background(Color.fill2)
-        .clipShape(RoundedRectangle(cornerRadius: 8))
-        .padding(1)
-        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
         .padding(.horizontal, 10)
         .padding(.bottom, 48)
     }
+}
+
+#Preview {
+    let objects = ObjectCollectionBuilder()
+    let route = objects.route { route in
+        route.color = "FFC72C"
+        route.shortName = "109"
+        route.textColor = "000000"
+        route.type = .bus
+    }
+    let stops = (1 ... 10).map { index in
+        objects.stop { stop in
+            stop.name = "Stop \(index)"
+            stop.wheelchairBoarding = .accessible
+        }
+    }
+    let trip = objects.trip { _ in }
+    let now = Date.now
+    let alertStartIndex = 7
+    let alert = objects.alert { $0.effect = .shuttle }
+    let stopList = TripDetailsStopList(
+        tripId: trip.id,
+        stops: stops.enumerated().map { index, stop in
+            .init(
+                stop: stop,
+                stopSequence: Int32(index),
+                disruption: index >= alertStartIndex ? .init(alert: alert, iconName: "alert-borderless-suspension") :
+                    nil,
+                schedule: nil,
+                prediction: objects
+                    .prediction { $0.departureTime = (now + TimeInterval(2 * 60 * index)).toKotlinInstant() },
+                predictionStop: nil,
+                vehicle: nil,
+                routes: []
+            )
+        }
+    )
+
+    VStack {
+        TripStops(
+            targetId: stops[4].id,
+            stops: stopList,
+            stopSequence: 4,
+            headerSpec: .noVehicle,
+            now: now,
+            alertSummaries: [:],
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: .init(route: route),
+            showStationAccessibility: true,
+            global: .init(objects: objects)
+        )
+    }
+    .padding(12)
+    .font(Typography.body)
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -79,7 +79,8 @@ final class TripDetailsViewTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            stopDetailsVM: stopDetailsVM
+            stopDetailsVM: stopDetailsVM,
+            onOpenAlertDetails: { _ in }
         )
 
         let exp = sut.on(\.didLoadData) { view in
@@ -144,7 +145,8 @@ final class TripDetailsViewTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            stopDetailsVM: stopDetailsVM
+            stopDetailsVM: stopDetailsVM,
+            onOpenAlertDetails: { _ in }
         )
 
         let exp = sut.on(\.didLoadData) { view in
@@ -224,7 +226,8 @@ final class TripDetailsViewTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            stopDetailsVM: stopDetailsVM
+            stopDetailsVM: stopDetailsVM,
+            onOpenAlertDetails: { _ in }
         )
 
         let exp = sut.on(\.didLoadData) { view in
@@ -302,7 +305,8 @@ final class TripDetailsViewTests: XCTestCase {
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
             mapVM: .init(),
-            stopDetailsVM: stopDetailsVM
+            stopDetailsVM: stopDetailsVM,
+            onOpenAlertDetails: { _ in }
         )
 
         let newNavEntry: SheetNavigationStackEntry = .stopDetails(

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -37,7 +37,9 @@ final class TripStopRowTests: XCTestCase {
             ),
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
-            routeAccents: TripRouteAccents(route: route)
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:]
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: stop.name))
@@ -63,7 +65,9 @@ final class TripStopRowTests: XCTestCase {
             ),
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
-            routeAccents: TripRouteAccents(route: route)
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:]
         )
 
         XCTAssertNotNil(try sut.inspect().find(UpcomingTripView.self))
@@ -95,7 +99,9 @@ final class TripStopRowTests: XCTestCase {
             ),
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
-            routeAccents: .init(route: route)
+            onOpenAlertDetails: { _ in },
+            routeAccents: .init(route: route),
+            alertSummaries: [:]
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Track 7"))
@@ -122,7 +128,9 @@ final class TripStopRowTests: XCTestCase {
             ),
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             targeted: true
         )
 
@@ -138,7 +146,9 @@ final class TripStopRowTests: XCTestCase {
             ),
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
-            routeAccents: TripRouteAccents(route: route)
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:]
         )
 
         XCTAssertThrowsError(try notTargeted.inspect().find(ViewType.Image.self, where: { image in
@@ -168,7 +178,9 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
-            routeAccents: TripRouteAccents(route: route)
+            onOpenAlertDetails: { _ in },
+            routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:]
         )
         XCTAssertNotNil(try basicRow.inspect().find(viewWithAccessibilityLabel: "stop"))
 
@@ -176,7 +188,9 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             targeted: true
         )
         XCTAssertNotNil(try selectedRow.inspect().find(viewWithAccessibilityLabel: "stop, selected stop"))
@@ -185,7 +199,9 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             firstStop: true
         )
         XCTAssertNotNil(try firstRow.inspect().find(viewWithAccessibilityLabel: "stop, first stop"))
@@ -194,7 +210,9 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             targeted: true,
             firstStop: true
         )
@@ -228,7 +246,9 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             showStationAccessibility: true
         )
         XCTAssertNotNil(try row.inspect().find(viewWithTag: "wheelchair_not_accessible"))
@@ -265,10 +285,50 @@ final class TripStopRowTests: XCTestCase {
             stop: stopEntry,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
+            alertSummaries: [:],
             showStationAccessibility: true
         )
         XCTAssertNotNil(try row.inspect().find(viewWithTag: "elevator_alert"))
         XCTAssertNotNil(try row.inspect().find(viewWithAccessibilityLabel: "This stop has 1 elevator closed"))
+    }
+
+    func testAlertCard() throws {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let route = objects.route { _ in }
+        let alert = objects.alert { $0.effect = .shuttle }
+        let summary = AlertSummary(
+            effect: alert.effect,
+            location: AlertSummary
+                .LocationSuccessiveStops(startStopName: "Roxbury Crossing", endStopName: "Green Street"),
+            timeframe: AlertSummary.TimeframeTomorrow.shared
+        )
+
+        let entry = TripDetailsStopList.Entry(
+            stop: stop,
+            stopSequence: 0,
+            disruption: .init(alert: alert, mapStopRoute: .orange),
+            schedule: nil,
+            prediction: nil,
+            predictionStop: nil,
+            vehicle: nil,
+            routes: []
+        )
+
+        let sut = TripStopRow(
+            stop: entry,
+            now: now.toKotlinInstant(),
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: .init(route: route),
+            alertSummaries: [alert.id: summary],
+            showDownstreamAlert: true
+        )
+
+        XCTAssertNotNil(try sut.inspect()
+            .find(text: "Shuttle buses from Roxbury Crossing to Green Street through tomorrow"))
     }
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -99,7 +99,9 @@ final class TripStopsTests: XCTestCase {
             stopSequence: 1,
             headerSpec: .vehicle(vehicle, stop1, nil, false),
             now: now,
+            alertSummaries: [:],
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
             showStationAccessibility: false,
             global: .init(objects: objects)
@@ -180,7 +182,9 @@ final class TripStopsTests: XCTestCase {
             stopSequence: 0,
             headerSpec: TripHeaderSpec.vehicle(vehicle, stop1, nil, false),
             now: now,
+            alertSummaries: [:],
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
             showStationAccessibility: false,
             global: .init(objects: objects)
@@ -257,7 +261,9 @@ final class TripStopsTests: XCTestCase {
             stopSequence: 1,
             headerSpec: .scheduled(stop1, firstStop),
             now: now,
+            alertSummaries: [:],
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
             showStationAccessibility: false,
             global: .init(objects: objects)
@@ -340,7 +346,9 @@ final class TripStopsTests: XCTestCase {
             stopSequence: 3,
             headerSpec: .finishingAnotherTrip,
             now: now,
+            alertSummaries: [:],
             onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
             routeAccents: TripRouteAccents(route: route),
             showStationAccessibility: false,
             global: .init(objects: objects)
@@ -350,5 +358,203 @@ final class TripStopsTests: XCTestCase {
         XCTAssertNotNil(try firstRow.find(text: stop1.name))
         XCTAssert(try firstRow.actualView().firstStop)
         XCTAssertNotNil(try sut.inspect().find(text: "1 stop away"))
+    }
+
+    func testDownstreamAlert() {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route()
+        let pattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: pattern)
+
+        let stop1 = objects.stop { $0.name = "Stop A" }
+        let stop2Target = objects.stop { $0.name = "Stop B" }
+        let stop3 = objects.stop { $0.name = "Stop C" }
+
+        let alert = objects.alert { $0.effect = .stopClosure }
+
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.tripId = trip.id
+            vehicle.routeId = route.id
+            vehicle.currentStatus = .stoppedAt
+            vehicle.stopId = stop1.id
+        }
+
+        func makeSchedule(stop: Stop) -> Schedule {
+            objects.schedule { schedule in
+                schedule.routeId = route.id
+                schedule.stopId = stop.id
+                schedule.trip = trip
+            }
+        }
+
+        var predictionTime = now
+
+        func makePrediction(schedule: Schedule) -> Prediction {
+            predictionTime += 5
+            return objects.prediction(schedule: schedule) { prediction in
+                prediction.departureTime = predictionTime.toKotlinInstant()
+                prediction.vehicleId = vehicle.id
+            }
+        }
+
+        let schedule1 = makeSchedule(stop: stop1)
+        let prediction1 = makePrediction(schedule: schedule1)
+        let schedule2 = makeSchedule(stop: stop2Target)
+        let prediction2 = makePrediction(schedule: schedule2)
+        let schedule3 = makeSchedule(stop: stop3)
+        let prediction3 = makePrediction(schedule: schedule3)
+
+        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+            .init(
+                stop: stop1,
+                stopSequence: 1,
+                disruption: nil,
+                schedule: schedule1,
+                prediction: prediction1,
+                predictionStop: stop1,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+            .init(
+                stop: stop2Target,
+                stopSequence: 2,
+                disruption: nil,
+                schedule: schedule2,
+                prediction: prediction2,
+                predictionStop: stop2Target,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+            .init(
+                stop: stop3,
+                stopSequence: 3,
+                disruption: .init(alert: alert, mapStopRoute: nil),
+                schedule: schedule3,
+                prediction: prediction3,
+                predictionStop: stop3,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+        ])
+
+        let sut = TripStops(
+            targetId: stop2Target.id,
+            stops: stops,
+            stopSequence: 1,
+            headerSpec: .vehicle(vehicle, stop1, nil, false),
+            now: now,
+            alertSummaries: [alert.id: .init(
+                effect: alert.effect,
+                location: AlertSummary.LocationSingleStop(stopName: stop3.name),
+                timeframe: AlertSummary.TimeframeEndOfService.shared
+            )],
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: .init(route: route),
+            showStationAccessibility: false,
+            global: .init(objects: objects)
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Stop closed at Stop C through end of service"))
+    }
+
+    func testUpstreamAlert() {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route()
+        let pattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: pattern)
+
+        let stop1 = objects.stop { $0.name = "Stop A" }
+        let stop2Target = objects.stop { $0.name = "Stop B" }
+        let stop3 = objects.stop { $0.name = "Stop C" }
+
+        let alert = objects.alert { $0.effect = .stopClosure }
+
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.tripId = trip.id
+            vehicle.routeId = route.id
+            vehicle.currentStatus = .stoppedAt
+            vehicle.stopId = stop1.id
+        }
+
+        func makeSchedule(stop: Stop) -> Schedule {
+            objects.schedule { schedule in
+                schedule.routeId = route.id
+                schedule.stopId = stop.id
+                schedule.trip = trip
+            }
+        }
+
+        var predictionTime = now
+
+        func makePrediction(schedule: Schedule) -> Prediction {
+            predictionTime += 5
+            return objects.prediction(schedule: schedule) { prediction in
+                prediction.departureTime = predictionTime.toKotlinInstant()
+                prediction.vehicleId = vehicle.id
+            }
+        }
+
+        let schedule1 = makeSchedule(stop: stop1)
+        let prediction1 = makePrediction(schedule: schedule1)
+        let schedule2 = makeSchedule(stop: stop2Target)
+        let prediction2 = makePrediction(schedule: schedule2)
+        let schedule3 = makeSchedule(stop: stop3)
+        let prediction3 = makePrediction(schedule: schedule3)
+
+        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+            .init(
+                stop: stop1,
+                stopSequence: 1,
+                disruption: .init(alert: alert, mapStopRoute: nil),
+                schedule: schedule1,
+                prediction: prediction1,
+                predictionStop: stop1,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+            .init(
+                stop: stop2Target,
+                stopSequence: 2,
+                disruption: nil,
+                schedule: schedule2,
+                prediction: prediction2,
+                predictionStop: stop2Target,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+            .init(
+                stop: stop3,
+                stopSequence: 3,
+                disruption: nil,
+                schedule: schedule3,
+                prediction: prediction3,
+                predictionStop: stop3,
+                vehicle: vehicle,
+                routes: [route]
+            ),
+        ])
+
+        let sut = TripStops(
+            targetId: stop2Target.id,
+            stops: stops,
+            stopSequence: 1,
+            headerSpec: .vehicle(vehicle, stop1, nil, false),
+            now: now,
+            alertSummaries: [alert.id: .init(
+                effect: alert.effect,
+                location: AlertSummary.LocationSingleStop(stopName: stop1.name),
+                timeframe: AlertSummary.TimeframeEndOfService.shared
+            )],
+            onTapLink: { _ in },
+            onOpenAlertDetails: { _ in },
+            routeAccents: .init(route: route),
+            showStationAccessibility: false,
+            global: .init(objects: objects)
+        )
+
+        XCTAssertNil(try? sut.inspect().find(textWhere: { text, _ in text.contains("Stop closed") }))
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -56,8 +56,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
     fun splitForTarget(
         targetStopId: String,
         targetStopSequence: Int?,
-        globalData: GlobalResponse?,
-        truncateForDisruptions: Boolean
+        globalData: GlobalResponse?
     ): TargetSplit {
         val targetStopIndex =
             stops
@@ -94,7 +93,6 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             followingStops
                 .indexOfFirst { it.isTruncating() }
                 .takeUnless { it == -1 || it == followingStops.lastIndex }
-                .takeIf { truncateForDisruptions }
         val isTruncated = truncatedStopIndex != null
         val truncatedFollowingStops =
             if (truncatedStopIndex != null)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -828,7 +828,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("A", 10),
                 followingStops = listOf(entry("B", 20), entry("C", 30), entry("A", 40))
             ),
-            list.splitForTarget("A", 10, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("A", 10, globalData())
         )
         assertEquals(
             TripDetailsStopList.TargetSplit(
@@ -837,7 +837,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("A", 40),
                 followingStops = emptyList()
             ),
-            list.splitForTarget("A", 40, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("A", 40, globalData())
         )
     }
 
@@ -852,7 +852,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("A", 998),
                 followingStops = listOf(entry("B", 999))
             ),
-            list.splitForTarget("A", 3, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("A", 3, globalData())
         )
     }
 
@@ -868,7 +868,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("B1", 20),
                 followingStops = listOf(entry("C1", 30)),
             ),
-            list.splitForTarget("B2", 20, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("B2", 20, globalData())
         )
     }
 
@@ -883,7 +883,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("C", 30),
                 followingStops = listOf(entry("D", 40)),
             ),
-            list.splitForTarget("C", 30, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("C", 30, globalData())
         )
     }
 
@@ -911,7 +911,7 @@ class TripDetailsStopListTest {
                 targetStop = entry("C", 30, vehicle = vehicle),
                 followingStops = listOf(entry("D", 40, vehicle = vehicle)),
             ),
-            list.splitForTarget("C", 30, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("C", 30, globalData())
         )
     }
 
@@ -927,7 +927,7 @@ class TripDetailsStopListTest {
                 targetStop = null,
                 followingStops = list.stops
             ),
-            list.splitForTarget("D", 40, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("D", 40, globalData())
         )
     }
 
@@ -948,27 +948,7 @@ class TripDetailsStopListTest {
                 followingStops = listOf(entryB, entryC),
                 isTruncatedByLastAlert = true
             ),
-            list.splitForTarget("A", 10, globalData(), truncateForDisruptions = true)
-        )
-    }
-
-    @Test
-    fun `splitForTarget does not truncate if told not to`() = test {
-        val shuttleAlert = alert(Alert.Effect.Shuttle)
-        val entryA = entry("A", 10)
-        val entryB = entry("B", 20)
-        val entryC = entry("C", 30, alert = shuttleAlert)
-        val entryD = entry("D", 40, alert = shuttleAlert)
-        val list = stopListOf(entryA, entryB, entryC, entryD)
-        assertEquals(
-            TripDetailsStopList.TargetSplit(
-                firstStop = null,
-                collapsedStops = emptyList(),
-                targetStop = entryA,
-                followingStops = listOf(entryB, entryC, entryD),
-                isTruncatedByLastAlert = false
-            ),
-            list.splitForTarget("A", 10, globalData(), truncateForDisruptions = false)
+            list.splitForTarget("A", 10, globalData())
         )
     }
 
@@ -989,7 +969,7 @@ class TripDetailsStopListTest {
                 followingStops = listOf(entryB),
                 isTruncatedByLastAlert = true
             ),
-            list.splitForTarget("A", 10, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("A", 10, globalData())
         )
         assertEquals(
             TripDetailsStopList.TargetSplit(
@@ -998,7 +978,7 @@ class TripDetailsStopListTest {
                 targetStop = entryD,
                 followingStops = listOf(entryE)
             ),
-            list.splitForTarget("D", 40, globalData(), truncateForDisruptions = true)
+            list.splitForTarget("D", 40, globalData())
         )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display downstream shuttles & suspensions in trip details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209527076283977?focus=true)

The iOS version of #900.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added new unit tests for new functionality. Confirmed that existing unit tests aren’t broken by this (none of the relevant ones appear to be broken by Xcode 16.3).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
