### PR TITLE
fix(iOS): Accidental taps while scrolling

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -172,6 +172,7 @@ struct NearbyTransitView: View {
                     }
                 }
             }
+            .highPriorityGesture(DragGesture())
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -143,6 +143,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                     }
                 }
             }
+            .highPriorityGesture(DragGesture())
         }
         .onAppear { handleViewportForStatus(noPredictionsStatus) }
         .onChange(of: noPredictionsStatus) { status in handleViewportForStatus(status) }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -175,7 +175,9 @@ struct StopDetailsUnfilteredView: View {
                                 loadingBody()
                             }
                         }
-                    }.padding(.top, 16)
+                    }
+                    .highPriorityGesture(DragGesture())
+                    .padding(.top, 16)
                 }
             }
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: Scrolling Nearby Transit accidentally opens stop details](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1210114954224733?focus=true)

This was annoying me and took like 5 mins to test

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manual
