### PR TITLE
feat(RouteCard): Secondary alert icon at the direction level

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -2,10 +2,12 @@ package com.mbta.tid.mbta_app.android.component.routeCard
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -28,6 +30,8 @@ class DeparturesTest {
     fun testDepartures() {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
+
+        val downstreamAlert = objects.alert { effect = Alert.Effect.Shuttle }
         val stop = objects.stop {}
         val route =
             objects.route {
@@ -71,7 +75,7 @@ class DeparturesTest {
                         emptyList(),
                         true,
                         true,
-                        emptyList()
+                        listOf(downstreamAlert)
                     )
                 )
             )
@@ -92,6 +96,9 @@ class DeparturesTest {
 
         composeTestRule.onNodeWithText("20 min").assertIsDisplayed()
         composeTestRule.onNodeWithText(bTrip.headsign).assertIsDisplayed()
+        composeTestRule.onNodeWithText(bTrip.headsign).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("Alert").assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -1,14 +1,18 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
@@ -21,6 +25,8 @@ import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.HeadsignRowView
 import com.mbta.tid.mbta_app.android.component.NavDrilldownRow
 import com.mbta.tid.mbta_app.android.component.PillDecoration
+import com.mbta.tid.mbta_app.android.generated.drawableByName
+import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.LeafFormat
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -88,7 +94,17 @@ fun Departures(
                             )
                         }
                         is LeafFormat.Branched -> {
-                            DirectionLabel(direction, showDestination = false)
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                formatted.secondaryAlert?.let { secondaryAlert ->
+                                    Image(
+                                        painterResource(drawableByName(secondaryAlert.iconName)),
+                                        stringResource(R.string.alert),
+                                        modifier =
+                                            Modifier.placeholderIfLoading().padding(end = 8.dp)
+                                    )
+                                }
+                                DirectionLabel(direction, showDestination = false)
+                            }
                             for (branch in formatted.branches) {
                                 HeadsignRowView(
                                     branch.headsign,

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
@@ -17,7 +17,14 @@ struct RouteCardDirection: View {
         switch onEnum(of: formatted) {
         case let .branched(branched):
             VStack(alignment: .leading, spacing: 0) {
-                DirectionLabel(direction: direction, showDestination: false).foregroundStyle(Color.text)
+                HStack(alignment: .center) {
+                    if let secondaryAlert = branched.secondaryAlert {
+                        Image(secondaryAlert.iconName)
+                            .accessibilityLabel("Alert")
+                            .frame(width: 18, height: 18)
+                    }
+                    DirectionLabel(direction: direction, showDestination: false).foregroundStyle(Color.text)
+                }
                 ForEach(branched.branches) { branch in
                     let pillDecoration: PredictionRowView.PillDecoration = if let route = branch
                         .route { .onRow(route: route) } else { .none }

--- a/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
@@ -109,6 +109,9 @@ final class RouteCardDeparturesTests: XCTestCase {
         let objects = Green.shared.objects
 
         let stop = objects.stop { _ in }
+        let downstreamAlert = objects.alert { alert in
+            alert.effect = .shuttle
+        }
 
         let tripB0 = objects.trip(routePattern: Green.shared.rpB0)
         let schedB0 = objects.schedule { schedule in
@@ -210,7 +213,7 @@ final class RouteCardDeparturesTests: XCTestCase {
                     .init(trip: tripE0, prediction: predE0),
                     .init(trip: tripC02, prediction: predC02),
                 ], alertsHere: [], allDataLoaded: true,
-                hasSchedulesToday: true, alertsDownstream: []
+                hasSchedulesToday: true, alertsDownstream: [downstreamAlert]
             ),
             .init(
                 directionId: 1,
@@ -247,6 +250,7 @@ final class RouteCardDeparturesTests: XCTestCase {
         let westDirection = try sut.inspect().find(text: "Westbound to")
             .find(RouteCardDirection.self, relation: .parent)
         XCTAssertNotNil(westDirection)
+        XCTAssertNotNil(try westDirection.find(viewWithAccessibilityLabel: "Alert"))
         XCTAssertNotNil(try westDirection.find(text: "1 min")
             .find(HeadsignRowView.self, relation: .parent).find(text: "Boston College"))
         XCTAssertNotNil(try westDirection.find(text: "3 min")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
@@ -34,8 +34,14 @@ sealed class LeafFormat {
         override fun noPredictionsStatus() = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
     }
 
-    /** A [RouteCardData.Leaf] which has multiple destinations within its direction. */
-    data class Branched(val branches: List<Branch>) : LeafFormat() {
+    /**
+     * A [RouteCardData.Leaf] which has multiple destinations within its direction. The secondary
+     * alert will be displayed once for the entire direction
+     */
+    data class Branched(
+        val branches: List<Branch>,
+        val secondaryAlert: UpcomingFormat.SecondaryAlert? = null
+    ) : LeafFormat() {
         data class Branch
         @OptIn(ExperimentalUuidApi::class)
         constructor(
@@ -83,6 +89,7 @@ sealed class LeafFormat {
 
     class BranchedBuilder {
         private val branches = mutableListOf<Branched.Branch>()
+        var secondaryAlert: UpcomingFormat.SecondaryAlert? = null
 
         fun branch(headsign: String, format: UpcomingFormat) = branch(null, headsign, format)
 
@@ -90,7 +97,7 @@ sealed class LeafFormat {
             branches.add(Branched.Branch(route, headsign, format))
         }
 
-        internal fun built() = Branched(branches)
+        internal fun built() = Branched(branches, secondaryAlert)
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -312,9 +312,10 @@ data class RouteCardData(
                         LeafFormat.Branched.Branch(
                             route,
                             trip.headsign,
-                            UpcomingFormat.Some(format, secondaryAlert)
+                            UpcomingFormat.Some(format, null)
                         )
-                    }
+                    },
+                    secondaryAlert
                 )
             }
 
@@ -361,7 +362,7 @@ data class RouteCardData(
                     LeafFormat.Branched.Branch(
                         route,
                         upcomingTrip.trip.headsign,
-                        UpcomingFormat.Some(formatted, secondaryAlert)
+                        UpcomingFormat.Some(formatted, null)
                     )
                 }
 
@@ -389,7 +390,7 @@ data class RouteCardData(
                                 LeafFormat.Branched.Branch(
                                     route,
                                     headsign,
-                                    UpcomingFormat.NoTrips(noTripsFormat, secondaryAlert)
+                                    UpcomingFormat.NoTrips(noTripsFormat, null)
                                 )
                             } else {
                                 null
@@ -401,7 +402,8 @@ data class RouteCardData(
                 }
 
             return LeafFormat.Branched(
-                upcomingTripBranches + predictionsUnavailableBranches + disruptedHeadsignBranches
+                upcomingTripBranches + predictionsUnavailableBranches + disruptedHeadsignBranches,
+                secondaryAlert
             )
         }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Group By Direction | Secondary alert - show direction-level icon rather than trip level](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209979069137600?focus=true)

What is this PR for?
Instead of putting secondary alert icons on each row, there is now a single secondary alert icon next to the direction label. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests 
* Verified looks as expected on running iOS & android apps
![IMG_0288](https://github.com/user-attachments/assets/5edd13c1-c2cb-4e92-8aeb-f09f82bbe92b)
![image](https://github.com/user-attachments/assets/8f05a70a-f1be-4d85-9652-b60b561e28dc)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
