### PR TITLE
fix(iOS): Get stop details map stop taps working

### DIFF
--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -99,6 +99,7 @@ struct AlertCard: View {
                     .frame(minHeight: 44)
                     .background(color)
                     .clipShape(.rect(cornerRadius: 8.0))
+                    .simultaneousGesture(TapGesture())
                 }
             }
         }
@@ -116,7 +117,9 @@ struct AlertCard: View {
             Button(
                 action: onViewDetails,
                 label: { card }
-            ).foregroundStyle(Color.text)
+            )
+            .foregroundStyle(Color.text)
+            .simultaneousGesture(TapGesture())
         } else {
             card
         }

--- a/iosApp/iosApp/ComponentViews/PinButton.swift
+++ b/iosApp/iosApp/ComponentViews/PinButton.swift
@@ -37,5 +37,6 @@ struct PinButton: View {
         )
         .accessibilityIdentifier("pinButton")
         .accessibilityAddTraits(pinned ? [.isSelected] : [])
+        .simultaneousGesture(TapGesture())
     }
 }

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -32,7 +32,7 @@ struct AnnotatedMap: View {
 
     var handleCameraChange: (CameraChanged) -> Void
     var handleStyleLoaded: () -> Void
-    var handleTapStopLayer: (QueriedFeature, MapContentGestureContext) -> Bool
+    var handleTapStopLayer: (QueriedFeature, InteractionContext) -> Bool
     var handleTapVehicle: (Vehicle) -> Void
 
     @State private var zoomLevel: CGFloat = 0

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -37,7 +37,6 @@ struct DepartureTile: View {
                 }
             }
         }
-        .simultaneousGesture(TapGesture())
         .padding(.horizontal, 10)
         .padding(.vertical, 10)
         .frame(minHeight: 56)

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsDisclosureGroup.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsDisclosureGroup.swift
@@ -30,7 +30,7 @@ struct TripDetailsDisclosureGroup: DisclosureGroupStyle {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     caretRotation = expanded ? .degrees(90) : .zero
                 }
-            }
+            }.simultaneousGesture(TapGesture())
             configuration.content
                 .frame(height: configuration.isExpanded ? nil : 0, alignment: .top)
                 .clipped()


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS | [Fix: tapping on stops on the filtered stop details map doesn't do anything]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210177544414522?focus=true)

In a kind of absurd turn of events, the `.simultaneousGesture(TapGesture())` modifier on the `DepartureTile` button was the thing that was, somehow, preventing taps on stops in the map from registering. This isn't actually a problem for the scrolling issue, because for some other arcane SwiftUI reason, scrolls that happen in horizontally scrolling containers don't seem to register as taps in the same way that scrolls in vertically scrolling containers do.

I also added a handful more `.simultaneousGesture(TapGesture())`s to a few other buttons I noticed could be triggered on scroll.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Tested manually on the simulator and on a physical device
