### PR TITLE
fix: Discard track change alerts at core CR stops

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -476,3 +476,6 @@ data class Alert(
         }
     }
 }
+
+fun List<Alert>.discardTrackChangesAtCRCore(isCRCore: Boolean): List<Alert> =
+    if (isCRCore) this.filterNot { it.effect == Alert.Effect.TrackChange } else this

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NearbyStaticData.kt
@@ -612,9 +612,6 @@ fun NearbyStaticData.withRealtimeInfoWithoutTripHeadsigns(
         return (isTypical() || isUpcoming) && !(shouldBeFilteredAsArrivalOnly)
     }
 
-    fun List<Alert>.discardTrackChangesAtCRCore(isCRCore: Boolean): List<Alert> =
-        if (isCRCore) this.filterNot { it.effect == Alert.Effect.TrackChange } else this
-
     fun List<PatternsByStop>.filterEmptyAndSort(): List<PatternsByStop> {
         return this.filterNot { it.patterns.isEmpty() }
             .sortedWith(PatternSorting.comparePatternsByStop(pinnedRoutes, sortByDistanceFrom))
@@ -726,9 +723,6 @@ fun NearbyStaticData.withRealtimeInfoViaTripHeadsigns(
             }
         return (isTypical() || isUpcoming) && !isArrivalOnly()
     }
-
-    fun List<Alert>.discardTrackChangesAtCRCore(isCRCore: Boolean): List<Alert> =
-        if (isCRCore) this.filterNot { it.effect == Alert.Effect.TrackChange } else this
 
     fun List<PatternsByStop>.filterEmptyAndSort(): List<PatternsByStop> {
         return this.filterNot { it.patterns.isEmpty() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -852,9 +852,6 @@ data class RouteCardData(
             }
         }
 
-        private fun List<Alert>.discardTrackChangesAtCRCore(isCRCore: Boolean): List<Alert> =
-            if (isCRCore) this.filterNot { it.effect == Alert.Effect.TrackChange } else this
-
         fun addAlerts(
             alerts: AlertsStreamDataResponse?,
             includeMinorAlerts: Boolean,


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | Discard track changes at core stations](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210082542778227?focus=true)

We had a check in the `NearbyStaticData` to remove track change alerts from core CR stops (South and North St, Ruggles, Back Bay), which hadn't been included in the `RouteCardData` logic. This adds it.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added new unit test verifying this behavior, manually verified with test alerts on dev orange