### PR TITLE
feat(iOS): group by direction in unfiltered stop details

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -613,7 +613,7 @@ fun stopDetailsManagedVM(
                             stopData?.predictionsLoaded == true
                     ) {
                         RouteCardData.routeCardsForStopList(
-                            globalResponse.getStop(stopId)?.childStopIds.orEmpty(),
+                            listOf(stopId) + globalResponse.getStop(stopId)?.childStopIds.orEmpty(),
                             globalResponse,
                             sortByDistanceFrom = null,
                             schedules,

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -21,8 +21,8 @@ struct StopDetailsView: View {
     var setTripFilter: (TripDetailsFilter?) -> Void
 
     var departures: StopDetailsDepartures?
+    var routeCardData: [RouteCardData]?
     var now: Date
-    var servedRoutes: [StopDetailsFilterPills.FilterBy] = []
 
     @ObservedObject var errorBannerVM: ErrorBannerViewModel
     @ObservedObject var nearbyVM: NearbyViewModel
@@ -38,6 +38,7 @@ struct StopDetailsView: View {
         setStopFilter: @escaping (StopDetailsFilter?) -> Void,
         setTripFilter: @escaping (TripDetailsFilter?) -> Void,
         departures: StopDetailsDepartures?,
+        routeCardData: [RouteCardData]?,
         now: Date,
         errorBannerVM: ErrorBannerViewModel,
         nearbyVM: NearbyViewModel,
@@ -50,22 +51,12 @@ struct StopDetailsView: View {
         self.setStopFilter = setStopFilter
         self.setTripFilter = setTripFilter
         self.departures = departures
+        self.routeCardData = routeCardData
         self.now = now
         self.errorBannerVM = errorBannerVM
         self.nearbyVM = nearbyVM
         self.mapVM = mapVM
         self.stopDetailsVM = stopDetailsVM
-
-        if let departures {
-            servedRoutes = departures.routes.map { patterns in
-                if let line = patterns.line {
-                    return .line(line)
-                }
-                return .route(
-                    patterns.representativeRoute
-                )
-            }
-        }
     }
 
     var body: some View {
@@ -83,16 +74,19 @@ struct StopDetailsView: View {
                 mapVM: mapVM,
                 stopDetailsVM: stopDetailsVM
             )
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
         } else {
             StopDetailsUnfilteredView(
                 stopId: stopId,
                 setStopFilter: setStopFilter,
                 departures: departures,
+                routeCardData: routeCardData,
                 now: now,
                 errorBannerVM: errorBannerVM,
                 nearbyVM: nearbyVM,
                 stopDetailsVM: stopDetailsVM
             )
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
         }
     }
 }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -107,6 +107,15 @@ class NearbyViewModel: ObservableObject {
         }
     }
 
+    /**
+     Set the route card data from the given stop if it is the last stop in the stack.
+     */
+    func setRouteCardData(_ stopId: String, _ newRouteCardData: [RouteCardData]?) {
+        if stopId == navigationStack.lastStopId {
+            routeCardData = newRouteCardData
+        }
+    }
+
     func isNearbyVisible() -> Bool {
         navigationStack.lastSafe() == .nearby
     }

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -172,7 +172,7 @@ class StopDetailsViewModel: ObservableObject {
     ) async -> [RouteCardData]? {
         if let global, let schedules = stopData?.schedules {
             try? await RouteCardData.companion.routeCardsForStopList(
-                stopIds: [stopId] + global.getStop(stopId: stopId)?.childStopIds ?? [],
+                stopIds: [stopId] + (global.getStop(stopId: stopId)?.childStopIds ?? []),
                 globalData: global,
                 sortByDistanceFrom: nil,
                 schedules: schedules,

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -164,6 +164,29 @@ class StopDetailsViewModel: ObservableObject {
         }
     }
 
+    func getRouteCardData(
+        stopId: String,
+        alerts: AlertsStreamDataResponse?,
+        now: Date,
+        isFiltered: Bool
+    ) async -> [RouteCardData]? {
+        if let global, let schedules = stopData?.schedules {
+            try? await RouteCardData.companion.routeCardsForStopList(
+                stopIds: [stopId] + global.getStop(stopId: stopId)?.childStopIds ?? [],
+                globalData: global,
+                sortByDistanceFrom: nil,
+                schedules: schedules,
+                predictions: stopData?.predictionsByStop?.toPredictionsStreamDataResponse(),
+                alerts: alerts,
+                now: now.toKotlinInstant(),
+                pinnedRoutes: pinnedRoutes,
+                context: isFiltered ? .stopDetailsFiltered : .stopDetailsUnfiltered
+            )
+        } else {
+            nil
+        }
+    }
+
     func getTripRouteAccents() -> TripRouteAccents {
         guard let routeId = tripData?.trip.routeId,
               let route = global?.getRoute(routeId: routeId)

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsUnfilteredViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsUnfilteredViewTests.swift
@@ -1,0 +1,290 @@
+//
+//  StopDetailsUnfilteredViewTests.swift
+//  iosApp
+//
+//  Created by Melody Horn on 4/24/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@MainActor final class StopDetailsUnfilteredViewTests: XCTestCase {
+    // can’t initialize these in place because can’t reference other instance variables while initializing, can’t
+    // override init for XCTestCase Swift interop reasons, no equivalent to Kotlin’s lateinit, must make these optional
+    // variables and then force-unwrap every time they’re used
+    var builder: ObjectCollectionBuilder?
+    var now: Date?
+    var route: Route?
+    var routePatternOne: RoutePattern?
+    var routePatternTwo: RoutePattern?
+    var stop: Stop?
+    var inaccessibleStop: Stop?
+    var globalResponse: GlobalResponse?
+
+    override func setUp() {
+        executionTimeAllowance = 60
+
+        builder = ObjectCollectionBuilder()
+        let now = Date.now
+        self.now = now
+        route = builder!.route { route in
+            route.id = "route_1"
+            route.type = .bus
+            route.color = "FF0000"
+            route.directionNames = ["North", "South"]
+            route.directionDestinations = ["Downtown", "Uptown"]
+            route.longName = "Sample Route Long Name"
+            route.shortName = "Sample Route"
+            route.textColor = "000000"
+            route.lineId = "line_1"
+            route.routePatternIds = ["pattern_1", "pattern_2"]
+        }
+        routePatternOne = builder!.routePattern(route: route!) { routePattern in
+            routePattern.id = "pattern_1"
+            routePattern.directionId = 0
+            routePattern.name = "Sample Route Pattern"
+            routePattern.routeId = "route_1"
+            routePattern.representativeTripId = "trip_1"
+        }
+        routePatternTwo = builder!.routePattern(route: route!) { routePattern in
+            routePattern.id = "pattern_2"
+            routePattern.directionId = 1
+            routePattern.name = "Sample Route Pattern Two"
+            routePattern.routeId = "route_1"
+            routePattern.representativeTripId = "trip_1"
+        }
+        stop = builder!.stop { stop in
+            stop.id = "stop_1"
+            stop.name = "Sample Stop"
+            stop.locationType = .stop
+            stop.latitude = 0.0
+            stop.longitude = 0.0
+            stop.wheelchairBoarding = .accessible
+        }
+        inaccessibleStop = builder!.stop { stop in
+            stop.id = "stop_2"
+            stop.name = "Inaccessible Stop"
+            stop.locationType = .stop
+            stop.latitude = 0.0
+            stop.longitude = 0.0
+            stop.wheelchairBoarding = .inaccessible
+        }
+        builder!.line { line in
+            line.id = "line_1"
+            line.color = "FF0000"
+            line.textColor = "FFFFFF"
+        }
+        builder!.trip { trip in
+            trip.id = "trip_1"
+            trip.routeId = "route_1"
+            trip.directionId = 0
+            trip.headsign = "Sample Headsign"
+            trip.routePatternId = "pattern_1"
+        }
+        builder!.prediction { prediction in
+            prediction.id = "prediction_1"
+            prediction.revenue = true
+            prediction.stopId = "stop_1"
+            prediction.tripId = "trip_1"
+            prediction.routeId = "route_1"
+            prediction.stopSequence = 1
+            prediction.directionId = 0
+            prediction.arrivalTime = (now + 60).toKotlinInstant()
+            prediction.departureTime = (now + 1.5 * 60).toKotlinInstant()
+        }
+
+        globalResponse = .init(
+            objects: builder!,
+            patternIdsByStop: [stop!.id: [routePatternOne!.id, routePatternTwo!.id]]
+        )
+    }
+
+    private let errorBannerViewModel = ErrorBannerViewModel(
+        errorRepository: MockErrorBannerStateRepository(),
+        settingsRepository: MockSettingsRepository(),
+        initialLoadingWhenPredictionsStale: false
+    )
+
+    func testStopDetailsRoutesViewDisplaysCorrectly() async throws {
+        let departures = try await StopDetailsDepartures.companion.fromData(
+            stop: stop!,
+            global: globalResponse!,
+            schedules: nil,
+            predictions: .init(objects: builder!),
+            alerts: .init(alerts: [:]),
+            pinnedRoutes: [],
+            filterAtTime: now!.toKotlinInstant()
+        )
+
+        let stopDetailsVM = StopDetailsViewModel()
+        stopDetailsVM.global = globalResponse!
+
+        let sut = StopDetailsUnfilteredView(
+            stopId: stop!.id,
+            setStopFilter: { _ in },
+            departures: departures,
+            routeCardData: nil,
+            now: now!,
+            errorBannerVM: errorBannerViewModel,
+            nearbyVM: .init(),
+            stopDetailsVM: stopDetailsVM
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Sample Route"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Sample Headsign"))
+        XCTAssertNotNil(try sut.inspect().find(text: "1 min"))
+        XCTAssertThrowsError(try sut.inspect().find(text: "This stop is not accessible"))
+    }
+
+    func testNotAccessibleStopDetails() async throws {
+        let departures = try await StopDetailsDepartures.companion.fromData(
+            stop: inaccessibleStop!,
+            global: globalResponse!,
+            schedules: nil,
+            predictions: .init(objects: builder!),
+            alerts: .init(alerts: [:]),
+            pinnedRoutes: [],
+            filterAtTime: now!.toKotlinInstant()
+        )
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.showStationAccessibility = true
+        let stopDetailsVM = StopDetailsViewModel()
+        stopDetailsVM.global = globalResponse!
+        stopDetailsVM.showStationAccessibility = true
+
+        let sut = StopDetailsUnfilteredView(
+            stopId: inaccessibleStop!.id,
+            setStopFilter: { _ in },
+            departures: departures,
+            routeCardData: nil,
+            now: now!,
+            errorBannerVM: errorBannerViewModel,
+            nearbyVM: nearbyVM,
+            stopDetailsVM: stopDetailsVM
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "This stop is not accessible"))
+        XCTAssertNotNil(try sut.inspect().find(viewWithTag: "wheelchair_not_accessible"))
+    }
+
+    func testGroupsByDirection() async throws {
+        let routeCardData = try await RouteCardData.companion.routeCardsForStopList(
+            stopIds: [stop!.id] + stop!.childStopIds,
+            globalData: globalResponse!,
+            sortByDistanceFrom: nil,
+            schedules: nil,
+            predictions: .init(objects: builder!),
+            alerts: .init(alerts: [:]),
+            now: now!.toKotlinInstant(),
+            pinnedRoutes: [],
+            context: .stopDetailsUnfiltered
+        )
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.groupByDirection = true
+        let stopDetailsVM = StopDetailsViewModel()
+        stopDetailsVM.global = globalResponse!
+
+        let sut = StopDetailsUnfilteredView(
+            stopId: stop!.id,
+            setStopFilter: { _ in },
+            departures: nil,
+            routeCardData: routeCardData,
+            now: now!,
+            errorBannerVM: errorBannerViewModel,
+            nearbyVM: nearbyVM,
+            stopDetailsVM: stopDetailsVM
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Sample Route"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Sample Headsign"))
+        XCTAssertNotNil(try sut.inspect().find(text: "1 min"))
+        XCTAssertThrowsError(try sut.inspect().find(text: "This stop is not accessible"))
+    }
+
+    func testInaccessibleByDirection() async throws {
+        let routeCardData = try await RouteCardData.companion.routeCardsForStopList(
+            stopIds: [inaccessibleStop!.id] + inaccessibleStop!.childStopIds,
+            globalData: globalResponse!,
+            sortByDistanceFrom: nil,
+            schedules: nil,
+            predictions: .init(objects: builder!),
+            alerts: .init(alerts: [:]),
+            now: now!.toKotlinInstant(),
+            pinnedRoutes: [],
+            context: .stopDetailsUnfiltered
+        )
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.showStationAccessibility = true
+        nearbyVM.groupByDirection = true
+        let stopDetailsVM = StopDetailsViewModel()
+        stopDetailsVM.global = globalResponse!
+        stopDetailsVM.showStationAccessibility = true
+
+        let sut = StopDetailsUnfilteredView(
+            stopId: inaccessibleStop!.id,
+            setStopFilter: { _ in },
+            departures: nil,
+            routeCardData: routeCardData,
+            now: now!,
+            errorBannerVM: errorBannerViewModel,
+            nearbyVM: nearbyVM,
+            stopDetailsVM: stopDetailsVM
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: "This stop is not accessible"))
+    }
+
+    func testShowsElevatorAlertsWhenGroupedByDirection() async throws {
+        let alert = builder!.clone().alert { alert in
+            alert.header = "Elevator alert"
+            alert.activePeriod(start: Date(timeIntervalSince1970: 0).toKotlinInstant(), end: nil)
+            alert.effect = .elevatorClosure
+            alert.informedEntity(
+                activities: [.usingWheelchair],
+                directionId: nil,
+                facility: nil,
+                route: nil,
+                routeType: nil,
+                stop: self.stop!.id,
+                trip: nil
+            )
+        }
+        let routeCardData = try await RouteCardData.companion.routeCardsForStopList(
+            stopIds: [stop!.id] + stop!.childStopIds,
+            globalData: globalResponse!,
+            sortByDistanceFrom: nil,
+            schedules: nil,
+            predictions: .init(objects: builder!),
+            alerts: .init(alerts: [alert.id: alert]),
+            now: now!.toKotlinInstant(),
+            pinnedRoutes: [],
+            context: .stopDetailsUnfiltered
+        )
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.showStationAccessibility = true
+        nearbyVM.groupByDirection = true
+        let stopDetailsVM = StopDetailsViewModel()
+        stopDetailsVM.global = globalResponse!
+        stopDetailsVM.showStationAccessibility = true
+
+        let sut = StopDetailsUnfilteredView(
+            stopId: stop!.id,
+            setStopFilter: { _ in },
+            departures: nil,
+            routeCardData: routeCardData,
+            now: now!,
+            errorBannerVM: errorBannerViewModel,
+            nearbyVM: nearbyVM,
+            stopDetailsVM: stopDetailsVM
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Elevator alert"))
+    }
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -41,9 +41,64 @@ final class StopDetailsViewTests: XCTestCase {
                 .init(route: routeDefaultSort1, stop: stop, patterns: [], elevatorAlerts: []),
                 .init(route: routeDefaultSort0, stop: stop, patterns: [], elevatorAlerts: []),
             ]),
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
+            mapVM: .init(),
+            stopDetailsVM: .init(
+                globalRepository: MockGlobalRepository(response: .init(objects: objects))
+            )
+        )
+
+        ViewHosting.host(view: sut)
+        let routePills = try sut.inspect().find(StopDetailsFilterPills.self).findAll(RoutePill.self)
+        XCTAssertEqual(2, routePills.count)
+        XCTAssertNotNil(try routePills[0].find(text: "Should be first"))
+        XCTAssertNotNil(try routePills[1].find(text: "Should be second"))
+    }
+
+    @MainActor func testFiltersInSameOrderAsRouteCardData() throws {
+        let objects = ObjectCollectionBuilder()
+        let routeDefaultSort0 = objects.route { route in
+            route.sortOrder = 0
+            route.type = .bus
+            route.shortName = "Should be second"
+        }
+        let routeDefaultSort1 = objects.route { route in
+            route.sortOrder = 1
+            route.type = .bus
+            route.shortName = "Should be first"
+        }
+        let stop = objects.stop { _ in }
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.groupByDirection = true
+
+        let sut = StopDetailsView(
+            stopId: stop.id,
+            stopFilter: nil,
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            departures: nil,
+            routeCardData: [
+                .init(
+                    lineOrRoute: RouteCardDataLineOrRouteRoute(route: routeDefaultSort1),
+                    stopData: [],
+                    context: .stopDetailsUnfiltered,
+                    at: Date.now.toKotlinInstant()
+                ),
+                .init(
+                    lineOrRoute: RouteCardDataLineOrRouteRoute(route: routeDefaultSort0),
+                    stopData: [],
+                    context: .stopDetailsUnfiltered,
+                    at: Date.now.toKotlinInstant()
+                ),
+            ],
+            now: Date.now,
+            errorBannerVM: .init(),
+            nearbyVM: nearbyVM,
             mapVM: .init(),
             stopDetailsVM: .init(
                 globalRepository: MockGlobalRepository(response: .init(objects: objects))
@@ -73,6 +128,7 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: [], elevatorAlerts: []),
             ]),
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
@@ -105,6 +161,7 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: [], elevatorAlerts: [alert]),
             ]),
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
@@ -139,6 +196,7 @@ final class StopDetailsViewTests: XCTestCase {
             departures: .init(routes: [
                 .init(route: route, stop: stop, patterns: [], elevatorAlerts: []),
             ]),
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: .init(),
@@ -166,6 +224,7 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
@@ -195,6 +254,7 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,
@@ -223,6 +283,7 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             departures: nil,
+            routeCardData: nil,
             now: Date.now,
             errorBannerVM: .init(),
             nearbyVM: nearbyVM,


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction |  Unfiltered Stop Details UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209912113394461?focus=true)

The iOS version of #853.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that grouping by direction works. Ported the Android unfiltered stop details tests to iOS including the old and the new behavior.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
