### PR TITLE
fix(RouteCardData): Only show 2 upcoming bus trips if branched

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -445,7 +445,7 @@ data class RouteCardData(
             val countTripsToDisplay =
                 when {
                     context == Context.StopDetailsFiltered -> null
-                    isBranching -> 3
+                    isBranching && routeType != RouteType.BUS -> 3
                     else -> 2
                 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -1358,7 +1358,7 @@ class RouteCardDataLeafTest {
     }
 
     @Test
-    fun `formats bus as branching if next two trips differ`() = parametricTest {
+    fun `formats bus as branching if next trips differ and only shows 2 trips`() = parametricTest {
         val objects = `87`.objects()
         val now = Clock.System.now()
 
@@ -1371,6 +1371,12 @@ class RouteCardDataLeafTest {
             objects.prediction {
                 departureTime = now + 32.minutes
                 trip = objects.trip(`87`.outboundDeviation)
+            }
+
+        val prediction3 =
+            objects.prediction {
+                departureTime = now + 60.minutes
+                trip = objects.trip(`87`.outboundTypical)
             }
 
         assertEquals(
@@ -1407,14 +1413,20 @@ class RouteCardDataLeafTest {
                         emptySet(),
                         listOf(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2)
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3)
                         ),
                         emptyList(),
                         allDataLoaded = true,
                         hasSchedulesToday = true,
                         emptyList()
                     )
-                    .format(now, `87`.route, `87`.global, anyEnumValue())
+                    .format(
+                        now,
+                        `87`.route,
+                        `87`.global,
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered)
+                    )
             )
         )
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | Limit branching bus routes to two trips](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210130069642278?focus=true)

What is this PR for?
Only show 2 upcoming departures for branched bus routes instead of 3.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Updated unit test
* Ran locally, confirmed showing 2 arrivals for route called out in the ticket
![image](https://github.com/user-attachments/assets/a6c9d3fd-7079-47b4-9b72-0197a69927e8)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
