### PR TITLE
fix(ios.MorePage): Ensure tab bar always has background

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -124,6 +124,7 @@ struct ContentView: View {
                     .tag(SelectedTab.nearby)
                     .tabItem { TabLabel(tab: SelectedTab.nearby) }
                 MorePage(viewModel: settingsVM)
+                    .toolbarBackground(.visible, for: .tabBar)
                     .tag(SelectedTab.more)
                     .tabItem { TabLabel(tab: SelectedTab.more) }
                     .onAppear { analytics.track(screen: .settings) }


### PR DESCRIPTION
### Summary

What is this PR for?

No ticket, quick fix based on[ slack discussion](https://mbta.slack.com/archives/C05QMG9GS9M/p1746631648361019)

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally and confirmed that the tab bar on the more page always has a background the first time I navigate to it. 
The bug seemed potentially device / OS related, so may require more testing to confirm if completely fixes the issue. 
![IMG_0299](https://github.com/user-attachments/assets/73df701e-13c2-4b10-a265-763de8dd2f70)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
