### PR TITLE
fix: Check that the trip id matches, not tile id

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -459,7 +459,7 @@ private fun DepartureTiles(
                 modifier = Modifier.bringIntoViewRequester(bringIntoViewRequester),
                 showRoutePill = lineOrRoute is RouteCardData.LineOrRoute.Line,
                 showHeadsign = showTileHeadsigns,
-                isSelected = tileData.upcoming.trip.id == tripFilter?.tripId
+                isSelected = tileData.isSelected(tripFilter)
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -459,7 +459,7 @@ private fun DepartureTiles(
                 modifier = Modifier.bringIntoViewRequester(bringIntoViewRequester),
                 showRoutePill = lineOrRoute is RouteCardData.LineOrRoute.Line,
                 showHeadsign = showTileHeadsigns,
-                isSelected = tileData.id == tripFilter?.tripId
+                isSelected = tileData.upcoming.trip.id == tripFilter?.tripId
             )
         }
     }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -270,7 +270,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                             view.scrollTo(tileData.id)
                         },
                         pillDecoration: pillDecoration(tileData: tileData),
-                        isSelected: tileData.id == tripFilter?.tripId
+                        isSelected: tileData.upcoming.trip.id == tripFilter?.tripId
                     )
                     .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
                     .padding(.horizontal, 4)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -270,7 +270,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                             view.scrollTo(tileData.id)
                         },
                         pillDecoration: pillDecoration(tileData: tileData),
-                        isSelected: tileData.upcoming.trip.id == tripFilter?.tripId
+                        isSelected: tileData.isSelected(tripFilter: tripFilter)
                     )
                     .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
                     .padding(.horizontal, 4)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.model.stopDetailsPage
 
 import com.mbta.tid.mbta_app.model.RealtimePatterns
 import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
@@ -14,6 +15,13 @@ data class TileData(
     val upcoming: UpcomingTrip
 ) {
     val id: String = upcoming.id
+
+    fun isSelected(tripFilter: TripDetailsFilter?): Boolean =
+        upcoming.trip.id == tripFilter?.tripId &&
+            tripFilter.stopSequence?.let { filterSequence ->
+                upcoming.stopSequence?.let { it == filterSequence }
+            }
+                ?: true
 
     companion object {
         fun fromUpcoming(upcoming: UpcomingTrip, route: Route, now: Instant): TileData? {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
@@ -1,12 +1,15 @@
 package com.mbta.tid.mbta_app.model.stopDetailsPage
 
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Clock
@@ -77,5 +80,28 @@ class TileDataTest {
         val upcomingTrip = objects.upcomingTrip(prediction)
 
         assertNull(TileData.fromUpcoming(upcomingTrip, route, now))
+    }
+
+    @Test
+    fun `isSelected is true when the filter matches`() {
+        val now = Clock.System.now()
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+        val trip = objects.trip()
+        val prediction =
+            objects.prediction {
+                this.trip = trip
+                departureTime = now + 5.minutes
+                stopSequence = 2
+            }
+        val upcomingTrip = objects.upcomingTrip(prediction)
+        val tileData = TileData.fromUpcoming(upcomingTrip, route, now)!!
+
+        assertFalse(tileData.isSelected(null))
+        assertFalse(tileData.isSelected(TripDetailsFilter("other-trip", null, null)))
+        assertFalse(tileData.isSelected(TripDetailsFilter(trip.id, null, 0)))
+
+        assertTrue(tileData.isSelected(TripDetailsFilter(trip.id, null, null)))
+        assertTrue(tileData.isSelected(TripDetailsFilter(trip.id, null, prediction.stopSequence)))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Selected trip is not highlighted on stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210176112492141?focus=true)

This was introduced in #952, where upcoming trip IDs were made actually unique. This updates the departure tiles to check the UpcomingTrip's Trip id against the trip filter ID.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified that selected trips are highlighted again