### PR TITLE
fix(iOS): preserve nearby state while loading nearby stops

### DIFF
--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -210,7 +210,7 @@ class NearbyViewModel: ObservableObject {
             if nearbyState.loadedLocation != nil {
                 analytics.refetchedNearbyTransit()
             }
-            nearbyState = NearbyTransitState(loading: true)
+            nearbyState.loading = true
             nearbyStaticData = nil
             routeCardData = nil
 


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1745840910660239)

Fixes nearby transit resetting on location jitter.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that it fixes location transitions that previously caused a reset.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
