### PR TITLE
feat: always use group by direction variants when loading

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/LoadingRouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/LoadingRouteCard.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.component.routeCard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyRouteView
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import kotlinx.datetime.Clock
@@ -12,6 +11,6 @@ import kotlinx.datetime.Clock
 fun LoadingRouteCard() {
     val placeholderRouteData = LoadingPlaceholders.nearbyRoute()
     Column(modifier = Modifier.loadingShimmer()) {
-        NearbyRouteView(placeholderRouteData, false, {}, Clock.System.now(), { _, _ -> })
+        RouteCard(placeholderRouteData, null, Clock.System.now(), false, {}, false, { _, _ -> })
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -130,13 +130,13 @@ fun NearbyTransitView(
 
             if (routeCardData == null) {
                 CompositionLocalProvider(IsLoadingSheetContents provides true) {
-                    Column(
-                        Modifier.verticalScroll(rememberScrollState()).padding(8.dp).weight(1f),
+                    LazyColumn(
+                        contentPadding =
+                            PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        for (i in 1..5) {
-                            LoadingRouteCard()
-                        }
-                        Spacer(Modifier.weight(1f))
+                        items(5) { LoadingRouteCard() }
                     }
                 }
             } else if (routeCardData.isEmpty()) {
@@ -196,13 +196,13 @@ fun NearbyTransitView(
 
             if (nearbyWithRealtimeInfo == null) {
                 CompositionLocalProvider(IsLoadingSheetContents provides true) {
-                    Column(
-                        Modifier.verticalScroll(rememberScrollState()).padding(8.dp).weight(1f),
+                    LazyColumn(
+                        contentPadding =
+                            PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
-                        for (i in 1..5) {
-                            LoadingRouteCard()
-                        }
-                        Spacer(Modifier.weight(1f))
+                        items(5) { LoadingRouteCard() }
                     }
                 }
             } else if (nearbyWithRealtimeInfo.isEmpty()) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -19,7 +19,6 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
 import kotlinx.datetime.Instant
 
 @Composable
@@ -185,28 +184,35 @@ private fun Loading(
 ) {
     CompositionLocalProvider(IsLoadingSheetContents provides true) {
         Column(modifier = Modifier.loadingShimmer()) {
-            val placeholderDepartures = LoadingPlaceholders.stopDetailsDepartures(stopFilter)
+            val placeholderData =
+                LoadingPlaceholders.departureDataBundle(
+                    stopFilter.routeId,
+                    trips = 10,
+                    RouteCardData.Context.StopDetailsFiltered,
+                    now
+                )
             StopDetailsFilteredDeparturesView(
                 stopId = stopId,
                 stopFilter = stopFilter,
                 tripFilter = tripFilter,
                 data =
-                    FilteredDeparturesData.PreGroupByDirection(
-                        patternsByStop = placeholderDepartures.routes.first()
+                    FilteredDeparturesData.PostGroupByDirection(
+                        routeCardData = placeholderData.routeData,
+                        routeStopData = placeholderData.stopData,
+                        leaf = placeholderData.leaf
                     ),
                 tileData =
-                    placeholderDepartures
-                        .stopDetailsFormattedTrips(stopFilter.routeId, stopFilter.directionId, now)
-                        .mapNotNull { tripAndFormat ->
-                            TileData.fromUpcoming(
-                                tripAndFormat.upcoming,
-                                placeholderDepartures.routes.first().representativeRoute,
-                                now
-                            )
-                        },
+                    placeholderData.leaf
+                        .format(
+                            now,
+                            placeholderData.routeData.lineOrRoute.sortRoute,
+                            globalResponse,
+                            RouteCardData.Context.StopDetailsFiltered
+                        )
+                        .tileData(),
                 noPredictionsStatus = null,
                 allAlerts = null,
-                elevatorAlerts = placeholderDepartures.elevatorAlerts,
+                elevatorAlerts = placeholderData.stopData.elevatorAlerts,
                 global = globalResponse,
                 now = now,
                 viewModel = viewModel,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -99,7 +99,7 @@ fun StopDetailsUnfilteredRoutesView(
     errorBannerViewModel: ErrorBannerViewModel,
     showStationAccessibility: Boolean,
     now: Instant,
-    globalData: GlobalResponse,
+    globalData: GlobalResponse?,
     pinnedRoutes: Set<String>,
     pinRoute: (String) -> Unit,
     onClose: () -> Unit,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -131,23 +131,24 @@ fun StopDetailsUnfilteredView(
     } else {
         CompositionLocalProvider(IsLoadingSheetContents provides true) {
             Column(modifier = Modifier.loadingShimmer()) {
-                val placeholderDepartures = LoadingPlaceholders.stopDetailsDepartures(null)
+                val placeholderData = LoadingPlaceholders.stopDetailsRouteCards()
                 val filterRoutes =
                     if (globalResponse != null) {
-                        getFilterPillRoutes(placeholderDepartures, globalResponse)
+                        getFilterPillRoutes(placeholderData, globalResponse)
                     } else {
                         emptyList()
                     }
 
                 StopDetailsUnfilteredRoutesView(
-                    placeholderDepartures.routes.first().stop,
-                    placeholderDepartures,
+                    placeholderData.first().stopData.first().stop,
+                    placeholderData,
                     filterRoutes,
                     errorBannerViewModel,
                     showStationAccessibility,
                     now,
-                    {},
+                    globalResponse,
                     emptySet(),
+                    {},
                     onClose = onClose,
                     onTapRoutePill = {},
                     updateStopFilter = {},

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -123,7 +123,7 @@ fun TripDetailsView(
         )
     } else {
         val placeholderTripInfo = LoadingPlaceholders.tripDetailsInfo()
-        val placeholderTripStops = LoadingPlaceholders.tripDetailsStops()
+        val placeholderTripStops = placeholderTripInfo.stops
         val placeholderTripId = placeholderTripInfo.vehicle.tripId ?: ""
 
         val placeholderHeaderSpec =

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct RouteCard: View {
     let cardData: RouteCardData
-    let global: GlobalResponse
+    let global: GlobalResponse?
     let now: Date
     let onPin: (String) -> Void
     let pinned: Bool

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
@@ -13,7 +13,7 @@ struct RouteCardDepartures: View {
     var analytics: Analytics = AnalyticsProvider.shared
     let cardData: RouteCardData
     let stopData: RouteCardData.RouteStopData
-    let global: GlobalResponse
+    let global: GlobalResponse?
     let now: Date
     let pinned: Bool
     let pushNavEntry: (SheetNavigationStackEntry) -> Void

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -223,19 +223,22 @@ struct NearbyTransitView: View {
 
     @ViewBuilder private func loadingBody() -> some View {
         ScrollView {
-            LazyVStack(spacing: 0) {
+            LazyVStack(spacing: 18) {
                 ForEach(1 ... 5, id: \.self) { _ in
-                    NearbyRouteView(
-                        nearbyRoute: LoadingPlaceholders.shared.nearbyRoute(),
-                        pinned: false,
+                    RouteCard(
+                        cardData: LoadingPlaceholders.shared.nearbyRoute(),
+                        global: globalData,
+                        now: now,
                         onPin: { _ in },
+                        pinned: false,
                         pushNavEntry: { _ in },
-                        now: now.toKotlinInstant(),
                         showStationAccessibility: false
                     )
                     .loadingPlaceholder()
                 }
-            }.padding(.vertical, 4)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 16)
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -184,16 +184,20 @@ struct StopDetailsUnfilteredView: View {
     }
 
     @ViewBuilder private func loadingBody() -> some View {
-        let placeholderDepartures = LoadingPlaceholders.shared.stopDetailsDepartures(filter: nil)
+        let placeholderCards = LoadingPlaceholders.shared.stopDetailsRouteCards()
         VStack(spacing: 0) {
-            ForEach(placeholderDepartures.routes, id: \.routeIdentifier) { patternsByStop in
-                StopDetailsRouteView(
-                    patternsByStop: patternsByStop,
-                    now: now.toKotlinInstant(),
-                    pushNavEntry: { _ in },
+            ForEach(placeholderCards, id: \.id) { card in
+                RouteCard(
+                    cardData: card,
+                    global: stopDetailsVM.global,
+                    now: now,
+                    onPin: { _ in },
                     pinned: false,
-                    onPin: { _ in }
+                    pushNavEntry: { _ in },
+                    showStationAccessibility: false
                 )
+                .padding(.horizontal, 16)
+                .padding(.bottom, 16)
             }
         }.loadingPlaceholder()
     }

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewLegacyTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewLegacyTests.swift
@@ -54,7 +54,7 @@ final class NearbyTransitViewLegacyTests: XCTestCase {
             nearbyVM: .init(),
             noNearbyStops: noNearbyStops
         )
-        let cards = try sut.inspect().findAll(NearbyRouteView.self)
+        let cards = try sut.inspect().findAll(RouteCard.self)
         XCTAssertEqual(cards.count, 5)
         for card in cards {
             XCTAssertNotNil(try card.modifier(LoadingPlaceholderModifier.self))
@@ -77,7 +77,7 @@ final class NearbyTransitViewLegacyTests: XCTestCase {
         )
 
         let hasAppeared = sut.on(\.didAppear) { view in
-            let cards = view.findAll(NearbyRouteView.self)
+            let cards = view.findAll(RouteCard.self)
             XCTAssertEqual(cards.count, 5)
             for card in cards {
                 XCTAssertNotNil(try card.modifier(LoadingPlaceholderModifier.self))

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -55,7 +55,7 @@ final class NearbyTransitViewTests: XCTestCase {
             nearbyVM: .init(groupByDirection: true),
             noNearbyStops: noNearbyStops
         )
-        let cards = try sut.inspect().findAll(NearbyRouteView.self)
+        let cards = try sut.inspect().findAll(RouteCard.self)
         XCTAssertEqual(cards.count, 5)
         for card in cards {
             XCTAssertNotNil(try card.modifier(LoadingPlaceholderModifier.self))
@@ -78,7 +78,7 @@ final class NearbyTransitViewTests: XCTestCase {
         )
 
         let hasAppeared = sut.on(\.didAppear) { view in
-            let cards = view.findAll(NearbyRouteView.self)
+            let cards = view.findAll(RouteCard.self)
             XCTAssertEqual(cards.count, 5)
             for card in cards {
                 XCTAssertNotNil(try card.modifier(LoadingPlaceholderModifier.self))


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | Cleanup old nearby data codepaths](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210113865246640?focus=true)

Splitting this out as its own PR for easier review once it’s time to actually start deleting things.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the loading placeholder state looks like the loaded state structurally and spacing-wise.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
