### PR TITLE
refactor: shared component and utilities in advance of route details

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -24,22 +23,20 @@ class DirectionPickerTest {
                 color = "000000"
                 textColor = "ffffff"
             }
-        var filter: StopDetailsFilter? = StopDetailsFilter(routeId = route.id, directionId = 0)
+        var directionId = 0
         composeTestRule.setContent {
             DirectionPicker(
                 availableDirections = listOf(0, 1),
                 directions = listOf(Direction("North", null, 0), Direction("South", null, 1)),
                 route = route,
-                line = null,
-                filter = filter,
-                updateStopFilter = { newFilter -> filter = newFilter },
+                selectedDirectionId = directionId,
+                updateDirectionId = { directionId = it },
             )
         }
 
         composeTestRule.onNodeWithText("Northbound").assertIsDisplayed()
         composeTestRule.onNodeWithText("Southbound").performClick()
-        assertTrue(filter?.routeId == route.id)
-        assertTrue(filter?.directionId == 1)
+        assertTrue(directionId == 1)
     }
 
     @Test
@@ -50,16 +47,15 @@ class DirectionPickerTest {
                 color = "000000"
                 textColor = "ffffff"
             }
-        var filter: StopDetailsFilter? = StopDetailsFilter(routeId = route.id, directionId = 1)
+        var directionId = 1
         composeTestRule.setContent {
             DirectionPicker(
                 availableDirections = listOf(1),
                 directions =
                     listOf(Direction("North", null, 0), Direction("South", "Destination", 1)),
                 route = route,
-                line = null,
-                filter = filter,
-                updateStopFilter = { newFilter -> filter = newFilter },
+                selectedDirectionId = directionId,
+                updateDirectionId = { directionId = it },
             )
         }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -1,0 +1,332 @@
+package com.mbta.tid.mbta_app.android.component
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.stopDetails.AlertCard
+import com.mbta.tid.mbta_app.android.stopDetails.AlertCardSpec
+import com.mbta.tid.mbta_app.android.stopDetails.ColoredRouteLine
+import com.mbta.tid.mbta_app.android.stopDetails.RouteLineState
+import com.mbta.tid.mbta_app.android.stopDetails.StopDot
+import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
+import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import com.mbta.tid.mbta_app.android.util.typeText
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.UpcomingFormat
+
+@Composable
+fun StopListRow(
+    stop: Stop,
+    onClick: () -> Unit,
+    routeAccents: TripRouteAccents,
+    modifier: Modifier = Modifier,
+    activeElevatorAlerts: Int = 0,
+    alertSummaries: Map<String, AlertSummary?> = emptyMap(),
+    connectingRoutes: List<Route>? = null,
+    disruption: UpcomingFormat.Disruption? = null,
+    firstStop: Boolean = false,
+    isTruncating: Boolean = false,
+    lastStop: Boolean = false,
+    onOpenAlertDetails: (Alert) -> Unit = {},
+    showDownstreamAlert: Boolean = false,
+    showStationAccessibility: Boolean = false,
+    targeted: Boolean = false,
+    trackNumber: String? = null,
+    rightSideContent: @Composable RowScope.(Modifier) -> Unit = {},
+) {
+    val context = LocalContext.current
+
+    val stateBefore =
+        when {
+            firstStop -> RouteLineState.Empty
+            else -> RouteLineState.Regular
+        }
+    val stateAfter =
+        when {
+            lastStop -> RouteLineState.Empty
+            showDownstreamAlert && disruption?.alert?.effect == Alert.Effect.Shuttle ->
+                RouteLineState.Shuttle
+            else -> RouteLineState.Regular
+        }
+    Column {
+        Box(
+            Modifier.padding(horizontal = 6.dp)
+                .then(modifier)
+                .height(IntrinsicSize.Min)
+                .defaultMinSize(minHeight = 48.dp)
+        ) {
+            if (!lastStop && !targeted && disruption == null) {
+                HaloSeparator(Modifier.align(Alignment.BottomCenter))
+            }
+            Row(
+                Modifier.fillMaxHeight().semantics { isTraversalGroup = true },
+                horizontalArrangement = Arrangement.spacedBy(0.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(
+                    Modifier.padding(start = 6.dp).width(28.dp).semantics {
+                        isTraversalGroup = true
+                        traversalIndex = 1F
+                    },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    if (showStationAccessibility && activeElevatorAlerts > 0) {
+                        Image(
+                            modifier = Modifier.height(18.dp).testTag("elevator_alert"),
+                            painter = painterResource(R.drawable.accessibility_icon_alert),
+                            contentDescription = null,
+                        )
+                    } else if (showStationAccessibility && !stop.isWheelchairAccessible) {
+                        Image(
+                            modifier =
+                                Modifier.height(18.dp)
+                                    .testTag("wheelchair_not_accessible")
+                                    .placeholderIfLoading(),
+                            painter = painterResource(R.drawable.accessibility_icon_not_accessible),
+                            contentDescription = null,
+                        )
+                    }
+                }
+                RouteLine(routeAccents, stateBefore, stateAfter, targeted)
+                Column(
+                    Modifier.padding(vertical = 12.dp).padding(start = 16.dp).semantics {
+                        isTraversalGroup = true
+                        traversalIndex = 0F
+                    }
+                ) {
+                    Row(
+                        Modifier.semantics(mergeDescendants = true) { heading() }
+                            .clickable { onClick() },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Column(
+                            DestinationPredictionBalance.destinationWidth(),
+                            horizontalAlignment = Alignment.Start,
+                            verticalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Text(
+                                stop.name,
+                                Modifier.semantics {
+                                        contentDescription =
+                                            stopAccessibilityLabel(
+                                                stop,
+                                                targeted,
+                                                firstStop,
+                                                context,
+                                            )
+                                    }
+                                    .placeholderIfLoading(),
+                                color = colorResource(R.color.text),
+                                style = if (targeted) Typography.headlineBold else Typography.body,
+                            )
+                            if (trackNumber != null) {
+                                Text(
+                                    stringResource(R.string.track_number, trackNumber),
+                                    Modifier.semantics {
+                                            contentDescription =
+                                                context.getString(
+                                                    R.string.boarding_track,
+                                                    trackNumber,
+                                                )
+                                        }
+                                        .placeholderIfLoading(),
+                                    color = MaterialTheme.colorScheme.onPrimary,
+                                    style = Typography.footnote,
+                                )
+                            }
+                        }
+                        rightSideContent(Modifier.padding(end = 12.dp))
+                        // Adding the accessibility description into the stop label rather than on
+                        // the accessibility icon so that it is clear which stop it is associated
+                        // with. Empty Rows, Canvas, Text that don't take up size, etc. do not have
+                        // their content descriptions read.
+                        val stopNotAccessibleContentDescription =
+                            stringResource(R.string.not_accessible_stop_card)
+                        val elevatorAlertContentDescription =
+                            pluralStringResource(
+                                R.plurals.elevator_closure_count_accessibility_description,
+                                activeElevatorAlerts,
+                                activeElevatorAlerts,
+                            )
+
+                        Text(
+                            "",
+                            modifier =
+                                Modifier.semantics {
+                                        contentDescription =
+                                            if (
+                                                showStationAccessibility &&
+                                                    !stop.isWheelchairAccessible
+                                            ) {
+                                                stopNotAccessibleContentDescription
+                                            } else if (
+                                                showStationAccessibility && activeElevatorAlerts > 0
+                                            ) {
+                                                elevatorAlertContentDescription
+                                            } else {
+                                                ""
+                                            }
+                                    }
+                                    .width(1.dp)
+                                    .height(1.dp),
+                        )
+                    }
+
+                    if (!connectingRoutes.isNullOrEmpty()) {
+                        ScrollRoutes(
+                            connectingRoutes,
+                            Modifier.clearAndSetSemantics {
+                                    contentDescription =
+                                        scrollRoutesAccessibilityLabel(connectingRoutes, context)
+                                }
+                                .clickable { onClick() },
+                        )
+                    }
+                }
+            }
+        }
+        if (disruption != null) {
+            Box(Modifier.height(IntrinsicSize.Min)) {
+                // Trying to get this spacing to look right in Android Studio previews at any device
+                // DPI requires both layers of padding; moving all 40 DP to one side or the other
+                // makes things stop lining up properly. Causality is a superstition.
+                Row(Modifier.padding(start = 6.dp).height(IntrinsicSize.Min).matchParentSize()) {
+                    Column(
+                        Modifier.fillMaxHeight().padding(start = 34.dp).width(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateAfter)
+                        if (isTruncating) {
+                            ColoredRouteLine(
+                                routeAccents.color,
+                                Modifier.weight(1f),
+                                RouteLineState.Empty,
+                            )
+                        }
+                    }
+                }
+                AlertCard(
+                    disruption.alert,
+                    alertSummaries[disruption.alert.id],
+                    AlertCardSpec.Downstream,
+                    routeAccents.color,
+                    routeAccents.textColor,
+                    onViewDetails = { onOpenAlertDetails(disruption.alert) },
+                    interiorPadding = PaddingValues(start = 26.dp),
+                )
+            }
+        }
+    }
+}
+
+private fun connectionLabel(route: Route, context: Context) =
+    context.getString(
+        R.string.route_with_type,
+        route.label,
+        route.type.typeText(context, isOnly = true),
+    )
+
+@Composable
+fun ScrollRoutes(routes: List<Route>, modifier: Modifier = Modifier) {
+    Row(
+        modifier.horizontalScroll(rememberScrollState()).padding(top = 8.dp, end = 20.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        for (route in routes) {
+            RoutePill(route, type = RoutePillType.Flex)
+        }
+    }
+}
+
+private fun scrollRoutesAccessibilityLabel(
+    connectingRoutes: List<Route>,
+    context: Context,
+): String =
+    when {
+        connectingRoutes.isEmpty() -> ""
+        connectingRoutes.size == 1 ->
+            context.getString(
+                R.string.connection_to,
+                connectionLabel(connectingRoutes.single(), context),
+            )
+        else -> {
+            val firstConnections = connectingRoutes.dropLast(1)
+            val lastConnection = connectingRoutes.last()
+            context.getString(
+                R.string.connections_to_and,
+                firstConnections.joinToString(separator = ", ") { connectionLabel(it, context) },
+                connectionLabel(lastConnection, context),
+            )
+        }
+    }
+
+private fun stopAccessibilityLabel(
+    stop: Stop,
+    targeted: Boolean,
+    firstStop: Boolean,
+    context: Context,
+): String {
+    val name = stop.name
+    return when {
+        targeted && firstStop -> context.getString(R.string.selected_stop_first_stop, name)
+        targeted -> context.getString(R.string.selected_stop, name)
+        firstStop -> context.getString(R.string.first_stop, name)
+        else -> name
+    }
+}
+
+@Composable
+private fun RouteLine(
+    routeAccents: TripRouteAccents,
+    stateBefore: RouteLineState,
+    stateAfter: RouteLineState,
+    targeted: Boolean,
+) {
+    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxHeight().width(20.dp)) {
+        Column(Modifier.fillMaxHeight()) {
+            ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateBefore)
+            ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateAfter)
+        }
+        StopDot(routeAccents, targeted)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.util.Typography
-import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.RoutePillSpec
 import com.mbta.tid.mbta_app.model.RouteResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -33,14 +32,13 @@ fun RouteResultsView(
     globalResponse: GlobalResponse?,
     handleSearch: (String) -> Unit,
 ) {
-    val route = globalResponse?.getRoute(routeResult.id)
-
-    val line: Line? =
-        if (route?.lineId != null) {
-            globalResponse.getLine(route.lineId)
-        } else {
-            null
+    val resultId =
+        when {
+            routeResult.id == "Green" -> "line-Green"
+            else -> routeResult.id
         }
+    val route = globalResponse?.getRoute(resultId)
+    val line = globalResponse?.getLine(resultId)
 
     val routePillSpec =
         RoutePillSpec(route, line, RoutePillSpec.Type.Fixed, RoutePillSpec.Context.Default)
@@ -49,7 +47,7 @@ fun RouteResultsView(
         Row(
             modifier =
                 Modifier.clip(shape)
-                    .clickable { handleSearch(routeResult.id) }
+                    .clickable { handleSearch(resultId) }
                     .background(colorResource(id = R.color.fill3))
                     .padding(12.dp)
                     .minimumInteractiveComponentSize()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
@@ -24,10 +24,8 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionLabel
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Direction
-import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
-import com.mbta.tid.mbta_app.model.StopDetailsFilter
 
 @ColorRes private fun deselectedBackgroundColor(route: Route): Int = R.color.deselected_toggle_2
 
@@ -36,9 +34,8 @@ fun DirectionPicker(
     availableDirections: List<Int>,
     directions: List<Direction>,
     route: Route,
-    line: Line?,
-    filter: StopDetailsFilter?,
-    updateStopFilter: (StopDetailsFilter?) -> Unit,
+    selectedDirectionId: Int?,
+    updateDirectionId: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     if (availableDirections.size > 1) {
@@ -55,17 +52,13 @@ fun DirectionPicker(
                     .padding(2.dp)
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(6.dp)),
-            selectedTabIndex = filter?.directionId ?: 0,
+            selectedTabIndex = selectedDirectionId ?: 0,
             indicator = {},
             divider = {},
         ) {
             for (direction in availableDirections) {
-                val isSelected = filter?.directionId == direction
-                val action = {
-                    updateStopFilter(
-                        StopDetailsFilter(routeId = line?.id ?: route.id, directionId = direction)
-                    )
-                }
+                val isSelected = selectedDirectionId == direction
+                val action = { updateDirectionId(direction) }
 
                 Tab(
                     selected = isSelected,
@@ -121,9 +114,8 @@ private fun DirectionPickerPreview() {
                     Direction(name = "Inbound", destination = "In", id = 1),
                 ),
             route = route,
-            line = null,
-            filter = StopDetailsFilter(routeId = route.id, directionId = 0),
-            updateStopFilter = {},
+            selectedDirectionId = 0,
+            updateDirectionId = {},
         )
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
@@ -91,9 +91,8 @@ fun StopDetailsFilteredPickerView(
                     availableDirections = availableDirections,
                     directions = directions,
                     route = lineOrRoute.sortRoute,
-                    line = (lineOrRoute as? RouteCardData.LineOrRoute.Line)?.line,
-                    stopFilter,
-                    updateStopFilter,
+                    selectedDirectionId = stopFilter.directionId,
+                    updateDirectionId = { updateStopFilter(stopFilter.copy(directionId = it)) },
                     modifier = Modifier.padding(horizontal = 10.dp),
                 )
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -1,63 +1,30 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
-import android.content.Context
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.isTraversalGroup
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.android.component.HaloSeparator
-import com.mbta.tid.mbta_app.android.component.RoutePill
-import com.mbta.tid.mbta_app.android.component.RoutePillType
+import com.mbta.tid.mbta_app.android.component.StopListRow
 import com.mbta.tid.mbta_app.android.component.UpcomingTripView
 import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
-import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.containsWrappableText
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
-import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
-import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.UpcomingFormat
@@ -81,267 +48,42 @@ fun TripStopRow(
     firstStop: Boolean = false,
     lastStop: Boolean = false,
 ) {
-    val context = LocalContext.current
     val activeElevatorAlerts = stop.activeElevatorAlerts(now)
 
-    val stateBefore =
-        when {
-            firstStop -> RouteLineState.Empty
-            else -> RouteLineState.Regular
-        }
-    val stateAfter =
-        when {
-            lastStop -> RouteLineState.Empty
-            showDownstreamAlert && stop.disruption?.alert?.effect == Alert.Effect.Shuttle ->
-                RouteLineState.Shuttle
-            else -> RouteLineState.Regular
-        }
     val disruption = stop.disruption?.takeIf { it.alert.hasNoThroughService && showDownstreamAlert }
-    Column {
-        Box(
-            Modifier.padding(horizontal = 6.dp)
-                .then(modifier)
-                .height(IntrinsicSize.Min)
-                .defaultMinSize(minHeight = 48.dp)
-        ) {
-            if (!lastStop && !targeted && disruption == null) {
-                HaloSeparator(Modifier.align(Alignment.BottomCenter))
-            }
-            Row(
-                Modifier.fillMaxHeight().semantics { isTraversalGroup = true },
-                horizontalArrangement = Arrangement.spacedBy(0.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Row(
-                    Modifier.padding(start = 6.dp).width(28.dp).semantics {
-                        isTraversalGroup = true
-                        traversalIndex = 1F
-                    },
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    if (showStationAccessibility && activeElevatorAlerts.isNotEmpty()) {
-                        Image(
-                            modifier = Modifier.height(18.dp).testTag("elevator_alert"),
-                            painter = painterResource(R.drawable.accessibility_icon_alert),
-                            contentDescription = null,
-                        )
-                    } else if (showStationAccessibility && !stop.stop.isWheelchairAccessible) {
-                        Image(
-                            modifier =
-                                Modifier.height(18.dp)
-                                    .testTag("wheelchair_not_accessible")
-                                    .placeholderIfLoading(),
-                            painter = painterResource(R.drawable.accessibility_icon_not_accessible),
-                            contentDescription = null,
-                        )
-                    }
-                }
-                RouteLine(routeAccents, stateBefore, stateAfter, targeted)
-                Column(
-                    Modifier.padding(vertical = 12.dp).padding(start = 16.dp).semantics {
-                        isTraversalGroup = true
-                        traversalIndex = 0F
-                    }
-                ) {
-                    Row(
-                        Modifier.semantics(mergeDescendants = true) { heading() }
-                            .clickable { onTapLink(stop) },
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Column(
-                            DestinationPredictionBalance.destinationWidth(),
-                            horizontalAlignment = Alignment.Start,
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                        ) {
-                            Text(
-                                stop.stop.name,
-                                Modifier.semantics {
-                                        contentDescription =
-                                            stopAccessibilityLabel(
-                                                stop,
-                                                targeted,
-                                                firstStop,
-                                                context,
-                                            )
-                                    }
-                                    .placeholderIfLoading(),
-                                color = colorResource(R.color.text),
-                                style = if (targeted) Typography.headlineBold else Typography.body,
-                            )
-                            val trackNumber = stop.trackNumber
-                            if (trackNumber != null) {
-                                Text(
-                                    stringResource(R.string.track_number, trackNumber),
-                                    Modifier.semantics {
-                                            contentDescription =
-                                                context.getString(
-                                                    R.string.boarding_track,
-                                                    trackNumber,
-                                                )
-                                        }
-                                        .placeholderIfLoading(),
-                                    color = MaterialTheme.colorScheme.onPrimary,
-                                    style = Typography.footnote,
-                                )
-                            }
-                        }
-                        CompositionLocalProvider(
-                            LocalContentColor provides colorResource(R.color.text)
-                        ) {
-                            val state = upcomingTripViewState(stop, now, routeAccents)
-                            UpcomingTripView(
-                                state,
-                                Modifier.padding(end = 12.dp)
-                                    .then(
-                                        DestinationPredictionBalance.predictionWidth(
-                                            state.containsWrappableText()
-                                        )
-                                    ),
-                                routeType = routeAccents.type,
-                                hideRealtimeIndicators = true,
-                                maxTextAlpha = 0.6f,
-                            )
-                        }
-                        // Adding the accessibility description into the stop label rather than on
-                        // the accessibility icon so that it is clear which stop it is associated
-                        // with. Empty Rows, Canvas, Text that don't take up size, etc. do not have
-                        // their content descriptions read.
-                        val stopNotAccessibleContentDescription =
-                            stringResource(R.string.not_accessible_stop_card)
-                        val elevatorAlertContentDescription =
-                            pluralStringResource(
-                                R.plurals.elevator_closure_count_accessibility_description,
-                                activeElevatorAlerts.size,
-                                activeElevatorAlerts.size,
-                            )
 
-                        Text(
-                            "",
-                            modifier =
-                                Modifier.semantics {
-                                        contentDescription =
-                                            if (
-                                                showStationAccessibility &&
-                                                    !stop.stop.isWheelchairAccessible
-                                            ) {
-                                                stopNotAccessibleContentDescription
-                                            } else if (
-                                                showStationAccessibility &&
-                                                    activeElevatorAlerts.isNotEmpty()
-                                            ) {
-                                                elevatorAlertContentDescription
-                                            } else {
-                                                ""
-                                            }
-                                    }
-                                    .width(1.dp)
-                                    .height(1.dp),
-                        )
-                    }
-
-                    if (stop.routes.isNotEmpty()) {
-                        ScrollRoutes(
-                            stop,
-                            Modifier.clearAndSetSemantics {
-                                    contentDescription =
-                                        scrollRoutesAccessibilityLabel(stop, context)
-                                }
-                                .clickable { onTapLink(stop) },
-                        )
-                    }
-                }
-            }
-        }
-        if (disruption != null) {
-            Box(Modifier.height(IntrinsicSize.Min)) {
-                // Trying to get this spacing to look right in Android Studio previews at any device
-                // DPI requires both layers of padding; moving all 40 DP to one side or the other
-                // makes things stop lining up properly. Causality is a superstition.
-                Row(Modifier.padding(start = 6.dp).height(IntrinsicSize.Min).matchParentSize()) {
-                    Column(
-                        Modifier.fillMaxHeight().padding(start = 34.dp).width(20.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateAfter)
-                        if (stop.isTruncating) {
-                            ColoredRouteLine(
-                                routeAccents.color,
-                                Modifier.weight(1f),
-                                RouteLineState.Empty,
-                            )
-                        }
-                    }
-                }
-                AlertCard(
-                    disruption.alert,
-                    alertSummaries[disruption.alert.id],
-                    AlertCardSpec.Downstream,
-                    routeAccents.color,
-                    routeAccents.textColor,
-                    onViewDetails = { onOpenAlertDetails(disruption.alert) },
-                    interiorPadding = PaddingValues(start = 26.dp),
+    StopListRow(
+        stop = stop.stop,
+        onClick = { onTapLink(stop) },
+        routeAccents = routeAccents,
+        modifier = modifier,
+        activeElevatorAlerts = activeElevatorAlerts.size,
+        alertSummaries = alertSummaries,
+        connectingRoutes = stop.routes,
+        disruption = disruption,
+        firstStop = firstStop,
+        isTruncating = stop.isTruncating,
+        lastStop = lastStop,
+        onOpenAlertDetails = onOpenAlertDetails,
+        showDownstreamAlert = showDownstreamAlert,
+        showStationAccessibility = showStationAccessibility,
+        targeted = targeted,
+        trackNumber = stop.trackNumber,
+        rightSideContent = { rightSideModifier ->
+            CompositionLocalProvider(LocalContentColor provides colorResource(R.color.text)) {
+                val state = upcomingTripViewState(stop, now, routeAccents)
+                UpcomingTripView(
+                    state,
+                    rightSideModifier.then(
+                        DestinationPredictionBalance.predictionWidth(state.containsWrappableText())
+                    ),
+                    routeType = routeAccents.type,
+                    hideRealtimeIndicators = true,
+                    maxTextAlpha = 0.6f,
                 )
             }
-        }
-    }
-}
-
-private fun connectionLabel(route: Route, context: Context) =
-    context.getString(
-        R.string.route_with_type,
-        route.label,
-        route.type.typeText(context, isOnly = true),
+        },
     )
-
-@Composable
-fun ScrollRoutes(stop: TripDetailsStopList.Entry, modifier: Modifier = Modifier) {
-    Row(
-        modifier.horizontalScroll(rememberScrollState()).padding(top = 8.dp, end = 20.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        for (route in stop.routes) {
-            RoutePill(route, type = RoutePillType.Flex)
-        }
-    }
-}
-
-private fun scrollRoutesAccessibilityLabel(
-    stop: TripDetailsStopList.Entry,
-    context: Context,
-): String =
-    when {
-        stop.routes.isEmpty() -> ""
-        stop.routes.size == 1 ->
-            context.getString(
-                R.string.connection_to,
-                connectionLabel(stop.routes.single(), context),
-            )
-        else -> {
-            val firstConnections = stop.routes.dropLast(1)
-            val lastConnection = stop.routes.last()
-            context.getString(
-                R.string.connections_to_and,
-                firstConnections.joinToString(separator = ", ") { connectionLabel(it, context) },
-                connectionLabel(lastConnection, context),
-            )
-        }
-    }
-
-private fun stopAccessibilityLabel(
-    stop: TripDetailsStopList.Entry,
-    targeted: Boolean,
-    firstStop: Boolean,
-    context: Context,
-): String {
-    val name = stop.stop.name
-    return when {
-        targeted && firstStop -> context.getString(R.string.selected_stop_first_stop, name)
-        targeted -> context.getString(R.string.selected_stop, name)
-        firstStop -> context.getString(R.string.first_stop, name)
-        else -> name
-    }
 }
 
 private fun upcomingTripViewState(
@@ -357,22 +99,6 @@ private fun upcomingTripViewState(
         )
     } else {
         UpcomingTripViewState.Some(stop.format(now, routeAccents.type))
-    }
-}
-
-@Composable
-private fun RouteLine(
-    routeAccents: TripRouteAccents,
-    stateBefore: RouteLineState,
-    stateAfter: RouteLineState,
-    targeted: Boolean,
-) {
-    Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxHeight().width(20.dp)) {
-        Column(Modifier.fillMaxHeight()) {
-            ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateBefore)
-            ColoredRouteLine(routeAccents.color, Modifier.weight(1f), stateAfter)
-        }
-        StopDot(routeAccents, targeted)
     }
 }
 

--- a/iosApp/iosApp/ComponentViews/DirectionLabel.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionLabel.swift
@@ -28,7 +28,8 @@ struct DirectionLabel: View {
     ]
 
     static func directionNameFormatted(_ direction: Direction) -> String {
-        localizedDirectionNames[direction.name] ?? NSLocalizedString("Heading", comment: "A route direction label")
+        localizedDirectionNames[direction.name ?? ""] ??
+            NSLocalizedString("Heading", comment: "A route direction label")
     }
 
     @ViewBuilder

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 
-data class Direction(var name: String, var destination: String?, var id: Int) {
+data class Direction(var name: String?, var destination: String?, var id: Int) {
     /**
      * This constructor is used to provide additional context to a Direction to allow for overriding
      * the destination label in cases where a route or line has branching. We want to display a

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -539,6 +539,13 @@ data class RouteCardData(
                     is Line -> this.routes.min()
                 }
 
+        val allRoutes: Set<RouteModel>
+            get() =
+                when (this) {
+                    is Route -> setOf(this.route)
+                    is Line -> this.routes
+                }
+
         fun directions(
             globalData: GlobalResponse,
             stop: Stop,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -311,14 +311,25 @@ constructor(val tripId: String, val stops: List<Entry>, val startTerminalEntry: 
             entry: WorkingEntry,
             globalData: GlobalResponse,
         ): List<Route> {
-            val stop = globalData.stops[entry.stopId] ?: return emptyList()
+            return getTransferRoutes(
+                entry.stopId,
+                entry.prediction?.routeId ?: entry.schedule?.routeId,
+                globalData,
+            )
+        }
+
+        fun getTransferRoutes(
+            stopId: String,
+            currentRouteId: String?,
+            globalData: GlobalResponse,
+        ): List<Route> {
+            val stop = globalData.stops[stopId] ?: return emptyList()
             val selfOrParent =
                 if (stop.parentStationId == null) stop
                 else globalData.stops[stop.parentStationId] ?: return emptyList()
             // Bail if stop is not a parent but its parent stop can't be found
 
-            val currentRoute =
-                globalData.routes[entry.prediction?.routeId ?: entry.schedule?.routeId]
+            val currentRoute = globalData.routes[currentRouteId]
 
             val transferStopIds =
                 listOf(selfOrParent.id) +

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -1585,12 +1585,7 @@ class RouteCardDataTest {
 
         assertEquals(
             listOf(closeSubwayRoute, farSubwayRoute, closeBusRoute, farBusRoute),
-            routeCardsSorted?.flatMap {
-                when (val lineOrRoute = it.lineOrRoute) {
-                    is RouteCardData.LineOrRoute.Line -> lineOrRoute.routes.toList()
-                    is RouteCardData.LineOrRoute.Route -> listOf(lineOrRoute.route)
-                }
-            },
+            routeCardsSorted?.flatMap { it.lineOrRoute.allRoutes },
         )
     }
 
@@ -1706,12 +1701,7 @@ class RouteCardDataTest {
 
         assertEquals(
             listOf(farSubwayRoute, farBusRoute, closeSubwayRoute, closeBusRoute),
-            routeCardsSorted?.flatMap {
-                when (val lineOrRoute = it.lineOrRoute) {
-                    is RouteCardData.LineOrRoute.Line -> lineOrRoute.routes.toList()
-                    is RouteCardData.LineOrRoute.Route -> listOf(lineOrRoute.route)
-                }
-            },
+            routeCardsSorted?.flatMap { it.lineOrRoute.allRoutes },
         )
     }
 
@@ -1902,12 +1892,7 @@ class RouteCardDataTest {
                 closeBusRoute,
                 farBusRoute,
             ),
-            checkNotNull(routeCardsSorted).flatMap {
-                when (val lineOrRoute = it.lineOrRoute) {
-                    is RouteCardData.LineOrRoute.Route -> listOf(lineOrRoute.route)
-                    is RouteCardData.LineOrRoute.Line -> lineOrRoute.routes
-                }
-            },
+            checkNotNull(routeCardsSorted).flatMap { it.lineOrRoute.allRoutes },
         )
     }
 
@@ -2121,12 +2106,7 @@ class RouteCardDataTest {
                     predictedBusRoute,
                     serviceEndedBusRoute,
                 ),
-                checkNotNull(routeCardsSorted).flatMap {
-                    when (val lineOrRoute = it.lineOrRoute) {
-                        is RouteCardData.LineOrRoute.Route -> listOf(lineOrRoute.route)
-                        is RouteCardData.LineOrRoute.Line -> lineOrRoute.routes
-                    }
-                },
+                checkNotNull(routeCardsSorted).flatMap { it.lineOrRoute.allRoutes },
             )
 
             val partialServiceEndedRoute =


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Route details - basic UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209816289542476?focus=true)

There are some refactoring pieces of this work that seem like they make sense to split out separately before the actual route details page implementation.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
