### PR TITLE
feat: Add Enhanced Favorites feature flag

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -97,6 +97,10 @@ class MoreViewModel(
                             settings = Settings.DevDebugMode
                         ),
                         MoreItem.Toggle(
+                            label = "Enhanced Favorites",
+                            settings = Settings.EnhancedFavorites
+                        ),
+                        MoreItem.Toggle(
                             label = context.getString(R.string.feature_flag_route_search),
                             settings = Settings.SearchRouteResults
                         )

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -100,6 +100,11 @@ class SettingsViewModel: ObservableObject {
                         value: settings[.devDebugMode] ?? false
                     ),
                     .toggle(
+                        label: "Enhanced Favorites",
+                        setting: .enhancedFavorites,
+                        value: settings[.enhancedFavorites] ?? false
+                    ),
+                    .toggle(
                         label: NSLocalizedString(
                             "Route Search",
                             comment: "A setting on the More page to display routes in search (only visible for developers)"

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -37,9 +37,10 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
 
 enum class Settings(val dataStoreKey: Preferences.Key<Boolean>) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
-    StationAccessibility(booleanPreferencesKey("elevator_accessibility")),
+    EnhancedFavorites(booleanPreferencesKey("enhanced_favorites_feature_flag")),
     HideMaps(booleanPreferencesKey("hide_maps")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
+    StationAccessibility(booleanPreferencesKey("elevator_accessibility")),
 }
 
 class MockSettingsRepository

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -41,6 +41,7 @@ class SettingsRepositoryTest : KoinTest {
                 Settings.SearchRouteResults to false,
                 Settings.StationAccessibility to false,
                 Settings.HideMaps to false,
+                Settings.EnhancedFavorites to false,
             ),
             repo.getSettings()
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Feature flag](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209816289542463?focus=true)

Add a feature flag for upcoming favorites changes.

I opted not to add translations for the toggle label since it will only ever show up in staging.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Updated existing test