### PR TITLE
chore(iOS): add previews and disrupted branch test

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -11,27 +11,11 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.component.PinButton
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
-import com.mbta.tid.mbta_app.model.Alert
-import com.mbta.tid.mbta_app.model.Line
-import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.RoutePattern
-import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
-import com.mbta.tid.mbta_app.model.UpcomingTrip
-import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
+import com.mbta.tid.mbta_app.utils.RouteCardPreviewData
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atTime
-import kotlinx.datetime.toInstant
-import kotlinx.datetime.toLocalDateTime
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
@@ -67,373 +51,14 @@ fun RouteCard(
 }
 
 class Previews() {
-    fun LocalDateTime.toInstant(): Instant = toInstant(TimeZone.currentSystemDefault())
-
-    val today: LocalDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
-    val now: Instant = today.atTime(11, 30).toInstant()
-    val objects = ObjectCollectionBuilder()
-    val greenLine =
-        objects.line {
-            id = "line-Green"
-            color = "00843D"
-            longName = "Green Line"
-            textColor = "FFFFFF"
-        }
-    val slWaterfront =
-        objects.line {
-            color = "7C878E"
-            longName = "Silver Line SL1/SL2/SL3"
-            textColor = "FFFFFF"
-        }
-    val orangeLine =
-        objects.route {
-            id = "Orange"
-            color = "ED8B00"
-            directionDestinations = listOf("Forest Hills", "Oak Grove")
-            directionNames = listOf("South", "North")
-            longName = "Orange Line"
-            textColor = "FFFFFF"
-            type = RouteType.HEAVY_RAIL
-        }
-    val redLine =
-        objects.route {
-            id = "Red"
-            color = "DA291C"
-            directionDestinations = listOf("Ashmont/Braintree", "Alewife")
-            directionNames = listOf("South", "North")
-            longName = "Red Line"
-            textColor = "FFFFFF"
-            type = RouteType.HEAVY_RAIL
-        }
-    val greenLineB =
-        objects.route {
-            id = "Green-B"
-            color = greenLine.color
-            directionDestinations = listOf("Boston College", "Government Center")
-            directionNames = listOf("West", "East")
-            lineId = greenLine.id
-            longName = "Green Line B"
-            shortName = "B"
-            textColor = greenLine.textColor
-            type = RouteType.LIGHT_RAIL
-        }
-    val greenLineC =
-        objects.route {
-            id = "Green-C"
-            color = greenLine.color
-            directionDestinations = listOf("Cleveland Circle", "Government Center")
-            directionNames = listOf("West", "East")
-            lineId = greenLine.id
-            longName = "Green Line C"
-            shortName = "C"
-            textColor = greenLine.textColor
-            type = RouteType.LIGHT_RAIL
-        }
-    val greenLineD =
-        objects.route {
-            id = "Green-D"
-            color = greenLine.color
-            directionDestinations = listOf("Riverside", "Union Square")
-            directionNames = listOf("West", "East")
-            lineId = greenLine.id
-            longName = "Green Line D"
-            shortName = "D"
-            textColor = greenLine.textColor
-            type = RouteType.LIGHT_RAIL
-        }
-    val sl1 =
-        objects.route {
-            color = slWaterfront.color
-            directionNames = listOf("Outbound", "Inbound")
-            lineId = slWaterfront.id
-            shortName = "SL1"
-            textColor = slWaterfront.textColor
-            type = RouteType.BUS
-        }
-    val sl2 =
-        objects.route {
-            color = slWaterfront.color
-            directionNames = listOf("Outbound", "Inbound")
-            lineId = slWaterfront.id
-            shortName = "SL2"
-            textColor = slWaterfront.textColor
-            type = RouteType.BUS
-        }
-    val sl3 =
-        objects.route {
-            color = slWaterfront.color
-            directionNames = listOf("Outbound", "Inbound")
-            lineId = slWaterfront.id
-            shortName = "SL3"
-            textColor = slWaterfront.textColor
-            type = RouteType.BUS
-        }
-    val providenceLine =
-        objects.route {
-            color = "80276C"
-            directionDestinations = listOf("Stoughton or Wickford Junction", "South Station")
-            directionNames = listOf("Outbound", "Inbound")
-            longName = "Providence/Stoughton Line"
-            textColor = "FFFFFF"
-            type = RouteType.COMMUTER_RAIL
-        }
-    val bus87 =
-        objects.route {
-            color = "FFC72C"
-            directionDestinations = listOf("Clarendon Hill or Arlington Center", "Lechmere Station")
-            directionNames = listOf("Outbound", "Inbound")
-            shortName = "87"
-            textColor = "000000"
-            type = RouteType.BUS
-        }
-    val bus15 =
-        objects.route {
-            color = "FFC72C"
-            directionDestinations =
-                listOf("Fields Corner Station or St Peter's Square", "Ruggles Station")
-            directionNames = listOf("Outbound", "Inbound")
-            shortName = "15"
-            textColor = "000000"
-            type = RouteType.BUS
-        }
-    val orangeLineSouthbound =
-        objects.routePattern(orangeLine) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Forest Hills" }
-        }
-    val orangeLineNorthbound =
-        objects.routePattern(orangeLine) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Oak Grove" }
-        }
-    val redLineAshmontSouthbound =
-        objects.routePattern(redLine) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Ashmont" }
-        }
-    val redLineBraintreeSouthbound =
-        objects.routePattern(redLine) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Braintree" }
-        }
-    val redLineAshmontNorthbound =
-        objects.routePattern(redLine) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Alewife" }
-        }
-    val redLineBraintreeNorthbound =
-        objects.routePattern(redLine) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Alewife" }
-        }
-    val greenLineBWestbound =
-        objects.routePattern(greenLineB) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip {
-                headsign = "Boston College"
-                // only the stops required to correctly apply the direction special casing
-                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-lake")
-            }
-        }
-    val greenLineBEastbound =
-        objects.routePattern(greenLineB) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Government Center" }
-        }
-    val greenLineCWestbound =
-        objects.routePattern(greenLineC) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip {
-                headsign = "Cleveland Circle"
-                // only the stops required to correctly apply the direction special casing
-                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-clmnl")
-            }
-        }
-    val greenLineCEastbound =
-        objects.routePattern(greenLineC) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Government Center" }
-        }
-    val greenLineDWestbound =
-        objects.routePattern(greenLineD) {
-            directionId = 0
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip {
-                headsign = "Riverside"
-                // only the stops required to correctly apply the direction special casing
-                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-river")
-            }
-        }
-    val greenLineDEastbound =
-        objects.routePattern(greenLineD) {
-            directionId = 1
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { headsign = "Union Square" }
-        }
-    val arlingtonOutbound =
-        objects.routePattern(bus87) {
-            directionId = 0
-            representativeTrip { headsign = "Arlington Center" }
-        }
-    val arlingtonInbound =
-        objects.routePattern(bus87) {
-            directionId = 1
-            representativeTrip { headsign = "Lechmere" }
-        }
-    val clarendonOutbound =
-        objects.routePattern(bus87) {
-            directionId = 0
-            representativeTrip { headsign = "Clarendon Hill" }
-        }
-    val clarendonInbound =
-        objects.routePattern(bus87) {
-            directionId = 1
-            representativeTrip { headsign = "Lechmere" }
-        }
-    val ruggles =
-        objects.stop {
-            name = "Ruggles"
-            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-        }
-    val jfkUmass =
-        objects.stop {
-            name = "JFK/UMass"
-            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-        }
-    val boylston =
-        objects.stop {
-            id = "place-boyls"
-            name = "Boylston"
-            wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
-        }
-
-    val kenmore =
-        objects.stop {
-            id = "place-kencl"
-            name = "Kenmore"
-            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-        }
-    val somervilleAtCarlton =
-        objects.stop {
-            name = "Somerville Ave @ Carlton St"
-            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-        }
-    val bowAtWarren =
-        objects.stop {
-            name = "Bow St @ Warren Ave"
-            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-        }
-    val shuttleAlert = objects.alert { effect = Alert.Effect.Shuttle }
-    val suspensionAlert = objects.alert { effect = Alert.Effect.Suspension }
-    val global = GlobalResponse(objects)
-    val context = RouteCardData.Context.NearbyTransit
-
+    val data = RouteCardPreviewData()
     val koin = koinApplication { modules(module { single<Analytics> { MockAnalytics() } }) }
-
-    fun cardStop(
-        lineOrRoute: RouteCardData.LineOrRoute,
-        stop: Stop,
-        patterns: List<RoutePattern>,
-        trips: List<UpcomingTrip>,
-        alertHere: Map<Int, Alert>,
-        alertDownstream: Map<Int, Alert>
-    ) =
-        RouteCardData.RouteStopData(
-            stop,
-            lineOrRoute,
-            listOfNotNull(
-                RouteCardData.Leaf(
-                        0,
-                        patterns.filter { it.directionId == 0 },
-                        setOf(stop.id),
-                        trips.filter { it.trip.directionId == 0 },
-                        listOfNotNull(alertHere[0]),
-                        true,
-                        true,
-                        listOfNotNull(alertDownstream[0])
-                    )
-                    .takeUnless { it.routePatterns.isEmpty() },
-                RouteCardData.Leaf(
-                        1,
-                        patterns.filter { it.directionId == 1 },
-                        setOf(stop.id),
-                        trips.filter { it.trip.directionId == 1 },
-                        listOfNotNull(alertHere[1]),
-                        true,
-                        true,
-                        listOfNotNull(alertDownstream[1])
-                    )
-                    .takeUnless { it.routePatterns.isEmpty() }
-            ),
-            global
-        )
-
-    fun card(
-        lineOrRoute: RouteCardData.LineOrRoute,
-        stop: Stop,
-        patterns: List<RoutePattern>,
-        trips: List<UpcomingTrip>,
-        alertHere: Map<Int, Alert>,
-        alertDownstream: Map<Int, Alert>
-    ) =
-        RouteCardData(
-            lineOrRoute,
-            listOf(cardStop(lineOrRoute, stop, patterns, trips, alertHere, alertDownstream)),
-            context,
-            now
-        )
-
-    fun card(
-        route: Route,
-        stop: Stop,
-        trips: List<UpcomingTrip>,
-        alertHere: Map<Int, Alert> = emptyMap(),
-        alertDownstream: Map<Int, Alert> = emptyMap()
-    ) =
-        card(
-            RouteCardData.LineOrRoute.Route(route),
-            stop,
-            objects.routePatterns.values.filter { it.routeId == route.id },
-            trips,
-            alertHere,
-            alertDownstream
-        )
-
-    fun card(
-        line: Line,
-        stop: Stop,
-        trips: List<UpcomingTrip>,
-        alertHere: Map<Int, Alert> = emptyMap(),
-        alertDownstream: Map<Int, Alert> = emptyMap()
-    ): RouteCardData {
-        val routes = objects.routes.values.filter { it.lineId == line.id }.toSet()
-        val routeIds = routes.map { it.id }
-        val routePatterns = objects.routePatterns.values.filter { routeIds.contains(it.routeId) }
-        return card(
-            RouteCardData.LineOrRoute.Line(line, routes),
-            stop,
-            routePatterns,
-            trips,
-            alertHere,
-            alertDownstream
-        )
-    }
 
     @Composable
     fun CardForPreview(card: RouteCardData) {
         KoinContext(koin.koin) {
             Box(Modifier.width(358.dp)) {
-                RouteCard(card, global, now, false, {}, true, { _, _ -> })
+                RouteCard(card, data.global, data.now, false, {}, true, { _, _ -> })
             }
         }
     }
@@ -441,57 +66,13 @@ class Previews() {
     @Preview(name = "Downstream disruption", group = "1. Orange Line disruption")
     @Composable
     fun OL1() {
-        CardForPreview(
-            card(
-                orangeLine,
-                ruggles,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
-                            departureTime = now + 16.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(orangeLineNorthbound)
-                            departureTime = now + 7.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(orangeLineNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                ),
-                alertDownstream = mapOf(0 to shuttleAlert)
-            )
-        )
+        CardForPreview(data.OL1())
     }
 
     @Preview(name = "Disrupted stop", group = "1. Orange Line disruption")
     @Composable
     fun OL2() {
-        CardForPreview(
-            card(
-                orangeLine,
-                objects.stop {
-                    name = "Stony Brook"
-                    wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-                },
-                listOf(),
-                mapOf(0 to shuttleAlert, 1 to shuttleAlert)
-            )
-        )
+        CardForPreview(data.OL2())
     }
 
     @Preview(
@@ -500,486 +81,55 @@ class Previews() {
     )
     @Composable
     fun RL1() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeSouthbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                )
-            )
-        )
+        CardForPreview(data.RL1())
     }
 
     @Preview(name = "Next three trips go to the same destination", group = "2. Red Line branching")
     @Composable
     fun RL2() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeSouthbound)
-                            departureTime = now + 15.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                )
-            )
-        )
+        CardForPreview(data.RL2())
     }
 
     @Preview(name = "Predictions unavailable for a branch", group = "2. Red Line branching")
     @Composable
     fun RL3() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                )
-            )
-        )
+        CardForPreview(data.RL3())
     }
 
     @Preview(name = "Service not running on a branch downstream", group = "2. Red Line branching")
     @Composable
     fun RL4() {
-        CardForPreview(
-            card(
-                redLine,
-                objects.stop {
-                    name = "Park Street"
-                    wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-                },
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                ),
-                alertDownstream = mapOf(0 to shuttleAlert)
-            )
-        )
+        CardForPreview(data.RL4())
     }
 
     @Preview(name = "Service disrupted on a branch downstream", group = "2. Red Line branching")
     @Composable
     fun RL5() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(redLineBraintreeSouthbound) { headsign = "Wollaston" }
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                ),
-                alertDownstream = mapOf(0 to suspensionAlert)
-            )
-        )
+        CardForPreview(data.RL5())
     }
 
     @Preview(name = "Branching in both directions", group = "3. Green Line branching")
     @Composable
     fun GL1() {
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDWestbound)
-                            departureTime = now + 10.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.GL1())
     }
 
     @Preview(name = "Downstream disruption", group = "3. Green Line branching")
     @Composable
     fun GL2() {
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDWestbound)
-                            departureTime = now + 10.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                ),
-                alertDownstream = mapOf(0 to suspensionAlert)
-            )
-        )
+        CardForPreview(data.GL2())
     }
 
     @Preview(name = "Branching in one direction", group = "4. Silver Line branching")
     @Composable
     fun SL1() {
-        CardForPreview(
-            card(
-                slWaterfront,
-                objects.stop {
-                    name = "World Trade Center"
-                    wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-                },
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(sl1) {
-                                        directionId = 1
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "South Station" }
-                                    }
-                                )
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(sl2) {
-                                        directionId = 1
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "South Station" }
-                                    }
-                                )
-                            departureTime = now + 7.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(sl1) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "Logan Airport" }
-                                    }
-                                )
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(sl2) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "Design Center" }
-                                    }
-                                )
-                            departureTime = now + 7.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(sl3) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "Chelsea" }
-                                    }
-                                )
-                            departureTime = now + 9.minutes
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.SL1())
     }
 
     @Preview(name = "Branching in one direction", group = "5. CR branching")
     @Composable
     fun CR1() {
-        CardForPreview(
-            card(
-                providenceLine,
-                ruggles,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(providenceLine) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.CanonicalOnly
-                                        representativeTrip { headsign = "Stoughton" }
-                                    }
-                                )
-                            departureTime = today.atTime(12, 5).toInstant()
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(providenceLine) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "Providence" }
-                                    }
-                                )
-                            departureTime = today.atTime(15, 28).toInstant()
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(providenceLine) {
-                                        directionId = 0
-                                        typicality = RoutePattern.Typicality.CanonicalOnly
-                                        representativeTrip { headsign = "Wickford Junction" }
-                                    }
-                                )
-                            departureTime = today.atTime(16, 1).toInstant()
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(providenceLine) {
-                                        directionId = 1
-                                        typicality = RoutePattern.Typicality.CanonicalOnly
-                                        representativeTrip { headsign = "South Station" }
-                                    }
-                                )
-                            departureTime = today.atTime(15, 31).toInstant()
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(providenceLine) {
-                                        directionId = 1
-                                        typicality = RoutePattern.Typicality.Typical
-                                        representativeTrip { headsign = "South Station" }
-                                    }
-                                )
-                            departureTime = today.atTime(15, 53).toInstant()
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.CR1())
     }
 
     @Preview(
@@ -988,64 +138,7 @@ class Previews() {
     )
     @Composable
     fun Bus1() {
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
-        CardForPreview(
-            RouteCardData(
-                lineOrRoute,
-                listOf(
-                    cardStop(
-                        lineOrRoute,
-                        somervilleAtCarlton,
-                        listOf(arlingtonInbound, clarendonInbound),
-                        listOf(
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(arlingtonInbound)
-                                    departureTime = now + 16.minutes
-                                }
-                            ),
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(clarendonInbound)
-                                    departureTime = now + 42.minutes
-                                }
-                            )
-                        ),
-                        emptyMap(),
-                        emptyMap()
-                    ),
-                    cardStop(
-                        lineOrRoute,
-                        bowAtWarren,
-                        listOf(arlingtonOutbound, clarendonOutbound),
-                        listOf(
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(arlingtonOutbound)
-                                    departureTime = now + 3.minutes
-                                }
-                            ),
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(arlingtonOutbound)
-                                    departureTime = now + 12.minutes
-                                }
-                            ),
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(clarendonOutbound)
-                                    departureTime = now + 45.minutes
-                                }
-                            )
-                        ),
-                        emptyMap(),
-                        emptyMap()
-                    )
-                ),
-                context,
-                now
-            )
-        )
+        CardForPreview(data.Bus1())
     }
 
     @Preview(
@@ -1054,58 +147,7 @@ class Previews() {
     )
     @Composable
     fun Bus2() {
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
-        CardForPreview(
-            RouteCardData(
-                lineOrRoute,
-                listOf(
-                    cardStop(
-                        lineOrRoute,
-                        somervilleAtCarlton,
-                        listOf(arlingtonInbound, clarendonInbound),
-                        listOf(
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(arlingtonInbound)
-                                    departureTime = now + 16.minutes
-                                }
-                            ),
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(clarendonInbound)
-                                    departureTime = now + 42.minutes
-                                }
-                            )
-                        ),
-                        emptyMap(),
-                        emptyMap()
-                    ),
-                    cardStop(
-                        lineOrRoute,
-                        bowAtWarren,
-                        listOf(arlingtonOutbound, clarendonOutbound),
-                        listOf(
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(arlingtonOutbound)
-                                    departureTime = now + 1.minutes
-                                }
-                            ),
-                            objects.upcomingTrip(
-                                objects.prediction {
-                                    trip = objects.trip(clarendonOutbound)
-                                    departureTime = now + 32.minutes
-                                }
-                            )
-                        ),
-                        emptyMap(),
-                        emptyMap()
-                    )
-                ),
-                context,
-                now
-            )
-        )
+        CardForPreview(data.Bus2())
     }
 
     @Preview(
@@ -1114,286 +156,37 @@ class Previews() {
     )
     @Composable
     fun Bus3() {
-        CardForPreview(
-            card(
-                bus15,
-                objects.stop {
-                    name = "Nubian"
-                    wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
-                },
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(bus15) {
-                                        directionId = 0
-                                        representativeTrip { headsign = "St Peter's Square" }
-                                    }
-                                )
-                            departureTime = now + 8.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(bus15) {
-                                        directionId = 0
-                                        representativeTrip { headsign = "Kane Square" }
-                                    }
-                                )
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(bus15) {
-                                        directionId = 1
-                                        representativeTrip { headsign = "Ruggles" }
-                                    }
-                                )
-                            departureTime = now + 15.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip =
-                                objects.trip(
-                                    objects.routePattern(bus15) {
-                                        directionId = 1
-                                        representativeTrip { headsign = "Ruggles" }
-                                    }
-                                )
-                            departureTime = now + 23.minutes
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.Bus3())
     }
 
     @Preview(name = "Service ended on a branch", group = "8. Service ended")
     @Composable
     fun RL6() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontSouthbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                )
-            )
-        )
+        CardForPreview(data.RL6())
     }
 
     @Preview(name = "Service ended on all branches", group = "8. Service ended")
     @Composable
     fun RL7() {
-        CardForPreview(
-            card(
-                redLine,
-                jfkUmass,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineAshmontNorthbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(redLineBraintreeNorthbound)
-                            departureTime = now + 12.minutes
-                        }
-                    )
-                )
-            )
-        )
+        CardForPreview(data.RL7())
     }
 
     @Preview(name = "Predictions unavailable on a branch", group = "9. Predictions unavailable")
     @Composable
     fun GL3() {
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 10.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineDWestbound)
-                            departureTime = now + 2.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.GL3())
     }
 
     @Preview(name = "Predictions unavailable on all branches", group = "9. Predictions unavailable")
     @Composable
     fun GL4() {
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineDWestbound)
-                            departureTime = now + 10.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                )
-            )
-        )
+        CardForPreview(data.GL4())
     }
 
     @Preview(name = "Disruption on a branch", group = "A. Disruption")
     @Composable
     fun GL5() {
-
-        val kenmoreShuttleToRiverside =
-            objects.alert {
-                effect = Alert.Effect.Shuttle
-                informedEntity =
-                    mutableListOf(
-                        Alert.InformedEntity(
-                            activities = listOf(Alert.InformedEntity.Activity.Board),
-                            directionId = 0,
-                            route = greenLineD.id,
-                            routeType = RouteType.LIGHT_RAIL,
-                            stop = kenmore.id,
-                            trip = null
-                        )
-                    )
-            }
-
-        CardForPreview(
-            card(
-                greenLine,
-                kenmore,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                ),
-                alertHere = mapOf(0 to kenmoreShuttleToRiverside)
-            )
-        )
+        CardForPreview(data.GL5())
     }
 
     @Preview(
@@ -1402,119 +195,12 @@ class Previews() {
     )
     @Composable
     fun GL6() {
-
-        val boylstonShuttleToRiverside =
-            objects.alert {
-                effect = Alert.Effect.Shuttle
-                informedEntity =
-                    mutableListOf(
-                        Alert.InformedEntity(
-                            activities = listOf(Alert.InformedEntity.Activity.Board),
-                            directionId = 0,
-                            route = greenLineD.id,
-                            routeType = RouteType.LIGHT_RAIL,
-                            stop = boylston.id,
-                            trip = null
-                        )
-                    )
-            }
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineCWestbound)
-                            departureTime = now + 3.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineBWestbound)
-                            departureTime = now + 5.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.prediction {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                ),
-                alertHere = mapOf(0 to boylstonShuttleToRiverside)
-            )
-        )
+        CardForPreview(data.GL6())
     }
 
     @Preview(name = "Disruption on all branches", group = "A. Disruption")
     @Composable
     fun GL7() {
-
-        val shuttleAllBranches =
-            objects.alert {
-                effect = Alert.Effect.Shuttle
-                informedEntity =
-                    mutableListOf(
-                        Alert.InformedEntity(
-                            activities = listOf(Alert.InformedEntity.Activity.Board),
-                            directionId = 0,
-                            route = greenLineB.id,
-                            routeType = RouteType.LIGHT_RAIL,
-                            stop = boylston.id,
-                            trip = null
-                        ),
-                        Alert.InformedEntity(
-                            activities = listOf(Alert.InformedEntity.Activity.Board),
-                            directionId = 0,
-                            route = greenLineC.id,
-                            routeType = RouteType.LIGHT_RAIL,
-                            stop = boylston.id,
-                            trip = null
-                        ),
-                        Alert.InformedEntity(
-                            activities = listOf(Alert.InformedEntity.Activity.Board),
-                            directionId = 0,
-                            route = greenLineD.id,
-                            routeType = RouteType.LIGHT_RAIL,
-                            stop = boylston.id,
-                            trip = null
-                        )
-                    )
-            }
-
-        CardForPreview(
-            card(
-                greenLine,
-                boylston,
-                listOf(
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineDEastbound)
-                            departureTime = now + 1.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineBEastbound)
-                            departureTime = now + 6.minutes
-                        }
-                    ),
-                    objects.upcomingTrip(
-                        objects.schedule {
-                            trip = objects.trip(greenLineCEastbound)
-                            departureTime = now + 12.minutes
-                        }
-                    ),
-                ),
-                alertHere = mapOf(0 to shuttleAllBranches)
-            )
-        )
+        CardForPreview(data.GL7())
     }
 }

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -55,3 +55,82 @@ struct RouteCard: View {
         .withRoundedBorder()
     }
 }
+
+private func cardForPreview(_ card: RouteCardData, _ previewData: RouteCardPreviewData) -> some View {
+    RouteCard(
+        cardData: card,
+        global: previewData.global,
+        now: previewData.now.toNSDate(),
+        onPin: { _ in },
+        pinned: false,
+        pushNavEntry: { _ in },
+        showStationAccessibility: true
+    )
+}
+
+#Preview {
+    let data = RouteCardPreviewData()
+    ScrollView {
+        VStack {
+            Section("Orange Line disruption") {
+                // Downstream disruption
+                cardForPreview(data.OL1(), data)
+                // Disrupted stop
+                cardForPreview(data.OL2(), data)
+            }
+            Section("Red Line branching") {
+                // Show up to the next three trips in the branching direction
+                cardForPreview(data.RL1(), data)
+                // Next three trips go to the same destination
+                cardForPreview(data.RL2(), data)
+                // Predictions unavailable for a branch
+                cardForPreview(data.RL3(), data)
+                // Service not running on a branch downstream
+                cardForPreview(data.RL4(), data)
+                // Service disrupted on a branch downstream
+                cardForPreview(data.RL5(), data)
+            }
+            Section("Green Line Branching") {
+                // Branching in both directions
+                cardForPreview(data.GL1(), data)
+                // Downstream disruption
+                cardForPreview(data.GL2(), data)
+            }
+            Section("Silver Line Branching") {
+                // Branching in one direction
+                cardForPreview(data.SL1(), data)
+            }
+            Section("CR Branching") {
+                // Branching in one direction
+                cardForPreview(data.CR1(), data)
+            }
+            Section("Bus Route Single Direction") {
+                // "Next two trips go to the same destination"
+                cardForPreview(data.Bus1(), data)
+                // "Next two trips go to different destinations"
+                cardForPreview(data.Bus2(), data)
+                // "Next two trips go to different destinations"
+                cardForPreview(data.Bus3(), data)
+            }
+            Section("Service ended") {
+                // Service ended on a branch
+                cardForPreview(data.RL6(), data)
+                // Service ended on all branches
+                cardForPreview(data.RL7(), data)
+                // Predictions unavailable on a branch
+                cardForPreview(data.GL3(), data)
+                // Predictions unavailable on all branches
+                cardForPreview(data.GL4(), data)
+            }
+            Section("Disruption") {
+                // Disruption on a branch
+                cardForPreview(data.GL5(), data)
+                // "Disruption on a branch, predictions unavailable for other branches"
+                cardForPreview(data.GL6(), data)
+                // "Disruption on all branches"
+                cardForPreview(data.GL7(), data)
+            }
+        }
+        .padding()
+    }
+}

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -194,4 +194,35 @@ final class RouteCardTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(RouteCardDepartures.self))
         XCTAssertNotNil(try sut.inspect().find(text: "Inbound to"))
     }
+
+    func testBranchDisrupted() throws {
+        let data = RouteCardPreviewData()
+        let sut = RouteCard(
+            cardData: data.GL5(),
+            global: data.global,
+            now: data.now.toNSDate(),
+            onPin: { _ in },
+            pinned: false,
+            pushNavEntry: { _ in },
+            showStationAccessibility: false
+        )
+        XCTAssertNotNil(try sut.inspect().find(RouteCardDepartures.self))
+        let westDirection = try sut.inspect().find(text: "Westbound to")
+            .find(RouteCardDirection.self, relation: .parent)
+        XCTAssertNotNil(westDirection)
+        XCTAssertNotNil(try westDirection.find(text: "3 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Cleveland Circle"))
+        XCTAssertNotNil(try westDirection.find(text: "5 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Boston College"))
+        XCTAssertNotNil(try westDirection.find(text: "Shuttle Bus")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Riverside"))
+
+        let eastDirection = try sut.inspect().find(text: "Eastbound to")
+            .find(RouteCardDirection.self, relation: .parent)
+        XCTAssertNotNil(eastDirection)
+        XCTAssertNotNil(try eastDirection.find(text: "6 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Government Center"))
+        XCTAssertNotNil(try eastDirection.find(text: "12 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Government Center"))
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -1,0 +1,1367 @@
+package com.mbta.tid.mbta_app.utils
+
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.UpcomingTrip
+import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atTime
+import kotlinx.datetime.toInstant
+import kotlinx.datetime.toLocalDateTime
+
+open class RouteCardPreviewData {
+    private fun LocalDateTime.toInstant(): Instant = toInstant(TimeZone.currentSystemDefault())
+
+    private val today: LocalDate =
+        Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    private val objects = ObjectCollectionBuilder()
+    private val greenLine =
+        objects.line {
+            id = "line-Green"
+            color = "00843D"
+            longName = "Green Line"
+            textColor = "FFFFFF"
+        }
+    private val slWaterfront =
+        objects.line {
+            color = "7C878E"
+            longName = "Silver Line SL1/SL2/SL3"
+            textColor = "FFFFFF"
+        }
+    private val orangeLine =
+        objects.route {
+            id = "Orange"
+            color = "ED8B00"
+            directionDestinations = listOf("Forest Hills", "Oak Grove")
+            directionNames = listOf("South", "North")
+            longName = "Orange Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+        }
+    private val redLine =
+        objects.route {
+            id = "Red"
+            color = "DA291C"
+            directionDestinations = listOf("Ashmont/Braintree", "Alewife")
+            directionNames = listOf("South", "North")
+            longName = "Red Line"
+            textColor = "FFFFFF"
+            type = RouteType.HEAVY_RAIL
+        }
+    private val greenLineB =
+        objects.route {
+            id = "Green-B"
+            color = greenLine.color
+            directionDestinations = listOf("Boston College", "Government Center")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line B"
+            shortName = "B"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    private val greenLineC =
+        objects.route {
+            id = "Green-C"
+            color = greenLine.color
+            directionDestinations = listOf("Cleveland Circle", "Government Center")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line C"
+            shortName = "C"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    private val greenLineD =
+        objects.route {
+            id = "Green-D"
+            color = greenLine.color
+            directionDestinations = listOf("Riverside", "Union Square")
+            directionNames = listOf("West", "East")
+            lineId = greenLine.id
+            longName = "Green Line D"
+            shortName = "D"
+            textColor = greenLine.textColor
+            type = RouteType.LIGHT_RAIL
+        }
+    private val sl1 =
+        objects.route {
+            color = slWaterfront.color
+            directionNames = listOf("Outbound", "Inbound")
+            lineId = slWaterfront.id
+            shortName = "SL1"
+            textColor = slWaterfront.textColor
+            type = RouteType.BUS
+        }
+    private val sl2 =
+        objects.route {
+            color = slWaterfront.color
+            directionNames = listOf("Outbound", "Inbound")
+            lineId = slWaterfront.id
+            shortName = "SL2"
+            textColor = slWaterfront.textColor
+            type = RouteType.BUS
+        }
+    private val sl3 =
+        objects.route {
+            color = slWaterfront.color
+            directionNames = listOf("Outbound", "Inbound")
+            lineId = slWaterfront.id
+            shortName = "SL3"
+            textColor = slWaterfront.textColor
+            type = RouteType.BUS
+        }
+    private val providenceLine =
+        objects.route {
+            color = "80276C"
+            directionDestinations = listOf("Stoughton or Wickford Junction", "South Station")
+            directionNames = listOf("Outbound", "Inbound")
+            longName = "Providence/Stoughton Line"
+            textColor = "FFFFFF"
+            type = RouteType.COMMUTER_RAIL
+        }
+    private val bus87 =
+        objects.route {
+            color = "FFC72C"
+            directionDestinations = listOf("Clarendon Hill or Arlington Center", "Lechmere Station")
+            directionNames = listOf("Outbound", "Inbound")
+            shortName = "87"
+            textColor = "000000"
+            type = RouteType.BUS
+        }
+    private val bus15 =
+        objects.route {
+            color = "FFC72C"
+            directionDestinations =
+                listOf("Fields Corner Station or St Peter's Square", "Ruggles Station")
+            directionNames = listOf("Outbound", "Inbound")
+            shortName = "15"
+            textColor = "000000"
+            type = RouteType.BUS
+        }
+    private val orangeLineSouthbound =
+        objects.routePattern(orangeLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Forest Hills" }
+        }
+    private val orangeLineNorthbound =
+        objects.routePattern(orangeLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Oak Grove" }
+        }
+    private val redLineAshmontSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Ashmont" }
+        }
+    private val redLineBraintreeSouthbound =
+        objects.routePattern(redLine) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Braintree" }
+        }
+    private val redLineAshmontNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    private val redLineBraintreeNorthbound =
+        objects.routePattern(redLine) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Alewife" }
+        }
+    private val greenLineBWestbound =
+        objects.routePattern(greenLineB) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip {
+                headsign = "Boston College"
+                // only the stops required to correctly apply the direction special casing
+                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-lake")
+            }
+        }
+    private val greenLineBEastbound =
+        objects.routePattern(greenLineB) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Government Center" }
+        }
+    private val greenLineCWestbound =
+        objects.routePattern(greenLineC) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip {
+                headsign = "Cleveland Circle"
+                // only the stops required to correctly apply the direction special casing
+                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-clmnl")
+            }
+        }
+    private val greenLineCEastbound =
+        objects.routePattern(greenLineC) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Government Center" }
+        }
+    private val greenLineDWestbound =
+        objects.routePattern(greenLineD) {
+            directionId = 0
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip {
+                headsign = "Riverside"
+                // only the stops required to correctly apply the direction special casing
+                stopIds = listOf("place-boyls", "place-armnl", "place-kencl", "place-river")
+            }
+        }
+    private val greenLineDEastbound =
+        objects.routePattern(greenLineD) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { headsign = "Union Square" }
+        }
+    private val arlingtonOutbound =
+        objects.routePattern(bus87) {
+            directionId = 0
+            representativeTrip { headsign = "Arlington Center" }
+        }
+    private val arlingtonInbound =
+        objects.routePattern(bus87) {
+            directionId = 1
+            representativeTrip { headsign = "Lechmere" }
+        }
+    private val clarendonOutbound =
+        objects.routePattern(bus87) {
+            directionId = 0
+            representativeTrip { headsign = "Clarendon Hill" }
+        }
+    private val clarendonInbound =
+        objects.routePattern(bus87) {
+            directionId = 1
+            representativeTrip { headsign = "Lechmere" }
+        }
+    private val ruggles =
+        objects.stop {
+            name = "Ruggles"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    private val jfkUmass =
+        objects.stop {
+            name = "JFK/UMass"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    private val boylston =
+        objects.stop {
+            id = "place-boyls"
+            name = "Boylston"
+            wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
+        }
+
+    private val kenmore =
+        objects.stop {
+            id = "place-kencl"
+            name = "Kenmore"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    private val somervilleAtCarlton =
+        objects.stop {
+            name = "Somerville Ave @ Carlton St"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    private val bowAtWarren =
+        objects.stop {
+            name = "Bow St @ Warren Ave"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    private val shuttleAlert = objects.alert { effect = Alert.Effect.Shuttle }
+    private val suspensionAlert = objects.alert { effect = Alert.Effect.Suspension }
+    private val context = RouteCardData.Context.NearbyTransit
+
+    val now: Instant = today.atTime(11, 30).toInstant()
+    val global = GlobalResponse(objects)
+
+    private fun cardStop(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        stop: Stop,
+        patterns: List<RoutePattern>,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert>,
+        alertDownstream: Map<Int, Alert>
+    ) =
+        RouteCardData.RouteStopData(
+            stop,
+            lineOrRoute,
+            listOfNotNull(
+                RouteCardData.Leaf(
+                        0,
+                        patterns.filter { it.directionId == 0 },
+                        setOf(stop.id),
+                        trips.filter { it.trip.directionId == 0 },
+                        listOfNotNull(alertHere[0]),
+                        true,
+                        true,
+                        listOfNotNull(alertDownstream[0])
+                    )
+                    .takeUnless { it.routePatterns.isEmpty() },
+                RouteCardData.Leaf(
+                        1,
+                        patterns.filter { it.directionId == 1 },
+                        setOf(stop.id),
+                        trips.filter { it.trip.directionId == 1 },
+                        listOfNotNull(alertHere[1]),
+                        true,
+                        true,
+                        listOfNotNull(alertDownstream[1])
+                    )
+                    .takeUnless { it.routePatterns.isEmpty() }
+            ),
+            global
+        )
+
+    private fun card(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        stop: Stop,
+        patterns: List<RoutePattern>,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert>,
+        alertDownstream: Map<Int, Alert>
+    ) =
+        RouteCardData(
+            lineOrRoute,
+            listOf(cardStop(lineOrRoute, stop, patterns, trips, alertHere, alertDownstream)),
+            context,
+            now
+        )
+
+    private fun card(
+        route: Route,
+        stop: Stop,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert> = emptyMap(),
+        alertDownstream: Map<Int, Alert> = emptyMap()
+    ) =
+        card(
+            RouteCardData.LineOrRoute.Route(route),
+            stop,
+            objects.routePatterns.values.filter { it.routeId == route.id },
+            trips,
+            alertHere,
+            alertDownstream
+        )
+
+    private fun card(
+        line: Line,
+        stop: Stop,
+        trips: List<UpcomingTrip>,
+        alertHere: Map<Int, Alert> = emptyMap(),
+        alertDownstream: Map<Int, Alert> = emptyMap()
+    ): RouteCardData {
+        val routes = objects.routes.values.filter { it.lineId == line.id }.toSet()
+        val routeIds = routes.map { it.id }
+        val routePatterns = objects.routePatterns.values.filter { routeIds.contains(it.routeId) }
+        return card(
+            RouteCardData.LineOrRoute.Line(line, routes),
+            stop,
+            routePatterns,
+            trips,
+            alertHere,
+            alertDownstream
+        )
+    }
+
+    // "Downstream disruption" group = "1. Orange Line disruption"
+    fun OL1() =
+        card(
+            orangeLine,
+            ruggles,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(orangeLineSouthbound) { headsign = "Jackson Square" }
+                        departureTime = now + 16.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(orangeLineNorthbound)
+                        departureTime = now + 7.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(orangeLineNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            ),
+            alertDownstream = mapOf(0 to shuttleAlert)
+        )
+
+    // "Disrupted stop" group = "1. Orange Line disruption"
+    fun OL2() =
+        card(
+            orangeLine,
+            objects.stop {
+                name = "Stony Brook"
+                wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+            },
+            listOf(),
+            mapOf(0 to shuttleAlert, 1 to shuttleAlert)
+        )
+
+    // "Show up to the next three trips in the branching direction" group = "2. Red Line branching"
+    fun RL1() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeSouthbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 9.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            )
+        )
+
+    // "Next three trips go to the same destination" group = "2. Red Line branching"
+    fun RL2() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 9.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeSouthbound)
+                        departureTime = now + 15.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            )
+        )
+
+    // "Predictions unavailable for a branch" group = "2. Red Line branching"
+    fun RL3() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 9.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            )
+        )
+
+    // "Service not running on a branch downstream", group = "2. Red Line branching"
+    fun RL4() =
+        card(
+            redLine,
+            objects.stop {
+                name = "Park Street"
+                wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+            },
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 9.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            ),
+            alertDownstream = mapOf(0 to shuttleAlert)
+        )
+
+    // "Service disrupted on a branch downstream", group = "2. Red Line branching"
+    fun RL5() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeSouthbound) { headsign = "Wollaston" }
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 9.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            ),
+            alertDownstream = mapOf(0 to suspensionAlert)
+        )
+
+    // "Branching in both directions" group = "3. Green Line branching")
+    fun GL1() =
+        card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDWestbound)
+                        departureTime = now + 10.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDEastbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            )
+        )
+
+    // "Downstream disruption", group = "3. Green Line branching"
+    fun GL2() =
+        card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDWestbound)
+                        departureTime = now + 10.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDEastbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            ),
+            alertDownstream = mapOf(0 to suspensionAlert)
+        )
+
+    // "Branching in one direction", group = "4. Silver Line branching"
+    fun SL1() =
+        card(
+            slWaterfront,
+            objects.stop {
+                name = "World Trade Center"
+                wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+            },
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(sl1) {
+                                    directionId = 1
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "South Station" }
+                                }
+                            )
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(sl2) {
+                                    directionId = 1
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "South Station" }
+                                }
+                            )
+                        departureTime = now + 7.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(sl1) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "Logan Airport" }
+                                }
+                            )
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(sl2) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "Design Center" }
+                                }
+                            )
+                        departureTime = now + 7.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(sl3) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "Chelsea" }
+                                }
+                            )
+                        departureTime = now + 9.minutes
+                    }
+                ),
+            )
+        )
+
+    // "Branching in one direction", group = "5. CR branching"
+    fun CR1() =
+        card(
+            providenceLine,
+            ruggles,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(providenceLine) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.CanonicalOnly
+                                    representativeTrip { headsign = "Stoughton" }
+                                }
+                            )
+                        departureTime = today.atTime(12, 5).toInstant()
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(providenceLine) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "Providence" }
+                                }
+                            )
+                        departureTime = today.atTime(15, 28).toInstant()
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(providenceLine) {
+                                    directionId = 0
+                                    typicality = RoutePattern.Typicality.CanonicalOnly
+                                    representativeTrip { headsign = "Wickford Junction" }
+                                }
+                            )
+                        departureTime = today.atTime(16, 1).toInstant()
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(providenceLine) {
+                                    directionId = 1
+                                    typicality = RoutePattern.Typicality.CanonicalOnly
+                                    representativeTrip { headsign = "South Station" }
+                                }
+                            )
+                        departureTime = today.atTime(15, 31).toInstant()
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(providenceLine) {
+                                    directionId = 1
+                                    typicality = RoutePattern.Typicality.Typical
+                                    representativeTrip { headsign = "South Station" }
+                                }
+                            )
+                        departureTime = today.atTime(15, 53).toInstant()
+                    }
+                ),
+            )
+        )
+
+    // "Next two trips go to the same destination" group = "6. Bus route single direction"
+    fun Bus1(): RouteCardData {
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
+        return RouteCardData(
+            lineOrRoute,
+            listOf(
+                cardStop(
+                    lineOrRoute,
+                    somervilleAtCarlton,
+                    listOf(arlingtonInbound, clarendonInbound),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(arlingtonInbound)
+                                departureTime = now + 16.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(clarendonInbound)
+                                departureTime = now + 42.minutes
+                            }
+                        )
+                    ),
+                    emptyMap(),
+                    emptyMap()
+                ),
+                cardStop(
+                    lineOrRoute,
+                    bowAtWarren,
+                    listOf(arlingtonOutbound, clarendonOutbound),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(arlingtonOutbound)
+                                departureTime = now + 3.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(arlingtonOutbound)
+                                departureTime = now + 12.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(clarendonOutbound)
+                                departureTime = now + 45.minutes
+                            }
+                        )
+                    ),
+                    emptyMap(),
+                    emptyMap()
+                )
+            ),
+            context,
+            now
+        )
+    }
+
+    // "Next two trips go to different destinations" group = "6. Bus route single direction"
+    fun Bus2(): RouteCardData {
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
+        return RouteCardData(
+            lineOrRoute,
+            listOf(
+                cardStop(
+                    lineOrRoute,
+                    somervilleAtCarlton,
+                    listOf(arlingtonInbound, clarendonInbound),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(arlingtonInbound)
+                                departureTime = now + 16.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(clarendonInbound)
+                                departureTime = now + 42.minutes
+                            }
+                        )
+                    ),
+                    emptyMap(),
+                    emptyMap()
+                ),
+                cardStop(
+                    lineOrRoute,
+                    bowAtWarren,
+                    listOf(arlingtonOutbound, clarendonOutbound),
+                    listOf(
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(arlingtonOutbound)
+                                departureTime = now + 1.minutes
+                            }
+                        ),
+                        objects.upcomingTrip(
+                            objects.prediction {
+                                trip = objects.trip(clarendonOutbound)
+                                departureTime = now + 32.minutes
+                            }
+                        )
+                    ),
+                    emptyMap(),
+                    emptyMap()
+                )
+            ),
+            context,
+            now
+        )
+    }
+
+    // "Next two trips go to different destinations" group = "7. Bus route both directions"
+    fun Bus3() =
+        card(
+            bus15,
+            objects.stop {
+                name = "Nubian"
+                wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+            },
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(bus15) {
+                                    directionId = 0
+                                    representativeTrip { headsign = "St Peter's Square" }
+                                }
+                            )
+                        departureTime = now + 8.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(bus15) {
+                                    directionId = 0
+                                    representativeTrip { headsign = "Kane Square" }
+                                }
+                            )
+                        departureTime = now + 12.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(bus15) {
+                                    directionId = 1
+                                    representativeTrip { headsign = "Ruggles" }
+                                }
+                            )
+                        departureTime = now + 15.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip =
+                            objects.trip(
+                                objects.routePattern(bus15) {
+                                    directionId = 1
+                                    representativeTrip { headsign = "Ruggles" }
+                                }
+                            )
+                        departureTime = now + 23.minutes
+                    }
+                ),
+            )
+        )
+
+    // "Service ended on a branch", group = "8. Service ended")
+    fun RL6() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontSouthbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            )
+        )
+
+    // "Service ended on all branches" group = "8. Service ended"
+    fun RL7() =
+        card(
+            redLine,
+            jfkUmass,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineAshmontNorthbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(redLineBraintreeNorthbound)
+                        departureTime = now + 12.minutes
+                    }
+                )
+            )
+        )
+
+    // "Predictions unavailable on a branch", group = "9. Predictions unavailable"
+    fun GL3() =
+        card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 10.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineDWestbound)
+                        departureTime = now + 2.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDEastbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            )
+        )
+
+    // "Predictions unavailable on all branches", group = "9. Predictions unavailable"
+    fun GL4() =
+        card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineDWestbound)
+                        departureTime = now + 10.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineDEastbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            )
+        )
+
+    // "Disruption on a branch" group = "A. Disruption"
+    fun GL5(): RouteCardData {
+        val kenmoreShuttleToRiverside =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = kenmore.id,
+                            trip = null
+                        )
+                    )
+            }
+
+        return card(
+            greenLine,
+            kenmore,
+            listOf(
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            ),
+            alertHere = mapOf(0 to kenmoreShuttleToRiverside)
+        )
+    }
+
+    // "Disruption on a branch, predictions unavailable for other branches" group = "A. Disruption"
+    fun GL6(): RouteCardData {
+        val boylstonShuttleToRiverside =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        )
+                    )
+            }
+        return card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineCWestbound)
+                        departureTime = now + 3.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineBWestbound)
+                        departureTime = now + 5.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.prediction {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            ),
+            alertHere = mapOf(0 to boylstonShuttleToRiverside)
+        )
+    }
+
+    // "Disruption on all branches" group = "A. Disruption"
+    fun GL7(): RouteCardData {
+
+        val shuttleAllBranches =
+            objects.alert {
+                effect = Alert.Effect.Shuttle
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineB.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        ),
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineC.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        ),
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = 0,
+                            route = greenLineD.id,
+                            routeType = RouteType.LIGHT_RAIL,
+                            stop = boylston.id,
+                            trip = null
+                        )
+                    )
+            }
+
+        return card(
+            greenLine,
+            boylston,
+            listOf(
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineDEastbound)
+                        departureTime = now + 1.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineBEastbound)
+                        departureTime = now + 6.minutes
+                    }
+                ),
+                objects.upcomingTrip(
+                    objects.schedule {
+                        trip = objects.trip(greenLineCEastbound)
+                        departureTime = now + 12.minutes
+                    }
+                ),
+            ),
+            alertHere = mapOf(0 to shuttleAllBranches)
+        )
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction |  Handle branching vs non-branching](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209912113394443?focus=true)

Since it seemed as if branching/non-branching was already handled I decided to port the extensive previews Melody created for Android to iOS! This also helped me make sure I wasn't missing something. Instead of duplicating the test data in both code bases I moved it to a util in the shared library. Let me know if you have any thoughts on this.

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added a test to cover disrupted case mentioned in ticket.