### PR TITLE
fix: Update group by direction sort logic

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -100,4 +100,19 @@ object PatternSorting {
             },
             { it.lineOrRoute.sortRoute },
         )
+
+    fun compareStopsOnRoute(
+        sortByDistanceFrom: Position?
+    ): Comparator<RouteCardData.RouteStopData> =
+        compareBy(
+            { patternServiceBucket(it.data.first()) },
+            if (sortByDistanceFrom != null) {
+                { it.stop.distanceFrom(sortByDistanceFrom) }
+            } else {
+                { 0 }
+            }
+        )
+
+    fun compareLeavesAtStop(): Comparator<RouteCardData.Leaf> =
+        compareBy({ patternServiceBucket(it) }, { it.directionId })
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
@@ -2,6 +2,8 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import io.github.dellisd.spatialk.geojson.Position
+import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
+import io.github.dellisd.spatialk.turf.distance
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -43,6 +45,11 @@ data class Stop(
     }
 
     fun resolveParent(global: GlobalResponse) = resolveParent(global.stops)
+
+    @OptIn(ExperimentalTurfApi::class)
+    fun distanceFrom(position: Position): Double {
+        return distance(position, this.position)
+    }
 
     companion object {
         /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
@@ -47,9 +47,7 @@ data class Stop(
     fun resolveParent(global: GlobalResponse) = resolveParent(global.stops)
 
     @OptIn(ExperimentalTurfApi::class)
-    fun distanceFrom(position: Position): Double {
-        return distance(position, this.position)
-    }
+    fun distanceFrom(position: Position): Double = distance(position, this.position)
 
     companion object {
         /**


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by direction | Rearrange sort precedence](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210130069642283?focus=true)

Don't sort routes to the bottom of nearby if only a single stop has service ended for the day. Also start sorting multiple stops in a route card based on distance and service ended status, along with service ended leaves.

![Screenshot_20250505_123946](https://github.com/user-attachments/assets/267bb6e5-5037-4f1a-ba64-cd26ae12b511)


iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Updated existing sort test to actually test RouteCardData, and added a new test for the updated behavior