### PR TITLE
ci: tweak a few things in response to merge queue

### DIFF
--- a/.github/workflows/android-staging-deploy.yaml
+++ b/.github/workflows/android-staging-deploy.yaml
@@ -6,16 +6,6 @@ on:
       - main
 
 jobs:
-  pre-commit:
-    name: Run pre-commit to check formatting and linting
-    permissions:
-      contents: read
-    uses: ./.github/workflows/pre-commit.yaml
-  test-android:
-    name: Test for Android
-    permissions:
-      contents: read
-    uses: ./.github/workflows/test-android.yaml
   build-android:
     name: Build for Android
     permissions:

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -34,6 +34,11 @@ on:
       SENTRY_DSN_ANDROID:
         required: true
 
+concurrency:
+  # non-deploy builds shouldn’t conflict, but builds for deployment can’t overlap or they’ll claim the same version number
+  group: build-android-${{ inputs.flavor }}${{ inputs.deploy && '' || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   build-android:
     name: Build for Android
@@ -84,9 +89,6 @@ jobs:
   deploy-android:
     name: Upload to Google Play
     if: ${{ inputs.deploy }}
-    concurrency:
-      group: deploy-android-${{ inputs.flavor }}
-      cancel-in-progress: false
     needs:
       - build-android
     runs-on: ubuntu-latest

--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -36,7 +36,7 @@ on:
 
 concurrency:
   # non-deploy builds shouldn’t conflict, but builds for deployment can’t overlap or they’ll claim the same version number
-  group: build-android-${{ inputs.flavor }}${{ inputs.deploy && '' || github.run_id }}
+  group: build-android-${{ inputs.flavor }}${{ inputs.deploy && '-deployment' || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -28,7 +28,7 @@ on:
 
 concurrency:
   # non-deploy builds shouldn’t conflict, but builds for deployment can’t overlap or they’ll claim the same version number
-  group: build-ios-${{ inputs.scheme }}${{ inputs.deploy && '' || github.run_id }}
+  group: build-ios-${{ inputs.scheme }}${{ inputs.deploy && '-deployment' || github.run_id }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -26,6 +26,11 @@ on:
       SENTRY_DSN_IOS:
         required: true
 
+concurrency:
+  # non-deploy builds shouldn’t conflict, but builds for deployment can’t overlap or they’ll claim the same version number
+  group: build-ios-${{ inputs.scheme }}${{ inputs.deploy && '' || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   build-ios:
     name: Build for iOS
@@ -90,9 +95,6 @@ jobs:
   deploy-ios:
     name: Upload to App Store
     if: ${{ inputs.deploy }}
-    concurrency:
-      group: deploy-ios-${{ inputs.scheme }}
-      cancel-in-progress: false
     needs:
       - build-ios
     runs-on: macos-14-xlarge


### PR DESCRIPTION
### Summary

_Ticket:_ [Try out GitHub merge queue](https://app.asana.com/1/15492006741476/project/1205991273035889/task/1209644129662966?focus=true)

Merge queue is working pretty nicely, but we don’t need to run the tests again as part of staging deploys, and the concurrency protections were set up before merge queue and contained some assumptions that aren’t valid anymore.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Not tested.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
