### PR TITLE
fix(UpcomingTrip): Unique id to differentiate upcoming arrivals on looped routes

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -67,7 +67,7 @@ sealed class UpcomingFormat {
             val format: TripInstantDisplay
         ) {
             val id: String
-                get() = trip.trip.id
+                get() = trip.id
 
             constructor(
                 trip: UpcomingTrip,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -35,6 +35,8 @@ constructor(
         predictionStop: Stop? = null
     ) : this(trip, null, prediction, predictionStop, null)
 
+    val id = "${trip.id}-${prediction?.stopSequence ?: schedule?.stopSequence}"
+
     val time =
         if (
             prediction != null &&

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -13,7 +13,7 @@ data class TileData(
     val formatted: UpcomingFormat,
     val upcoming: UpcomingTrip
 ) {
-    val id = upcoming.trip.id
+    val id: String = upcoming.id
 
     companion object {
         fun fromUpcoming(upcoming: UpcomingTrip, route: Route, now: Instant): TileData? {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
@@ -13,10 +13,11 @@ import kotlinx.datetime.Clock
 
 class TileDataTest {
     @Test
-    fun `id matches upcoming trip id`() {
+    fun `id matches upcoming trip id + stopSequence`() {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()
-        val upcomingTrip = UpcomingTrip(objects.trip())
+        val prediction = objects.prediction { stopSequence = 1 }
+        val upcomingTrip = UpcomingTrip(objects.trip(), prediction)
         val format =
             UpcomingFormat.Some(
                 UpcomingFormat.Some.FormattedTrip(
@@ -28,7 +29,7 @@ class TileDataTest {
             )
         val tileData = TileData(route, "Headsign", format, upcomingTrip)
 
-        assertEquals(upcomingTrip.trip.id, tileData.id)
+        assertEquals("${upcomingTrip.trip.id}-1", tileData.id)
     }
 
     @Test


### PR DESCRIPTION
### Summary

_Ticket:_ [Handle cases where a trip stops at the same stop more than once](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210103117999218?focus=true)

What is this PR for?

This PR adds the stop sequence to the id used for `UpcomingTrip` and `TileData` so that the same arrival time doesn't appear twice for looped routes. 

This was not an issue for android with group by direction on, but was for iOS, presumably because of the requirements for a unique`id` when using `ForEach` in views on iOS. 

Note: The only other potentially affected id I found was for `LeafFormat` which is `"$headsign-$format-${Uuid.random()}"`, and therefore already unique.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing
What testing have you done?
* Updated unit test
* Ran locally on iOS & android, confirmed this is fixed in group by direction. Note - it continues to be a problem with group by direction turned off on android, but I didn't worry about why since that will be removed by the time this is released.


"Boat-Logan" in the below images is the scheduled `stopHeadsign` for these trips
![image](https://github.com/user-attachments/assets/ff8049b4-14b4-4eb9-9e1e-3ec5ffc216f9)![image](https://github.com/user-attachments/assets/29941f98-77b5-4191-ad17-9dbdae0d829a)
![IMG_0295](https://github.com/user-attachments/assets/9df32c52-ea6c-4052-b33b-194c9c7605ff)![IMG_0293](https://github.com/user-attachments/assets/e04529c3-0bec-4bd1-bd5a-9cae60096804)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
