### PR TITLE
feat(RouteCardData): Disruption on branch cases

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -316,6 +316,13 @@ class Previews() {
             name = "Boylston"
             wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
         }
+
+    val kenmore =
+        objects.stop {
+            id = "place-kencl"
+            name = "Kenmore"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
     val somervilleAtCarlton =
         objects.stop {
             name = "Somerville Ave @ Carlton St"
@@ -1337,14 +1344,27 @@ class Previews() {
     @Preview(name = "Disruption on a branch", group = "A. Disruption")
     @Composable
     fun GL5() {
+
+        val kenmoreShuttleToRiverside =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = kenmore.id,
+                            trip = null
+                        )
+                    )
+            }
+
         CardForPreview(
             card(
                 greenLine,
-                objects.stop {
-                    id = "place-kencl"
-                    name = "Kenmore"
-                    wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-                },
+                kenmore,
                 listOf(
                     objects.upcomingTrip(
                         objects.prediction {
@@ -1360,12 +1380,6 @@ class Previews() {
                     ),
                     objects.upcomingTrip(
                         objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
                             trip = objects.trip(greenLineBEastbound)
                             departureTime = now + 6.minutes
                         }
@@ -1377,7 +1391,7 @@ class Previews() {
                         }
                     ),
                 ),
-                alertHere = mapOf(0 to shuttleAlert)
+                alertHere = mapOf(0 to kenmoreShuttleToRiverside)
             )
         )
     }
@@ -1388,6 +1402,22 @@ class Previews() {
     )
     @Composable
     fun GL6() {
+
+        val boylstonShuttleToRiverside =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        )
+                    )
+            }
         CardForPreview(
             card(
                 greenLine,
@@ -1407,12 +1437,6 @@ class Previews() {
                     ),
                     objects.upcomingTrip(
                         objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
                             trip = objects.trip(greenLineBEastbound)
                             departureTime = now + 6.minutes
                         }
@@ -1424,7 +1448,7 @@ class Previews() {
                         }
                     ),
                 ),
-                alertHere = mapOf(0 to shuttleAlert)
+                alertHere = mapOf(0 to boylstonShuttleToRiverside)
             )
         )
     }
@@ -1432,31 +1456,64 @@ class Previews() {
     @Preview(name = "Disruption on all branches", group = "A. Disruption")
     @Composable
     fun GL7() {
+
+        val shuttleAllBranches =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineB.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        ),
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineC.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        ),
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        )
+                    )
+            }
+
         CardForPreview(
             card(
                 greenLine,
                 boylston,
                 listOf(
                     objects.upcomingTrip(
-                        objects.prediction {
+                        objects.schedule {
                             trip = objects.trip(greenLineDEastbound)
                             departureTime = now + 1.minutes
                         }
                     ),
                     objects.upcomingTrip(
-                        objects.prediction {
+                        objects.schedule {
                             trip = objects.trip(greenLineBEastbound)
                             departureTime = now + 6.minutes
                         }
                     ),
                     objects.upcomingTrip(
-                        objects.prediction {
+                        objects.schedule {
                             trip = objects.trip(greenLineCEastbound)
                             departureTime = now + 12.minutes
                         }
                     ),
                 ),
-                alertHere = mapOf(0 to shuttleAlert)
+                alertHere = mapOf(0 to shuttleAllBranches)
             )
         )
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1033,7 +1033,8 @@ data class RouteCardData(
                 this.upcomingTrips ?: emptyList(),
                 checkNotNull(alertsHere),
                 allDataLoaded ?: false,
-                hasSchedulesTodayByPattern ?: routePatterns!!.associate { it.id to false },
+                hasSchedulesTodayByPattern
+                    ?: checkNotNull(routePatterns).associate { it.id to false },
                 checkNotNull(alertsDownstream)
             )
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -143,7 +143,8 @@ data class RouteCardData(
             upcomingTrips,
             alertsHere,
             allDataLoaded,
-            mapOf((routePatterns.firstOrNull()?.id ?: "fakeId") to hasSchedulesToday),
+            if (routePatterns.isEmpty()) mapOf("fakeId" to hasSchedulesToday)
+            else routePatterns.associate { it.id to hasSchedulesToday },
             alertsDownstream
         )
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -221,7 +221,6 @@ data class RouteCardData(
             val routePatterns: List<RoutePattern>,
             val hasSchedulesToday: Boolean,
             val allUpcomingTrips: List<UpcomingTrip>,
-            val upcomingTripsToShow: List<Pair<UpcomingTrip, UpcomingFormat.Some.FormattedTrip>>,
             val majorAlert: Alert?
         )
 
@@ -231,7 +230,6 @@ data class RouteCardData(
          */
         private fun dataByHeadsign(
             potentialHeadsigns: Set<String>,
-            tripsWithFormat: List<Pair<UpcomingTrip, UpcomingFormat.Some.FormattedTrip>>,
             globalData: GlobalResponse?
         ): Map<String, ByHeadsignData> {
             return potentialHeadsigns
@@ -270,7 +268,6 @@ data class RouteCardData(
                                 .filterKeys { it in routePatternIds }
                                 .any { it.value },
                             upcomingTrips.filter { it.headsign == headsign },
-                            tripsWithFormat.filter { it.first.headsign == headsign },
                             majorAlert.firstOrNull()
                         )
                 }
@@ -302,7 +299,7 @@ data class RouteCardData(
             // show the route alongside the UpcomingTripFormat
             val shouldIncludeRoute = routePatterns.distinctBy { it.routeId }.size > 1
 
-            val dataByHeadsign = dataByHeadsign(potentialHeadsigns, tripsWithFormat, globalData)
+            val dataByHeadsign = dataByHeadsign(potentialHeadsigns, globalData)
             val (nonDisruptedHeadsigns, disruptedHeadsigns) =
                 dataByHeadsign.entries.partition { it.value.majorAlert == null }
 
@@ -374,8 +371,6 @@ data class RouteCardData(
                 if (remainingRowsToShow > 0) {
                     nonDisruptedHeadsigns
                         .sortedBy { it.value.routePatterns.minOf { pattern -> pattern.sortOrder } }
-                        .filter { it.value.upcomingTripsToShow.isEmpty() }
-                        .take(remainingRowsToShow)
                         .mapNotNull { (headsign, groupedData) ->
                             val route =
                                 if (shouldIncludeRoute)
@@ -400,6 +395,7 @@ data class RouteCardData(
                                 null
                             }
                         }
+                        .take(remainingRowsToShow)
                 } else {
                     emptyList()
                 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.model.RouteCardDataLeafTest.RedLine.route
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.parametric.ParametricTest
 import com.mbta.tid.mbta_app.parametric.parametricTest
@@ -508,42 +507,95 @@ class RouteCardDataLeafTest {
             lateinit var north2: Stop
             val parent =
                 objects.stop {
-                    south1 = childStop()
-                    south2 = childStop()
-                    north1 = childStop()
-                    north2 = childStop()
+                    south1 = childStop { id = "south1" }
+                    south2 = childStop { id = "south2" }
+                    north1 = childStop { id = "north1" }
+                    north2 = childStop { id = "north2" }
                 }
             return Stop4(parent, south1, south2, north1, north2)
         }
 
         val jfkUmass = stop4()
+        // braintree stops
+        val northQuincy = objects.stop()
+        val wollaston = objects.stop()
+        val quincyCenter = objects.stop()
+        val quincyAdams = objects.stop()
+        val braintree = objects.stop()
+
+        val stopsBraintreeBranchSouth =
+            listOf(jfkUmass.south2, northQuincy, wollaston, quincyCenter, quincyAdams, braintree)
+
+        val stopsBraintreeBranchNorth =
+            listOf(
+                braintree,
+                quincyAdams,
+                quincyCenter,
+                wollaston,
+                northQuincy,
+                jfkUmass.north2,
+            )
+
+        // ashmont Stops
+        val savinHill = objects.stop()
+        val fieldsCorner = objects.stop()
+        val shawmut = objects.stop()
+        val ashmont = objects.stop()
+
+        val stopsAshmontBranchSouth =
+            listOf(
+                jfkUmass.south1,
+                savinHill,
+                fieldsCorner,
+                shawmut,
+                ashmont,
+            )
+
+        val stopsAshmontBranchNorth =
+            listOf(ashmont, shawmut, fieldsCorner, savinHill, jfkUmass.north1)
 
         val ashmontSouth =
             objects.routePattern(route) {
                 directionId = 0
+                routeId = route.id
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Ashmont" }
+                representativeTrip {
+                    headsign = "Ashmont"
+                    stopIds = stopsAshmontBranchSouth.map { it.id }
+                }
             }
 
         val braintreeSouth =
             objects.routePattern(route) {
                 directionId = 0
+                routeId = route.id
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Braintree" }
+                representativeTrip {
+                    headsign = "Braintree"
+                    stopIds = stopsBraintreeBranchSouth.map { it.id }
+                }
             }
 
         val ashmontNorth =
             objects.routePattern(route) {
                 directionId = 1
+                routeId = route.id
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Alewife" }
+                representativeTrip {
+                    headsign = "Alewife"
+                    stopIds = stopsAshmontBranchNorth.map { it.id }
+                }
             }
 
         val braintreeNorth =
             objects.routePattern(route) {
                 directionId = 1
+                routeId = route.id
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Alewife" }
+                representativeTrip {
+                    headsign = "Alewife"
+                    stopIds = stopsBraintreeBranchNorth.map { it.id }
+                }
             }
 
         val global = GlobalResponse(objects)
@@ -799,105 +851,114 @@ class RouteCardDataLeafTest {
     }
 
     @Test
-    fun `formats Red Line southbound as non-branching if one branch is closed`() = parametricTest {
-        // ⚠ Southbound to Ashmont 3 min 12 min
-        val objects = RedLine.objects()
-        val now = Clock.System.now()
+    fun `formats Red Line southbound as branching with Braintree suspended from JFK`() =
+        parametricTest {
+            // ⚠ Southbound to Ashmont 3 min 12 min
+            val objects = RedLine.objects()
+            val now = Clock.System.now()
 
-        val northQuincy = objects.stop()
-        val wollaston = objects.stop()
-        val quincyCenter = objects.stop()
-        val quincyAdams = objects.stop()
-        val braintree = objects.stop()
+            val prediction1 =
+                objects.prediction {
+                    arrivalTime = now + 3.minutes
+                    departureTime = arrivalTime
+                    trip = objects.trip(RedLine.ashmontSouth)
+                    stopId = RedLine.jfkUmass.south1.id
+                }
 
-        val stopsBraintreeBranch =
-            listOf(
-                RedLine.jfkUmass.south2,
-                northQuincy,
-                wollaston,
-                quincyCenter,
-                quincyAdams,
-                braintree
-            )
-        val prediction1 =
-            objects.prediction {
-                arrivalTime = now + 3.minutes
-                departureTime = arrivalTime
-                trip = objects.trip(RedLine.ashmontSouth)
-                stopId = RedLine.jfkUmass.south1.id
-            }
+            val prediction2 =
+                objects.prediction {
+                    arrivalTime = now + 12.minutes
+                    departureTime = arrivalTime
+                    trip = objects.trip(RedLine.ashmontSouth)
+                    stopId = RedLine.jfkUmass.south1.id
+                }
 
-        val prediction2 =
-            objects.prediction {
-                arrivalTime = now + 12.minutes
-                departureTime = arrivalTime
-                trip = objects.trip(RedLine.ashmontSouth)
-                stopId = RedLine.jfkUmass.south1.id
-            }
+            val alert =
+                objects.alert {
+                    effect = Alert.Effect.Suspension
+                    informedEntity =
+                        RedLine.stopsBraintreeBranchSouth
+                            .map {
+                                Alert.InformedEntity(
+                                    activities = listOf(Alert.InformedEntity.Activity.Board),
+                                    directionId = 0,
+                                    route = RedLine.route.id,
+                                    routeType = RouteType.HEAVY_RAIL,
+                                    stop = it.id,
+                                    trip = null
+                                )
+                            }
+                            .toMutableList()
+                }
 
-        val alert =
-            objects.alert {
-                effect = Alert.Effect.Suspension
-                informedEntity =
-                    stopsBraintreeBranch
-                        .map {
-                            Alert.InformedEntity(
-                                activities = listOf(Alert.InformedEntity.Activity.Board),
-                                directionId = 0,
-                                route = "Red",
-                                routeType = RouteType.HEAVY_RAIL,
-                                stop = it.id,
-                                trip = null
+            val mapStopRoute = MapStopRoute.matching(RedLine.route)
+
+            assertEquals(
+                wipeBranchUUID(
+                    LeafFormat.Branched(
+                        listOf(
+                            LeafFormat.Branched.Branch(
+                                null,
+                                "Ashmont",
+                                UpcomingFormat.Some(
+                                    UpcomingFormat.Some.FormattedTrip(
+                                        objects.upcomingTrip(prediction1),
+                                        RouteType.HEAVY_RAIL,
+                                        TripInstantDisplay.Minutes(3)
+                                    ),
+                                    null
+                                )
+                            ),
+                            LeafFormat.Branched.Branch(
+                                null,
+                                "Ashmont",
+                                UpcomingFormat.Some(
+                                    UpcomingFormat.Some.FormattedTrip(
+                                        objects.upcomingTrip(prediction2),
+                                        RouteType.HEAVY_RAIL,
+                                        TripInstantDisplay.Minutes(12)
+                                    ),
+                                    null
+                                )
+                            ),
+                            LeafFormat.Branched.Branch(
+                                null,
+                                "Braintree",
+                                UpcomingFormat.Disruption(alert, mapStopRoute)
                             )
-                        }
-                        .toMutableList()
-            }
-
-        val mapStopRoute = MapStopRoute.matching(RedLine.route)
-
-        assertEquals(
-            LeafFormat.Single(
-                "Ashmont",
-                UpcomingFormat.Some(
-                    listOf(
-                        UpcomingFormat.Some.FormattedTrip(
-                            objects.upcomingTrip(prediction1),
-                            RouteType.HEAVY_RAIL,
-                            TripInstantDisplay.Minutes(3)
-                        ),
-                        UpcomingFormat.Some.FormattedTrip(
-                            objects.upcomingTrip(prediction2),
-                            RouteType.HEAVY_RAIL,
-                            TripInstantDisplay.Minutes(12)
                         )
-                    ),
-                    UpcomingFormat.SecondaryAlert(StopAlertState.Issue, mapStopRoute)
+                    )
+                ),
+                wipeBranchUUID(
+                    RouteCardData.Leaf(
+                            0,
+                            listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                            setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                            listOf(
+                                objects.upcomingTrip(prediction1),
+                                objects.upcomingTrip(prediction2)
+                            ),
+                            listOf(alert),
+                            allDataLoaded = true,
+                            hasSchedulesToday = true,
+                            emptyList(),
+                        )
+                        .format(
+                            now,
+                            RedLine.route,
+                            RedLine.global,
+                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered)
+                        )
                 )
-            ),
-            RouteCardData.Leaf(
-                    0,
-                    listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                    setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
-                    listOf(objects.upcomingTrip(prediction1), objects.upcomingTrip(prediction2)),
-                    listOf(alert),
-                    allDataLoaded = true,
-                    hasSchedulesToday = true,
-                    emptyList(),
-                )
-                .format(
-                    now,
-                    RedLine.route,
-                    RedLine.global,
-                    anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered)
-                )
-        )
-    }
+            )
+        }
 
     @Test
     @Ignore // TODO once alerts are added
-    fun `formats Red Line southbound as branching if one branch is disrupted`() = parametricTest {
-        TODO("Southbound to Ashmont 1 min ⚠ Wollaston 2 min Ashmont 9 min")
-    }
+    fun `formats Red Line southbound as branching if one branch is disrupted downstream`() =
+        parametricTest {
+            TODO("Southbound to Ashmont 1 min ⚠ Wollaston 2 min Ashmont 9 min")
+        }
 
     private object GreenLine {
         private val objects = ObjectCollectionBuilder()
@@ -927,25 +988,80 @@ class RouteCardDataLeafTest {
                 lineId = line.id
             }
 
+        val parkSt = objects.stop()
+        val boylston = objects.stop()
+        val arlington = objects.stop()
+        val copley = objects.stop()
+        val hynes = objects.stop()
+        val kenmore = objects.stop()
+
+        val fenway = objects.stop() // D
+        val prudential = objects.stop() // E
+        val stMarys = objects.stop() // C
+        val blanford = objects.stop() // B
+
         val bWestbound =
             objects.routePattern(b) {
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Boston College" }
+                routeId = b.id
+                representativeTrip {
+                    headsign = "Boston College"
+                    stopIds =
+                        listOf(
+                            parkSt.id,
+                            boylston.id,
+                            arlington.id,
+                            copley.id,
+                            hynes.id,
+                            kenmore.id,
+                            blanford.id
+                        )
+                }
             }
         val cWestbound =
             objects.routePattern(c) {
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Cleveland Circle" }
+                routeId = c.id
+                representativeTrip {
+                    headsign = "Cleveland Circle"
+                    stopIds =
+                        listOf(
+                            parkSt.id,
+                            boylston.id,
+                            arlington.id,
+                            copley.id,
+                            hynes.id,
+                            kenmore.id,
+                            stMarys.id
+                        )
+                }
             }
         val dWestbound =
             objects.routePattern(d) {
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Riverside" }
+                routeId = d.id
+                representativeTrip {
+                    headsign = "Riverside"
+                    stopIds =
+                        listOf(
+                            parkSt.id,
+                            boylston.id,
+                            arlington.id,
+                            copley.id,
+                            hynes.id,
+                            kenmore.id,
+                            fenway.id
+                        )
+                }
             }
         val eWestbound =
             objects.routePattern(e) {
                 typicality = RoutePattern.Typicality.Typical
-                representativeTrip { headsign = "Heath Street" }
+                routeId = e.id
+                representativeTrip {
+                    headsign = "Heath Street"
+                    stopIds = listOf(parkSt.id, boylston.id, arlington.id, copley.id, prudential.id)
+                }
             }
 
         val global = GlobalResponse(objects)
@@ -1631,11 +1747,106 @@ class RouteCardDataLeafTest {
         }
 
     @Test
-    @Ignore // TODO once alerts are added
     fun `formats Green Line westbound at Kenmore as branching showing alert if disruption on one branch`() =
         parametricTest {
-            TODO(
-                "Westbound to C Cleveland Circle 3 min B Boston College 5 min D Riverside Shuttle Bus"
+            val objects = GreenLine.objects()
+            val now = Clock.System.now()
+
+            val prediction1 =
+                objects.prediction {
+                    departureTime = now + 3.minutes
+                    trip = objects.trip(GreenLine.cWestbound)
+                    stopId = GreenLine.kenmore.id
+                }
+            val prediction2 =
+                objects.prediction {
+                    departureTime = now + 5.minutes
+                    trip = objects.trip(GreenLine.bWestbound)
+                    stopId = GreenLine.kenmore.id
+                }
+            val prediction3 = // Won't be shown - only 2 predictions shown + shuttle
+                objects.prediction {
+                    departureTime = now + 10.minutes
+                    trip = objects.trip(GreenLine.bWestbound)
+                    stopId = GreenLine.kenmore.id
+                }
+            val alert =
+                objects.alert {
+                    effect = Alert.Effect.Shuttle
+                    informedEntity =
+                        mutableListOf(
+                            Alert.InformedEntity(
+                                activities = listOf(Alert.InformedEntity.Activity.Board),
+                                directionId = 0,
+                                route = GreenLine.d.id,
+                                routeType = RouteType.LIGHT_RAIL,
+                                stop = GreenLine.kenmore.id,
+                                trip = null
+                            )
+                        )
+                }
+
+            assertEquals(
+                wipeBranchUUID(
+                    LeafFormat.branched {
+                        branch(
+                            GreenLine.c,
+                            "Cleveland Circle",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction1),
+                                    RouteType.LIGHT_RAIL,
+                                    TripInstantDisplay.Minutes(3)
+                                ),
+                                null
+                            )
+                        )
+                        branch(
+                            GreenLine.b,
+                            "Boston College",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction2),
+                                    RouteType.LIGHT_RAIL,
+                                    TripInstantDisplay.Minutes(5)
+                                ),
+                                null
+                            )
+                        )
+                        branch(
+                            GreenLine.d,
+                            "Riverside",
+                            UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d))
+                        )
+                    }
+                ),
+                wipeBranchUUID(
+                    RouteCardData.Leaf(
+                            0,
+                            listOf(
+                                GreenLine.bWestbound,
+                                GreenLine.cWestbound,
+                                GreenLine.dWestbound,
+                                GreenLine.eWestbound
+                            ),
+                            setOf(GreenLine.kenmore.id),
+                            listOf(
+                                objects.upcomingTrip(prediction1),
+                                objects.upcomingTrip(prediction2),
+                                objects.upcomingTrip(prediction3)
+                            ),
+                            listOf(alert),
+                            true,
+                            true,
+                            emptyList()
+                        )
+                        .format(
+                            now,
+                            GreenLine.b,
+                            GreenLine.global,
+                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered)
+                        )
+                )
             )
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -1136,7 +1136,8 @@ class RouteCardDataTest {
                                                 upcomingTrips =
                                                     listOf(objects.upcomingTrip(futureSchedule)),
                                                 allDataLoaded = true,
-                                                hasSchedulesToday = true
+                                                hasSchedulesTodayByPattern =
+                                                    mapOf(pattern1.id to true)
                                             )
                                     ),
                                     global
@@ -1153,7 +1154,8 @@ class RouteCardDataTest {
                                                 stopIds = setOf(stop2.id),
                                                 upcomingTrips = null,
                                                 allDataLoaded = true,
-                                                hasSchedulesToday = true
+                                                hasSchedulesTodayByPattern =
+                                                    mapOf(pattern2.id to true)
                                             )
                                     ),
                                     global
@@ -1170,7 +1172,8 @@ class RouteCardDataTest {
                                                 stopIds = setOf(stop3.id),
                                                 upcomingTrips = null,
                                                 allDataLoaded = true,
-                                                hasSchedulesToday = false
+                                                hasSchedulesTodayByPattern =
+                                                    mapOf(pattern3.id to false)
                                             )
                                     ),
                                     global
@@ -3287,7 +3290,12 @@ class RouteCardDataTest {
                                             ),
                                         allDataLoaded = true,
                                         alertsHere = emptyList(),
-                                        hasSchedulesToday = true,
+                                        hasSchedulesTodayByPattern =
+                                            mapOf(
+                                                routePatternB1.id to true,
+                                                routePatternC1.id to true,
+                                                routePatternE1.id to true
+                                            ),
                                         alertsDownstream = emptyList()
                                     ),
                                     RouteCardData.Leaf(
@@ -3312,7 +3320,12 @@ class RouteCardDataTest {
                                             ),
                                         allDataLoaded = true,
                                         alertsHere = emptyList(),
-                                        hasSchedulesToday = true,
+                                        hasSchedulesTodayByPattern =
+                                            mapOf(
+                                                routePatternB2.id to true,
+                                                routePatternC2.id to true,
+                                                routePatternE2.id to true
+                                            ),
                                         alertsDownstream = emptyList()
                                     )
                                 )
@@ -3818,7 +3831,11 @@ class RouteCardDataTest {
                                             ),
                                         allDataLoaded = true,
                                         alertsHere = emptyList(),
-                                        hasSchedulesToday = true,
+                                        hasSchedulesTodayByPattern =
+                                            mapOf(
+                                                orangeSouthboundDiversion.id to true,
+                                                orangeSouthboundTypical.id to false
+                                            ),
                                         alertsDownstream = emptyList()
                                     ),
                                     RouteCardData.Leaf(
@@ -3832,7 +3849,11 @@ class RouteCardDataTest {
                                         upcomingTrips = listOf(),
                                         allDataLoaded = true,
                                         alertsHere = listOf(alert),
-                                        hasSchedulesToday = true,
+                                        hasSchedulesTodayByPattern =
+                                            mapOf(
+                                                orangeNorthboundDiversion.id to true,
+                                                orangeNorthboundTypical.id to false
+                                            ),
                                         alertsDownstream = emptyList()
                                     )
                                 ),
@@ -4237,7 +4258,11 @@ class RouteCardDataTest {
                                             allDataLoaded = true,
                                             alertsHere =
                                                 listOf(parkShuttleAlert, parkElevatorAlert),
-                                            hasSchedulesToday = true,
+                                            hasSchedulesTodayByPattern =
+                                                mapOf(
+                                                    routePatternAshmont.id to true,
+                                                    routePatternBraintree.id to true
+                                                ),
                                             alertsDownstream = southboundDownstreamAlerts
                                         )
                                     ),


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Group By Direction | Disruption on a branch](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209979069137605?focus=true)

What is this PR for?

With this PR, we now show a separate row for disrupted branches when grouped by headsign to match designs.
Grouping by headsign when we know we are dealing with a branched route seemed like the most straightforward way to accomplish this. TY to @EmmaSimon for feedback on where that grouping logic should live! 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Updated stubbed out unit tests 
* Updated android preview data & confirmed displayed as expected
![image](https://github.com/user-attachments/assets/8cff00fb-771d-4d21-bb78-dee0c0700b81)

* Tested in running app for a few alerts
![image](https://github.com/user-attachments/assets/6e8714a1-59ee-4d05-be90-1b5d02be701c)![image](https://github.com/user-attachments/assets/34f52079-9d10-411f-8803-186526e153d3)



<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210072519830418