### PR TITLE
fix(Android): Add padding to unfiltered stop details route cards

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavDrilldownRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavDrilldownRow.kt
@@ -29,11 +29,11 @@ fun NavDrilldownRow(
     content: @Composable RowScope.(Modifier) -> Unit
 ) {
     Row(
-        modifier
-            .background(color = MaterialTheme.colorScheme.background)
+        Modifier.background(color = MaterialTheme.colorScheme.background)
             .fillMaxWidth()
             .minimumInteractiveComponentSize()
-            .clickable(onClickLabel = onClickLabel, onClick = onClick),
+            .clickable(onClickLabel = onClickLabel, onClick = onClick)
+            .then(modifier),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -77,7 +77,8 @@ fun StopDetailsUnfilteredRoutesView(
         onClose,
         onTapRoutePill,
         updateStopFilter,
-        openModal
+        openModal,
+        groupByDirection = false
     ) {
         items(departures.routes, key = { it.routeIdentifier }) { patternsByStop ->
             StopDetailsRouteView(
@@ -116,7 +117,8 @@ fun StopDetailsUnfilteredRoutesView(
         onClose,
         onTapRoutePill,
         updateStopFilter,
-        openModal
+        openModal,
+        groupByDirection = true
     ) {
         items(routeCardData, key = { it.lineOrRoute.id }) { routeCardData ->
             RouteCard(
@@ -143,12 +145,13 @@ private fun Layout(
     onTapRoutePill: (PillFilter) -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,
     openModal: (ModalRoutes) -> Unit,
-    body: LazyListScope.() -> Unit,
+    groupByDirection: Boolean,
+    body: LazyListScope.() -> Unit
 ) {
     val hasAccessibilityWarning = elevatorAlerts.isNotEmpty() || !stop.isWheelchairAccessible
     Column(
         Modifier.background(colorResource(R.color.fill2)),
-        verticalArrangement = Arrangement.spacedBy(0.dp)
+        verticalArrangement = Arrangement.spacedBy(0.dp),
     ) {
         Column(Modifier.heightIn(min = 48.dp)) {
             SheetHeader(onClose = onClose, title = stop.name)
@@ -170,13 +173,19 @@ private fun Layout(
                 Modifier.fillMaxWidth().zIndex(1f).border(2.dp, colorResource(R.color.halo))
             )
             LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(0.dp),
-                contentPadding = PaddingValues(top = 16.dp)
+                verticalArrangement =
+                    if (groupByDirection) Arrangement.spacedBy(14.dp)
+                    else Arrangement.spacedBy(0.dp),
+                contentPadding =
+                    if (groupByDirection)
+                        PaddingValues(start = 15.dp, top = 17.dp, end = 15.dp, bottom = 16.dp)
+                    else PaddingValues(top = 16.dp)
             ) {
                 if (showStationAccessibility && hasAccessibilityWarning) {
                     item {
                         Column(
-                            Modifier.padding(bottom = 14.dp, start = 14.dp, end = 14.dp),
+                            if (groupByDirection) Modifier
+                            else Modifier.padding(bottom = 14.dp, start = 14.dp, end = 14.dp),
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             if (elevatorAlerts.isNotEmpty()) {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Group by direction | Unfiltered stop details padding](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210024591221884?focus=true)

Fix padding on direction grouped unfiltered stop details, including for accessibility alerts. Also snuck in a fix for the clickable fill color not including the padding around the `NavDrilldownRow`.

![Screenshot_20250424_153353](https://github.com/user-attachments/assets/3e001659-b7c1-484d-953c-b2d29303b91d) ![Screenshot_20250424_155010](https://github.com/user-attachments/assets/aecf1dfe-42d4-4438-bddd-290e1d2c4843)



android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Used screenshots to verify that these paddings match the spacing in direction grouped nearby transit.