### PR TITLE
feat(Android): add helper for getting settings

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.captureToImage
@@ -120,6 +119,6 @@ fun testKoinApplication(
                 repositoryOverrides()
             }
         ),
-        MainApplication.koinViewModelModule
+        MainApplication.koinViewModelModule()
     )
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import org.junit.Rule
@@ -18,7 +17,7 @@ class ErrorBannerTests {
     @Test
     fun testRespondsToState() {
         val errorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-        val viewModel = ErrorBannerViewModel(false, errorRepo, MockSettingsRepository())
+        val viewModel = ErrorBannerViewModel(false, errorRepo)
 
         composeTestRule.setContent {
             LaunchedEffect(null) { viewModel.activate() }
@@ -45,7 +44,7 @@ class ErrorBannerTests {
     fun testNetworkError() {
         val networkErrorRepo =
             MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-        val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo, MockSettingsRepository())
+        val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo)
 
         composeTestRule.setContent {
             LaunchedEffect(null) { networkErrorVM.activate() }
@@ -61,7 +60,7 @@ class ErrorBannerTests {
             MockErrorBannerStateRepository(
                 state = ErrorBannerState.DataError(messages = emptySet(), action = {})
             )
-        val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo, MockSettingsRepository())
+        val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo)
         composeTestRule.setContent {
             LaunchedEffect(null) { dataErrorVM.activate() }
             ErrorBanner(dataErrorVM)
@@ -80,7 +79,7 @@ class ErrorBannerTests {
                         action = {}
                     )
             )
-        val staleVM = ErrorBannerViewModel(false, staleRepo, MockSettingsRepository())
+        val staleVM = ErrorBannerViewModel(false, staleRepo)
         composeTestRule.setContent {
             LaunchedEffect(null) { staleVM.activate() }
             ErrorBanner(staleVM)
@@ -99,7 +98,7 @@ class ErrorBannerTests {
                         action = {}
                     )
             )
-        val staleVM = ErrorBannerViewModel(false, staleRepo, MockSettingsRepository())
+        val staleVM = ErrorBannerViewModel(false, staleRepo)
         composeTestRule.setContent {
             LaunchedEffect(null) { staleVM.activate() }
             ErrorBanner(staleVM)
@@ -118,7 +117,7 @@ class ErrorBannerTests {
                         action = {}
                     )
             )
-        val staleVM = ErrorBannerViewModel(true, staleRepo, MockSettingsRepository())
+        val staleVM = ErrorBannerViewModel(true, staleRepo)
         composeTestRule.setContent {
             LaunchedEffect(null) { staleVM.activate() }
             ErrorBanner(staleVM)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
@@ -4,8 +4,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertTrue
 import org.junit.Rule
@@ -23,15 +25,18 @@ class MoreSectionViewTests {
                 section =
                     MoreSection(
                         MoreSection.Category.Settings,
-                        listOf(MoreItem.Toggle("Toggle 1", Settings.HideMaps, true))
+                        listOf(MoreItem.Toggle("Toggle 1", Settings.HideMaps))
+                    ),
+                settingsCache =
+                    SettingsCache(
+                        MockSettingsRepository(onSaveSettings = { toggleCallbackCalled = true })
                     )
-            ) {
-                toggleCallbackCalled = true
-            }
+            )
         }
 
         composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
         composeTestRule.onNodeWithText("Toggle 1").performClick()
+        composeTestRule.waitForIdle()
 
         assertTrue { toggleCallbackCalled }
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -4,44 +4,14 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
-import com.mbta.tid.mbta_app.repositories.Settings
 import java.util.Locale
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
 class MoreViewModelTests {
 
     @get:Rule val composeTestRule = createComposeRule()
-
-    @Test
-    fun testToggleSetting() {
-        var toggledHideMaps = false
-
-        val settingsRepository =
-            MockSettingsRepository(
-                settings = mapOf(Settings.HideMaps to false),
-                onSaveSettings = { settings ->
-                    if (settings.size == 1 && settings.containsKey(Settings.HideMaps)) {
-                        toggledHideMaps = true
-                    }
-                }
-            )
-
-        var vm: MoreViewModel? = null
-        composeTestRule.setContent {
-            vm = MoreViewModel(LocalContext.current, {}, settingsRepository)
-        }
-
-        composeTestRule.waitForIdle()
-        vm!!.toggleSetting(Settings.HideMaps)
-        composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { toggledHideMaps }
-
-        assertTrue { toggledHideMaps }
-    }
 
     @Test
     fun testLocalizedFeedbackLink() {
@@ -55,7 +25,7 @@ class MoreViewModelTests {
             config.setLocale(Locale.forLanguageTag("es-MX"))
             val subContext = context.createConfigurationContext(config)
 
-            vm = MoreViewModel(subContext, {}, MockSettingsRepository())
+            vm = MoreViewModel(subContext, {})
         }
 
         composeTestRule.waitUntil {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModelTest.kt
@@ -13,7 +13,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -73,7 +72,6 @@ class NearbyTransitViewModelTest {
         val nearbyVM =
             NearbyTransitViewModel(
                 nearbyRepository,
-                settingsRepository = MockSettingsRepository(),
                 errorBannerRepository = MockErrorBannerStateRepository(),
                 analytics = MockAnalytics()
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -14,7 +14,6 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Instant
@@ -178,7 +177,6 @@ class NearbyTransitViewTest : KoinTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         )
                 )
             }
@@ -214,7 +212,6 @@ class NearbyTransitViewTest : KoinTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         )
                 )
             }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
 import com.mbta.tid.mbta_app.android.hasRole
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
@@ -68,7 +69,7 @@ class OnboardingScreenViewTest {
                 screen = OnboardingScreen.StationAccessibility,
                 advance = { advanced = true },
                 locationDataManager = MockLocationDataManager(),
-                settingsRepository = settingsRepo
+                settingsCache = SettingsCache(settingsRepo)
             )
         }
 
@@ -111,7 +112,7 @@ class OnboardingScreenViewTest {
                 screen = OnboardingScreen.HideMaps,
                 advance = { advanced = true },
                 locationDataManager = MockLocationDataManager(),
-                settingsRepository = settingsRepo
+                settingsCache = SettingsCache(settingsRepo)
             )
         }
         composeTestRule
@@ -133,6 +134,7 @@ class OnboardingScreenViewTest {
         composeTestRule.onNodeWithText("Map Display").assertIsOn()
 
         composeTestRule.onNodeWithText("Continue").assertIsDisplayed().performClick()
+        composeTestRule.waitForIdle()
         assertTrue(savedSetting)
         assertTrue(advanced)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -8,17 +8,15 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
-import org.koin.dsl.koinApplication
-import org.koin.dsl.module
 import org.koin.test.KoinTest
 
 class MorePageTests : KoinTest {
@@ -38,20 +36,15 @@ class MorePageTests : KoinTest {
     fun testSettings() {
         var hideMapValue = false
 
-        val koinApplication = koinApplication {
-            modules(
-                module {
-                    single<ISettingsRepository> {
-                        MockSettingsRepository(
-                            onSaveSettings = { settings ->
-                                if (settings.size == 1 && settings.containsKey(Settings.HideMaps)) {
-                                    hideMapValue = settings.getValue(Settings.HideMaps)
-                                }
-                            }
-                        )
+        val koinApplication = testKoinApplication {
+            settings =
+                MockSettingsRepository(
+                    onSaveSettings = { settings ->
+                        if (settings.size == 1 && settings.containsKey(Settings.HideMaps)) {
+                            hideMapValue = settings.getValue(Settings.HideMaps)
+                        }
                     }
-                }
-            )
+                )
         }
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
@@ -71,13 +64,7 @@ class MorePageTests : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testLinksExist() {
-        val koinApplication = koinApplication {
-            modules(
-                module {
-                    single<ISettingsRepository> { MockSettingsRepository(onSaveSettings = {}) }
-                }
-            )
-        }
+        val koinApplication = testKoinApplication()
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }
@@ -104,13 +91,7 @@ class MorePageTests : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testSoftwareLicenses() {
-        val koinApplication = koinApplication {
-            modules(
-                module {
-                    single<ISettingsRepository> { MockSettingsRepository(onSaveSettings = {}) }
-                }
-            )
-        }
+        val koinApplication = testKoinApplication()
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -17,7 +17,6 @@ import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
@@ -61,7 +60,6 @@ class SubscribeToPredictionsTest {
                     ErrorBannerViewModel(
                         false,
                         MockErrorBannerStateRepository(),
-                        MockSettingsRepository()
                     )
                 )
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
@@ -112,7 +110,6 @@ class SubscribeToPredictionsTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         )
                     )
                 predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
@@ -156,7 +153,6 @@ class SubscribeToPredictionsTest {
                     ErrorBannerViewModel(
                         false,
                         MockErrorBannerStateRepository(),
-                        MockSettingsRepository()
                     )
                 )
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
@@ -192,7 +188,6 @@ class SubscribeToPredictionsTest {
                 ErrorBannerViewModel(
                     false,
                     mockErrorRepo,
-                    MockSettingsRepository(),
                 ),
                 1.seconds
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -13,7 +13,6 @@ import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +38,6 @@ class StopDetailsPageTest : KoinTest {
                     ErrorBannerViewModel(
                         false,
                         MockErrorBannerStateRepository(),
-                        MockSettingsRepository()
                     )
 
                 StopDetailsPage(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -20,7 +20,6 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Instant
@@ -112,8 +111,7 @@ class StopDetailsUnfilteredRoutesViewTest {
             )
         )
 
-    private val errorBannerViewModel =
-        ErrorBannerViewModel(false, MockErrorBannerStateRepository(), MockSettingsRepository())
+    private val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
 
     @get:Rule val composeTestRule = createComposeRule()
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -165,7 +165,6 @@ class StopDetailsViewTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         ),
                     openModal = {},
                     openSheetRoute = {}
@@ -244,7 +243,6 @@ class StopDetailsViewTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         ),
                     openModal = {},
                     openSheetRoute = {}
@@ -269,13 +267,7 @@ class StopDetailsViewTest {
                 header = "Elevator alert header"
             }
 
-        val viewModel =
-            StopDetailsViewModel.mocked(
-                settingsRepository =
-                    MockSettingsRepository(
-                        settings = mapOf(Pair(Settings.StationAccessibility, true))
-                    )
-            )
+        val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setDepartures(
             StopDetailsDepartures(
@@ -333,7 +325,6 @@ class StopDetailsViewTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         ),
                     openModal = {},
                     openSheetRoute = {}
@@ -352,7 +343,7 @@ class StopDetailsViewTest {
                 header = "Elevator alert header"
             }
 
-        val viewModel = StopDetailsViewModel.mocked(settingsRepository = settingsRepository)
+        val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setDepartures(
             StopDetailsDepartures(
@@ -412,7 +403,6 @@ class StopDetailsViewTest {
                         ErrorBannerViewModel(
                             false,
                             MockErrorBannerStateRepository(),
-                            MockSettingsRepository()
                         ),
                     openModal = {},
                     openSheetRoute = {}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
@@ -1,0 +1,111 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.test.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
+
+class SettingsCacheTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testLoadsSettings() {
+        var gotSettings = false
+        val settingsRepo =
+            MockSettingsRepository(
+                mapOf(Settings.HideMaps to true),
+                onGetSettings = { gotSettings = true }
+            )
+        val koin = testKoinApplication { settings = settingsRepo }
+
+        val hideMapsValues = mutableListOf<Boolean>()
+        val debugModeValues = mutableListOf<Boolean>()
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                val cache: SettingsCache = koinInject()
+                val hideMaps = cache.get(Settings.HideMaps)
+                hideMapsValues.add(hideMaps)
+                val debugMode = cache.get(Settings.DevDebugMode)
+                debugModeValues.add(debugMode)
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { gotSettings }
+        assertEquals(listOf(false, true), hideMapsValues)
+        assertEquals(listOf(false, false), debugModeValues)
+    }
+
+    @Test
+    fun testUsesCachedSettings() {
+        var gotSettings by mutableStateOf(false)
+        val settingsRepo =
+            MockSettingsRepository(
+                mapOf(Settings.HideMaps to true),
+                onGetSettings = { gotSettings = true }
+            )
+        val koin = testKoinApplication { settings = settingsRepo }
+
+        val hideMapsValues = mutableListOf<Boolean>()
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                val cache: SettingsCache = koinInject()
+                cache.get(Settings.StationAccessibility)
+                if (gotSettings) {
+                    val hideMaps = cache.get(Settings.HideMaps)
+                    hideMapsValues.add(hideMaps)
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { gotSettings }
+        assertEquals(listOf(true), hideMapsValues)
+    }
+
+    @Test
+    fun testSavesSettings() {
+        var gotSettings = false
+        var savedSettings = false
+        val settingsRepo =
+            MockSettingsRepository(
+                settings = mapOf(Settings.HideMaps to false),
+                onGetSettings = { gotSettings = true },
+                onSaveSettings = { newSettings ->
+                    assertEquals(mapOf(Settings.HideMaps to true), newSettings)
+                    savedSettings = true
+                }
+            )
+        val koin = testKoinApplication { settings = settingsRepo }
+
+        val hideMapsValues = mutableListOf<Boolean>()
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                val cache: SettingsCache = koinInject()
+                val hideMaps = cache.get(Settings.HideMaps)
+                hideMapsValues.add(hideMaps)
+                Button({ cache.set(Settings.HideMaps, true) }) { Text("Hide maps") }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { gotSettings }
+        composeTestRule.onNodeWithText("Hide maps").performClick()
+        composeTestRule.waitUntil { savedSettings }
+        composeTestRule.waitForIdle()
+        // false while loading and still false after loading
+        assertEquals(listOf(false, false, true), hideMapsValues)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.rememberMapViewportState
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.AnalyticsColorScheme
@@ -33,14 +32,16 @@ import com.mbta.tid.mbta_app.android.phoenix.PhoenixSocketWrapper
 import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.subscribeToAlerts
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
+import com.mbta.tid.mbta_app.repositories.Settings
 import io.github.dellisd.spatialk.geojson.Position
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
-@OptIn(MapboxExperimental::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContentView(
     socket: PhoenixSocket = koinInject(),
@@ -50,7 +51,7 @@ fun ContentView(
     val navController = rememberNavController()
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()
     val globalResponse = getGlobalData("ContentView.getGlobalData")
-    val hideMaps by viewModel.hideMaps.collectAsState()
+    val hideMaps = SettingsCache.get(Settings.HideMaps)
     val pendingOnboarding = viewModel.pendingOnboarding.collectAsState().value
     val locationDataManager = rememberLocationDataManager()
     val mapViewportState = rememberMapViewportState {
@@ -97,8 +98,6 @@ fun ContentView(
     val sheetModifier = Modifier.fillMaxSize()
     NavHost(navController = navController, startDestination = Routes.NearbyTransit) {
         composable<Routes.NearbyTransit> {
-            LaunchedEffect(null) { viewModel.loadHideMaps() }
-
             NearbyTransitPage(
                 modifier = sheetModifier,
                 NearbyTransit(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
-import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,10 +14,7 @@ import kotlinx.coroutines.launch
 class ContentViewModel(
     private val featurePromoUseCase: FeaturePromoUseCase,
     private val onboardingRepository: IOnboardingRepository,
-    private val settingsRepository: ISettingsRepository
 ) : ViewModel() {
-    private val _hideMaps: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val hideMaps: StateFlow<Boolean> = _hideMaps
     private val _pendingFeaturePromos: MutableStateFlow<List<FeaturePromo>?> =
         MutableStateFlow(null)
     val pendingFeaturePromos: StateFlow<List<FeaturePromo>?> = _pendingFeaturePromos
@@ -28,16 +23,8 @@ class ContentViewModel(
     val pendingOnboarding: StateFlow<List<OnboardingScreen>?> = _pendingOnboarding
 
     init {
-        loadHideMaps()
         loadPendingFeaturePromos()
         loadPendingOnboarding()
-    }
-
-    fun loadHideMaps() {
-        CoroutineScope(Dispatchers.IO).launch {
-            val data = settingsRepository.getSettings()
-            _hideMaps.value = data[Settings.HideMaps] ?: false
-        }
     }
 
     fun loadPendingFeaturePromos() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
@@ -10,11 +10,13 @@ import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitViewModel
 import com.mbta.tid.mbta_app.android.phoenix.wrapped
 import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.stopDetails.StopDetailsViewModel
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.decodeMessage
 import com.mbta.tid.mbta_app.dependencyInjection.makeNativeModule
 import com.mbta.tid.mbta_app.initKoin
 import com.mbta.tid.mbta_app.repositories.AccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.CurrentAppVersionRepository
+import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.dsl.*
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -42,17 +44,20 @@ class MainApplication : Application() {
                         else MockAnalytics()
                     }
                 } +
-                koinViewModelModule,
+                koinViewModelModule(),
             this
         )
     }
 
     companion object {
-        val koinViewModelModule = module {
+        fun koinViewModelModule() = module {
+            single { SettingsCache(get()) }
             viewModelOf(::ContentViewModel)
             viewModelOf(::NearbyTransitViewModel)
             viewModelOf(::SearchResultsViewModel)
-            viewModel { StopDetailsViewModel(get(), get(), get(), get(), get(), get(), get()) }
+            viewModel {
+                StopDetailsViewModel(get(), get(), get(), get(), get(), get(), Dispatchers.Default)
+            }
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
@@ -5,11 +5,6 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.PathEffect
@@ -18,20 +13,14 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
-import org.koin.compose.koinInject
 
 @Composable
-fun DebugView(
-    modifier: Modifier = Modifier,
-    settingsRepo: ISettingsRepository = koinInject(),
-    content: @Composable ColumnScope.() -> Unit
-) {
-    var settings by remember { mutableStateOf<Map<Settings, Boolean>>(emptyMap()) }
-    LaunchedEffect(null) { settings = settingsRepo.getSettings() }
-    if (settings[Settings.DevDebugMode] != true) return
+fun DebugView(modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
+    val debugMode = SettingsCache.get(Settings.DevDebugMode)
+    if (!debugMode) return
     val color = colorResource(R.color.text)
     val density = LocalDensity.current
     Column(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -35,8 +35,6 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
-import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 
@@ -169,17 +167,16 @@ private fun RefreshButton(
 @Composable
 private fun ErrorBannerPreviews() {
     val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-    val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo, MockSettingsRepository())
+    val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo)
     val dataErrorRepo =
         MockErrorBannerStateRepository(
             state = ErrorBannerState.DataError(messages = setOf("foo"), action = {})
         )
-    val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo, MockSettingsRepository())
+    val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo)
     val dataErrorDebugVM =
         ErrorBannerViewModel(
             false,
             dataErrorRepo,
-            MockSettingsRepository(mapOf(Settings.DevDebugMode to true))
         )
     val staleRepo =
         MockErrorBannerStateRepository(
@@ -189,8 +186,8 @@ private fun ErrorBannerPreviews() {
                     action = {}
                 )
         )
-    val staleVM = ErrorBannerViewModel(false, staleRepo, MockSettingsRepository())
-    val staleLoadingVM = ErrorBannerViewModel(true, staleRepo, MockSettingsRepository())
+    val staleVM = ErrorBannerViewModel(false, staleRepo)
+    val staleLoadingVM = ErrorBannerViewModel(true, staleRepo)
     LaunchedEffect(null) { networkErrorVM.activate() }
     LaunchedEffect(null) { dataErrorVM.activate() }
     LaunchedEffect(null) { dataErrorDebugVM.activate() }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBannerViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBannerViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
-import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -15,17 +13,13 @@ import kotlinx.coroutines.flow.onEach
 class ErrorBannerViewModel(
     var loadingWhenPredictionsStale: Boolean = false,
     val errorRepository: IErrorBannerStateRepository,
-    val settingsRepository: ISettingsRepository
 ) : ViewModel() {
 
     private val _errorState = MutableStateFlow<ErrorBannerState?>(null)
     val errorState: StateFlow<ErrorBannerState?> = _errorState.asStateFlow()
 
-    var showDebugMessages: Boolean = false
-
     suspend fun activate() {
         errorRepository.subscribeToNetworkStatusChanges()
-        showDebugMessages = settingsRepository.getSettings()[Settings.DevDebugMode] ?: false
 
         errorRepository.state.onEach { _errorState.emit(it) }.collect()
     }
@@ -36,16 +30,10 @@ class ErrorBannerViewModel(
 
     class Factory(
         var loadingWhenPredictionsStale: Boolean = false,
-        val errorRepository: IErrorBannerStateRepository,
-        val settingsRepository: ISettingsRepository
+        val errorRepository: IErrorBannerStateRepository
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ErrorBannerViewModel(
-                loadingWhenPredictionsStale,
-                errorRepository,
-                settingsRepository
-            )
-                as T
+            return ErrorBannerViewModel(loadingWhenPredictionsStale, errorRepository) as T
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
@@ -18,13 +18,15 @@ import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.appVariant
 import com.mbta.tid.mbta_app.android.component.LabeledSwitch
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import com.mbta.tid.mbta_app.repositories.Settings
+import org.koin.compose.koinInject
 
 @Composable
-fun MoreSectionView(section: MoreSection, toggleSetting: ((Settings) -> Unit)) {
+fun MoreSectionView(section: MoreSection, settingsCache: SettingsCache = koinInject()) {
 
     val name: String? =
         when (section.id) {
@@ -61,18 +63,20 @@ fun MoreSectionView(section: MoreSection, toggleSetting: ((Settings) -> Unit)) {
             ) {
                 section.items.mapIndexed { index, item ->
                     when (item) {
-                        is MoreItem.Toggle ->
+                        is MoreItem.Toggle -> {
+                            val settingValue = settingsCache.get(item.settings)
                             LabeledSwitch(
                                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
                                 label = item.label,
                                 // Setting is hide maps, but label is "Map Display" - invert the
                                 // value of hide maps to match the label
                                 value =
-                                    if (item.settings == Settings.HideMaps) !item.value
-                                    else item.value
+                                    if (item.settings == Settings.HideMaps) !settingValue
+                                    else settingValue
                             ) {
-                                toggleSetting(item.settings)
+                                settingsCache.set(item.settings, !settingValue)
                             }
+                        }
                         is MoreItem.Link ->
                             MoreLink(
                                 item.label,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -32,6 +32,7 @@ import com.mbta.tid.mbta_app.android.component.routeCard.RouteCard
 import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
@@ -41,6 +42,7 @@ import com.mbta.tid.mbta_app.model.StopsAssociated
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.withRealtimeInfo
+import com.mbta.tid.mbta_app.repositories.Settings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.launch
@@ -59,8 +61,6 @@ fun NearbyTransitView(
     nearbyVM: NearbyTransitViewModel = koinViewModel(),
     errorBannerViewModel: ErrorBannerViewModel
 ) {
-    LaunchedEffect(null) { nearbyVM.loadSettings() }
-
     LaunchedEffect(targetLocation, globalResponse) {
         if (globalResponse != null && targetLocation != null) {
             nearbyVM.getNearby(
@@ -77,8 +77,8 @@ fun NearbyTransitView(
     val predictionsVM = subscribeToPredictions(stopIds, errorBannerViewModel = errorBannerViewModel)
     val predictions by predictionsVM.predictionsFlow.collectAsState(initial = null)
 
-    val groupByDirection by nearbyVM.groupByDirection.collectAsState(false)
-    val showStationAccessibility by nearbyVM.showStationAccessibility.collectAsState(false)
+    val groupByDirection = SettingsCache.get(Settings.GroupByDirection)
+    val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
 
     val analytics: Analytics = koinInject()
     val coroutineScope = rememberCoroutineScope()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
@@ -15,43 +15,25 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
-import com.mbta.tid.mbta_app.repositories.Settings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 
 class NearbyTransitViewModel(
     private val nearbyRepository: INearbyRepository,
-    private val settingsRepository: ISettingsRepository,
     private val errorBannerRepository: IErrorBannerStateRepository,
     private val analytics: Analytics,
 ) : KoinComponent, ViewModel() {
-    private val _showStationAccessibility: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val showStationAccessibility: StateFlow<Boolean> = _showStationAccessibility
-    private val _groupByDirection: MutableStateFlow<Boolean> = MutableStateFlow(false)
-    val groupByDirection: StateFlow<Boolean> = _groupByDirection
-
     var loadedLocation by mutableStateOf<Position?>(null)
     var loading by mutableStateOf(false)
     var nearby by mutableStateOf<NearbyStaticData?>(null)
     var routeCardData by mutableStateOf<List<RouteCardData>?>(null)
 
     private var fetchNearbyTask: Job? = null
-
-    fun loadSettings() {
-        CoroutineScope(Dispatchers.IO).launch {
-            val data = settingsRepository.getSettings()
-            _showStationAccessibility.value = data[Settings.StationAccessibility] ?: false
-            _groupByDirection.value = data[Settings.GroupByDirection] ?: false
-        }
-    }
 
     fun getNearby(
         globalResponse: GlobalResponse,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -41,7 +41,6 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
-import org.koin.compose.koinInject
 
 @Composable
 fun MorePage(
@@ -49,8 +48,7 @@ fun MorePage(
 ) {
 
     val navController = rememberNavController()
-    val viewModel =
-        MoreViewModel(LocalContext.current, { navController.navigate("licenses") }, koinInject())
+    val viewModel = MoreViewModel(LocalContext.current, { navController.navigate("licenses") })
 
     val sections by viewModel.sections.collectAsState()
     val dependencies = Dependency.getAllDependencies()
@@ -85,11 +83,7 @@ fun MorePage(
                                 .padding(16.dp),
                             verticalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
-                            sections.map { section ->
-                                MoreSectionView(section = section) { setting ->
-                                    viewModel.toggleSetting(setting)
-                                }
-                            }
+                            sections.map { section -> MoreSectionView(section = section) }
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                                 verticalAlignment = Alignment.CenterVertically

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -125,13 +125,7 @@ fun NearbyTransitPage(
     mapViewModel: IMapViewModel = viewModel(factory = MapViewModel.Factory()),
     searchResultsViewModel: SearchResultsViewModel,
     errorBannerViewModel: ErrorBannerViewModel =
-        viewModel(
-            factory =
-                ErrorBannerViewModel.Factory(
-                    errorRepository = koinInject(),
-                    settingsRepository = koinInject()
-                )
-        ),
+        viewModel(factory = ErrorBannerViewModel.Factory(errorRepository = koinInject())),
     visitHistoryUsecase: VisitHistoryUsecase = koinInject(),
     clock: Clock = koinInject()
 ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -40,6 +40,7 @@ import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.routeSlashIcon
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSignificance
@@ -54,6 +55,7 @@ import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
@@ -130,8 +132,8 @@ fun StopDetailsFilteredDeparturesView(
 
     val alertSummaries by viewModel.alertSummaries.collectAsState()
 
-    val hideMaps by viewModel.hideMaps.collectAsState()
-    val showStationAccessibility by viewModel.showStationAccessibility.collectAsState()
+    val hideMaps = SettingsCache.get(Settings.HideMaps)
+    val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
 
     val hasAccessibilityWarning = (elevatorAlerts.isNotEmpty() || !stop.isWheelchairAccessible)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -45,7 +45,6 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -325,7 +324,6 @@ private fun StopDetailsRoutesViewPreview() {
                 ErrorBannerViewModel(
                     false,
                     MockErrorBannerStateRepository(),
-                    MockSettingsRepository()
                 ),
                 showStationAccessibility = true,
                 now = Clock.System.now(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.analytics.Analytics
@@ -12,6 +11,7 @@ import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -19,6 +19,7 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsDepartures
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
@@ -35,13 +36,13 @@ fun StopDetailsUnfilteredView(
     errorBannerViewModel: ErrorBannerViewModel
 ) {
     val globalResponse = getGlobalData("StopDetailsView.getGlobalData")
-    val showStationAccessibility by viewModel.showStationAccessibility.collectAsState()
+    val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
 
     val stop: Stop? = globalResponse?.getStop(stopId)
 
     val analytics: Analytics = koinInject()
 
-    val groupByDirection by viewModel.groupByDirection.collectAsState()
+    val groupByDirection = SettingsCache.get(Settings.GroupByDirection)
     val departures = viewModel.stopDepartures.collectAsState().value
     val routeCardData = viewModel.routeCardData.collectAsState().value
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -10,10 +9,12 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.time.Duration.Companion.seconds
 import org.koin.compose.koinInject
 
@@ -40,9 +41,7 @@ fun StopDetailsView(
 
     val departures by viewModel.stopDepartures.collectAsState()
     val routeCardData by viewModel.routeCardData.collectAsState()
-    val groupByDirection by viewModel.groupByDirection.collectAsState()
-
-    LaunchedEffect(null) { viewModel.loadSettings() }
+    val groupByDirection = SettingsCache.get(Settings.GroupByDirection)
 
     fun openModalAndRecord(modal: ModalRoutes) {
         openModal(modal)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.DebugView
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
@@ -30,6 +31,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
@@ -47,7 +49,7 @@ fun TripDetailsView(
     analytics: Analytics = koinInject(),
     modifier: Modifier = Modifier
 ) {
-    val showStationAccessibility = stopDetailsVM.showStationAccessibility.collectAsState().value
+    val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
     val tripData: TripData? = stopDetailsVM.tripData.collectAsState().value
     val globalResponse: GlobalResponse? = getGlobalData(errorKey = "TripDetailsView.getGlobalData")
     val vehicle = tripData?.vehicle

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
@@ -1,0 +1,42 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+import org.koin.core.component.KoinComponent
+
+class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinComponent {
+    private val cache = MutableStateFlow<Map<Settings, Boolean>?>(null)
+
+    fun set(setting: Settings, value: Boolean) {
+        val newSettings = mapOf(setting to value)
+        cache.update { it.orEmpty() + newSettings }
+        CoroutineScope(Dispatchers.IO).launch { settingsRepository.setSettings(newSettings) }
+    }
+
+    @Composable
+    fun get(setting: Settings): Boolean {
+        val cachedData by cache.collectAsState()
+
+        LaunchedEffect(cachedData == null) {
+            if (cachedData == null) {
+                cache.value = settingsRepository.getSettings()
+            }
+        }
+
+        return cachedData?.get(setting) ?: false
+    }
+
+    companion object {
+        @Composable fun get(setting: Settings) = koinInject<SettingsCache>().get(setting)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
@@ -13,7 +13,7 @@ sealed class MoreItem {
 
     data class Phone(val label: String, val phoneNumber: String) : MoreItem()
 
-    data class Toggle(val label: String, val settings: Settings, val value: Boolean) : MoreItem()
+    data class Toggle(val label: String, val settings: Settings) : MoreItem()
 
     fun id() {
         when (this) {


### PR DESCRIPTION
### Summary

_Ticket:_ [Explore helpers for reading settings on iOS and Android](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209925176921390?focus=true)

Stores a single cache in Koin that updates via a StateFlow and loads inline if needed.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added tests for the cache itself. Updated all existing unit tests to pass settings in the new structure.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
