### PR TITLE
feat(iOS): Filtered stop direction grouping UX

### DIFF
--- a/iosApp/iosApp.xctestplan
+++ b/iosApp/iosApp.xctestplan
@@ -43,20 +43,21 @@
       ],
       "target" : {
         "containerPath" : "container:iosApp.xcodeproj",
-        "identifier" : "6EED5E8B2B3DC69F0052A1B8",
+        "identifier" : "EDDC9037D014CD9DDCA653AC",
         "name" : "iosAppTests"
       }
     },
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "EndToEndOpenStopDetailsTest\/testOpenStopDetails()",
         "HomeMapViewUITests\/testRecentersToUserLocation()",
         "IosAppUITests\/testMapShown()",
         "IosAppUITestsLaunchTests\/testLaunch()"
       ],
       "target" : {
         "containerPath" : "container:iosApp.xcodeproj",
-        "identifier" : "6EED5E982B3DC6C10052A1B8",
+        "identifier" : "C6FCE5742C7A4D59A165E213",
         "name" : "iosAppUITests"
       }
     }

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -13,7 +13,6 @@ struct DepartureTile: View {
     var data: TileData
     var onTap: () -> Void
     var pillDecoration: PillDecoration = .none
-    var showHeadsign: Bool = true
     var isSelected: Bool = false
 
     enum PillDecoration {
@@ -24,7 +23,7 @@ struct DepartureTile: View {
     var body: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
-                if showHeadsign, let headsign = data.headsign {
+                if let headsign = data.headsign {
                     Text(headsign)
                         .font(Typography.footnoteSemibold)
                         .multilineTextAlignment(.leading)
@@ -86,7 +85,6 @@ struct DepartureTile: View {
                 upcoming: upcomingTrip
             ),
             onTap: {},
-            showHeadsign: false,
             isSelected: true
         )
         DepartureTile(
@@ -99,7 +97,6 @@ struct DepartureTile: View {
                 upcoming: upcomingTrip
             ),
             onTap: {},
-            showHeadsign: true,
             isSelected: false
         )
         DepartureTile(
@@ -113,7 +110,6 @@ struct DepartureTile: View {
             ),
             onTap: {},
             pillDecoration: .onPrediction(route: routeB),
-            showHeadsign: true,
             isSelected: false
         )
     }

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -29,6 +29,19 @@ struct DirectionPicker: View {
         line = patternsByStop.line
     }
 
+    init(data: DepartureDataBundle, filter: StopDetailsFilter?,
+         setFilter: @escaping (StopDetailsFilter?) -> Void) {
+        self.filter = filter
+        self.setFilter = setFilter
+        availableDirections = Set(data.stopData.data.map(\.directionId)).sorted()
+        directions = data.stopData.directions
+        route = data.routeData.lineOrRoute.sortRoute
+        line = switch onEnum(of: data.routeData.lineOrRoute) {
+        case let .line(line): line.line
+        default: nil
+        }
+    }
+
     var body: some View {
         if availableDirections.count > 1 {
             let deselectedBackroundColor = Color.deselectedToggle2.opacity(0.6)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -36,16 +36,6 @@ struct StopDetailsFilteredDepartureDetails: View {
 
     var analytics: Analytics = AnalyticsProvider.shared
 
-    var showTileHeadsigns: Bool {
-        let isLine = switch onEnum(of: data.routeData.lineOrRoute) {
-        case .line: true
-        default: false
-        }
-        return isLine || !tiles.allSatisfy { tile in
-            tile.headsign == tiles.first?.headsign
-        }
-    }
-
     var stop: Stop? { stopDetailsVM.global?.getStop(stopId: stopId) }
 
     var routeColor: Color { Color(hex: data.routeData.lineOrRoute.backgroundColor) }
@@ -233,7 +223,6 @@ struct StopDetailsFilteredDepartureDetails: View {
                             view.scrollTo(tileData.id)
                         },
                         pillDecoration: pillDecoration(tileData: tileData),
-                        showHeadsign: showTileHeadsigns,
                         isSelected: tileData.id == tripFilter?.tripId
                     )
                     .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -17,10 +17,10 @@ struct StopDetailsFilteredDepartureDetails: View {
     var setTripFilter: (TripDetailsFilter?) -> Void
 
     var tiles: [TileData]
+    var data: DepartureDataBundle
     var noPredictionsStatus: UpcomingFormat.NoTripsFormat?
     var alerts: [Shared.Alert]
     var downstreamAlerts: [Shared.Alert]
-    var patternsByStop: PatternsByStop
     var pinned: Bool
 
     var now: Date
@@ -37,21 +37,26 @@ struct StopDetailsFilteredDepartureDetails: View {
     var analytics: Analytics = AnalyticsProvider.shared
 
     var showTileHeadsigns: Bool {
-        patternsByStop.line != nil || !tiles.allSatisfy { tile in
+        let isLine = switch onEnum(of: data.routeData.lineOrRoute) {
+        case .line: true
+        default: false
+        }
+        return isLine || !tiles.allSatisfy { tile in
             tile.headsign == tiles.first?.headsign
         }
     }
 
     var stop: Stop? { stopDetailsVM.global?.getStop(stopId: stopId) }
 
-    var routeColor: Color { Color(hex: patternsByStop.representativeRoute.color) }
-    var routeTextColor: Color { Color(hex: patternsByStop.representativeRoute.textColor) }
-    var routeType: RouteType { patternsByStop.representativeRoute.type }
+    var routeColor: Color { Color(hex: data.routeData.lineOrRoute.backgroundColor) }
+    var routeTextColor: Color { Color(hex: data.routeData.lineOrRoute.textColor) }
+    var routeType: RouteType { data.routeData.lineOrRoute.type }
 
     var selectedTripIsCancelled: Bool {
         if let tripFilter {
-            patternsByStop.tripIsCancelled(tripId: tripFilter.tripId)
-
+            data.leaf.upcomingTrips.contains { upcoming in
+                upcoming.trip.id == tripFilter.tripId && upcoming.isCancelled
+            }
         } else {
             false
         }
@@ -62,7 +67,7 @@ struct StopDetailsFilteredDepartureDetails: View {
     }
 
     var hasAccessibilityWarning: Bool {
-        !patternsByStop.elevatorAlerts.isEmpty || !patternsByStop.stop.isWheelchairAccessible
+        data.stopData.hasElevatorAlerts || !data.stopData.stop.isWheelchairAccessible
     }
 
     @State var patternsHere: [RoutePattern]?
@@ -91,7 +96,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                 VStack(spacing: 16) {
                     ScrollViewReader { view in
                         DirectionPicker(
-                            patternsByStop: patternsByStop,
+                            data: data,
                             filter: stopFilter,
                             setFilter: { setStopFilter($0) }
                         )
@@ -156,37 +161,33 @@ struct StopDetailsFilteredDepartureDetails: View {
             selectedDepartureFocus = tiles.first { $0.id == tripFilter?.tripId }?.id ?? cardFocusId
         }
         .onAppear {
-            patternsHere = patternsHere(patternsByStop)
-            setAlertSummaries(AlertSummaryParams(global: stopDetailsVM.global,
-                                                 alerts: alerts,
-                                                 downstreamAlerts: downstreamAlerts,
-                                                 stopId: stopId,
-                                                 directionId: stopFilter.directionId,
-                                                 patternsHere: patternsHere,
-                                                 now: now))
+            patternsHere = data.leaf.routePatterns
+            setAlertSummaries(AlertSummaryParams(
+                global: stopDetailsVM.global,
+                alerts: alerts,
+                downstreamAlerts: downstreamAlerts,
+                stopId: stopId,
+                directionId: stopFilter.directionId,
+                patternsHere: patternsHere,
+                now: now
+            ))
         }
-        .onChange(of: patternsByStop) { patternsByStop in
-            patternsHere = patternsHere(patternsByStop)
+        .onChange(of: data.leaf) { leaf in
+            patternsHere = leaf.routePatterns
         }
-        .onChange(of: AlertSummaryParams(global: stopDetailsVM.global,
-                                         alerts: alerts,
-                                         downstreamAlerts: downstreamAlerts,
-                                         stopId: stopId,
-                                         directionId: stopFilter.directionId,
-                                         patternsHere: patternsHere,
-                                         now: now)) { newParams in
+        .onChange(of: AlertSummaryParams(
+            global: stopDetailsVM.global,
+            alerts: alerts,
+            downstreamAlerts: downstreamAlerts,
+            stopId: stopId,
+            directionId: stopFilter.directionId,
+            patternsHere: patternsHere,
+            now: now
+        )) { newParams in
             setAlertSummaries(newParams)
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .ignoresSafeArea(.all)
-    }
-
-    func patternsHere(_ patternsByStop: PatternsByStop) -> [RoutePattern] {
-        // RealtimePatterns.patterns is a List<RoutePattern?> but that gets bridged as [Any] for some reason
-        patternsByStop.patterns.flatMap { $0.patterns
-            .compactMap { pattern in pattern as? RoutePattern }
-        }
-        .filter { $0.directionId == stopFilter.directionId }
     }
 
     func handleViewportForStatus(_ status: UpcomingFormat.NoTripsFormat?) {
@@ -222,11 +223,11 @@ struct StopDetailsFilteredDepartureDetails: View {
                                 selectionLock: false
                             )
                             analytics.tappedDeparture(
-                                routeId: patternsByStop.routeIdentifier,
-                                stopId: patternsByStop.stop.id,
+                                routeId: data.routeData.lineOrRoute.id,
+                                stopId: data.stopData.stop.id,
                                 pinned: pinned,
                                 alert: alerts.count > 0,
-                                routeType: patternsByStop.representativeRoute.type,
+                                routeType: data.routeData.lineOrRoute.type,
                                 noTrips: nil
                             )
                             view.scrollTo(tileData.id)
@@ -259,11 +260,13 @@ struct StopDetailsFilteredDepartureDetails: View {
 
         if let global = alertSummaryParams.global, let patternsHere = alertSummaryParams.patternsHere {
             for alert in allAlerts {
-                let summary = try? await alert.summary(stopId: alertSummaryParams.stopId,
-                                                       directionId: alertSummaryParams.directionId,
-                                                       patterns: patternsHere,
-                                                       atTime: alertSummaryParams.now.toKotlinInstant(),
-                                                       global: global)
+                let summary = try? await alert.summary(
+                    stopId: alertSummaryParams.stopId,
+                    directionId: alertSummaryParams.directionId,
+                    patterns: patternsHere,
+                    atTime: alertSummaryParams.now.toKotlinInstant(),
+                    global: global
+                )
                 alertMap[alert.id] = summary
             }
         }
@@ -271,20 +274,32 @@ struct StopDetailsFilteredDepartureDetails: View {
     }
 
     private func pillDecoration(tileData: TileData) -> DepartureTile.PillDecoration {
-        if patternsByStop.line != nil, let route = tileData.route { .onPrediction(route: route) } else { .none }
+        if case .line = onEnum(of: data.routeData.lineOrRoute), let route = tileData.route {
+            .onPrediction(route: route)
+        } else {
+            .none
+        }
     }
 
     func getAlertDetailsHandler(_ alertId: String, spec: AlertCardSpec) -> () -> Void {
         {
+            let line: Line? = switch onEnum(of: data.routeData.lineOrRoute) {
+            case let .line(line): line.line
+            default: nil
+            }
+            let routes = switch onEnum(of: data.routeData.lineOrRoute) {
+            case let .line(line): Array(line.routes)
+            case let .route(route): [route.route]
+            }
             nearbyVM.pushNavEntry(.alertDetails(
                 alertId: alertId,
-                line: spec == .elevator ? nil : patternsByStop.line,
-                routes: spec == .elevator ? nil : patternsByStop.routes,
-                stop: patternsByStop.stop
+                line: spec == .elevator ? nil : line,
+                routes: spec == .elevator ? nil : routes,
+                stop: data.stopData.stop
             ))
             analytics.tappedAlertDetails(
-                routeId: patternsByStop.routeIdentifier,
-                stopId: patternsByStop.stop.id,
+                routeId: data.routeData.lineOrRoute.id,
+                stopId: data.stopData.stop.id,
                 alertId: alertId,
                 elevator: spec == .elevator
             )
@@ -330,8 +345,8 @@ struct StopDetailsFilteredDepartureDetails: View {
                     }
                 }
                 if stopDetailsVM.showStationAccessibility, hasAccessibilityWarning {
-                    if !patternsByStop.elevatorAlerts.isEmpty {
-                        ForEach(patternsByStop.elevatorAlerts, id: \.id) { alert in
+                    if data.stopData.hasElevatorAlerts {
+                        ForEach(data.stopData.elevatorAlerts, id: \.id) { alert in
                             alertCard(alert, nil, .elevator)
                         }
                     } else {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -15,7 +15,7 @@ struct StopDetailsPage: View {
 
     // StopDetailsPage maintains its own internal state of the departures presented.
     // This way, when transitioning between one StopDetailsPage and another, each separate page shows
-    // their respective  departures rather than both showing the departures for the newly presented stop.
+    // their respective departures rather than both showing the departures for the newly presented stop.
     @State var internalDepartures: StopDetailsDepartures?
     @State var internalRouteCardData: [RouteCardData]?
     @State var now = Date.now

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsView.swift
@@ -67,7 +67,7 @@ struct StopDetailsView: View {
                 tripFilter: tripFilter,
                 setStopFilter: setStopFilter,
                 setTripFilter: setTripFilter,
-                departures: departures,
+                routeCardData: routeCardData,
                 now: now,
                 errorBannerVM: errorBannerVM,
                 nearbyVM: nearbyVM,

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsPageTests.swift
@@ -39,7 +39,7 @@ final class StopDetailsPageTests: XCTestCase {
             directionId: routePattern.directionId
         )
 
-        let nearbyVM = NearbyViewModel()
+        let nearbyVM = NearbyViewModel(groupByDirection: true)
         nearbyVM.alerts = .init(alerts: [:])
 
         let stopDetailsVM = StopDetailsViewModel(

--- a/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
+++ b/iosApp/iosAppUITests/EndToEndOpenStopDetailsTest.swift
@@ -18,6 +18,7 @@ final class EndToEndOpenStopDetailsTest: XCTestCase {
         continueAfterFailure = false
     }
 
+    // TODO: Re-enable this test once the groupByDirection toggle is removed
     func testOpenStopDetails() throws {
         app.launch()
         let alewifeHeadsign = app.staticTexts["Alewife"]

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 
 data class Direction(
@@ -19,6 +20,7 @@ data class Direction(
      * in the majority of typical cases. If this doesn't exist for some reason, fall back to null so
      * that the direction label will just display the direction name.
      */
+    @DefaultArgumentInterop.Enabled
     constructor(
         directionId: Int,
         route: Route,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -39,6 +39,12 @@ interface ILeafData {
     val hasSchedulesToday: Boolean
 }
 
+data class DepartureDataBundle(
+    val routeData: RouteCardData,
+    val stopData: RouteCardData.RouteStopData,
+    val leaf: RouteCardData.Leaf
+)
+
 /**
  * Contain all data for presentation in a route card. A route card is a snapshot of service for a
  * route at a set of stops. It has the general structure: Route (or Line) => Stop(s) => Direction =>


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction |  Filtered Stop Details uses new data types](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209914022959070?focus=true)

Switch over to using the `RouteCardData` objects in filtered stop details. This completely breaks the headsign grouped stop details, if you try to use it, you'll get a message telling you to turn on the Group by Direction feature toggle.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Updated all relevant unit tests to pass using direction grouping.

One UI test that we have, `EndToEndOpenStopDetailsTest.testOpenStopDetails` was deactivated, since it can't be tested without the feature flag being enabled, and getting that to work didn't seem worth it (maybe it'll be trivial with the new iOS settings updates?).
I added a TODO and an AC to [this](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1210113865246640?focus=true) cleanup ticket to enable it again.