### PR TITLE
refactor: split direction toggle from tiles in filtered stop details

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -41,13 +41,16 @@ class DeparturesTest {
         val aTrip = objects.trip { headsign = "A" }
         val bTrip = objects.trip { headsign = "B" }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val stopData =
             RouteCardData.RouteStopData(
-                RouteCardData.LineOrRoute.Route(route),
+                lineOrRoute,
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         0,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),
@@ -63,6 +66,8 @@ class DeparturesTest {
                         emptyList()
                     ),
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         1,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),
@@ -110,13 +115,16 @@ class DeparturesTest {
         val aSchedule = objects.schedule { stopHeadsign = "A Stop Headsign" }
         val bTrip = objects.trip { headsign = "B" }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val stopData =
             RouteCardData.RouteStopData(
-                RouteCardData.LineOrRoute.Route(route),
+                lineOrRoute,
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         0,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),
@@ -133,6 +141,8 @@ class DeparturesTest {
                         emptyList()
                     ),
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         1,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),
@@ -174,13 +184,16 @@ class DeparturesTest {
         val aTrip = objects.trip { headsign = "A" }
         val bTrip = objects.trip { headsign = "B" }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val stopData =
             RouteCardData.RouteStopData(
-                RouteCardData.LineOrRoute.Route(route),
+                lineOrRoute,
                 stop,
                 listOf(Direction("A Headsign", null, 0), Direction("B Headsign", null, 1)),
                 listOf(
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         0,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),
@@ -196,6 +209,8 @@ class DeparturesTest {
                         emptyList()
                     ),
                     RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         1,
                         listOf(objects.routePattern(route) {}),
                         setOf(stop.id),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
@@ -87,14 +87,17 @@ class StopHeaderTest {
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
         val alert = objects.alert { effect = Alert.Effect.ElevatorClosure }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         composeTestRule.setContent {
             StopHeader(
                 RouteCardData.RouteStopData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute,
                     stop,
                     emptyList(),
                     listOf(
                         RouteCardData.Leaf(
+                            lineOrRoute,
+                            stop,
                             0,
                             emptyList(),
                             emptySet(),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
@@ -1,0 +1,353 @@
+package com.mbta.tid.mbta_app.android.stopDetails
+
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
+import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Instant
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.koin.compose.KoinContext
+
+class StopDetailsFilteredPickerViewTest {
+    val builder = ObjectCollectionBuilder()
+    val now = Instant.fromEpochMilliseconds(System.currentTimeMillis())
+    val route =
+        builder.route {
+            id = "route_1"
+            type = RouteType.LIGHT_RAIL
+            color = "FF0000"
+            directionNames = listOf("North", "South")
+            directionDestinations = listOf("Downtown", "Uptown")
+            longName = "Sample Route Long Name"
+            shortName = "Sample Route"
+            textColor = "000000"
+            lineId = "line_1"
+            routePatternIds = mutableListOf("pattern_1", "pattern_2")
+        }
+    val routePatternOne =
+        builder.routePattern(route) {
+            id = "pattern_1"
+            directionId = 0
+            name = "Sample Route Pattern"
+            routeId = "route_1"
+            representativeTripId = "trip_1"
+        }
+    val routePatternTwo =
+        builder.routePattern(route) {
+            id = "pattern_2"
+            directionId = 1
+            name = "Sample Route Pattern Two"
+            routeId = "route_1"
+            representativeTripId = "trip_1"
+        }
+    val downstreamStop =
+        builder.stop {
+            id = "stop_2"
+            name = "Sample Stop 2"
+            locationType = LocationType.STOP
+            latitude = 0.0
+            longitude = 0.0
+        }
+    val stop =
+        builder.stop {
+            id = "stop_1"
+            name = "Sample Stop"
+            locationType = LocationType.STOP
+            latitude = 0.0
+            longitude = 0.0
+        }
+    val inaccessibleStop =
+        builder.stop {
+            id = "stop_3"
+            name = "Sample Stop 3"
+            locationType = LocationType.STOP
+            latitude = 0.0
+            longitude = 0.0
+            wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
+        }
+    val line =
+        builder.line {
+            id = "line_1"
+            color = "FF0000"
+            textColor = "FFFFFF"
+        }
+    val trip =
+        builder.trip {
+            id = "trip_1"
+            routeId = "route_1"
+            directionId = 0
+            headsign = "Sample Headsign"
+            routePatternId = "pattern_1"
+            stopIds = listOf(stop.id, downstreamStop.id, inaccessibleStop.id)
+        }
+    val prediction =
+        builder.prediction {
+            id = "prediction_1"
+            revenue = true
+            stopId = "stop_1"
+            tripId = "trip_1"
+            routeId = "route_1"
+            stopSequence = 1
+            directionId = 0
+            arrivalTime = now.plus(1.minutes)
+            departureTime = now.plus(1.5.minutes)
+        }
+
+    private val globalResponse =
+        GlobalResponse(
+            builder,
+            mutableMapOf(
+                stop.id to listOf(routePatternOne.id, routePatternTwo.id),
+                inaccessibleStop.id to listOf(routePatternOne.id, routePatternTwo.id)
+            )
+        )
+
+    private val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
+
+    private val settings = mutableMapOf<Settings, Boolean>()
+    private val settingsRepository =
+        object : ISettingsRepository {
+            override suspend fun getSettings() = settings
+
+            override suspend fun setSettings(settings: Map<Settings, Boolean>) {}
+        }
+
+    private val koinApplication = testKoinApplication { settings = settingsRepository }
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Before fun resetSettings() = settings.clear()
+
+    @Test
+    fun testStopDetailsRouteViewDisplaysCorrectly(): Unit = runBlocking {
+        val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)
+        val viewModel = StopDetailsViewModel.mocked()
+        val routeCardData =
+            checkNotNull(
+                RouteCardData.routeCardsForStopList(
+                    listOf(stop.id),
+                    globalResponse,
+                    null,
+                    null,
+                    PredictionsStreamDataResponse(builder),
+                    AlertsStreamDataResponse(emptyMap()),
+                    now,
+                    emptySet(),
+                    context = RouteCardData.Context.StopDetailsFiltered
+                )
+            )
+        val routeStopData = routeCardData.single().stopData.single()
+        viewModel.setRouteCardData(routeCardData)
+
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                StopDetailsFilteredPickerView(
+                    stopId = stop.id,
+                    stopFilter = filterState,
+                    tripFilter = null,
+                    routeStopData = routeStopData,
+                    allAlerts = null,
+                    global = globalResponse,
+                    now = now,
+                    viewModel = viewModel,
+                    errorBannerViewModel = errorBannerViewModel,
+                    updateStopFilter = {},
+                    updateTripFilter = {},
+                    tileScrollState = rememberScrollState(),
+                    pinnedRoutes = emptySet(),
+                    togglePinnedRoute = {},
+                    openModal = {},
+                    openSheetRoute = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("at ${stop.name}").assertExists()
+        composeTestRule.onNodeWithText("1 min").assertExists()
+    }
+
+    @Test
+    fun testTappingTripSetsFilter() = runBlocking {
+        var tripFilter: TripDetailsFilter? = null
+
+        val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)
+        val viewModel = StopDetailsViewModel.mocked()
+
+        val routeCardData =
+            checkNotNull(
+                RouteCardData.routeCardsForStopList(
+                    listOf(stop.id),
+                    globalResponse,
+                    null,
+                    null,
+                    PredictionsStreamDataResponse(builder),
+                    AlertsStreamDataResponse(emptyMap()),
+                    now,
+                    emptySet(),
+                    context = RouteCardData.Context.StopDetailsFiltered
+                )
+            )
+        val routeStopData = routeCardData.single().stopData.single()
+        viewModel.setRouteCardData(routeCardData)
+
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                StopDetailsFilteredPickerView(
+                    stopId = stop.id,
+                    stopFilter = filterState,
+                    tripFilter = null,
+                    routeStopData = routeStopData,
+                    allAlerts = null,
+                    global = globalResponse,
+                    now = now,
+                    viewModel = viewModel,
+                    errorBannerViewModel = errorBannerViewModel,
+                    updateStopFilter = {},
+                    updateTripFilter = { tripFilter = it },
+                    tileScrollState = rememberScrollState(),
+                    pinnedRoutes = emptySet(),
+                    togglePinnedRoute = {},
+                    openModal = {},
+                    openSheetRoute = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("at ${stop.name}").assertExists()
+        composeTestRule.onNodeWithText("1 min").assertExists().performClick()
+        composeTestRule.waitUntil { tripFilter?.tripId == trip.id }
+
+        assertEquals(tripFilter?.tripId, trip.id)
+    }
+
+    @Test
+    fun testShowsElevatorAlert(): Unit = runBlocking {
+        settings[Settings.StationAccessibility] = true
+        builder.alert {
+            effect = Alert.Effect.ElevatorClosure
+            header = "Elevator Alert Header"
+            informedEntity(listOf(Alert.InformedEntity.Activity.UsingWheelchair), stop = stop.id)
+            activePeriod(Instant.DISTANT_PAST, null)
+        }
+
+        val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)
+        val viewModel = StopDetailsViewModel.mocked()
+
+        val routeCardData =
+            checkNotNull(
+                RouteCardData.routeCardsForStopList(
+                    listOf(stop.id),
+                    globalResponse,
+                    null,
+                    null,
+                    PredictionsStreamDataResponse(builder),
+                    AlertsStreamDataResponse(builder),
+                    now,
+                    emptySet(),
+                    context = RouteCardData.Context.StopDetailsFiltered
+                )
+            )
+        val routeStopData = routeCardData.single().stopData.single()
+        viewModel.setRouteCardData(routeCardData)
+
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                StopDetailsFilteredPickerView(
+                    stopId = stop.id,
+                    stopFilter = filterState,
+                    tripFilter = null,
+                    routeStopData = routeStopData,
+                    allAlerts = null,
+                    global = globalResponse,
+                    now = now,
+                    viewModel = viewModel,
+                    errorBannerViewModel = errorBannerViewModel,
+                    updateStopFilter = {},
+                    updateTripFilter = {},
+                    tileScrollState = rememberScrollState(),
+                    pinnedRoutes = emptySet(),
+                    togglePinnedRoute = {},
+                    openModal = {},
+                    openSheetRoute = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Elevator Alert Header").assertIsDisplayed()
+    }
+
+    @Test
+    fun testShowsNotAccessibleAlert(): Unit = runBlocking {
+        settings[Settings.StationAccessibility] = true
+        val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)
+        val viewModel = StopDetailsViewModel.mocked()
+
+        val routeCardData =
+            checkNotNull(
+                RouteCardData.routeCardsForStopList(
+                    listOf(inaccessibleStop.id),
+                    globalResponse,
+                    null,
+                    null,
+                    PredictionsStreamDataResponse(builder),
+                    AlertsStreamDataResponse(emptyMap()),
+                    now,
+                    emptySet(),
+                    RouteCardData.Context.StopDetailsFiltered
+                )
+            )
+        val routeStopData = routeCardData.single().stopData.single()
+        viewModel.setRouteCardData(routeCardData)
+
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                StopDetailsFilteredPickerView(
+                    stopId = inaccessibleStop.id,
+                    stopFilter = filterState,
+                    tripFilter = null,
+                    routeStopData = routeStopData,
+                    allAlerts = null,
+                    global = globalResponse,
+                    now = now,
+                    viewModel = viewModel,
+                    errorBannerViewModel = errorBannerViewModel,
+                    updateStopFilter = {},
+                    updateTripFilter = {},
+                    tileScrollState = rememberScrollState(),
+                    pinnedRoutes = emptySet(),
+                    togglePinnedRoute = {},
+                    openModal = {},
+                    openSheetRoute = {},
+                    onClose = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("This stop is not accessible").assertIsDisplayed()
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -45,6 +45,7 @@ class StopDetailsViewTest {
             lineId = "line_1"
             routePatternIds = mutableListOf("pattern_1", "pattern_2")
         }
+    val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
     val routePatternOne =
         builder.routePattern(route) {
             id = "pattern_1"
@@ -111,13 +112,15 @@ class StopDetailsViewTest {
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute,
                     listOf(
                         RouteCardData.RouteStopData(
                             route,
                             stop,
                             listOf(
                                 RouteCardData.Leaf(
+                                    lineOrRoute,
+                                    stop,
                                     directionId = 0,
                                     listOf(routePatternOne),
                                     setOf(stop.id),
@@ -181,13 +184,15 @@ class StopDetailsViewTest {
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute,
                     listOf(
                         RouteCardData.RouteStopData(
                             route,
                             stop,
                             listOf(
                                 RouteCardData.Leaf(
+                                    lineOrRoute,
+                                    stop,
                                     directionId = 0,
                                     listOf(routePatternOne),
                                     setOf(stop.id),
@@ -257,13 +262,15 @@ class StopDetailsViewTest {
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute,
                     listOf(
                         RouteCardData.RouteStopData(
                             route,
                             stop,
                             listOf(
                                 RouteCardData.Leaf(
+                                    lineOrRoute,
+                                    stop,
                                     directionId = 0,
                                     listOf(routePatternOne),
                                     setOf(stop.id),
@@ -325,13 +332,15 @@ class StopDetailsViewTest {
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute,
                     listOf(
                         RouteCardData.RouteStopData(
                             route,
                             stop,
                             listOf(
                                 RouteCardData.Leaf(
+                                    lineOrRoute,
+                                    stop,
                                     directionId = 0,
                                     listOf(routePatternOne),
                                     setOf(stop.id),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -177,6 +177,8 @@ private fun DeparturesPreview() {
             jfkUmass,
             listOf(
                 RouteCardData.Leaf(
+                    lineOrRoute,
+                    jfkUmass,
                     0,
                     listOf(redLineAshmontSouthbound, redLineBraintreeSouthbound),
                     setOf(jfkUmass.id),
@@ -206,6 +208,8 @@ private fun DeparturesPreview() {
                     emptyList()
                 ),
                 RouteCardData.Leaf(
+                    lineOrRoute,
+                    jfkUmass,
                     1,
                     listOf(redLineAshmontNorthbound, redLineBraintreeNorthbound),
                     setOf(jfkUmass.id),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
@@ -1,0 +1,177 @@
+package com.mbta.tid.mbta_app.android.stopDetails
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.mbta.tid.mbta_app.android.ModalRoutes
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.SheetRoutes
+import com.mbta.tid.mbta_app.android.component.ErrorBanner
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
+import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlinx.datetime.Instant
+
+@Composable
+fun StopDetailsFilteredPickerView(
+    stopId: String,
+    stopFilter: StopDetailsFilter,
+    tripFilter: TripDetailsFilter?,
+    routeStopData: RouteCardData.RouteStopData,
+    allAlerts: AlertsStreamDataResponse?,
+    global: GlobalResponse?,
+    now: Instant,
+    viewModel: StopDetailsViewModel,
+    errorBannerViewModel: ErrorBannerViewModel,
+    updateStopFilter: (StopDetailsFilter?) -> Unit,
+    updateTripFilter: (TripDetailsFilter?) -> Unit,
+    tileScrollState: ScrollState,
+    pinnedRoutes: Set<String>,
+    togglePinnedRoute: (String) -> Unit,
+    openModal: (ModalRoutes) -> Unit,
+    openSheetRoute: (SheetRoutes) -> Unit,
+    onClose: () -> Unit
+) {
+    val leaf = routeStopData.data.find { it.directionId == stopFilter.directionId }
+
+    val lineOrRoute = routeStopData.lineOrRoute
+    val stop = routeStopData.stop
+    val availableDirections = routeStopData.data.map { it.directionId }.distinct().sorted()
+    val directions = routeStopData.directions
+
+    val pinned = pinnedRoutes.contains(lineOrRoute.id)
+
+    val routeHex: String = lineOrRoute.backgroundColor
+    val routeColor: Color = Color.fromHex(routeHex)
+
+    Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
+        StopDetailsFilteredHeader(
+            lineOrRoute.sortRoute,
+            (lineOrRoute as? RouteCardData.LineOrRoute.Line)?.line,
+            stop,
+            pinned = pinned,
+            onPin = { togglePinnedRoute(lineOrRoute.id) },
+            onClose = onClose
+        )
+
+        ErrorBanner(errorBannerViewModel, Modifier.padding(vertical = 16.dp))
+
+        Box(Modifier.fillMaxSize().background(routeColor)) {
+            HorizontalDivider(
+                Modifier.fillMaxWidth().zIndex(1f).border(2.dp, colorResource(R.color.halo))
+            )
+            Column(
+                Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(top = 14.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                DirectionPicker(
+                    availableDirections = availableDirections,
+                    directions = directions,
+                    route = lineOrRoute.sortRoute,
+                    line = (lineOrRoute as? RouteCardData.LineOrRoute.Line)?.line,
+                    stopFilter,
+                    updateStopFilter,
+                    modifier = Modifier.padding(horizontal = 10.dp)
+                )
+
+                if (leaf != null) {
+                    val leafFormat =
+                        leaf.format(
+                            now,
+                            routeStopData.lineOrRoute.sortRoute,
+                            global,
+                            RouteCardData.Context.StopDetailsFiltered
+                        )
+                    val tileData = leafFormat.tileData()
+                    val noPredictionsStatus = leafFormat.noPredictionsStatus()
+
+                    StopDetailsFilteredDeparturesView(
+                        stopId = stopId,
+                        stopFilter = stopFilter,
+                        tripFilter = tripFilter,
+                        leaf = leaf,
+                        tileData = tileData,
+                        noPredictionsStatus = noPredictionsStatus,
+                        isAllServiceDisrupted = leafFormat.isAllServiceDisrupted,
+                        allAlerts = allAlerts,
+                        elevatorAlerts = routeStopData.elevatorAlerts,
+                        global = global,
+                        now = now,
+                        viewModel = viewModel,
+                        updateTripFilter = updateTripFilter,
+                        tileScrollState = tileScrollState,
+                        pinnedRoutes = pinnedRoutes,
+                        openModal = openModal,
+                        openSheetRoute = openSheetRoute
+                    )
+                } else {
+                    CompositionLocalProvider(IsLoadingSheetContents provides true) {
+                        Column(modifier = Modifier.loadingShimmer()) {
+                            val routeData =
+                                LoadingPlaceholders.routeCardData(
+                                    stopFilter.routeId,
+                                    trips = 10,
+                                    RouteCardData.Context.StopDetailsFiltered,
+                                    now
+                                )
+                            val stopData = routeData.stopData.single()
+                            val placeholderLeaf = stopData.data.first()
+                            val leafFormat =
+                                placeholderLeaf.format(
+                                    now,
+                                    routeStopData.lineOrRoute.sortRoute,
+                                    global,
+                                    RouteCardData.Context.StopDetailsFiltered
+                                )
+                            val tileData = leafFormat.tileData()
+                            val noPredictionsStatus = leafFormat.noPredictionsStatus()
+
+                            StopDetailsFilteredDeparturesView(
+                                stopId = stopId,
+                                stopFilter = stopFilter,
+                                tripFilter = tripFilter,
+                                leaf = placeholderLeaf,
+                                tileData = tileData,
+                                noPredictionsStatus = noPredictionsStatus,
+                                isAllServiceDisrupted = false,
+                                allAlerts = AlertsStreamDataResponse(emptyMap()),
+                                elevatorAlerts = routeStopData.elevatorAlerts,
+                                global = global,
+                                now = now,
+                                viewModel = viewModel,
+                                updateTripFilter = {},
+                                tileScrollState = rememberScrollState(),
+                                pinnedRoutes = emptySet(),
+                                openModal = {},
+                                openSheetRoute = {}
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -33,7 +33,7 @@ fun StopDetailsFilteredView(
     togglePinnedRoute: (String) -> Unit,
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,
-    updateTripDetailsFilter: (TripDetailsFilter?) -> Unit,
+    updateTripFilter: (TripDetailsFilter?) -> Unit,
     tileScrollState: ScrollState,
     openModal: (ModalRoutes) -> Unit,
     openSheetRoute: (SheetRoutes) -> Unit,
@@ -42,36 +42,20 @@ fun StopDetailsFilteredView(
     val globalResponse = getGlobalData("StopDetailsView.getGlobalData")
     val thisRouteCardData = routeCardData?.find { it.lineOrRoute.id == stopFilter.routeId }
     val routeStopData = thisRouteCardData?.stopData?.get(0)
-    val leaf = routeStopData?.data?.find { it.directionId == stopFilter.directionId }
 
-    if (leaf != null) {
-        val leafFormat =
-            leaf.format(
-                now,
-                thisRouteCardData.lineOrRoute.sortRoute,
-                globalResponse,
-                RouteCardData.Context.StopDetailsFiltered
-            )
-        val tileData = leafFormat.tileData()
-        val noPredictionsStatus = leafFormat.noPredictionsStatus()
-
-        StopDetailsFilteredDeparturesView(
+    if (routeStopData != null) {
+        StopDetailsFilteredPickerView(
             stopId = stopId,
             stopFilter = stopFilter,
             tripFilter = tripFilter,
             routeStopData = routeStopData,
-            leaf = leaf,
-            tileData = tileData,
-            noPredictionsStatus = noPredictionsStatus,
-            isAllServiceDisrupted = leafFormat.isAllServiceDisrupted,
             allAlerts = allAlerts,
-            elevatorAlerts = routeStopData.elevatorAlerts,
             global = globalResponse,
             now = now,
             viewModel = viewModel,
             errorBannerViewModel = errorBannerViewModel,
             updateStopFilter = updateStopFilter,
-            updateTripFilter = updateTripDetailsFilter,
+            updateTripFilter = updateTripFilter,
             tileScrollState = tileScrollState,
             pinnedRoutes = pinnedRoutes,
             togglePinnedRoute = togglePinnedRoute,
@@ -114,26 +98,12 @@ private fun Loading(
                     now
                 )
             val stopData = routeData.stopData.single()
-            val leaf = stopData.data.first()
-            StopDetailsFilteredDeparturesView(
+            StopDetailsFilteredPickerView(
                 stopId = stopId,
                 stopFilter = stopFilter,
                 tripFilter = tripFilter,
                 routeStopData = stopData,
-                leaf = leaf,
-                tileData =
-                    leaf
-                        .format(
-                            now,
-                            routeData.lineOrRoute.sortRoute,
-                            globalResponse,
-                            RouteCardData.Context.StopDetailsFiltered
-                        )
-                        .tileData(),
-                noPredictionsStatus = null,
-                isAllServiceDisrupted = false,
                 allAlerts = null,
-                elevatorAlerts = stopData.elevatorAlerts,
                 global = globalResponse,
                 now = now,
                 viewModel = viewModel,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -192,16 +192,20 @@ private fun StopDetailsRoutesViewPreview() {
 
     val globalData = GlobalResponse(objects)
 
+    val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+    val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
     val routeCardData =
         listOf(
             RouteCardData(
-                RouteCardData.LineOrRoute.Route(route1),
+                lineOrRoute1,
                 listOf(
                     RouteCardData.RouteStopData(
                         route1,
                         stop,
                         listOf(
                             RouteCardData.Leaf(
+                                lineOrRoute1,
+                                stop,
                                 0,
                                 routePatterns = emptyList(),
                                 stopIds = emptySet(),
@@ -220,13 +224,15 @@ private fun StopDetailsRoutesViewPreview() {
                 now
             ),
             RouteCardData(
-                RouteCardData.LineOrRoute.Route(route2),
+                lineOrRoute2,
                 listOf(
                     RouteCardData.RouteStopData(
                         route2,
                         stop,
                         listOf(
                             RouteCardData.Leaf(
+                                lineOrRoute2,
+                                stop,
                                 0,
                                 routePatterns = emptyList(),
                                 stopIds = emptySet(),
@@ -240,6 +246,8 @@ private fun StopDetailsRoutesViewPreview() {
                                 alertsDownstream = emptyList()
                             ),
                             RouteCardData.Leaf(
+                                lineOrRoute2,
+                                stop,
                                 1,
                                 routePatterns = emptyList(),
                                 stopIds = emptySet(),

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -86,6 +86,8 @@ struct DirectionPicker: View {
     }
 
     let leaf0 = RouteCardData.Leaf(
+        lineOrRoute: .route(route),
+        stop: stop,
         directionId: 0,
         routePatterns: [patternOutbound],
         stopIds: [stop.id],
@@ -96,6 +98,8 @@ struct DirectionPicker: View {
         alertsDownstream: []
     )
     let leaf1 = RouteCardData.Leaf(
+        lineOrRoute: .route(route),
+        stop: stop,
         directionId: 1,
         routePatterns: [patternInbound],
         stopIds: [stop.id],

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredPickerView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredPickerView.swift
@@ -1,0 +1,131 @@
+//
+//  StopDetailsFilteredPickerView.swift
+//  iosApp
+//
+//  Created by esimon on 12/2/24.
+//  Copyright © 2024 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopDetailsFilteredPickerView: View {
+    var stopId: String
+    var stopFilter: StopDetailsFilter
+    var tripFilter: TripDetailsFilter?
+    var setStopFilter: (StopDetailsFilter?) -> Void
+    var setTripFilter: (TripDetailsFilter?) -> Void
+
+    var stopData: RouteCardData.RouteStopData
+    var leaf: RouteCardData.Leaf?
+
+    var pinned: Bool
+
+    var now: Date
+
+    @ObservedObject var errorBannerVM: ErrorBannerViewModel
+    @ObservedObject var nearbyVM: NearbyViewModel
+    @ObservedObject var mapVM: MapViewModel
+    @ObservedObject var stopDetailsVM: StopDetailsViewModel
+
+    @EnvironmentObject var viewportProvider: ViewportProvider
+
+    let inspection = Inspection<Self>()
+
+    var routeColor: Color { Color(hex: stopData.lineOrRoute.backgroundColor) }
+
+    init(
+        stopId: String,
+        stopFilter: StopDetailsFilter,
+        tripFilter: TripDetailsFilter? = nil,
+        setStopFilter: @escaping (StopDetailsFilter?) -> Void,
+        setTripFilter: @escaping (TripDetailsFilter?) -> Void,
+        stopData: RouteCardData.RouteStopData, pinned: Bool, now: Date,
+        errorBannerVM: ErrorBannerViewModel, nearbyVM: NearbyViewModel, mapVM: MapViewModel,
+        stopDetailsVM: StopDetailsViewModel, viewportProvider _: ViewportProvider
+    ) {
+        self.stopId = stopId
+        self.stopFilter = stopFilter
+        self.tripFilter = tripFilter
+        self.setStopFilter = setStopFilter
+        self.setTripFilter = setTripFilter
+        self.stopData = stopData
+        self.pinned = pinned
+        self.now = now
+        self.errorBannerVM = errorBannerVM
+        self.nearbyVM = nearbyVM
+        self.mapVM = mapVM
+        self.stopDetailsVM = stopDetailsVM
+
+        leaf = stopData.data.first { $0.directionId == stopFilter.directionId }
+    }
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            routeColor.ignoresSafeArea(.all)
+            Rectangle()
+                .fill(Color.halo)
+                .frame(height: 2)
+                .frame(maxWidth: .infinity)
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 16) {
+                    DirectionPicker(
+                        stopData: stopData,
+                        filter: stopFilter,
+                        setFilter: { setStopFilter($0) }
+                    )
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding([.horizontal, .top], 16)
+                    .padding(.bottom, 6)
+                    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+
+                    if let leaf {
+                        StopDetailsFilteredDepartureDetails(
+                            stopId: stopId,
+                            stopFilter: stopFilter,
+                            tripFilter: tripFilter,
+                            setStopFilter: setStopFilter,
+                            setTripFilter: setTripFilter,
+                            leaf: leaf,
+                            pinned: pinned,
+                            elevatorAlerts: stopData.elevatorAlerts,
+                            now: now,
+                            errorBannerVM: errorBannerVM,
+                            nearbyVM: nearbyVM,
+                            mapVM: mapVM,
+                            stopDetailsVM: stopDetailsVM,
+                            viewportProvider: .init()
+                        )
+                    } else {
+                        let routeData = LoadingPlaceholders.shared.routeCardData(
+                            routeId: stopFilter.routeId,
+                            trips: 10,
+                            context: .stopDetailsFiltered,
+                            now: now.toKotlinInstant()
+                        )
+                        let stopData = routeData.stopData.first!
+                        let leaf = stopData.data.first!
+                        StopDetailsFilteredDepartureDetails(
+                            stopId: stopId,
+                            stopFilter: stopFilter,
+                            tripFilter: tripFilter,
+                            setStopFilter: { _ in },
+                            setTripFilter: { _ in },
+                            leaf: leaf,
+                            pinned: false,
+                            elevatorAlerts: [],
+                            now: now,
+                            errorBannerVM: errorBannerVM,
+                            nearbyVM: nearbyVM,
+                            mapVM: mapVM,
+                            stopDetailsVM: stopDetailsVM,
+                            viewportProvider: .init()
+                        ).loadingPlaceholder()
+                    }
+                }
+            }
+        }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        .ignoresSafeArea(.all)
+    }
+}

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -21,7 +21,6 @@ struct StopDetailsFilteredView: View {
     var now: Date
 
     var stopData: RouteCardData.RouteStopData?
-    var leaf: RouteCardData.Leaf?
 
     var servedRoutes: [StopDetailsFilterPills.FilterBy] = []
 
@@ -62,7 +61,6 @@ struct StopDetailsFilteredView: View {
 
         let routeData = routeCardData?.first { $0.lineOrRoute.id == stopFilter.routeId }
         stopData = routeData?.stopData.first { $0.stop.id == stopId }
-        leaf = stopData?.data.first { $0.directionId == stopFilter.directionId }
     }
 
     var pinned: Bool {
@@ -87,15 +85,14 @@ struct StopDetailsFilteredView: View {
             }
             .fixedSize(horizontal: false, vertical: true)
 
-            if let stopData, let leaf {
-                StopDetailsFilteredDepartureDetails(
+            if let stopData {
+                StopDetailsFilteredPickerView(
                     stopId: stopId,
                     stopFilter: stopFilter,
                     tripFilter: tripFilter,
                     setStopFilter: setStopFilter,
                     setTripFilter: setTripFilter,
                     stopData: stopData,
-                    leaf: leaf,
                     pinned: pinned,
                     now: now,
                     errorBannerVM: errorBannerVM,
@@ -146,14 +143,13 @@ struct StopDetailsFilteredView: View {
         let stopData = routeData.stopData.first!
         let leaf = stopData.data.first!
 
-        StopDetailsFilteredDepartureDetails(
+        StopDetailsFilteredPickerView(
             stopId: stopId,
             stopFilter: stopFilter,
             tripFilter: tripFilter,
             setStopFilter: setStopFilter,
             setTripFilter: setTripFilter,
             stopData: stopData,
-            leaf: leaf,
             pinned: pinned,
             now: now,
             errorBannerVM: errorBannerVM,

--- a/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
@@ -32,6 +32,8 @@ final class DirectionPickerTests: XCTestCase {
         }
 
         let leaf0 = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
             directionId: 0,
             routePatterns: [patternNorth],
             stopIds: [stop.id],
@@ -42,6 +44,8 @@ final class DirectionPickerTests: XCTestCase {
             alertsDownstream: []
         )
         let leaf1 = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
             directionId: 1,
             routePatterns: [patternSouth],
             stopIds: [stop.id],

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsViewTests.swift
@@ -128,6 +128,8 @@ final class StopDetailsViewTests: XCTestCase {
                 stopData: [.init(
                     route: route, stop: stop,
                     data: [.init(
+                        lineOrRoute: .route(route),
+                        stop: stop,
                         directionId: 0,
                         routePatterns: [],
                         stopIds: [],
@@ -173,6 +175,8 @@ final class StopDetailsViewTests: XCTestCase {
         }
 
         let leaf = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
             directionId: 0,
             routePatterns: [routePattern],
             stopIds: Set([stop.id]),

--- a/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
+++ b/iosApp/iosAppTests/ViewModels/StopDetailsViewModelTests.swift
@@ -173,6 +173,7 @@ final class StopDetailsViewModelTests: XCTestCase {
             stopData: [
                 .init(lineOrRoute: .route(route), stop: stop, directions: [direction0, direction1], data: [
                     .init(
+                        lineOrRoute: .route(route), stop: stop,
                         directionId: 0,
                         routePatterns: [pattern0],
                         stopIds: [stop.id],
@@ -183,6 +184,7 @@ final class StopDetailsViewModelTests: XCTestCase {
                         alertsDownstream: []
                     ),
                     .init(
+                        lineOrRoute: .route(route), stop: stop,
                         directionId: 1,
                         routePatterns: [pattern1],
                         stopIds: [stop.id],

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -360,6 +360,8 @@ final class HomeMapViewTests: XCTestCase {
             stopData: [
                 .init(route: MapTestDataHelper.shared.routeOrange, stop: stop, data: [
                     .init(
+                        lineOrRoute: .route(MapTestDataHelper.shared.routeOrange),
+                        stop: stop,
                         directionId: 0,
                         routePatterns: [MapTestDataHelper.shared.patternOrange30],
                         stopIds: [stop.id],
@@ -458,6 +460,8 @@ final class HomeMapViewTests: XCTestCase {
             stopData: [
                 .init(route: MapTestDataHelper.shared.routeOrange, stop: stop, data: [
                     .init(
+                        lineOrRoute: .route(MapTestDataHelper.shared.routeOrange),
+                        stop: stop,
                         directionId: 0,
                         routePatterns: [MapTestDataHelper.shared.patternOrange30],
                         stopIds: [stop.id],

--- a/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
@@ -31,6 +31,7 @@ final class RouteCardDeparturesTests: XCTestCase {
             stop: stop,
             directions: [.init(name: "Outbound", destination: "Harvard", id: 0)],
             data: [.init(
+                lineOrRoute: .route(route), stop: stop,
                 directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                 upcomingTrips: [], alertsHere: [], allDataLoaded: true,
                 hasSchedulesToday: true, alertsDownstream: []
@@ -73,6 +74,7 @@ final class RouteCardDeparturesTests: XCTestCase {
             stop: stop,
             directions: [.init(name: "South", destination: "Forest Hills", id: 0)],
             data: [.init(
+                lineOrRoute: .route(route), stop: stop,
                 directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                 upcomingTrips: [.init(trip: trip, schedule: schedule)], alertsHere: [], allDataLoaded: true,
                 hasSchedulesToday: true, alertsDownstream: []
@@ -200,6 +202,8 @@ final class RouteCardDeparturesTests: XCTestCase {
                 .init(name: "East", destination: "Park St & North", id: 1),
             ],
             data: [.init(
+                lineOrRoute: lineOrRoute,
+                stop: stop,
                 directionId: 0,
                 routePatterns: [Green.shared.rpB0, Green.shared.rpC0, Green.shared.rpE0],
                 stopIds: [stop.id],
@@ -212,6 +216,8 @@ final class RouteCardDeparturesTests: XCTestCase {
                 hasSchedulesToday: true, alertsDownstream: [downstreamAlert]
             ),
             .init(
+                lineOrRoute: lineOrRoute,
+                stop: stop,
                 directionId: 1,
                 routePatterns: [Green.shared.rpB1, Green.shared.rpC1, Green.shared.rpE1],
                 stopIds: [stop.id],

--- a/iosApp/iosAppTests/Views/RouteCardStopHeaderTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardStopHeaderTests.swift
@@ -80,6 +80,7 @@ final class RouteCardStopHeaderTests: XCTestCase {
                 stop: stop,
                 directions: [.init(name: "", destination: "", id: 0)],
                 data: [.init(
+                    lineOrRoute: .route(route), stop: stop,
                     directionId: 0, routePatterns: [], stopIds: [], upcomingTrips: [],
                     alertsHere: [alert], allDataLoaded: true, hasSchedulesToday: true, alertsDownstream: []
                 )],

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -189,6 +189,7 @@ final class RouteCardTests: XCTestCase {
                     stop: stop,
                     directions: [.init(name: "Inbound", destination: "", id: 0)],
                     data: [.init(
+                        lineOrRoute: .route(route), stop: stop,
                         directionId: 0, routePatterns: [pattern], stopIds: [stop.id],
                         upcomingTrips: [], alertsHere: [], allDataLoaded: true,
                         hasSchedulesToday: true, alertsDownstream: []

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -49,8 +49,12 @@ object LoadingPlaceholders {
             return UpcomingTrip(trip, prediction = prediction)
         }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+
         val leaf1 =
             RouteCardData.Leaf(
+                lineOrRoute = lineOrRoute,
+                stop = stop,
                 directionId = 0,
                 routePatterns = listOf(pattern1),
                 stopIds = setOf(stop.id),
@@ -62,6 +66,8 @@ object LoadingPlaceholders {
             )
         val leaf2 =
             RouteCardData.Leaf(
+                lineOrRoute = lineOrRoute,
+                stop = stop,
                 directionId = 1,
                 routePatterns = listOf(pattern2),
                 stopIds = setOf(stop.id),
@@ -72,7 +78,6 @@ object LoadingPlaceholders {
                 alertsDownstream = emptyList(),
             )
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val stopData =
             RouteCardData.RouteStopData(
                 lineOrRoute,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -89,6 +89,8 @@ open class RouteCardPreviewData {
             stop,
             listOfNotNull(
                 RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         0,
                         patterns.filter { it.directionId == 0 },
                         setOf(stop.id),
@@ -100,6 +102,8 @@ open class RouteCardPreviewData {
                     )
                     .takeUnless { it.routePatterns.isEmpty() },
                 RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
                         1,
                         patterns.filter { it.directionId == 1 },
                         setOf(stop.id),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -51,6 +51,8 @@ class RouteCardDataLeafTest {
         assertEquals(
             LeafFormat.Single(null, UpcomingFormat.Disruption(alert, "alert-large-red-suspension")),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -96,6 +98,8 @@ class RouteCardDataLeafTest {
                     )
                 ),
                 RouteCardData.Leaf(
+                        RouteCardData.LineOrRoute.Route(route),
+                        objects.stop(),
                         0,
                         emptyList(),
                         emptySet(),
@@ -137,6 +141,8 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.Disruption(alert, "alert-large-silver-suspension")
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -182,6 +188,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -227,6 +235,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -253,6 +263,8 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.ServiceEndedToday)
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -284,6 +296,8 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable)
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -307,6 +321,8 @@ class RouteCardDataLeafTest {
         assertEquals(
             LeafFormat.Single(null, UpcomingFormat.Loading),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     listOf(pattern),
                     emptySet(),
@@ -358,6 +374,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -411,6 +429,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(subwayRoute),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -442,6 +462,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(busRoute),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -468,6 +490,8 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.NoSchedulesToday)
             ),
             RouteCardData.Leaf(
+                    RouteCardData.LineOrRoute.Route(route),
+                    objects.stop(),
                     0,
                     emptyList(),
                     emptySet(),
@@ -487,8 +511,10 @@ class RouteCardDataLeafTest {
         fun objects() = objects.clone()
 
         val route = objects.getRoute("Red")
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
 
         object jfkUmass {
+            val itself = objects.getStop("place-jfk")
             val south1 = objects.getStop("70085")
             val south2 = objects.getStop("70095")
             val north1 = objects.getStop("70086")
@@ -578,6 +604,8 @@ class RouteCardDataLeafTest {
             ),
             wipeBranchUUID(
                 RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        RedLine.jfkUmass.itself,
                         0,
                         listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                         setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
@@ -680,6 +708,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            RedLine.lineOrRoute,
+                            RedLine.jfkUmass.itself,
                             0,
                             listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                             setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
@@ -750,6 +780,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    RedLine.lineOrRoute,
+                    RedLine.jfkUmass.itself,
                     1,
                     listOf(RedLine.ashmontNorth, RedLine.braintreeNorth),
                     setOf(RedLine.jfkUmass.north1.id, RedLine.jfkUmass.north2.id),
@@ -838,6 +870,8 @@ class RouteCardDataLeafTest {
             ),
             wipeBranchUUID(
                 RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        RedLine.jfkUmass.itself,
                         0,
                         listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                         setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
@@ -937,6 +971,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            RedLine.lineOrRoute,
+                            RedLine.jfkUmass.itself,
                             0,
                             listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                             setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
@@ -971,10 +1007,14 @@ class RouteCardDataLeafTest {
 
         fun objects() = objects.clone()
 
+        val line = objects.getLine("line-Green")
+
         val b = objects.getRoute("Green-B")
         val c = objects.getRoute("Green-C")
         val d = objects.getRoute("Green-D")
         val e = objects.getRoute("Green-E")
+
+        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(b, c, d, e))
 
         val boylston = objects.getStop("place-boyls")
         val kenmore = objects.getStop("place-kencl")
@@ -1056,6 +1096,8 @@ class RouteCardDataLeafTest {
             ),
             wipeBranchUUID(
                 RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.boylston,
                         0,
                         listOf(
                             GreenLine.bWestbound,
@@ -1098,6 +1140,8 @@ class RouteCardDataLeafTest {
 
         val route = objects.getRoute("CR-Providence")
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+
         val toWickford = objects.getRoutePattern("CR-Providence-9cf54fb3-0")
         val toStoughton = objects.getRoutePattern("CR-Providence-9515a09b-0")
         val toProvidence =
@@ -1114,6 +1158,8 @@ class RouteCardDataLeafTest {
                 typicality = RoutePattern.Typicality.Deviation
                 representativeTrip { headsign = "South Station" }
             }
+
+        val ruggles = objects.getStop("place-rugg")
 
         val global = GlobalResponse(objects)
     }
@@ -1181,6 +1227,8 @@ class RouteCardDataLeafTest {
             ),
             wipeBranchUUID(
                 RouteCardData.Leaf(
+                        ProvidenceStoughtonLine.lineOrRoute,
+                        ProvidenceStoughtonLine.ruggles,
                         0,
                         listOf(
                             ProvidenceStoughtonLine.toProvidence,
@@ -1251,6 +1299,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    ProvidenceStoughtonLine.lineOrRoute,
+                    ProvidenceStoughtonLine.ruggles,
                     1,
                     listOf(
                         ProvidenceStoughtonLine.fromProvidence,
@@ -1283,6 +1333,7 @@ class RouteCardDataLeafTest {
         fun objects() = objects.clone()
 
         val route = objects.getRoute("87")
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         val outboundTypical = objects.getRoutePattern("87-2-0")
         val outboundDeviation =
             objects.routePattern(route) {
@@ -1335,6 +1386,8 @@ class RouteCardDataLeafTest {
                 )
             ),
             RouteCardData.Leaf(
+                    `87`.lineOrRoute,
+                    objects.stop(),
                     0,
                     listOf(`87`.outboundTypical, `87`.outboundDeviation),
                     emptySet(),
@@ -1408,6 +1461,8 @@ class RouteCardDataLeafTest {
             ),
             wipeBranchUUID(
                 RouteCardData.Leaf(
+                        `87`.lineOrRoute,
+                        objects.stop(),
                         0,
                         listOf(`87`.outboundTypical, `87`.outboundDeviation),
                         emptySet(),
@@ -1477,6 +1532,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            RedLine.lineOrRoute,
+                            objects.stop(),
                             0,
                             listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                             emptySet(),
@@ -1497,6 +1554,7 @@ class RouteCardDataLeafTest {
     @Test
     fun `formats Red Line southbound as non-branching if service ended on all branches`() =
         parametricTest {
+            val objects = RedLine.objects()
             val now = Clock.System.now()
 
             assertEquals(
@@ -1505,6 +1563,8 @@ class RouteCardDataLeafTest {
                     UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.ServiceEndedToday)
                 ),
                 RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        objects.stop(),
                         0,
                         listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
                         emptySet(),
@@ -1583,6 +1643,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            GreenLine.lineOrRoute,
+                            GreenLine.boylston,
                             0,
                             listOf(
                                 GreenLine.bWestbound,
@@ -1629,6 +1691,8 @@ class RouteCardDataLeafTest {
                     UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable)
                 ),
                 RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.boylston,
                         0,
                         listOf(
                             GreenLine.bWestbound,
@@ -1723,6 +1787,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            GreenLine.lineOrRoute,
+                            GreenLine.kenmore,
                             0,
                             listOf(
                                 GreenLine.bWestbound,
@@ -1823,6 +1889,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            GreenLine.lineOrRoute,
+                            GreenLine.kenmore,
                             0,
                             listOf(
                                 GreenLine.bWestbound,
@@ -1928,6 +1996,8 @@ class RouteCardDataLeafTest {
                 ),
                 wipeBranchUUID(
                     RouteCardData.Leaf(
+                            GreenLine.lineOrRoute,
+                            GreenLine.boylston,
                             0,
                             listOf(
                                 GreenLine.bWestbound,
@@ -2013,6 +2083,8 @@ class RouteCardDataLeafTest {
                     UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.b))
                 ),
                 RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.boylston,
                         0,
                         listOf(
                             GreenLine.bWestbound,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -47,11 +47,12 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = Clock.System.now()
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(route1),
+                            lineOrRoute1,
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -60,6 +61,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop1,
                                                     directionId = 0,
                                                     routePatterns = listOf(route1rp1),
                                                     stopIds = setOf(stop1.id),
@@ -118,11 +121,12 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = Clock.System.now()
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(route1),
+                            lineOrRoute1,
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -131,6 +135,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop1,
                                                     directionId = 0,
                                                     routePatterns = listOf(route1rp1),
                                                     stopIds = setOf(stop1.id),
@@ -147,6 +153,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop2,
                                                     directionId = 0,
                                                     routePatterns = listOf(route1rp1, route1rp2),
                                                     patternsNotSeenAtEarlierStops =
@@ -205,11 +213,12 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = Clock.System.now()
 
+        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
         assertEquals(
             mapOf(
                 route1.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute1,
                         mapOf(
                             stop1.id to
                                 RouteCardData.RouteStopDataBuilder(
@@ -218,6 +227,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute1,
+                                                stop = stop1,
                                                 directionId = 0,
                                                 routePatterns = listOf(route1rp1, route1rp2),
                                                 stopIds = setOf(stop1.id),
@@ -225,6 +236,8 @@ class RouteCardDataTest {
                                             ),
                                         1 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute1,
+                                                stop = stop1,
                                                 directionId = 1,
                                                 routePatterns = listOf(route1rp3),
                                                 stopIds = setOf(stop1.id),
@@ -275,11 +288,13 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = Clock.System.now()
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
             assertEquals(
                 mapOf(
                     route1.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(route1),
+                            lineOrRoute1,
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -288,6 +303,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop1,
                                                     directionId = 0,
                                                     routePatterns = listOf(route1rp1),
                                                     stopIds = setOf(stop1.id),
@@ -303,7 +320,7 @@ class RouteCardDataTest {
                         ),
                     route2.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(route2),
+                            lineOrRoute2,
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -312,6 +329,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute2,
+                                                    stop = stop1,
                                                     directionId = 0,
                                                     routePatterns = listOf(route2rp1),
                                                     stopIds = setOf(stop1.id),
@@ -383,11 +402,12 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = Clock.System.now()
 
+        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
         assertEquals(
             mapOf(
                 route1.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute1,
                         mapOf(
                             station1.id to
                                 RouteCardData.RouteStopDataBuilder(
@@ -396,6 +416,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute1,
+                                                stop = station1,
                                                 directionId = 0,
                                                 routePatterns = listOf(route1rp1, route1rp2),
                                                 stopIds =
@@ -417,6 +439,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute1,
+                                                stop = stop2,
                                                 directionId = 0,
                                                 routePatterns = listOf(route1rp3),
                                                 stopIds = setOf(stop2.id),
@@ -474,11 +498,12 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = Clock.System.now()
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         assertEquals(
             mapOf(
                 route.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute,
                         mapOf(
                             parentStation.id to
                                 RouteCardData.RouteStopDataBuilder(
@@ -487,6 +512,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = parentStation,
                                                 directionId = 0,
                                                 routePatterns = listOf(routePattern),
                                                 stopIds =
@@ -558,21 +585,24 @@ class RouteCardDataTest {
             val westDir = Direction("West", "Boston College", 0)
             val eastDir = Direction("East", "Government Center", 1)
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(railRoute))
+            val railLineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(railRoute))
+            val shuttleLineOrRoute = RouteCardData.LineOrRoute.Route(shuttleRoute)
             assertEquals(
                 mapOf(
                     line.id to
                         RouteCardData.Builder(
-                            lineOrRoute,
+                            railLineOrRoute,
                             mapOf(
                                 stop.id to
                                     RouteCardData.RouteStopDataBuilder(
-                                        lineOrRoute,
+                                        railLineOrRoute,
                                         stop,
                                         listOf(westDir, eastDir),
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = railLineOrRoute,
+                                                    stop = stop,
                                                     directionId = 0,
                                                     routePatterns = listOf(railPattern),
                                                     stopIds = setOf(stop.id),
@@ -587,7 +617,7 @@ class RouteCardDataTest {
                         ),
                     shuttleRoute.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(shuttleRoute),
+                            shuttleLineOrRoute,
                             mapOf(
                                 stop.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -596,6 +626,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = shuttleLineOrRoute,
+                                                    stop = stop,
                                                     directionId = 0,
                                                     routePatterns = listOf(shuttlePattern),
                                                     stopIds = setOf(stop.id),
@@ -675,11 +707,12 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = Clock.System.now()
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute))
         assertEquals(
             mapOf(
                 line.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute)),
+                        lineOrRoute,
                         mapOf(
                             parkSt.id to
                                 RouteCardData.RouteStopDataBuilder(
@@ -689,6 +722,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = parkSt,
                                                 directionId = 0,
                                                 routePatterns =
                                                     listOf(
@@ -708,6 +743,8 @@ class RouteCardDataTest {
                                             ),
                                         1 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = parkSt,
                                                 directionId = 1,
                                                 routePatterns = listOf(bEastPattern, cEastPattern),
                                                 stopIds =
@@ -902,6 +939,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute,
+                                                    stop = stopGov,
                                                     directionId = 0,
                                                     routePatterns =
                                                         listOf(routeBrp1, routeCrp1, routeDrp1),
@@ -910,6 +949,8 @@ class RouteCardDataTest {
                                                 ),
                                             1 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute,
+                                                    stop = stopGov,
                                                     directionId = 1,
                                                     routePatterns =
                                                         listOf(
@@ -1012,11 +1053,12 @@ class RouteCardDataTest {
                     trip = trip3
                 }
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
                         RouteCardData.Builder(
-                            RouteCardData.LineOrRoute.Route(route1),
+                            lineOrRoute1,
                             mapOf(
                                 stop1.id to
                                     RouteCardData.RouteStopDataBuilder(
@@ -1025,6 +1067,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop1,
                                                     directionId = 0,
                                                     routePatterns = listOf(pattern1, pattern2),
                                                     stopIds = setOf(stop1.id),
@@ -1050,6 +1094,8 @@ class RouteCardDataTest {
                                         mapOf(
                                             0 to
                                                 RouteCardData.LeafBuilder(
+                                                    lineOrRoute = lineOrRoute1,
+                                                    stop = stop2,
                                                     directionId = 0,
                                                     routePatterns = listOf(pattern3),
                                                     stopIds = setOf(stop2.id),
@@ -1136,11 +1182,12 @@ class RouteCardDataTest {
             departureTime = now - 2.hours
         }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         assertEquals(
             mapOf(
                 route.id to
                     RouteCardData.Builder(
-                        RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute,
                         mapOf(
                             stop1.id to
                                 RouteCardData.RouteStopDataBuilder(
@@ -1149,6 +1196,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = stop1,
                                                 directionId = 0,
                                                 routePatterns = listOf(pattern1),
                                                 stopIds = setOf(stop1.id),
@@ -1169,6 +1218,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = stop2,
                                                 directionId = 0,
                                                 routePatterns = listOf(pattern2),
                                                 stopIds = setOf(stop2.id),
@@ -1188,6 +1239,8 @@ class RouteCardDataTest {
                                     mapOf(
                                         0 to
                                             RouteCardData.LeafBuilder(
+                                                lineOrRoute = lineOrRoute,
+                                                stop = stop3,
                                                 directionId = 0,
                                                 routePatterns = listOf(pattern3),
                                                 stopIds = setOf(stop3.id),
@@ -1254,10 +1307,12 @@ class RouteCardDataTest {
         val time = Instant.parse("2024-02-22T12:08:19-05:00")
         val context = RouteCardData.Context.NearbyTransit
 
+        val subwayLineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute)
+        val busLineOrRoute = RouteCardData.LineOrRoute.Route(busRoute)
         assertEquals(
             listOf(
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute),
+                    lineOrRoute = subwayLineOrRoute,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -1265,12 +1320,14 @@ class RouteCardDataTest {
                                 subwayStop,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = subwayLineOrRoute,
+                                        stop = subwayStop,
                                         directionId = 0,
                                         routePatterns = listOf(subwayRp),
                                         stopIds = setOf(subwayStop.id),
                                         upcomingTrips = listOf(),
-                                        allDataLoaded = false,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = false,
                                         hasSchedulesToday = false,
                                         alertsDownstream = emptyList()
                                     )
@@ -1283,7 +1340,7 @@ class RouteCardDataTest {
                     time
                 ),
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                    lineOrRoute = busLineOrRoute,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -1291,12 +1348,14 @@ class RouteCardDataTest {
                                 busStop,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = busLineOrRoute,
+                                        stop = busStop,
                                         directionId = 0,
                                         routePatterns = listOf(busRp),
                                         stopIds = setOf(busStop.id),
                                         upcomingTrips = listOf(),
-                                        allDataLoaded = false,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = false,
                                         hasSchedulesToday = false,
                                         alertsDownstream = emptyList()
                                     )
@@ -1360,10 +1419,12 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val time = Instant.parse("2024-02-22T12:08:19-05:00")
 
+            val subwayLineOrRoute1 = RouteCardData.LineOrRoute.Route(subwayRoute1)
+            val subwayLineOrRoute2 = RouteCardData.LineOrRoute.Route(subwayRoute2)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute2),
+                        lineOrRoute = subwayLineOrRoute2,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -1371,12 +1432,14 @@ class RouteCardDataTest {
                                     closerStop,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = subwayLineOrRoute2,
+                                            stop = closerStop,
                                             directionId = 0,
                                             routePatterns = listOf(subway2Rp1),
                                             stopIds = setOf(closerStop.id),
                                             upcomingTrips = listOf(),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -1389,7 +1452,7 @@ class RouteCardDataTest {
                         time
                     ),
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute1),
+                        lineOrRoute = subwayLineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -1397,12 +1460,14 @@ class RouteCardDataTest {
                                     furtherStop,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = subwayLineOrRoute1,
+                                            stop = furtherStop,
                                             directionId = 0,
                                             routePatterns = listOf(subway1Rp1),
                                             stopIds = setOf(furtherStop.id),
                                             upcomingTrips = listOf(),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2148,10 +2213,11 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationInbound.representativeTripId
                 }
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2159,6 +2225,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -2166,8 +2234,8 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(typicalOutboundPrediction),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2259,10 +2327,11 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationInboundTrip2.id
                 }
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2270,6 +2339,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -2277,12 +2348,14 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(typicalOutboundPrediction),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         ),
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 1,
                                             routePatterns = listOf(deviationInbound),
                                             stopIds = setOf(stop1.id),
@@ -2295,8 +2368,8 @@ class RouteCardDataTest {
                                                         deviationInboundPredictionLater
                                                     ),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2378,10 +2451,11 @@ class RouteCardDataTest {
                     stopId = stop2.id
                     tripId = typicalOutbound.representativeTripId
                 }
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2389,6 +2463,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -2398,8 +2474,8 @@ class RouteCardDataTest {
                                                         typicalOutboundPredictionStop1
                                                     ),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2489,10 +2565,11 @@ class RouteCardDataTest {
                     stopId = stop2.id
                     tripId = deviationOutbound.representativeTripId
                 }
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2500,6 +2577,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -2509,8 +2588,8 @@ class RouteCardDataTest {
                                                         typicalOutboundPredictionStop1
                                                     ),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2523,6 +2602,8 @@ class RouteCardDataTest {
                                     stop2,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop2,
                                             directionId = 0,
                                             routePatterns =
                                                 listOf(typicalOutbound, deviationOutbound),
@@ -2536,8 +2617,8 @@ class RouteCardDataTest {
                                                         typicalOutboundPredictionStop2
                                                     ),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2612,10 +2693,11 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationOutbound.representativeTripId
                 }
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2623,6 +2705,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(deviationOutbound),
                                             stopIds = setOf(stop1.id),
@@ -2632,8 +2716,8 @@ class RouteCardDataTest {
                                                         deviationOutboundPredictionStop1
                                                     ),
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2646,12 +2730,14 @@ class RouteCardDataTest {
                                     stop2,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop2,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop2.id),
                                             upcomingTrips = listOf(),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2810,10 +2896,12 @@ class RouteCardDataTest {
                     departureTime = time + 121.minutes
                 }
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute3 = RouteCardData.LineOrRoute.Route(route3)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2821,6 +2909,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 1,
                                             routePatterns = listOf(scheduleSoon),
                                             stopIds = setOf(stop1.id),
@@ -2828,8 +2918,8 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(scheduleSoonSchedule),
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -2842,7 +2932,7 @@ class RouteCardDataTest {
                         time
                     ),
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route3),
+                        lineOrRoute = lineOrRoute3,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -2850,6 +2940,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute3,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(predictionBrd),
                                             stopIds = setOf(stop1.id),
@@ -2860,12 +2952,14 @@ class RouteCardDataTest {
                                                         vehicle = predictionBrdVehicle
                                                     ),
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         ),
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute3,
+                                            stop = stop1,
                                             directionId = 1,
                                             routePatterns = listOf(predictionSoon),
                                             stopIds = setOf(stop1.id),
@@ -2873,8 +2967,8 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(predictionSoonPrediction),
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -2936,10 +3030,11 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val time = Instant.parse("2024-02-22T12:08:19-05:00")
 
+        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
         assertEquals(
             listOf(
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                    lineOrRoute = lineOrRoute1,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -2947,12 +3042,14 @@ class RouteCardDataTest {
                                 stop1,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = lineOrRoute1,
+                                        stop = stop1,
                                         directionId = 0,
                                         routePatterns = listOf(typicalOutbound),
                                         stopIds = setOf(stop1.id),
                                         upcomingTrips = listOf(),
-                                        allDataLoaded = false,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = false,
                                         hasSchedulesToday = false,
                                         alertsDownstream = emptyList()
                                     )
@@ -3031,10 +3128,11 @@ class RouteCardDataTest {
                     tripId = deviationInbound.representativeTripId
                 }
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -3042,6 +3140,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -3049,12 +3149,14 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(typicalOutboundPrediction)
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         ),
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 1,
                                             routePatterns = listOf(deviationInbound),
                                             stopIds = setOf(stop1.id),
@@ -3062,8 +3164,8 @@ class RouteCardDataTest {
                                                 listOf(
                                                     objects.upcomingTrip(deviationInboundPrediction)
                                                 ),
-                                            allDataLoaded = false,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = false,
                                             hasSchedulesToday = false,
                                             alertsDownstream = emptyList()
                                         )
@@ -3132,10 +3234,11 @@ class RouteCardDataTest {
                     scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
                 }
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -3143,6 +3246,8 @@ class RouteCardDataTest {
                                     stop1,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
                                             directionId = 0,
                                             routePatterns = listOf(typicalOutbound),
                                             stopIds = setOf(stop1.id),
@@ -3153,8 +3258,8 @@ class RouteCardDataTest {
                                                         schedule = typicalOutboundSchedule
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -3206,10 +3311,11 @@ class RouteCardDataTest {
                 tripId = pattern1.representativeTripId
             }
 
+        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
         assertEquals(
             listOf(
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                    lineOrRoute = lineOrRoute1,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -3217,12 +3323,14 @@ class RouteCardDataTest {
                                 parentStop,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = lineOrRoute1,
+                                        stop = parentStop,
                                         directionId = 0,
                                         routePatterns = listOf(pattern1),
                                         stopIds = setOf(parentStop.id, childStop.id),
                                         upcomingTrips = listOf(objects.upcomingTrip(prediction1)),
-                                        allDataLoaded = false,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = false,
                                         hasSchedulesToday = false,
                                         alertsDownstream = emptyList()
                                     )
@@ -3281,10 +3389,11 @@ class RouteCardDataTest {
         val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
         val pred2 = objects.prediction(sched2) { departureTime = null }
 
+        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
         assertEquals(
             listOf(
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(route),
+                    lineOrRoute = lineOrRoute,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -3292,6 +3401,8 @@ class RouteCardDataTest {
                                 stop,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = lineOrRoute,
+                                        stop = stop,
                                         directionId = 0,
                                         routePatterns = listOf(routePattern),
                                         stopIds = setOf(stop.id),
@@ -3306,8 +3417,8 @@ class RouteCardDataTest {
                                                     schedule = sched2
                                                 )
                                             ),
-                                        allDataLoaded = true,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = true,
                                         hasSchedulesToday = true,
                                         alertsDownstream = emptyList()
                                     )
@@ -3375,16 +3486,19 @@ class RouteCardDataTest {
                 departureTime = time - 2.hours
             }
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute,
                         listOf(
                             RouteCardData.RouteStopData(
                                 route,
                                 stop,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute,
+                                        stop,
                                         directionId = 0,
                                         listOf(routePatternA, routePatternB, routePatternC),
                                         setOf(stop.id),
@@ -3475,10 +3589,12 @@ class RouteCardDataTest {
             val pred2 = objects.prediction(sched2) { departureTime = time + 2.3.minutes }
             val pred3 = objects.prediction(sched3) { departureTime = time + 3.4.minutes }
 
+            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route1),
+                        lineOrRoute = lineOrRoute1,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -3486,6 +3602,8 @@ class RouteCardDataTest {
                                     stop,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop,
                                             directionId = 0,
                                             routePatterns = listOf(routePattern1),
                                             stopIds = setOf(stop.id),
@@ -3496,8 +3614,8 @@ class RouteCardDataTest {
                                                         schedule = sched1
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -3510,7 +3628,7 @@ class RouteCardDataTest {
                         time
                     ),
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route2),
+                        lineOrRoute = lineOrRoute2,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -3518,6 +3636,8 @@ class RouteCardDataTest {
                                     stop,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute2,
+                                            stop = stop,
                                             directionId = 0,
                                             routePatterns = listOf(routePattern2),
                                             stopIds = setOf(stop.id),
@@ -3532,8 +3652,8 @@ class RouteCardDataTest {
                                                         schedule = sched3
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -3770,6 +3890,8 @@ class RouteCardDataTest {
                                 listOf(directionWest, directionEast),
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = lineOrRoute,
+                                        stop = hynes,
                                         directionId = 0,
                                         routePatterns =
                                             listOf(routePatternB1, routePatternC1, routePatternE1),
@@ -3789,8 +3911,8 @@ class RouteCardDataTest {
                                                     schedule = schedE1
                                                 )
                                             ),
-                                        allDataLoaded = true,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = true,
                                         hasSchedulesTodayByPattern =
                                             mapOf(
                                                 routePatternB1.id to true,
@@ -3800,6 +3922,8 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     ),
                                     RouteCardData.Leaf(
+                                        lineOrRoute = lineOrRoute,
+                                        stop = hynes,
                                         directionId = 1,
                                         routePatterns =
                                             listOf(routePatternB2, routePatternC2, routePatternE2),
@@ -3819,8 +3943,8 @@ class RouteCardDataTest {
                                                     schedule = schedE2
                                                 )
                                             ),
-                                        allDataLoaded = true,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = true,
                                         hasSchedulesTodayByPattern =
                                             mapOf(
                                                 routePatternB2.id to true,
@@ -3941,6 +4065,8 @@ class RouteCardDataTest {
                                     listOf(directionWest, directionEast),
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = southSt,
                                             directionId = 0,
                                             routePatterns = listOf(routePatternB1),
                                             stopIds = setOf(southSt.id),
@@ -3951,12 +4077,14 @@ class RouteCardDataTest {
                                                         schedule = schedB1
                                                     ),
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         ),
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = southSt,
                                             directionId = 1,
                                             routePatterns = listOf(routePatternB2),
                                             stopIds = setOf(southSt.id),
@@ -3967,8 +4095,8 @@ class RouteCardDataTest {
                                                         schedule = schedB2
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -4057,6 +4185,8 @@ class RouteCardDataTest {
                                     ),
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = stop,
                                             directionId = 0,
                                             routePatterns = listOf(routePattern1),
                                             stopIds = setOf(stop.id),
@@ -4067,8 +4197,8 @@ class RouteCardDataTest {
                                                         schedule = sched1
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -4309,10 +4439,11 @@ class RouteCardDataTest {
         val global = GlobalResponse(objects)
         val context = RouteCardData.Context.NearbyTransit
 
+        val orangeLineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute)
         assertEquals(
             listOf(
                 RouteCardData(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute),
+                    lineOrRoute = orangeLineOrRoute,
                     stopData =
                         listOf(
                             RouteCardData.RouteStopData(
@@ -4320,6 +4451,8 @@ class RouteCardDataTest {
                                 northStation,
                                 listOf(
                                     RouteCardData.Leaf(
+                                        lineOrRoute = orangeLineOrRoute,
+                                        stop = northStation,
                                         directionId = 0,
                                         routePatterns =
                                             listOf(
@@ -4337,8 +4470,8 @@ class RouteCardDataTest {
                                                     schedule = southboundSchedule
                                                 )
                                             ),
-                                        allDataLoaded = true,
                                         alertsHere = emptyList(),
+                                        allDataLoaded = true,
                                         hasSchedulesTodayByPattern =
                                             mapOf(
                                                 orangeSouthboundDiversion.id to true,
@@ -4347,6 +4480,8 @@ class RouteCardDataTest {
                                         alertsDownstream = emptyList()
                                     ),
                                     RouteCardData.Leaf(
+                                        lineOrRoute = orangeLineOrRoute,
+                                        stop = northStation,
                                         directionId = 1,
                                         routePatterns =
                                             listOf(
@@ -4355,8 +4490,8 @@ class RouteCardDataTest {
                                             ),
                                         stopIds = setOf(northStationNorthboundPlatform.id),
                                         upcomingTrips = listOf(),
-                                        allDataLoaded = true,
                                         alertsHere = listOf(alert),
+                                        allDataLoaded = true,
                                         hasSchedulesTodayByPattern =
                                             mapOf(
                                                 orangeNorthboundDiversion.id to true,
@@ -4461,10 +4596,11 @@ class RouteCardDataTest {
                     departureTime = null
                 }
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -4472,6 +4608,8 @@ class RouteCardDataTest {
                                     oakGrove,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = oakGrove,
                                             directionId = 0,
                                             routePatterns = listOf(orangeSouthboundTypical),
                                             stopIds = setOf(oakGrove.id),
@@ -4482,8 +4620,8 @@ class RouteCardDataTest {
                                                         schedule = sched1
                                                     )
                                                 ),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -4581,10 +4719,11 @@ class RouteCardDataTest {
                     departureTime = time + 2.minutes
                 }
 
+            val ferryLineOrRoute = RouteCardData.LineOrRoute.Route(ferryRoute)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(ferryRoute),
+                        lineOrRoute = ferryLineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -4592,13 +4731,15 @@ class RouteCardDataTest {
                                     longWharf,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = ferryLineOrRoute,
+                                            stop = longWharf,
                                             directionId = 0,
                                             routePatterns = listOf(ferryOutboundToHingham),
                                             stopIds = setOf(longWharf.id),
                                             upcomingTrips =
                                                 listOf(objects.upcomingTrip(schedOutbound)),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             alertsDownstream = emptyList()
                                         )
@@ -4750,10 +4891,11 @@ class RouteCardDataTest {
                     targetStopWithChildren = setOf(park.id),
                     tripsById = global.trips
                 )
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -4761,14 +4903,16 @@ class RouteCardDataTest {
                                     park,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = park,
                                             directionId = 0,
                                             routePatterns =
                                                 listOf(routePatternAshmont, routePatternBraintree),
                                             stopIds = setOf(park.id),
                                             upcomingTrips = emptyList(),
-                                            allDataLoaded = true,
                                             alertsHere =
                                                 listOf(parkShuttleAlert, parkElevatorAlert),
+                                            allDataLoaded = true,
                                             hasSchedulesTodayByPattern =
                                                 mapOf(
                                                     routePatternAshmont.id to true,
@@ -4867,10 +5011,11 @@ class RouteCardDataTest {
                     )
                 )
 
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -4878,12 +5023,14 @@ class RouteCardDataTest {
                                     southStation,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = southStation,
                                             directionId = 0,
                                             routePatterns = listOf(routePatternPvd),
                                             stopIds = setOf(southStation.id),
                                             upcomingTrips = emptyList(),
-                                            allDataLoaded = true,
                                             alertsHere = emptyList(),
+                                            allDataLoaded = true,
                                             hasSchedulesTodayByPattern =
                                                 mapOf(routePatternPvd.id to true),
                                             alertsDownstream = emptyList()
@@ -4913,7 +5060,7 @@ class RouteCardDataTest {
             assertEquals(
                 listOf(
                     RouteCardData(
-                        lineOrRoute = RouteCardData.LineOrRoute.Route(route),
+                        lineOrRoute = lineOrRoute,
                         stopData =
                             listOf(
                                 RouteCardData.RouteStopData(
@@ -4921,12 +5068,14 @@ class RouteCardDataTest {
                                     providence,
                                     listOf(
                                         RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute,
+                                            stop = providence,
                                             directionId = 0,
                                             routePatterns = listOf(routePatternPvd),
                                             stopIds = setOf(providence.id),
                                             upcomingTrips = emptyList(),
-                                            allDataLoaded = true,
                                             alertsHere = listOf(providenceTrackChangeAlert),
+                                            allDataLoaded = true,
                                             hasSchedulesTodayByPattern =
                                                 mapOf(routePatternPvd.id to true),
                                             alertsDownstream = emptyList()


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | Refactor RouteStopData and Leaf to include more context](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210114621155024?focus=true)

This just barely fit into the one point time box. I don’t know if I actually think it’s worth it, though.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all tests still pass and the app isn’t obviously broken.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
