### PR TITLE
refactor(RouteCardData): Split out branching logic to support branching disruption cases

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.RealtimePatterns.Companion.formatUpcomingTrip
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.utils.resolveParentId
@@ -228,4 +229,20 @@ fun List<UpcomingTrip>.isArrivalOnly(): Boolean {
         .let { upcomingTripsArrivalOnly ->
             upcomingTripsArrivalOnly.contains(true) && !upcomingTripsArrivalOnly.contains(false)
         }
+}
+
+/**
+ * Associate each upcoming trip with its format. Omits any upcoming trip that shouldn't be shown.
+ */
+fun List<UpcomingTrip>.withFormat(
+    now: Instant,
+    routeType: RouteType,
+    context: TripInstantDisplay.Context,
+    limit: Int?
+): List<Pair<UpcomingTrip, UpcomingFormat.Some.FormattedTrip>> {
+    return this.mapNotNull {
+            val format = formatUpcomingTrip(now, it, routeType, context) ?: return@mapNotNull null
+            Pair(it, format)
+        }
+        .run { if (limit != null) take(limit) else this }
 }


### PR DESCRIPTION
…isruptions easier

### Summary

_Ticket:_ [🤖 | Group By Direction | Disruption on a branch](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209979069137605?focus=true)

What is this PR for?

This splits out the `Leaf.format` fn into helper functions with clear split paths for branched route vs. non-branched route handing. This makes it easier to add logic specific to branched cases for disruptions / predictions unavailable in https://github.com/mbta/mobile_app/pull/918

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Pure refactor, confirmed all tests still pass

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
