### PR TITLE
fix(iosApp.NearbyTransitView): Don't reset nearby when stops reordered

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/LocationDataManager.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/LocationDataManager.kt
@@ -61,8 +61,8 @@ open class LocationDataManager {
                         it.permission == Manifest.permission.ACCESS_FINE_LOCATION
                     }
                 LocationRequest.Builder(5.seconds.inWholeMilliseconds)
-                    // ignore updates less than 0.1km
-                    .setMinUpdateDistanceMeters(100F)
+                    // ignore updates less than 10m
+                    .setMinUpdateDistanceMeters(10F)
                     .setPriority(
                         if (finePermission?.status?.isGranted == true)
                             Priority.PRIORITY_HIGH_ACCURACY

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -45,13 +45,6 @@ struct NearbyTransitView: View {
         let pinnedRoutes: Set<String>
     }
 
-    var setOfNearbyStopIds: Set<String>? {
-        guard let stopIds = nearbyVM.nearbyState.stopIds else {
-            return nil
-        }
-        return Set(stopIds)
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             if let routeCardData = nearbyVM.routeCardData,
@@ -72,10 +65,13 @@ struct NearbyTransitView: View {
         .onChange(of: location) { newLocation in
             getNearby(location: newLocation, globalData: globalData)
         }
-        .onChange(of: setOfNearbyStopIds) { nearbyStops in
-            getSchedule()
-            joinPredictions(nearbyStops)
-            scrollToTop()
+        .onChange(of: nearbyVM.nearbyState.stopIds) { [oldValue = nearbyVM.nearbyState.stopIds] newNearbyStops in
+
+            if Set(oldValue ?? []) != Set(newNearbyStops ?? []) {
+                getSchedule()
+                joinPredictions(newNearbyStops)
+                scrollToTop()
+            }
         }
         .onChange(of: predictionsByStop) { newPredictionsByStop in
             if let newPredictionsByStop {
@@ -246,11 +242,6 @@ struct NearbyTransitView: View {
                 onRefreshAfterError: loadEverything
             )
         }
-    }
-
-    func joinPredictions(_ stopIds: Set<String>?) {
-        guard let stopIds else { return }
-        joinPredictions(Array(stopIds))
     }
 
     func joinPredictions(_ stopIds: [String]?) {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -45,6 +45,13 @@ struct NearbyTransitView: View {
         let pinnedRoutes: Set<String>
     }
 
+    var setOfNearbyStopIds: Set<String>? {
+        guard let stopIds = nearbyVM.nearbyState.stopIds else {
+            return nil
+        }
+        return Set(stopIds)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if let routeCardData = nearbyVM.routeCardData,
@@ -65,7 +72,7 @@ struct NearbyTransitView: View {
         .onChange(of: location) { newLocation in
             getNearby(location: newLocation, globalData: globalData)
         }
-        .onChange(of: nearbyVM.nearbyState.stopIds) { nearbyStops in
+        .onChange(of: setOfNearbyStopIds) { nearbyStops in
             getSchedule()
             joinPredictions(nearbyStops)
             scrollToTop()
@@ -239,6 +246,11 @@ struct NearbyTransitView: View {
                 onRefreshAfterError: loadEverything
             )
         }
+    }
+
+    func joinPredictions(_ stopIds: Set<String>?) {
+        guard let stopIds else { return }
+        joinPredictions(Array(stopIds))
     }
 
     func joinPredictions(_ stopIds: [String]?) {

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -20,7 +20,6 @@ import SwiftUI
 #endif
 
 struct ProductionAppView: View {
-    // ignore updates less than 0.1km
     @StateObject var locationDataManager: LocationDataManager
 
     @StateObject var contentVM: ContentViewModel = .init()
@@ -43,6 +42,7 @@ struct ProductionAppView: View {
     }
 
     init(socket: PhoenixSocket) {
+        // ignore updates less than 10m
         _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 10))
         _socketProvider = StateObject(wrappedValue: SocketProvider(socket: socket))
         _viewportProvider = StateObject(wrappedValue: ViewportProvider())

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -43,7 +43,7 @@ struct ProductionAppView: View {
     }
 
     init(socket: PhoenixSocket) {
-        _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 5))
+        _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 10))
         _socketProvider = StateObject(wrappedValue: SocketProvider(socket: socket))
         _viewportProvider = StateObject(wrappedValue: ViewportProvider())
     }

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -43,7 +43,7 @@ struct ProductionAppView: View {
     }
 
     init(socket: PhoenixSocket) {
-        _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 1))
+        _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 5))
         _socketProvider = StateObject(wrappedValue: SocketProvider(socket: socket))
         _viewportProvider = StateObject(wrappedValue: ViewportProvider())
     }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -195,8 +195,6 @@ class NearbyViewModel: ObservableObject {
                 analytics.refetchedNearbyTransit()
             }
             nearbyState.loading = true
-            routeCardData = nil
-
             let stopIds = nearbyRepository.getStopIdsNearby(global: global, location: location.positionKt)
             nearbyState.stopIds = stopIds
             nearbyState.loadedLocation = location

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -436,7 +436,7 @@ final class NearbyTransitViewTests: XCTestCase {
 
         wait(for: [sawmillAtWalshExpectation], timeout: 1)
 
-        try sut.inspect().implicitAnyView().vStack().callOnChange(newValue: ["place-lech"])
+        try sut.inspect().implicitAnyView().vStack().callOnChange(newValue: Set(["place-lech"]))
 
         wait(for: [lechmereExpectation], timeout: 1)
     }
@@ -614,7 +614,7 @@ final class NearbyTransitViewTests: XCTestCase {
             }.store(in: &self.cancellables)
             actualView.nearbyVM.nearbyState.stopIds = ["new-stop"]
             try actualView.inspect().implicitAnyView().vStack()
-                .callOnChange(newValue: ["new-stop"])
+                .callOnChange(newValue: Set(["new-stop"]))
         }
         ViewHosting.host(view: sut)
         wait(for: [exp, scrollPositionSetExpectation], timeout: 2)


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, addresses[ issue raised in slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1745840910660239) where there have been some reports of nearby transit auto-scrolling to the top of the sheet when there are stops ~equidistant nearby. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* added a unit test
* Tested locally with artificial location jitter at a coordinate known to be affected by this issue
* Tested in dev orange

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
