### PR TITLE
chore(Android): back out downstream alert cards in trip details

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -546,7 +546,7 @@ class TripStopsTest {
 
         composeTestRule
             .onNodeWithText("Stop closed at Stop C through end of service")
-            .assertIsDisplayed()
+            .assertDoesNotExist()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -75,7 +75,7 @@ fun TripStops(
 
     val splitStops: TripDetailsStopList.TargetSplit =
         remember(targetId, stops, stopSequence, global) {
-            stops.splitForTarget(targetId, stopSequence, global, truncateForDisruptions = true)
+            stops.splitForTarget(targetId, stopSequence, global, truncateForDisruptions = false)
         }
 
     var stopsExpanded by rememberSaveable { mutableStateOf(false) }
@@ -101,7 +101,7 @@ fun TripStops(
     Box {
         Box(
             Modifier.matchParentSize()
-                .padding(4.dp)
+                .padding(horizontal = 4.dp)
                 .haloContainer(2.dp, backgroundColor = colorResource(R.color.fill2))
         )
         Column(
@@ -245,7 +245,7 @@ fun TripStops(
                 routeAccents,
                 alertSummaries,
                 showStationAccessibility,
-                showDownstreamAlerts = true
+                showDownstreamAlerts = false
             )
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display downstream shuttles & suspensions in trip details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209527076283977?focus=true) (kinda)

Since we want to get the next release out the door before we can QA #900 and #909, this is the lowest-footprint change that rolls back the effect of #900 in a way that’ll be easy to undo later.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Inverted the test that checks for downstream alerts being shown. Verified that downstream alerts are no longer shown in trip details.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
