### PR TITLE
fix: Don't show repetitive multi stop alert cards

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -54,7 +54,6 @@ import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.Alert
-import com.mbta.tid.mbta_app.model.AlertSignificance
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -97,10 +96,7 @@ fun TripStopRow(
                 RouteLineState.Shuttle
             else -> RouteLineState.Regular
         }
-    val disruption =
-        stop.disruption?.takeIf {
-            it.alert.significance >= AlertSignificance.Major && showDownstreamAlert
-        }
+    val disruption = stop.disruption?.takeIf { it.alert.hasNoThroughService && showDownstreamAlert }
     Column {
         Box(
             Modifier.padding(horizontal = 6.dp)
@@ -269,7 +265,7 @@ fun TripStopRow(
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
                         ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateAfter)
-                        if (stop.isTruncating()) {
+                        if (stop.isTruncating) {
                             ColoredRouteLine(
                                 routeAccents.color,
                                 Modifier.weight(1f),

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -24,7 +24,7 @@ struct TripStopRow: View {
     var background: Color? = nil
 
     var disruption: UpcomingFormat.Disruption? {
-        if let disruption = stop.disruption, disruption.alert.significance == .major, showDownstreamAlert {
+        if let disruption = stop.disruption, disruption.alert.hasNoThroughService, showDownstreamAlert {
             disruption
         } else {
             nil
@@ -60,7 +60,7 @@ struct TripStopRow: View {
                 ZStack(alignment: .leading) {
                     VStack(spacing: 0) {
                         ColoredRouteLine(routeAccents.color, state: stateAfter)
-                        if stop.isTruncating() {
+                        if stop.isTruncating {
                             ColoredRouteLine(routeAccents.color, state: .empty)
                         }
                     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -70,6 +70,8 @@ data class Alert(
             else -> AlertSignificance.None
         }
 
+    val hasNoThroughService = effect in setOf(Effect.Shuttle, Effect.Suspension)
+
     suspend fun summary(
         stopId: String,
         directionId: Int,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -31,10 +31,9 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
         val trackNumber: String? =
             if (predictionStop?.shouldShowTrackNumber == true) predictionStop.platformCode else null
 
-        fun activeElevatorAlerts(now: Instant) = elevatorAlerts.filter { it.isActive(now) }
+        val isTruncating = disruption?.alert?.hasNoThroughService == true
 
-        fun isTruncating() =
-            disruption?.alert?.effect in setOf(Alert.Effect.Shuttle, Alert.Effect.Suspension)
+        fun activeElevatorAlerts(now: Instant) = elevatorAlerts.filter { it.isActive(now) }
 
         fun format(now: Instant, routeType: RouteType?) =
             TripInstantDisplay.from(
@@ -91,7 +90,7 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
 
         val truncatedStopIndex =
             followingStops
-                .indexOfFirst { it.isTruncating() }
+                .indexOfFirst { it.isTruncating }
                 .takeUnless { it == -1 || it == followingStops.lastIndex }
         val isTruncated = truncatedStopIndex != null
         val truncatedFollowingStops =


### PR DESCRIPTION
### Summary

_Ticket:_ [Don't show downstream alerts for through service](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210161016755139?focus=true)

Stop displaying inline trip details alert cards on filtered stop details when the alert is not a shuttle or suspension.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Tested with dev alerts on DevOrange
