### PR TITLE
fix(iOS): Fix finnicky scrolling on iOS

### DIFF
--- a/iosApp/iosApp/ComponentViews/SheetNavigationLink.swift
+++ b/iosApp/iosApp/ComponentViews/SheetNavigationLink.swift
@@ -32,5 +32,6 @@ struct SheetNavigationLink<Label>: View where Label: View {
                 }
             }
         }
+        .simultaneousGesture(TapGesture())
     }
 }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -172,7 +172,6 @@ struct NearbyTransitView: View {
                     }
                 }
             }
-            .highPriorityGesture(DragGesture())
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -37,6 +37,7 @@ struct DepartureTile: View {
                 }
             }
         }
+        .simultaneousGesture(TapGesture())
         .padding(.horizontal, 10)
         .padding(.vertical, 10)
         .frame(minHeight: 56)

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -55,6 +55,7 @@ struct DirectionPicker: View {
                             .padding(8)
                             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     }
+                    .simultaneousGesture(TapGesture())
                     .accessibilityAddTraits(isSelected ? [.isSelected, .isHeader] : [])
                     .accessibilityHeading(isSelected ? .h2 : .unspecified)
                     .accessibilitySortPriority(isSelected ? 1 : 0)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -143,7 +143,6 @@ struct StopDetailsFilteredDepartureDetails: View {
                     }
                 }
             }
-            .highPriorityGesture(DragGesture())
         }
         .onAppear { handleViewportForStatus(noPredictionsStatus) }
         .onChange(of: noPredictionsStatus) { status in handleViewportForStatus(status) }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -176,7 +176,6 @@ struct StopDetailsUnfilteredView: View {
                             }
                         }
                     }
-                    .highPriorityGesture(DragGesture())
                     .padding(.top, 16)
                 }
             }


### PR DESCRIPTION
### Summary

This seems to simultaneously fix Buttons aggressively capturing touch gestures and the ScrollView drag gestures being finnicky.

iOS
~~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
~~- [ ] Add temporary machine translations, marked "Needs Review"~~

android
~~- [ ] All user-facing strings added to strings resource in alphabetical order~~
~~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manually tested on device.

