### PR TITLE
refactor: put more RouteCardData context into RouteStopData

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -21,7 +21,6 @@ import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
-import org.koin.dsl.koinApplication
 
 class DeparturesTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -44,6 +43,7 @@ class DeparturesTest {
 
         val stopData =
             RouteCardData.RouteStopData(
+                RouteCardData.LineOrRoute.Route(route),
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
@@ -77,18 +77,12 @@ class DeparturesTest {
                         true,
                         listOf(downstreamAlert)
                     )
-                )
-            )
-        val cardData =
-            RouteCardData(
-                RouteCardData.LineOrRoute.Route(route),
-                listOf(stopData),
+                ),
                 RouteCardData.Context.NearbyTransit,
-                now,
             )
 
         composeTestRule.setContent {
-            Departures(stopData, cardData, GlobalResponse(objects), now, false) { _ -> }
+            Departures(stopData, GlobalResponse(objects), now, false) { _ -> }
         }
 
         composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
@@ -118,6 +112,7 @@ class DeparturesTest {
 
         val stopData =
             RouteCardData.RouteStopData(
+                RouteCardData.LineOrRoute.Route(route),
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
@@ -152,18 +147,12 @@ class DeparturesTest {
                         true,
                         emptyList()
                     )
-                )
-            )
-        val cardData =
-            RouteCardData(
-                RouteCardData.LineOrRoute.Route(route),
-                listOf(stopData),
+                ),
                 RouteCardData.Context.NearbyTransit,
-                now,
             )
 
         composeTestRule.setContent {
-            Departures(stopData, cardData, GlobalResponse(objects), now, false) { _ -> }
+            Departures(stopData, GlobalResponse(objects), now, false) { _ -> }
         }
 
         composeTestRule.onNodeWithText(aTrip.headsign).assertDoesNotExist()
@@ -187,6 +176,7 @@ class DeparturesTest {
 
         val stopData =
             RouteCardData.RouteStopData(
+                RouteCardData.LineOrRoute.Route(route),
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
@@ -220,14 +210,8 @@ class DeparturesTest {
                         true,
                         emptyList()
                     )
-                )
-            )
-        val cardData =
-            RouteCardData(
-                RouteCardData.LineOrRoute.Route(route),
-                listOf(stopData),
+                ),
                 RouteCardData.Context.NearbyTransit,
-                now,
             )
 
         var tapAnalytics: Pair<String, Map<String, String>>? = null
@@ -240,7 +224,7 @@ class DeparturesTest {
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
-                Departures(stopData, cardData, GlobalResponse(objects), now, pinned = true) {
+                Departures(stopData, GlobalResponse(objects), now, pinned = true) {
                     onClickCalled = true
                 }
             }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
@@ -32,7 +32,15 @@ class RouteCardTest {
             RouteCard(
                 RouteCardData(
                     RouteCardData.LineOrRoute.Route(route),
-                    listOf(RouteCardData.RouteStopData(stop, emptyList(), emptyList())),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            RouteCardData.LineOrRoute.Route(route),
+                            stop,
+                            emptyList(),
+                            emptyList(),
+                            RouteCardData.Context.NearbyTransit
+                        )
+                    ),
                     RouteCardData.Context.NearbyTransit,
                     now,
                 ),
@@ -66,7 +74,15 @@ class RouteCardTest {
             RouteCard(
                 RouteCardData(
                     RouteCardData.LineOrRoute.Route(route),
-                    listOf(RouteCardData.RouteStopData(stop, emptyList(), emptyList())),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            RouteCardData.LineOrRoute.Route(route),
+                            stop,
+                            emptyList(),
+                            emptyList(),
+                            RouteCardData.Context.NearbyTransit
+                        )
+                    ),
                     RouteCardData.Context.NearbyTransit,
                     now,
                 ),
@@ -101,7 +117,15 @@ class RouteCardTest {
             RouteCard(
                 RouteCardData(
                     RouteCardData.LineOrRoute.Route(route),
-                    listOf(RouteCardData.RouteStopData(stop, emptyList(), emptyList())),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            RouteCardData.LineOrRoute.Route(route),
+                            stop,
+                            emptyList(),
+                            emptyList(),
+                            RouteCardData.Context.StopDetailsUnfiltered
+                        )
+                    ),
                     RouteCardData.Context.StopDetailsUnfiltered,
                     now,
                 ),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
@@ -17,10 +17,20 @@ class StopHeaderTest {
     @Test
     fun testBasic() {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route()
         val stop = objects.stop {}
 
         composeTestRule.setContent {
-            StopHeader(RouteCardData.RouteStopData(stop, emptyList(), emptyList()), false)
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    stop,
+                    emptyList(),
+                    emptyList(),
+                    RouteCardData.Context.StopDetailsUnfiltered
+                ),
+                false
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
     }
@@ -28,10 +38,20 @@ class StopHeaderTest {
     @Test
     fun testAccessible() {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
 
         composeTestRule.setContent {
-            StopHeader(RouteCardData.RouteStopData(stop, emptyList(), emptyList()), true)
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    stop,
+                    emptyList(),
+                    emptyList(),
+                    RouteCardData.Context.StopDetailsUnfiltered
+                ),
+                true
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertDoesNotExist()
@@ -40,10 +60,20 @@ class StopHeaderTest {
     @Test
     fun testNotAccessible() {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE }
 
         composeTestRule.setContent {
-            StopHeader(RouteCardData.RouteStopData(stop, emptyList(), emptyList()), true)
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    stop,
+                    emptyList(),
+                    emptyList(),
+                    RouteCardData.Context.StopDetailsUnfiltered
+                ),
+                true
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithText("Not accessible").assertIsDisplayed()
@@ -53,12 +83,14 @@ class StopHeaderTest {
     @Test
     fun testElevatorAlert() {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
         val alert = objects.alert { effect = Alert.Effect.ElevatorClosure }
 
         composeTestRule.setContent {
             StopHeader(
                 RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
                     stop,
                     emptyList(),
                     listOf(
@@ -72,7 +104,8 @@ class StopHeaderTest {
                             true,
                             emptyList()
                         )
-                    )
+                    ),
+                    RouteCardData.Context.StopDetailsUnfiltered
                 ),
                 true
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModelTest.kt
@@ -111,9 +111,10 @@ class NearbyTransitTabViewModelTest {
                     RouteCardData.LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            stop,
                             route,
+                            stop,
                             listOf(),
+                            RouteCardData.Context.NearbyTransit,
                             GlobalResponse(objectCollectionBuilder)
                         )
                     ),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -186,7 +186,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -251,7 +250,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -351,7 +349,14 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         val leafFormat =
             leaf.format(now, route, globalResponse, RouteCardData.Context.StopDetailsFiltered)
-        val routeStopData = RouteCardData.RouteStopData(stop, route, listOf(leaf), globalResponse)
+        val routeStopData =
+            RouteCardData.RouteStopData(
+                route,
+                stop,
+                listOf(leaf),
+                RouteCardData.Context.StopDetailsFiltered,
+                globalResponse
+            )
         val routeCardData =
             RouteCardData(
                 RouteCardData.LineOrRoute.Route(route),
@@ -371,7 +376,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopFilter =
                         StopDetailsFilter(routeId = route.id, directionId = trip.directionId),
                     tripFilter = TripDetailsFilter(trip.id, null, null, false),
-                    routeCardData = routeCardData,
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -424,10 +428,11 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         val routeStopData =
             RouteCardData.RouteStopData(
-                stop,
                 line,
                 setOf(route),
+                stop,
                 listOf(leaf),
+                RouteCardData.Context.StopDetailsFiltered,
                 GlobalResponse(objects)
             )
         val routeCardData =
@@ -444,7 +449,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = StopDetailsFilter(route.id, 0),
                     tripFilter = null,
-                    routeCardData = routeCardData,
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = listOf(),
@@ -529,7 +533,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -643,7 +646,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = leafFormat.tileData(),
@@ -725,7 +727,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -794,7 +795,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -880,7 +880,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = stop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,
@@ -945,7 +944,6 @@ class StopDetailsFilteredDeparturesViewTest {
                     stopId = inaccessibleStop.id,
                     stopFilter = filterState,
                     tripFilter = null,
-                    routeCardData = routeCardData.single(),
                     routeStopData = routeStopData,
                     leaf = leaf,
                     tileData = tileData,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -114,8 +114,8 @@ class StopDetailsViewTest {
                     RouteCardData.LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            stop,
                             route,
+                            stop,
                             listOf(
                                 RouteCardData.Leaf(
                                     directionId = 0,
@@ -128,6 +128,7 @@ class StopDetailsViewTest {
                                     alertsDownstream = emptyList()
                                 )
                             ),
+                            RouteCardData.Context.StopDetailsUnfiltered,
                             GlobalResponse(builder)
                         )
                     ),
@@ -183,8 +184,8 @@ class StopDetailsViewTest {
                     RouteCardData.LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            stop,
                             route,
+                            stop,
                             listOf(
                                 RouteCardData.Leaf(
                                     directionId = 0,
@@ -197,6 +198,7 @@ class StopDetailsViewTest {
                                     alertsDownstream = emptyList()
                                 )
                             ),
+                            RouteCardData.Context.StopDetailsUnfiltered,
                             GlobalResponse(builder)
                         )
                     ),
@@ -258,8 +260,8 @@ class StopDetailsViewTest {
                     RouteCardData.LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            stop,
                             route,
+                            stop,
                             listOf(
                                 RouteCardData.Leaf(
                                     directionId = 0,
@@ -272,6 +274,7 @@ class StopDetailsViewTest {
                                     alertsDownstream = emptyList()
                                 )
                             ),
+                            RouteCardData.Context.StopDetailsUnfiltered,
                             GlobalResponse(builder)
                         )
                     ),
@@ -325,8 +328,8 @@ class StopDetailsViewTest {
                     RouteCardData.LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            stop,
                             route,
+                            stop,
                             listOf(
                                 RouteCardData.Leaf(
                                     directionId = 0,
@@ -339,6 +342,7 @@ class StopDetailsViewTest {
                                     alertsDownstream = emptyList()
                                 )
                             ),
+                            RouteCardData.Context.StopDetailsUnfiltered,
                             GlobalResponse(builder)
                         )
                     ),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -43,7 +43,6 @@ import org.koin.compose.koinInject
 @Composable
 fun Departures(
     stopData: RouteCardData.RouteStopData,
-    cardData: RouteCardData,
     globalData: GlobalResponse?,
     now: Instant,
     pinned: Boolean,
@@ -58,17 +57,17 @@ fun Departures(
                 val format = (leafFormat as? LeafFormat.Single)?.format
                 val noTrips = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
                 analytics.tappedDeparture(
-                    cardData.lineOrRoute.id,
+                    stopData.lineOrRoute.id,
                     stopData.stop.id,
                     pinned,
                     leaf.alertsHere.isNotEmpty(),
-                    cardData.lineOrRoute.type,
+                    stopData.lineOrRoute.type,
                     noTrips
                 )
             }
 
             val formatted =
-                leaf.format(now, cardData.lineOrRoute.sortRoute, globalData, cardData.context)
+                leaf.format(now, stopData.lineOrRoute.sortRoute, globalData, stopData.context)
             val direction = stopData.directions.first { it.id == leaf.directionId }
 
             NavDrilldownRow(
@@ -174,8 +173,8 @@ private fun DeparturesPreview() {
     val lineOrRoute = RouteCardData.LineOrRoute.Route(redLine)
     val stopData =
         RouteCardData.RouteStopData(
-            jfkUmass,
             lineOrRoute,
+            jfkUmass,
             listOf(
                 RouteCardData.Leaf(
                     0,
@@ -230,21 +229,13 @@ private fun DeparturesPreview() {
                     emptyList()
                 )
             ),
+            context,
             global
         )
-    val card = RouteCardData(lineOrRoute, listOf(stopData), context, now)
 
     MyApplicationTheme {
         Column(Modifier.background(MaterialTheme.colorScheme.background)) {
-            Departures(
-                card.stopData.single(),
-                card,
-                global,
-                now,
-                false,
-                MockAnalytics(),
-                onClick = {}
-            )
+            Departures(stopData, global, now, false, MockAnalytics(), onClick = {})
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -40,7 +40,7 @@ fun RouteCard(
                 StopHeader(it, showStationAccessibility)
             }
 
-            Departures(it, data, globalData, now, pinned) { leaf ->
+            Departures(it, globalData, now, pinned) { leaf ->
                 onOpenStopDetails(
                     it.stop.id,
                     StopDetailsFilter(data.lineOrRoute.id, leaf.directionId)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -65,7 +65,6 @@ fun StopDetailsFilteredDeparturesView(
     stopId: String,
     stopFilter: StopDetailsFilter,
     tripFilter: TripDetailsFilter?,
-    routeCardData: RouteCardData,
     routeStopData: RouteCardData.RouteStopData,
     leaf: RouteCardData.Leaf,
     tileData: List<TileData>,
@@ -87,7 +86,7 @@ fun StopDetailsFilteredDeparturesView(
     openSheetRoute: (SheetRoutes) -> Unit,
     analytics: Analytics = koinInject()
 ) {
-    val lineOrRoute = routeCardData.lineOrRoute
+    val lineOrRoute = routeStopData.lineOrRoute
     val stop = routeStopData.stop
     val availableDirections = routeStopData.data.map { it.directionId }.distinct().sorted()
     val directions = routeStopData.directions

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -59,7 +59,6 @@ fun StopDetailsFilteredView(
             stopId = stopId,
             stopFilter = stopFilter,
             tripFilter = tripFilter,
-            routeCardData = routeCardData.single(),
             routeStopData = routeStopData,
             leaf = leaf,
             tileData = tileData,
@@ -107,25 +106,26 @@ private fun Loading(
 ) {
     CompositionLocalProvider(IsLoadingSheetContents provides true) {
         Column(modifier = Modifier.loadingShimmer()) {
-            val placeholderData =
-                LoadingPlaceholders.departureDataBundle(
+            val routeData =
+                LoadingPlaceholders.routeCardData(
                     stopFilter.routeId,
                     trips = 10,
                     RouteCardData.Context.StopDetailsFiltered,
                     now
                 )
+            val stopData = routeData.stopData.single()
+            val leaf = stopData.data.first()
             StopDetailsFilteredDeparturesView(
                 stopId = stopId,
                 stopFilter = stopFilter,
                 tripFilter = tripFilter,
-                routeCardData = placeholderData.routeData,
-                routeStopData = placeholderData.stopData,
-                leaf = placeholderData.leaf,
+                routeStopData = stopData,
+                leaf = leaf,
                 tileData =
-                    placeholderData.leaf
+                    leaf
                         .format(
                             now,
-                            placeholderData.routeData.lineOrRoute.sortRoute,
+                            routeData.lineOrRoute.sortRoute,
                             globalResponse,
                             RouteCardData.Context.StopDetailsFiltered
                         )
@@ -133,7 +133,7 @@ private fun Loading(
                 noPredictionsStatus = null,
                 isAllServiceDisrupted = false,
                 allAlerts = null,
-                elevatorAlerts = placeholderData.stopData.elevatorAlerts,
+                elevatorAlerts = stopData.elevatorAlerts,
                 global = globalResponse,
                 now = now,
                 viewModel = viewModel,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -198,8 +198,8 @@ private fun StopDetailsRoutesViewPreview() {
                 RouteCardData.LineOrRoute.Route(route1),
                 listOf(
                     RouteCardData.RouteStopData(
-                        stop,
                         route1,
+                        stop,
                         listOf(
                             RouteCardData.Leaf(
                                 0,
@@ -212,6 +212,7 @@ private fun StopDetailsRoutesViewPreview() {
                                 alertsDownstream = emptyList()
                             )
                         ),
+                        RouteCardData.Context.StopDetailsUnfiltered,
                         globalData
                     )
                 ),
@@ -222,8 +223,8 @@ private fun StopDetailsRoutesViewPreview() {
                 RouteCardData.LineOrRoute.Route(route2),
                 listOf(
                     RouteCardData.RouteStopData(
-                        stop,
                         route2,
+                        stop,
                         listOf(
                             RouteCardData.Leaf(
                                 0,
@@ -249,6 +250,7 @@ private fun StopDetailsRoutesViewPreview() {
                                 alertsDownstream = emptyList()
                             )
                         ),
+                        RouteCardData.Context.StopDetailsUnfiltered,
                         globalData
                     )
                 ),

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -38,7 +38,6 @@ struct RouteCard: View {
                     )
                 }
                 RouteCardDepartures(
-                    cardData: cardData,
                     stopData: stopData,
                     global: global,
                     now: now,

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
@@ -11,7 +11,6 @@ import SwiftUI
 
 struct RouteCardDepartures: View {
     var analytics: Analytics = AnalyticsProvider.shared
-    let cardData: RouteCardData
     let stopData: RouteCardData.RouteStopData
     let global: GlobalResponse?
     let now: Date
@@ -24,15 +23,15 @@ struct RouteCardDepartures: View {
                 if let direction = stopData.directions.first(where: { $0.id == leaf.directionId }) {
                     let formatted = leaf.format(
                         now: now.toKotlinInstant(),
-                        representativeRoute: cardData.lineOrRoute.sortRoute,
+                        representativeRoute: stopData.lineOrRoute.sortRoute,
                         globalData: global,
-                        context: cardData.context
+                        context: stopData.context
                     )
                     SheetNavigationLink(
                         value: .stopDetails(
                             stopId: stopData.stop.id,
                             stopFilter: .init(
-                                routeId: cardData.lineOrRoute.id,
+                                routeId: stopData.lineOrRoute.id,
                                 directionId: leaf.directionId
                             ),
                             tripFilter: nil
@@ -70,11 +69,11 @@ struct RouteCardDepartures: View {
         default: nil
         }
         analytics.tappedDeparture(
-            routeId: cardData.lineOrRoute.id,
+            routeId: stopData.lineOrRoute.id,
             stopId: stopData.stop.id,
             pinned: pinned,
             alert: leaf.alertsHere.count > 0,
-            routeType: cardData.lineOrRoute.type,
+            routeType: stopData.lineOrRoute.type,
             noTrips: noTrips
         )
     }

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -17,14 +17,14 @@ struct DirectionPicker: View {
     let route: Route
     let line: Line?
 
-    init(data: DepartureDataBundle, filter: StopDetailsFilter?,
+    init(stopData: RouteCardData.RouteStopData, filter: StopDetailsFilter?,
          setFilter: @escaping (StopDetailsFilter?) -> Void) {
         self.filter = filter
         self.setFilter = setFilter
-        availableDirections = Set(data.stopData.data.map(\.directionId)).sorted()
-        directions = data.stopData.directions
-        route = data.routeData.lineOrRoute.sortRoute
-        line = switch onEnum(of: data.routeData.lineOrRoute) {
+        availableDirections = Set(stopData.data.map(\.directionId)).sorted()
+        directions = stopData.directions
+        route = stopData.lineOrRoute.sortRoute
+        line = switch onEnum(of: stopData.lineOrRoute) {
         case let .line(line): line.line
         default: nil
         }
@@ -105,19 +105,13 @@ struct DirectionPicker: View {
         hasSchedulesToday: true,
         alertsDownstream: []
     )
-    let stopCard = RouteCardData.RouteStopData(stop: stop, directions: [
+    let stopCard = RouteCardData.RouteStopData(lineOrRoute: .route(route), stop: stop, directions: [
         .init(name: "Outbound", destination: "Out", id: 0),
         .init(name: "Inbound", destination: "In", id: 1),
-    ], data: [leaf0, leaf1])
-    let routeCard = RouteCardData(
-        lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-        stopData: [stopCard],
-        context: .stopDetailsFiltered,
-        at: Date.now.toKotlinInstant()
-    )
+    ], data: [leaf0, leaf1], context: .stopDetailsFiltered)
 
     DirectionPicker(
-        data: .init(routeData: routeCard, stopData: stopCard, leaf: leaf0),
+        stopData: stopCard,
         filter: .init(routeId: route.id, directionId: 0),
         setFilter: { _ in }
     )

--- a/iosApp/iosApp/Utils/LineOrRouteExtension.swift
+++ b/iosApp/iosApp/Utils/LineOrRouteExtension.swift
@@ -1,0 +1,19 @@
+//
+//  LineOrRouteExtension.swift
+//  iosApp
+//
+//  Created by Melody Horn on 5/7/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+
+extension RouteCardData.LineOrRoute {
+    static func route(_ route: Route) -> RouteCardData.LineOrRouteRoute {
+        RouteCardData.LineOrRouteRoute(route: route)
+    }
+
+    static func line(_ line: Line, _ routes: Set<Route>) -> RouteCardData.LineOrRouteLine {
+        RouteCardData.LineOrRouteLine(line: line, routes: routes)
+    }
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
@@ -13,7 +13,7 @@ import ViewInspector
 import XCTest
 
 final class DirectionPickerTests: XCTestCase {
-    private func getTestData() -> DepartureDataBundle {
+    private func getTestData() -> RouteCardData.RouteStopData {
         let objects = ObjectCollectionBuilder()
         let route = objects.route()
         let stop = objects.stop { _ in }
@@ -51,32 +51,26 @@ final class DirectionPickerTests: XCTestCase {
             hasSchedulesToday: true,
             alertsDownstream: []
         )
-        let stopData = RouteCardData.RouteStopData(stop: stop, directions: [
+        let stopData = RouteCardData.RouteStopData(lineOrRoute: .route(route), stop: stop, directions: [
             Direction(name: "North", destination: "Selected Destination", id: 0),
             Direction(name: "South", destination: "Other Destination", id: 1),
-        ], data: [leaf0, leaf1])
-        let routeData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-            stopData: [stopData],
-            context: .stopDetailsFiltered,
-            at: Date.now.toKotlinInstant()
-        )
+        ], data: [leaf0, leaf1], context: .stopDetailsFiltered)
 
-        return .init(routeData: routeData, stopData: stopData, leaf: leaf0)
+        return stopData
     }
 
     func testDirectionFilter() throws {
-        let data = getTestData()
+        let stopData = getTestData()
 
         let setFilter1Exp: XCTestExpectation = .init(description: "set filter called with direction 1")
         let setFilter0Exp: XCTestExpectation = .init(description: "set filter called with direction 0")
 
         let filter: StopDetailsFilter? = .init(
-            routeId: data.routeData.id,
+            routeId: stopData.lineOrRoute.id,
             directionId: 0
         )
 
-        let sut = DirectionPicker(data: data, filter: filter, setFilter: { filter in
+        let sut = DirectionPicker(stopData: stopData, filter: filter, setFilter: { filter in
             if filter?.directionId == 1 {
                 setFilter1Exp.fulfill()
             }
@@ -93,14 +87,14 @@ final class DirectionPickerTests: XCTestCase {
     }
 
     func testFormatsNorthSouth() throws {
-        let data = getTestData()
+        let stopData = getTestData()
 
         let filter: StopDetailsFilter? = .init(
-            routeId: data.routeData.id,
+            routeId: stopData.lineOrRoute.id,
             directionId: 0
         )
 
-        let sut = DirectionPicker(data: data, filter: filter, setFilter: { _ in })
+        let sut = DirectionPicker(stopData: stopData, filter: filter, setFilter: { _ in })
         XCTAssertNotNil(try sut.inspect().find(text: "Northbound to"))
         XCTAssertNotNil(try? sut.inspect().find(text: "Southbound to"))
     }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -41,13 +41,13 @@ final class StopDetailsViewTests: XCTestCase {
             setTripFilter: { _ in },
             routeCardData: [
                 .init(
-                    lineOrRoute: RouteCardDataLineOrRouteRoute(route: routeDefaultSort1),
+                    lineOrRoute: .route(routeDefaultSort1),
                     stopData: [],
                     context: .stopDetailsUnfiltered,
                     at: Date.now.toKotlinInstant()
                 ),
                 .init(
-                    lineOrRoute: RouteCardDataLineOrRouteRoute(route: routeDefaultSort0),
+                    lineOrRoute: .route(routeDefaultSort0),
                     stopData: [],
                     context: .stopDetailsUnfiltered,
                     at: Date.now.toKotlinInstant()
@@ -83,8 +83,14 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             routeCardData: [.init(
-                lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-                stopData: [.init(stop: stop, route: route, data: [], globalData: .init(objects: objects))],
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    route: route,
+                    stop: stop,
+                    data: [],
+                    context: .stopDetailsUnfiltered,
+                    globalData: .init(objects: objects)
+                )],
                 context: .stopDetailsUnfiltered,
                 at: Date.now.toKotlinInstant()
             )],
@@ -118,10 +124,9 @@ final class StopDetailsViewTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             routeCardData: [.init(
-                lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+                lineOrRoute: .route(route),
                 stopData: [.init(
-                    stop: stop,
-                    route: route,
+                    route: route, stop: stop,
                     data: [.init(
                         directionId: 0,
                         routePatterns: [],
@@ -132,6 +137,7 @@ final class StopDetailsViewTests: XCTestCase {
                         hasSchedulesToday: true,
                         alertsDownstream: []
                     )],
+                    context: .stopDetailsUnfiltered,
                     globalData: .init(objects: objects)
                 )],
                 context: .stopDetailsUnfiltered,
@@ -175,15 +181,17 @@ final class StopDetailsViewTests: XCTestCase {
             hasSchedulesToday: true, alertsDownstream: []
         )
         let stopData = RouteCardData.RouteStopData(
+            lineOrRoute: .route(route),
             stop: stop,
             directions: [
                 .init(directionId: 0, route: route),
                 .init(directionId: 1, route: route),
             ],
-            data: [leaf]
+            data: [leaf],
+            context: .stopDetailsFiltered
         )
         let routeData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+            lineOrRoute: .route(route),
             stopData: [stopData],
             context: .stopDetailsFiltered,
             at: now.toKotlinInstant()

--- a/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
+++ b/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
@@ -169,9 +169,9 @@ final class StopDetailsViewModelTests: XCTestCase {
         )
 
         XCTAssertEqual([RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+            lineOrRoute: .route(route),
             stopData: [
-                .init(stop: stop, directions: [direction0, direction1], data: [
+                .init(lineOrRoute: .route(route), stop: stop, directions: [direction0, direction1], data: [
                     .init(
                         directionId: 0,
                         routePatterns: [pattern0],
@@ -192,7 +192,7 @@ final class StopDetailsViewModelTests: XCTestCase {
                         hasSchedulesToday: true,
                         alertsDownstream: []
                     ),
-                ]),
+                ], context: .stopDetailsUnfiltered),
             ], context: .stopDetailsUnfiltered, at: now.toKotlinInstant()
         )], routeCardData)
     }

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -356,9 +356,9 @@ final class HomeMapViewTests: XCTestCase {
         let railRouteShapeRepository = MockRailRouteShapeRepository(response: MapTestDataHelper.shared.routeResponse)
 
         let nearbyVM: NearbyViewModel = .init(routeCardData: [.init(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: MapTestDataHelper.shared.routeOrange),
+            lineOrRoute: .route(MapTestDataHelper.shared.routeOrange),
             stopData: [
-                .init(stop: stop, route: MapTestDataHelper.shared.routeOrange, data: [
+                .init(route: MapTestDataHelper.shared.routeOrange, stop: stop, data: [
                     .init(
                         directionId: 0,
                         routePatterns: [MapTestDataHelper.shared.patternOrange30],
@@ -369,7 +369,7 @@ final class HomeMapViewTests: XCTestCase {
                         hasSchedulesToday: true,
                         alertsDownstream: []
                     ),
-                ], globalData: .init(objects: objects)),
+                ], context: .stopDetailsFiltered, globalData: .init(objects: objects)),
             ],
             context: .stopDetailsFiltered,
             at: Date.now.toKotlinInstant()
@@ -454,9 +454,9 @@ final class HomeMapViewTests: XCTestCase {
         }
 
         let nearbyVM: NearbyViewModel = .init(routeCardData: [.init(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: MapTestDataHelper.shared.routeOrange),
+            lineOrRoute: .route(MapTestDataHelper.shared.routeOrange),
             stopData: [
-                .init(stop: stop, route: MapTestDataHelper.shared.routeOrange, data: [
+                .init(route: MapTestDataHelper.shared.routeOrange, stop: stop, data: [
                     .init(
                         directionId: 0,
                         routePatterns: [MapTestDataHelper.shared.patternOrange30],
@@ -467,7 +467,7 @@ final class HomeMapViewTests: XCTestCase {
                         hasSchedulesToday: true,
                         alertsDownstream: []
                     ),
-                ], globalData: .init(objects: objectCollection)),
+                ], context: .stopDetailsFiltered, globalData: .init(objects: objectCollection)),
             ],
             context: .stopDetailsFiltered,
             at: Date.now.toKotlinInstant()

--- a/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
@@ -27,23 +27,18 @@ final class RouteCardDeparturesTests: XCTestCase {
         }
 
         let stopData = RouteCardData.RouteStopData(
+            lineOrRoute: .route(route),
             stop: stop,
             directions: [.init(name: "Outbound", destination: "Harvard", id: 0)],
             data: [.init(
                 directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                 upcomingTrips: [], alertsHere: [], allDataLoaded: true,
                 hasSchedulesToday: true, alertsDownstream: []
-            )]
-        )
-        let cardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-            stopData: [stopData],
-            context: .nearbyTransit,
-            at: Date.now.toKotlinInstant()
+            )],
+            context: .nearbyTransit
         )
 
         let sut = RouteCardDepartures(
-            cardData: cardData,
             stopData: stopData,
             global: .init(objects: objects),
             now: Date.now,
@@ -74,23 +69,18 @@ final class RouteCardDeparturesTests: XCTestCase {
         }
 
         let stopData = RouteCardData.RouteStopData(
+            lineOrRoute: .route(route),
             stop: stop,
             directions: [.init(name: "South", destination: "Forest Hills", id: 0)],
             data: [.init(
                 directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                 upcomingTrips: [.init(trip: trip, schedule: schedule)], alertsHere: [], allDataLoaded: true,
                 hasSchedulesToday: true, alertsDownstream: []
-            )]
-        )
-        let cardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-            stopData: [stopData],
-            context: .nearbyTransit,
-            at: Date.now.toKotlinInstant()
+            )],
+            context: .nearbyTransit
         )
 
         let sut = RouteCardDepartures(
-            cardData: cardData,
             stopData: stopData,
             global: .init(objects: objects),
             now: Date.now,
@@ -197,7 +187,13 @@ final class RouteCardDeparturesTests: XCTestCase {
             prediction.tripId = tripE1.id
         }
 
+        let lineOrRoute = RouteCardData.LineOrRoute.line(
+            Green.shared.line,
+            [Green.shared.routeB, Green.shared.routeC, Green.shared.routeE]
+        )
+
         let stopData = RouteCardData.RouteStopData(
+            lineOrRoute: lineOrRoute,
             stop: stop,
             directions: [
                 .init(name: "West", destination: "Copley & West", id: 0),
@@ -226,20 +222,11 @@ final class RouteCardDeparturesTests: XCTestCase {
                     .init(trip: tripC12, prediction: predC12),
                 ], alertsHere: [], allDataLoaded: true,
                 hasSchedulesToday: true, alertsDownstream: []
-            )]
-        )
-        let cardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteLine(
-                line: Green.shared.line,
-                routes: [Green.shared.routeB, Green.shared.routeC, Green.shared.routeE]
-            ),
-            stopData: [stopData],
-            context: .nearbyTransit,
-            at: now.toKotlinInstant()
+            )],
+            context: .nearbyTransit
         )
 
         let sut = RouteCardDepartures(
-            cardData: cardData,
             stopData: stopData,
             global: .init(objects: objects),
             now: now,

--- a/iosApp/iosAppTests/Views/RouteCardStopHeaderTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardStopHeaderTests.swift
@@ -16,12 +16,19 @@ import XCTest
 final class RouteCardStopHeaderTests: XCTestCase {
     func testStopName() throws {
         let objects = ObjectCollectionBuilder()
+        let route = objects.route()
         let stop = objects.stop { stop in
             stop.name = "Stop Name"
         }
 
         let sut = RouteCardStopHeader(
-            data: .init(stop: stop, directions: [], data: []),
+            data: .init(
+                lineOrRoute: .route(route),
+                stop: stop,
+                directions: [],
+                data: [],
+                context: .stopDetailsFiltered
+            ),
             showStationAccessibility: false
         )
         XCTAssertNotNil(try sut.inspect().find(text: stop.name))
@@ -29,6 +36,7 @@ final class RouteCardStopHeaderTests: XCTestCase {
 
     func testNotAccessible() throws {
         let objects = ObjectCollectionBuilder()
+        let route = objects.route()
         let stop = objects.stop { stop in
             stop.name = "Boylston"
             stop.wheelchairBoarding = .inaccessible
@@ -36,7 +44,13 @@ final class RouteCardStopHeaderTests: XCTestCase {
         }
 
         let sut = RouteCardStopHeader(
-            data: .init(stop: stop, directions: [], data: []),
+            data: .init(
+                lineOrRoute: .route(route),
+                stop: stop,
+                directions: [],
+                data: [],
+                context: .stopDetailsFiltered
+            ),
             showStationAccessibility: true
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Not accessible"))
@@ -44,6 +58,7 @@ final class RouteCardStopHeaderTests: XCTestCase {
 
     func testElevatorAlert() throws {
         let objects = ObjectCollectionBuilder()
+        let route = objects.route()
         let stop = objects.stop { stop in
             stop.name = "Park Street"
             stop.wheelchairBoarding = .accessible
@@ -61,12 +76,14 @@ final class RouteCardStopHeaderTests: XCTestCase {
 
         let sut = RouteCardStopHeader(
             data: .init(
+                lineOrRoute: .route(route),
                 stop: stop,
                 directions: [.init(name: "", destination: "", id: 0)],
                 data: [.init(
                     directionId: 0, routePatterns: [], stopIds: [], upcomingTrips: [],
                     alertsHere: [alert], allDataLoaded: true, hasSchedulesToday: true, alertsDownstream: []
-                )]
+                )],
+                context: .stopDetailsFiltered
             ),
             showStationAccessibility: true
         )

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -22,7 +22,7 @@ final class RouteCardTests: XCTestCase {
         }
 
         let routeCardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+            lineOrRoute: .route(route),
             stopData: [],
             context: .nearbyTransit,
             at: Date.now.toKotlinInstant()
@@ -55,7 +55,7 @@ final class RouteCardTests: XCTestCase {
         }
 
         let routeCardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteLine(line: line, routes: [route]),
+            lineOrRoute: .line(line, [route]),
             stopData: [],
             context: .nearbyTransit,
             at: Date.now.toKotlinInstant()
@@ -84,7 +84,7 @@ final class RouteCardTests: XCTestCase {
         }
 
         let routeCardData = RouteCardData(
-            lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+            lineOrRoute: .route(route),
             stopData: [],
             context: .nearbyTransit,
             at: Date.now.toKotlinInstant()
@@ -126,8 +126,14 @@ final class RouteCardTests: XCTestCase {
 
         let nearbySut = RouteCard(
             cardData: RouteCardData(
-                lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-                stopData: [.init(stop: stop, directions: [], data: [])],
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    lineOrRoute: .route(route),
+                    stop: stop,
+                    directions: [],
+                    data: [],
+                    context: .nearbyTransit
+                )],
                 context: .nearbyTransit,
                 at: Date.now.toKotlinInstant()
             ),
@@ -142,8 +148,14 @@ final class RouteCardTests: XCTestCase {
 
         let stopDetailsSut = RouteCard(
             cardData: RouteCardData(
-                lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
-                stopData: [.init(stop: stop, directions: [], data: [])],
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    lineOrRoute: .route(route),
+                    stop: stop,
+                    directions: [],
+                    data: [],
+                    context: .stopDetailsUnfiltered
+                )],
                 context: .stopDetailsUnfiltered,
                 at: Date.now.toKotlinInstant()
             ),
@@ -171,15 +183,17 @@ final class RouteCardTests: XCTestCase {
 
         let sut = RouteCard(
             cardData: RouteCardData(
-                lineOrRoute: RouteCardDataLineOrRouteRoute(route: route),
+                lineOrRoute: .route(route),
                 stopData: [.init(
+                    lineOrRoute: .route(route),
                     stop: stop,
                     directions: [.init(name: "Inbound", destination: "", id: 0)],
                     data: [.init(
                         directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                         upcomingTrips: [], alertsHere: [], allDataLoaded: true,
                         hasSchedulesToday: true, alertsDownstream: []
-                    )]
+                    )],
+                    context: .nearbyTransit
                 )],
                 context: .nearbyTransit,
                 at: Date.now.toKotlinInstant()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -6,20 +6,15 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 object LoadingPlaceholders {
-    fun nearbyRoute(): RouteCardData {
-        return departureDataBundle(
-                context = RouteCardData.Context.NearbyTransit,
-                now = Clock.System.now()
-            )
-            .routeData
-    }
+    fun nearbyRoute() =
+        routeCardData(context = RouteCardData.Context.NearbyTransit, now = Clock.System.now())
 
-    fun departureDataBundle(
+    fun routeCardData(
         routeId: String? = null,
         trips: Int = 2,
         context: RouteCardData.Context,
         now: Instant
-    ): DepartureDataBundle {
+    ): RouteCardData {
         val objects = ObjectCollectionBuilder()
         val route =
             objects.route {
@@ -77,31 +72,27 @@ object LoadingPlaceholders {
                 alertsDownstream = emptyList(),
             )
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val stopData =
             RouteCardData.RouteStopData(
+                lineOrRoute,
                 stop,
                 listOf(Direction("Loading", null, 0), Direction("Loading", null, 1)),
                 listOf(leaf1, leaf2),
+                context
             )
 
-        val routeData =
-            RouteCardData(
-                RouteCardData.LineOrRoute.Route(route),
-                stopData = listOf(stopData),
-                context,
-                now
-            )
+        val routeData = RouteCardData(lineOrRoute, stopData = listOf(stopData), context, now)
 
-        return DepartureDataBundle(routeData, stopData, leaf1)
+        return routeData
     }
 
     fun stopDetailsRouteCards() =
         (1..5).map {
-            departureDataBundle(
-                    context = RouteCardData.Context.StopDetailsUnfiltered,
-                    now = Clock.System.now()
-                )
-                .routeData
+            routeCardData(
+                context = RouteCardData.Context.StopDetailsUnfiltered,
+                now = Clock.System.now()
+            )
         }
 
     data class TripDetailsInfo(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -85,8 +85,8 @@ open class RouteCardPreviewData {
         alertDownstream: Map<Int, Alert>
     ) =
         RouteCardData.RouteStopData(
-            stop,
             lineOrRoute,
+            stop,
             listOfNotNull(
                 RouteCardData.Leaf(
                         0,
@@ -111,6 +111,7 @@ open class RouteCardPreviewData {
                     )
                     .takeUnless { it.routePatterns.isEmpty() }
             ),
+            context,
             global
         )
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -68,7 +68,14 @@ class PatternSortingTest {
         stop: Stop,
         lineOrRoute: RouteCardData.LineOrRoute,
         vararg leaf: RouteCardData.Leaf
-    ) = RouteCardData.RouteStopData(stop, lineOrRoute, leaf.asList(), GlobalResponse(objects))
+    ) =
+        RouteCardData.RouteStopData(
+            lineOrRoute,
+            stop,
+            leaf.asList(),
+            RouteCardData.Context.NearbyTransit,
+            GlobalResponse(objects)
+        )
 
     private fun routeCard(route: Route, vararg stops: RouteCardData.RouteStopData) =
         routeCard(RouteCardData.LineOrRoute.Route(route), *stops)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -55,8 +55,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop1,
                                         route1,
+                                        stop1,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -66,6 +66,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = false,
                                                 )
                                         ),
+                                        context,
                                         global
                                     )
                             ),
@@ -125,8 +126,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop1,
                                         route1,
+                                        stop1,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -136,12 +137,13 @@ class RouteCardDataTest {
                                                     allDataLoaded = true,
                                                 )
                                         ),
+                                        context,
                                         global
                                     ),
                                 stop2.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop2,
                                         route1,
+                                        stop2,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -153,6 +155,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = true,
                                                 )
                                         ),
+                                        context,
                                         global
                                     )
                             ),
@@ -210,8 +213,8 @@ class RouteCardDataTest {
                         mapOf(
                             stop1.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -228,6 +231,7 @@ class RouteCardDataTest {
                                                 allDataLoaded = false,
                                             )
                                     ),
+                                    context,
                                     global
                                 )
                         ),
@@ -279,8 +283,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop1,
                                         route1,
+                                        stop1,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -290,6 +294,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = false,
                                                 )
                                         ),
+                                        context,
                                         global
                                     ),
                             ),
@@ -302,8 +307,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop1,
                                         route2,
+                                        stop1,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -313,6 +318,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = false,
                                                 )
                                         ),
+                                        context,
                                         global
                                     )
                             ),
@@ -385,8 +391,8 @@ class RouteCardDataTest {
                         mapOf(
                             station1.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    station1,
                                     route1,
+                                    station1,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -401,12 +407,13 @@ class RouteCardDataTest {
                                                 allDataLoaded = false,
                                             )
                                     ),
+                                    context,
                                     global
                                 ),
                             stop2.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stop2,
                                     route1,
+                                    stop2,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -416,6 +423,7 @@ class RouteCardDataTest {
                                                 allDataLoaded = false,
                                             )
                                     ),
+                                    context,
                                     global
                                 )
                         ),
@@ -474,8 +482,8 @@ class RouteCardDataTest {
                         mapOf(
                             parentStation.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    parentStation,
                                     route,
+                                    parentStation,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -490,6 +498,7 @@ class RouteCardDataTest {
                                                 allDataLoaded = false,
                                             )
                                     ),
+                                    context,
                                     global
                                 ),
                         ),
@@ -549,14 +558,16 @@ class RouteCardDataTest {
             val westDir = Direction("West", "Boston College", 0)
             val eastDir = Direction("East", "Government Center", 1)
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(railRoute))
             assertEquals(
                 mapOf(
                     line.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Line(line, setOf(railRoute)),
+                            lineOrRoute,
                             mapOf(
                                 stop.id to
                                     RouteCardData.RouteStopDataBuilder(
+                                        lineOrRoute,
                                         stop,
                                         listOf(westDir, eastDir),
                                         mapOf(
@@ -567,7 +578,8 @@ class RouteCardDataTest {
                                                     stopIds = setOf(stop.id),
                                                     allDataLoaded = false,
                                                 )
-                                        )
+                                        ),
+                                        context
                                     )
                             ),
                             context,
@@ -579,8 +591,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop,
                                         shuttleRoute,
+                                        stop,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -590,6 +602,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = false
                                                 )
                                         ),
+                                        context,
                                         global
                                     )
                             ),
@@ -670,9 +683,9 @@ class RouteCardDataTest {
                         mapOf(
                             parkSt.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    parkSt,
                                     line,
                                     setOf(bRoute, cRoute, dRoute),
+                                    parkSt,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -708,6 +721,7 @@ class RouteCardDataTest {
                                                 allDataLoaded = false,
                                             )
                                     ),
+                                    context,
                                     global
                                 )
                         ),
@@ -873,14 +887,16 @@ class RouteCardDataTest {
             val westDir = Direction("West", "Copley & West", 0)
             val northDir = Direction("East", "North Station & North", 1)
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeD))
             assertEquals(
                 mapOf(
                     line.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeD)),
+                            lineOrRoute,
                             mapOf(
                                 stopGov.id to
                                     RouteCardData.RouteStopDataBuilder(
+                                        lineOrRoute,
                                         stopGov,
                                         listOf(westDir, northDir),
                                         mapOf(
@@ -905,7 +921,8 @@ class RouteCardDataTest {
                                                     stopIds = setOf(stopGov.id),
                                                     allDataLoaded = false,
                                                 )
-                                        )
+                                        ),
+                                        context
                                     )
                             ),
                             context,
@@ -1003,8 +1020,8 @@ class RouteCardDataTest {
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop1,
                                         route1,
+                                        stop1,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -1023,12 +1040,13 @@ class RouteCardDataTest {
                                                     allDataLoaded = false
                                                 )
                                         ),
+                                        context,
                                         global
                                     ),
                                 stop2.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        stop2,
                                         route1,
+                                        stop2,
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
@@ -1047,6 +1065,7 @@ class RouteCardDataTest {
                                                     allDataLoaded = false
                                                 )
                                         ),
+                                        context,
                                         global
                                     )
                             ),
@@ -1125,8 +1144,8 @@ class RouteCardDataTest {
                         mapOf(
                             stop1.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stop1,
                                     route,
+                                    stop1,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -1140,12 +1159,13 @@ class RouteCardDataTest {
                                                     mapOf(pattern1.id to true)
                                             )
                                     ),
+                                    context,
                                     global
                                 ),
                             stop2.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stop2,
                                     route,
+                                    stop2,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -1158,12 +1178,13 @@ class RouteCardDataTest {
                                                     mapOf(pattern2.id to true)
                                             )
                                     ),
+                                    context,
                                     global
                                 ),
                             stop3.id to
                                 RouteCardData.RouteStopDataBuilder(
-                                    stop3,
                                     route,
+                                    stop3,
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
@@ -1176,6 +1197,7 @@ class RouteCardDataTest {
                                                     mapOf(pattern3.id to false)
                                             )
                                     ),
+                                    context,
                                     global
                                 )
                         ),
@@ -1239,8 +1261,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                subwayStop,
                                 subwayRoute,
+                                subwayStop,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -1253,6 +1275,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             )
                         ),
@@ -1264,8 +1287,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                busStop,
                                 busRoute,
+                                busStop,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -1278,6 +1301,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             )
                         ),
@@ -1343,8 +1367,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    closerStop,
                                     subwayRoute2,
+                                    closerStop,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -1357,6 +1381,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -1368,8 +1393,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    furtherStop,
                                     subwayRoute1,
+                                    furtherStop,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -1382,6 +1407,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2129,8 +2155,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2146,6 +2172,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2239,8 +2266,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2274,6 +2301,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2357,8 +2385,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2376,6 +2404,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2467,8 +2496,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2486,11 +2515,12 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 ),
                                 RouteCardData.RouteStopData(
-                                    stop2,
                                     route1,
+                                    stop2,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2512,6 +2542,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2588,8 +2619,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2607,11 +2638,12 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 ),
                                 RouteCardData.RouteStopData(
-                                    stop2,
                                     route1,
+                                    stop2,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2624,6 +2656,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2784,8 +2817,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 1,
@@ -2801,6 +2834,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 ),
                             ),
@@ -2812,8 +2846,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route3,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -2845,6 +2879,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -2908,8 +2943,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                stop1,
                                 route1,
+                                stop1,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -2922,6 +2957,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             ),
                         ),
@@ -3002,8 +3038,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -3032,6 +3068,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -3102,8 +3139,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop1,
                                     route1,
+                                    stop1,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -3122,6 +3159,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -3175,8 +3213,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                parentStop,
                                 route1,
+                                parentStop,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -3189,6 +3227,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             )
                         ),
@@ -3249,8 +3288,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                stop,
                                 route,
+                                stop,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -3273,6 +3312,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             )
                         ),
@@ -3341,8 +3381,8 @@ class RouteCardDataTest {
                         RouteCardData.LineOrRoute.Route(route),
                         listOf(
                             RouteCardData.RouteStopData(
-                                stop,
                                 route,
+                                stop,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -3360,6 +3400,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context = RouteCardData.Context.NearbyTransit,
                                 globalData = GlobalResponse(objects)
                             )
                         ),
@@ -3441,8 +3482,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop,
                                     route1,
+                                    stop,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -3461,6 +3502,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -3472,8 +3514,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    stop,
                                     route2,
+                                    stop,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -3496,6 +3538,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -3714,14 +3757,15 @@ class RouteCardDataTest {
             )
         val context = RouteCardData.Context.NearbyTransit
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeE))
         val expected =
             listOf(
                 RouteCardData(
-                    lineOrRoute =
-                        RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeE)),
+                    lineOrRoute = lineOrRoute,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
+                                lineOrRoute,
                                 hynes,
                                 listOf(directionWest, directionEast),
                                 listOf(
@@ -3785,7 +3829,8 @@ class RouteCardDataTest {
                                             ),
                                         alertsDownstream = emptyList()
                                     )
-                                )
+                                ),
+                                context
                             )
                         ),
                     context,
@@ -3883,13 +3928,15 @@ class RouteCardDataTest {
                 )
             val context = RouteCardData.Context.NearbyTransit
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB))
             val expected =
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB)),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
+                                    lineOrRoute,
                                     southSt,
                                     listOf(directionWest, directionEast),
                                     listOf(
@@ -3925,7 +3972,8 @@ class RouteCardDataTest {
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
-                                    )
+                                    ),
+                                    context
                                 )
                             ),
                         context,
@@ -3985,13 +4033,15 @@ class RouteCardDataTest {
                 )
             val context = RouteCardData.Context.NearbyTransit
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
+                                    lineOrRoute,
                                     stop,
                                     listOf(
                                         Direction(
@@ -4022,7 +4072,8 @@ class RouteCardDataTest {
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
-                                    )
+                                    ),
+                                    context
                                 )
                             ),
                         context,
@@ -4265,8 +4316,8 @@ class RouteCardDataTest {
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
-                                northStation,
                                 orangeRoute,
+                                northStation,
                                 listOf(
                                     RouteCardData.Leaf(
                                         directionId = 0,
@@ -4314,6 +4365,7 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     )
                                 ),
+                                context,
                                 global
                             )
                         ),
@@ -4416,8 +4468,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    oakGrove,
                                     orangeRoute,
+                                    oakGrove,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -4436,6 +4488,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -4535,8 +4588,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    longWharf,
                                     ferryRoute,
+                                    longWharf,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -4550,6 +4603,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -4703,8 +4757,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    park,
                                     route,
+                                    park,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -4723,6 +4777,7 @@ class RouteCardDataTest {
                                             alertsDownstream = southboundDownstreamAlerts
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -4819,8 +4874,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    southStation,
                                     route,
+                                    southStation,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -4834,6 +4889,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),
@@ -4861,8 +4917,8 @@ class RouteCardDataTest {
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
-                                    providence,
                                     route,
+                                    providence,
                                     listOf(
                                         RouteCardData.Leaf(
                                             directionId = 0,
@@ -4876,6 +4932,7 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList()
                                         )
                                     ),
+                                    context,
                                     global
                                 )
                             ),


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | Refactor RouteStopData and Leaf to include more context](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210114621155024?focus=true)

Not sure how easy the “If straightforward” section of the ticket will be, so may as well put the first half up as its own PR.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Updated unit tests. Checked that all tests pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
