### PR TITLE
feat(Android): Reset nearby transit state after app has been backgrounded for over 1 hour

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -18,6 +18,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.network.MockPhoenixSocket
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import kotlin.math.abs
+import kotlinx.datetime.Clock
 import org.junit.Assert.fail
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
@@ -104,12 +105,14 @@ fun testKoinApplication(
     objects: ObjectCollectionBuilder = ObjectCollectionBuilder(),
     analytics: Analytics = MockAnalytics(),
     socket: PhoenixSocket = MockPhoenixSocket(),
+    clock: Clock = Clock.System,
     repositoryOverrides: MockRepositories.() -> Unit = {},
 ) = koinApplication {
     modules(
         module {
             single<Analytics> { analytics }
             single<PhoenixSocket> { socket }
+            single<Clock> { clock }
         },
         repositoriesModule(
             MockRepositories().apply {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -460,8 +460,7 @@ class NearbyTransitPageTest : KoinTest {
                                 MockSearchResultRepository(),
                                 VisitHistoryUsecase(MockVisitHistoryRepository())
                             ),
-                        bottomBar = {},
-                        clock = mockClock
+                        bottomBar = {}
                     )
                 }
             }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitPageTest.kt
@@ -427,6 +427,8 @@ class NearbyTransitPageTest : KoinTest {
             }
 
         val startLocation = Position(0.0, 0.0)
+        val locationDataManager = MockLocationDataManager(startLocation)
+        locationDataManager.hasPermission = true
 
         val koinApplication = testKoinApplication(builder, clock = mockClock)
 
@@ -448,7 +450,7 @@ class NearbyTransitPageTest : KoinTest {
                             nearbyTransitSelectingLocationState =
                                 remember { mutableStateOf(false) },
                             scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(startLocation),
+                            locationDataManager = locationDataManager,
                             viewportProvider = viewportProvider,
                         ),
                         false,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
@@ -40,6 +40,8 @@ import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.datetime.Clock
+import org.koin.compose.koinInject
 
 @Composable
 fun AlertDetailsPage(
@@ -48,11 +50,12 @@ fun AlertDetailsPage(
     routeIds: List<String>?,
     stopId: String?,
     alerts: AlertsStreamDataResponse?,
-    goBack: () -> Unit
+    goBack: () -> Unit,
+    clock: Clock = koinInject()
 ) {
     val alert = getAlert(alerts, alertId, goBack)
     val globalResponse = getGlobalData("AlertDetailsPage.loadGlobal")
-    val now by timer(5.seconds)
+    val now by timer(5.seconds, clock)
 
     val line = globalResponse?.getLine(lineId)
     val routes = routeIds?.mapNotNull { globalResponse?.getRoute(it) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
@@ -52,7 +52,7 @@ fun AlertDetailsPage(
 ) {
     val alert = getAlert(alerts, alertId, goBack)
     val globalResponse = getGlobalData("AlertDetailsPage.loadGlobal")
-    val now = timer(5.seconds)
+    val now by timer(5.seconds)
 
     val line = globalResponse?.getLine(lineId)
     val routes = routeIds?.mapNotNull { globalResponse?.getRoute(it) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
@@ -40,8 +40,6 @@ import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
-import org.koin.compose.koinInject
 
 @Composable
 fun AlertDetailsPage(
@@ -50,12 +48,11 @@ fun AlertDetailsPage(
     routeIds: List<String>?,
     stopId: String?,
     alerts: AlertsStreamDataResponse?,
-    goBack: () -> Unit,
-    clock: Clock = koinInject()
+    goBack: () -> Unit
 ) {
     val alert = getAlert(alerts, alertId, goBack)
     val globalResponse = getGlobalData("AlertDetailsPage.loadGlobal")
-    val now by timer(5.seconds, clock)
+    val now by timer(5.seconds)
 
     val line = globalResponse?.getLine(lineId)
     val routes = routeIds?.mapNotNull { globalResponse?.getRoute(it) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -76,6 +76,7 @@ import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.map
+import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 @Composable
@@ -92,6 +93,7 @@ fun HomeMapView(
     stopDetailsDepartures: StopDetailsDepartures?,
     viewModel: IMapViewModel,
     searchResultsViewModel: SearchResultsViewModel,
+    clock: Clock = koinInject()
 ) {
     var nearbyTransitSelectingLocation by nearbyTransitSelectingLocationState
     val previousNavEntry: SheetRoutes? = rememberPrevious(current = currentNavEntry)
@@ -113,7 +115,7 @@ fun HomeMapView(
         }
     val previousSelectedVehicleId = rememberPrevious(current = selectedVehicle?.id)
     val currentLocation by locationDataManager.currentLocation.collectAsState(initial = null)
-    val now by timer(updateInterval = 300.seconds)
+    val now by timer(updateInterval = 300.seconds, clock)
     val globalMapData by viewModel.globalMapData.collectAsState(null)
     val isDarkMode = isSystemInDarkTheme()
     val stopMapData: StopMapResponse? = selectedStop?.let { getStopMapData(stopId = it.id) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -76,7 +76,6 @@ import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.map
-import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 @Composable
@@ -92,8 +91,7 @@ fun HomeMapView(
     vehiclesData: List<Vehicle>,
     stopDetailsDepartures: StopDetailsDepartures?,
     viewModel: IMapViewModel,
-    searchResultsViewModel: SearchResultsViewModel,
-    clock: Clock = koinInject()
+    searchResultsViewModel: SearchResultsViewModel
 ) {
     var nearbyTransitSelectingLocation by nearbyTransitSelectingLocationState
     val previousNavEntry: SheetRoutes? = rememberPrevious(current = currentNavEntry)
@@ -115,7 +113,7 @@ fun HomeMapView(
         }
     val previousSelectedVehicleId = rememberPrevious(current = selectedVehicle?.id)
     val currentLocation by locationDataManager.currentLocation.collectAsState(initial = null)
-    val now by timer(updateInterval = 300.seconds, clock)
+    val now by timer(updateInterval = 300.seconds)
     val globalMapData by viewModel.globalMapData.collectAsState(null)
     val isDarkMode = isSystemInDarkTheme()
     val stopMapData: StopMapResponse? = selectedStop?.let { getStopMapData(stopId = it.id) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -113,7 +113,7 @@ fun HomeMapView(
         }
     val previousSelectedVehicleId = rememberPrevious(current = selectedVehicle?.id)
     val currentLocation by locationDataManager.currentLocation.collectAsState(initial = null)
-    val now = timer(updateInterval = 300.seconds)
+    val now by timer(updateInterval = 300.seconds)
     val globalMapData by viewModel.globalMapData.collectAsState(null)
     val isDarkMode = isSystemInDarkTheme()
     val stopMapData: StopMapResponse? = selectedStop?.let { getStopMapData(stopId = it.id) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -44,7 +44,6 @@ import com.mbta.tid.mbta_app.model.withRealtimeInfo
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -58,8 +57,7 @@ fun NearbyTransitView(
     onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
     noNearbyStopsView: @Composable () -> Unit,
     nearbyVM: NearbyTransitViewModel = koinViewModel(),
-    errorBannerViewModel: ErrorBannerViewModel,
-    clock: Clock = koinInject()
+    errorBannerViewModel: ErrorBannerViewModel
 ) {
     LaunchedEffect(null) { nearbyVM.loadSettings() }
 
@@ -73,7 +71,7 @@ fun NearbyTransitView(
             )
         }
     }
-    val now by timer(updateInterval = 5.seconds, clock)
+    val now by timer(updateInterval = 5.seconds)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
     val schedules = getSchedule(stopIds, "NearbyTransitView.getSchedule")
     val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -71,7 +71,7 @@ fun NearbyTransitView(
             )
         }
     }
-    val now = timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
     val schedules = getSchedule(stopIds, "NearbyTransitView.getSchedule")
     val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -44,6 +44,7 @@ import com.mbta.tid.mbta_app.model.withRealtimeInfo
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -57,7 +58,8 @@ fun NearbyTransitView(
     onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
     noNearbyStopsView: @Composable () -> Unit,
     nearbyVM: NearbyTransitViewModel = koinViewModel(),
-    errorBannerViewModel: ErrorBannerViewModel
+    errorBannerViewModel: ErrorBannerViewModel,
+    clock: Clock = koinInject()
 ) {
     LaunchedEffect(null) { nearbyVM.loadSettings() }
 
@@ -71,7 +73,7 @@ fun NearbyTransitView(
             )
         }
     }
-    val now by timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds, clock)
     val stopIds = remember(nearbyVM.nearby) { nearbyVM.nearby?.stopIds()?.toList() }
     val schedules = getSchedule(stopIds, "NearbyTransitView.getSchedule")
     val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -149,7 +149,7 @@ fun NearbyTransitPage(
 
     val (pinnedRoutes) = managePinnedRoutes()
 
-    val now by timer(updateInterval = 5.seconds, clock)
+    val now by timer(updateInterval = 5.seconds)
 
     fun updateStopFilter(stopId: String, stopFilter: StopDetailsFilter?) {
         viewModel.setStopFilter(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -132,7 +132,8 @@ fun NearbyTransitPage(
                     settingsRepository = koinInject()
                 )
         ),
-    visitHistoryUsecase: VisitHistoryUsecase = koinInject()
+    visitHistoryUsecase: VisitHistoryUsecase = koinInject(),
+    clock: Clock = koinInject()
 ) {
     LaunchedEffect(Unit) { errorBannerViewModel.activate() }
 
@@ -148,7 +149,7 @@ fun NearbyTransitPage(
 
     val (pinnedRoutes) = managePinnedRoutes()
 
-    val now by timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds, clock)
 
     fun updateStopFilter(stopId: String, stopFilter: StopDetailsFilter?) {
         viewModel.setStopFilter(
@@ -290,7 +291,7 @@ fun NearbyTransitPage(
     var backgroundTimestamp: Long? by rememberSaveable { mutableStateOf(null) }
     LifecycleResumeEffect(null) {
         backgroundTimestamp?.let {
-            val timeSinceBackground = Clock.System.now().minus(Instant.fromEpochMilliseconds(it))
+            val timeSinceBackground = clock.now().minus(Instant.fromEpochMilliseconds(it))
             if (timeSinceBackground > 1.hours) {
                 navController.navigate(SheetRoutes.NearbyTransit) {
                     popUpTo(navController.graph.id) { inclusive = true }
@@ -299,7 +300,7 @@ fun NearbyTransitPage(
             }
         }
         backgroundTimestamp = null
-        onPauseOrDispose { backgroundTimestamp = Clock.System.now().toEpochMilliseconds() }
+        onPauseOrDispose { backgroundTimestamp = clock.now().toEpochMilliseconds() }
     }
 
     LaunchedEffect(mapViewModel.lastMapboxErrorTimestamp.collectAsState(initial = null).value) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -296,7 +296,9 @@ fun NearbyTransitPage(
                 navController.navigate(SheetRoutes.NearbyTransit) {
                     popUpTo(navController.graph.id) { inclusive = true }
                 }
-                nearbyTransit.viewportProvider.follow()
+                if (nearbyTransit.locationDataManager.hasPermission) {
+                    nearbyTransit.viewportProvider.follow()
+                }
             }
         }
         backgroundTimestamp = null

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
@@ -81,13 +82,15 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.reflect.typeOf
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -282,6 +285,21 @@ fun NearbyTransitPage(
 
     fun openSearch() {
         searchFocusRequester.requestFocus()
+    }
+
+    var backgroundTimestamp: Long? by rememberSaveable { mutableStateOf(null) }
+    LifecycleResumeEffect(null) {
+        backgroundTimestamp?.let {
+            val timeSinceBackground = Clock.System.now().minus(Instant.fromEpochMilliseconds(it))
+            if (timeSinceBackground > 1.hours) {
+                navController.navigate(SheetRoutes.NearbyTransit) {
+                    popUpTo(navController.graph.id) { inclusive = true }
+                }
+                nearbyTransit.viewportProvider.follow()
+            }
+        }
+        backgroundTimestamp = null
+        onPauseOrDispose { backgroundTimestamp = Clock.System.now().toEpochMilliseconds() }
     }
 
     LaunchedEffect(mapViewModel.lastMapboxErrorTimestamp.collectAsState(initial = null).value) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -148,7 +148,7 @@ fun NearbyTransitPage(
 
     val (pinnedRoutes) = managePinnedRoutes()
 
-    val now = timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds)
 
     fun updateStopFilter(stopId: String, stopFilter: StopDetailsFilter?) {
         viewModel.setStopFilter(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.state
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.LifecycleResumeEffect
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 import org.koin.core.component.KoinComponent
 
@@ -162,14 +164,15 @@ fun subscribeToPredictions(
     stopIds: List<String>?,
     predictionsRepository: IPredictionsRepository = koinInject(),
     errorBannerViewModel: ErrorBannerViewModel,
-    checkPredictionsStaleInterval: Duration = 5.seconds
+    checkPredictionsStaleInterval: Duration = 5.seconds,
+    clock: Clock = koinInject()
 ): PredictionsViewModel {
     val viewModel: PredictionsViewModel =
         viewModel(
             factory = PredictionsViewModel.Factory(predictionsRepository, errorBannerViewModel)
         )
 
-    val timer = timer(checkPredictionsStaleInterval)
+    val timer by timer(checkPredictionsStaleInterval, clock)
 
     LifecycleResumeEffect(key1 = stopIds) {
         CoroutineScope(Dispatchers.IO).launch {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToPredictions.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 import org.koin.core.component.KoinComponent
 
@@ -164,15 +163,14 @@ fun subscribeToPredictions(
     stopIds: List<String>?,
     predictionsRepository: IPredictionsRepository = koinInject(),
     errorBannerViewModel: ErrorBannerViewModel,
-    checkPredictionsStaleInterval: Duration = 5.seconds,
-    clock: Clock = koinInject()
+    checkPredictionsStaleInterval: Duration = 5.seconds
 ): PredictionsViewModel {
     val viewModel: PredictionsViewModel =
         viewModel(
             factory = PredictionsViewModel.Factory(predictionsRepository, errorBannerViewModel)
         )
 
-    val timer by timer(checkPredictionsStaleInterval, clock)
+    val timer by timer(checkPredictionsStaleInterval)
 
     LifecycleResumeEffect(key1 = stopIds) {
         CoroutineScope(Dispatchers.IO).launch {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -35,7 +35,7 @@ fun StopDetailsView(
     openSheetRoute: (SheetRoutes) -> Unit,
     errorBannerViewModel: ErrorBannerViewModel
 ) {
-    val now = timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds)
     val analytics: Analytics = koinInject()
 
     val departures by viewModel.stopDepartures.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 @Composable
@@ -34,10 +33,9 @@ fun StopDetailsView(
     tileScrollState: ScrollState,
     openModal: (ModalRoutes) -> Unit,
     openSheetRoute: (SheetRoutes) -> Unit,
-    errorBannerViewModel: ErrorBannerViewModel,
-    clock: Clock = koinInject()
+    errorBannerViewModel: ErrorBannerViewModel
 ) {
-    val now by timer(updateInterval = 5.seconds, clock)
+    val now by timer(updateInterval = 5.seconds)
     val analytics: Analytics = koinInject()
 
     val departures by viewModel.stopDepartures.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -15,6 +15,7 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 @Composable
@@ -33,9 +34,10 @@ fun StopDetailsView(
     tileScrollState: ScrollState,
     openModal: (ModalRoutes) -> Unit,
     openSheetRoute: (SheetRoutes) -> Unit,
-    errorBannerViewModel: ErrorBannerViewModel
+    errorBannerViewModel: ErrorBannerViewModel,
+    clock: Clock = koinInject()
 ) {
-    val now by timer(updateInterval = 5.seconds)
+    val now by timer(updateInterval = 5.seconds, clock)
     val analytics: Analytics = koinInject()
 
     val departures by viewModel.stopDepartures.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.koin.androidx.compose.koinViewModel
+import org.koin.compose.koinInject
 
 class StopDetailsViewModel(
     private val errorBannerRepository: IErrorBannerStateRepository,
@@ -532,13 +533,15 @@ fun stopDetailsManagedVM(
     updateStopFilter: (String, StopDetailsFilter?) -> Unit,
     updateTripFilter: (String, TripDetailsFilter?) -> Unit,
     setMapSelectedVehicle: (Vehicle?) -> Unit,
-    now: Instant = Clock.System.now(),
+    now: Instant? = null,
     viewModel: StopDetailsViewModel = koinViewModel(),
     checkPredictionsStaleInterval: Duration = 5.seconds,
-    coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default
+    coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    clock: Clock = koinInject()
 ): StopDetailsViewModel {
+    val now = now ?: clock.now()
     val stopId = filters?.stopId
-    val timer = timer(checkPredictionsStaleInterval)
+    val timer by timer(checkPredictionsStaleInterval, clock)
 
     val stopData by viewModel.stopData.collectAsState()
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -541,7 +541,7 @@ fun stopDetailsManagedVM(
 ): StopDetailsViewModel {
     val now = now ?: clock.now()
     val stopId = filters?.stopId
-    val timer by timer(checkPredictionsStaleInterval, clock)
+    val timer by timer(checkPredictionsStaleInterval)
 
     val stopData by viewModel.stopData.collectAsState()
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.util
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
@@ -45,7 +46,7 @@ class TimerViewModel(tickInterval: Duration) : ViewModel() {
 }
 
 @Composable
-fun timer(updateInterval: Duration = 5.seconds): Instant {
+fun timer(updateInterval: Duration = 5.seconds): State<Instant> {
     val viewModel: TimerViewModel = remember { TimerViewModel(updateInterval) }
-    return viewModel.timerFlow.collectAsState(initial = Clock.System.now()).value
+    return viewModel.timerFlow.collectAsState(initial = Clock.System.now())
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.koin.compose.koinInject
 
 class ClockTickHandler {
     companion object {
@@ -46,7 +47,7 @@ class TimerViewModel(tickInterval: Duration, clock: Clock) : ViewModel() {
 }
 
 @Composable
-fun timer(updateInterval: Duration = 5.seconds, clock: Clock): State<Instant> {
+fun timer(updateInterval: Duration = 5.seconds, clock: Clock = koinInject()): State<Instant> {
     val viewModel: TimerViewModel = remember { TimerViewModel(updateInterval, clock) }
     return viewModel.timerFlow.collectAsState(initial = clock.now())
 }

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
@@ -4,12 +4,14 @@ import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.network.NetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.utils.AndroidSystemPaths
 import com.mbta.tid.mbta_app.utils.SystemPaths
+import kotlinx.datetime.Clock
 import org.koin.dsl.module
 
 fun platformModule() = module {
     includes(
         module { single { createDataStore(get()) } },
         module { single<SystemPaths> { AndroidSystemPaths(get()) } },
-        module { single<INetworkConnectivityMonitor> { NetworkConnectivityMonitor(get()) } }
+        module { single<INetworkConnectivityMonitor> { NetworkConnectivityMonitor(get()) } },
+        module { single<Clock> { Clock.System } }
     )
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Android recenter button bug](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209802459425032?focus=true)

Follow up to #908 

When the app goes to background, remember the timestamp, then the next time it comes back to the foreground, check how long ago it was backgrounded. If it was over an hour ago, clear the navigation stack, and follow the user's current location.

In order to test this, I needed to start injecting `Clock.System` with koin, this is recommended by the [kotlin docs](https://kotlinlang.org/api/kotlinx-datetime/kotlinx-datetime/kotlinx.datetime/-clock/-system/) to make usage of clocks more testable, but it required a bit of refactoring. 

I also switched the `timer` helper to return the state object rather than a single value, because I noticed that the value of `now` was not being updated in the `LifecycleResumeEffect` I added (though I didn't end up actually using `now` there and just call `clock.now()` directly).

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a unit test that checks that the state is reset after 1 hour of backgrounding