### PR TITLE
fix(iOS): Fix PredictionRowView height

### DIFF
--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -44,10 +44,9 @@ struct PredictionRowView: View {
             AnyView(destination())
             Spacer(minLength: 8)
             statuses.foregroundStyle(Color.text)
-                .frame(minHeight: 24)
         }
         .background(Color.fill3)
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, minHeight: 24)
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Summary

_Ticket:_ [[Fix: vertical spacing for disruption messages / predictions unavailable]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210177544414517?focus=true)

The height of `PredictionRowView` was not taking up the desired minHeight in cases where the prediction text was less tall, like "Predictions unavailable" next to a "Shuttle Bus" alert row. I'm not certain why the inner minHeight wasn't being obeyed, but moving it up onto the HStack seems to have fixed the problem.

![Simulator Screenshot - iPhone 16 - 2025-05-07 at 14 53 47](https://github.com/user-attachments/assets/822d0aaf-8e6c-430f-b171-f3002a814793)

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Verified that the height is properly set when "Predictions unavailable" is displayed on one line
