### PR TITLE
feat(Android): basic route details UX

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -1,0 +1,170 @@
+package com.mbta.tid.mbta_app.android.routeDetails
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
+
+class RouteStopListViewTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testDisplaysEverything() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop { name = "Stop 1" }
+        val stop2 = objects.stop { name = "Stop 2" }
+        val stop3 = objects.stop { name = "Stop 3" }
+        val mainRoute =
+            objects.route {
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Here", "There")
+                longName = "Mauve Line"
+                type = RouteType.HEAVY_RAIL
+            }
+        objects.routePattern(mainRoute) { directionId = 0 }
+        objects.routePattern(mainRoute) { directionId = 1 }
+        val connectingRoute =
+            objects.route {
+                shortName = "32"
+                type = RouteType.BUS
+            }
+        objects.routePattern(connectingRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(stop2.id) }
+        }
+
+        val clicks = mutableListOf<RouteDetailsStopList.Entry>()
+        var closed = false
+
+        val koin =
+            testKoinApplication(objects) {
+                routeStops = MockRouteStopsRepository(listOf(stop1.id, stop2.id, stop3.id))
+            }
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                RouteStopListView(
+                    RouteCardData.LineOrRoute.Route(mainRoute),
+                    GlobalResponse(objects),
+                    onClick = clicks::add,
+                    onClose = { closed = true },
+                    errorBannerViewModel = ErrorBannerViewModel(errorRepository = koinInject()),
+                    rightSideContent = { entry, _ ->
+                        Text("rightSideContent for ${entry.stop.name}")
+                    },
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop1.name))
+
+        composeTestRule.onNodeWithText(mainRoute.longName).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Westbound to").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Here").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Eastbound to").assertIsDisplayed()
+        composeTestRule.onNodeWithText("There").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop3.name).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("rightSideContent for ${stop1.name}").assertIsDisplayed()
+        composeTestRule.onNodeWithText("rightSideContent for ${stop2.name}").assertIsDisplayed()
+        composeTestRule.onNodeWithText("rightSideContent for ${stop3.name}").assertIsDisplayed()
+
+        composeTestRule
+            .onNodeWithText(connectingRoute.shortName, useUnmergedTree = true)
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText(stop2.name).performClick()
+        assertEquals(listOf(RouteDetailsStopList.Entry(stop2, listOf(connectingRoute))), clicks)
+
+        composeTestRule.onNodeWithContentDescription("Close").performClick()
+        assertTrue(closed)
+    }
+
+    @Test
+    fun selectsWithinLine() {
+        val objects = ObjectCollectionBuilder()
+        val line = objects.line()
+        val route1 =
+            objects.route {
+                lineId = line.id
+                type = RouteType.BUS
+                shortName = "1"
+                directionDestinations = listOf("One", "")
+            }
+        val route2 =
+            objects.route {
+                lineId = line.id
+                type = RouteType.BUS
+                shortName = "2"
+                directionDestinations = listOf("Two", "")
+            }
+        val route3 =
+            objects.route {
+                lineId = line.id
+                type = RouteType.BUS
+                shortName = "3"
+                directionDestinations = listOf("Three", "")
+            }
+        objects.routePattern(route1) { directionId = 0 }
+
+        var lastSelectedRoute: String? = null
+
+        val koin =
+            testKoinApplication(objects) {
+                routeStops =
+                    MockRouteStopsRepository(
+                        listOf(),
+                        onGet = { routeId, _ -> lastSelectedRoute = routeId },
+                    )
+            }
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                RouteStopListView(
+                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
+                    GlobalResponse(objects),
+                    onClick = {},
+                    onClose = {},
+                    errorBannerViewModel = ErrorBannerViewModel(errorRepository = koinInject()),
+                    defaultSelectedRouteId = route2.id,
+                    rightSideContent = { _, _ -> },
+                )
+            }
+        }
+
+        composeTestRule.waitUntil { lastSelectedRoute != null }
+        assertEquals(route2.id, lastSelectedRoute)
+
+        composeTestRule.onNodeWithText(route3.shortName).performClick()
+        composeTestRule.waitForIdle()
+        assertEquals(route3.id, lastSelectedRoute)
+
+        composeTestRule.onNodeWithText(checkNotNull(route1.directionDestinations[0])).performClick()
+        composeTestRule.waitForIdle()
+        assertEquals(route1.id, lastSelectedRoute)
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
@@ -1,0 +1,109 @@
+package com.mbta.tid.mbta_app.android.state
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.model.ErrorBannerState
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class GetRouteStopsTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testRouteStops() {
+        fun buildSomeRouteStops(): RouteStopsResponse {
+            val objects = ObjectCollectionBuilder()
+            return RouteStopsResponse(listOf(objects.stop().id, objects.stop().id))
+        }
+        val expectedRouteStops1 = buildSomeRouteStops()
+        val expectedRouteStops2 = buildSomeRouteStops()
+
+        val routeStopsRepo =
+            object : IRouteStopsRepository {
+                override suspend fun getRouteStops(
+                    routeId: String,
+                    directionId: Int,
+                ): ApiResult<RouteStopsResponse> {
+                    return if (directionId == 0) ApiResult.Ok(expectedRouteStops1)
+                    else ApiResult.Ok(expectedRouteStops2)
+                }
+            }
+
+        var directionId by mutableIntStateOf(0)
+        var actualRouteStops: RouteStopsResponse? = expectedRouteStops1
+        composeTestRule.setContent {
+            actualRouteStops = getRouteStops("", directionId, "errorKey", routeStopsRepo)
+        }
+
+        composeTestRule.waitUntil { actualRouteStops != null }
+        composeTestRule.waitForIdle()
+        assertEquals(expectedRouteStops1, actualRouteStops)
+
+        directionId = 1
+        composeTestRule.waitUntil { actualRouteStops != null }
+        composeTestRule.waitForIdle()
+        assertEquals(expectedRouteStops2, actualRouteStops)
+    }
+
+    @Test
+    fun testNullWhileLoading(): Unit = runBlocking {
+        val sync = Channel<Unit>(capacity = Channel.RENDEZVOUS)
+        val routeStopsRepo =
+            object : IRouteStopsRepository {
+                override suspend fun getRouteStops(
+                    routeId: String,
+                    directionId: Int,
+                ): ApiResult<RouteStopsResponse> {
+                    sync.receive()
+                    return ApiResult.Ok(RouteStopsResponse(emptyList()))
+                }
+            }
+        var actualRouteStops: RouteStopsResponse? = null
+
+        var directionId by mutableIntStateOf(0)
+        composeTestRule.setContent {
+            actualRouteStops = getRouteStops("", directionId, "errorKey", routeStopsRepo)
+        }
+
+        sync.send(Unit)
+        composeTestRule.waitUntil { actualRouteStops != null }
+        assertNotNull(actualRouteStops)
+
+        directionId = 1
+        composeTestRule.waitForIdle()
+        assertNull(actualRouteStops)
+
+        sync.send(Unit)
+        composeTestRule.waitForIdle()
+        assertNotNull(actualRouteStops)
+    }
+
+    @Test
+    fun testErrorCase() {
+        val schedulesRepo = MockRouteStopsRepository(ApiResult.Error(500, "oops"))
+
+        val errorRepo = MockErrorBannerStateRepository()
+
+        composeTestRule.setContent { getRouteStops("", 0, "errorKey", schedulesRepo, errorRepo) }
+
+        composeTestRule.waitUntil {
+            when (val errorState = errorRepo.state.value) {
+                is ErrorBannerState.DataError -> errorState.messages == setOf("errorKey")
+                else -> false
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
@@ -27,6 +27,8 @@ sealed class SheetRoutes {
         val tripFilter: TripDetailsFilter?,
     ) : SheetRoutes()
 
+    @Serializable data class RouteDetails(val routeId: String) : SheetRoutes()
+
     val showSearchBar: Boolean
         get() =
             when (this) {
@@ -63,6 +65,8 @@ sealed class SheetRoutes {
         fun fromNavBackStackEntry(backStackEntry: NavBackStackEntry): SheetRoutes {
             return if (backStackEntry.destination.route?.contains("StopDetails") == true) {
                 backStackEntry.toRoute<StopDetails>()
+            } else if (backStackEntry.destination.route?.contains("RouteDetails") == true) {
+                backStackEntry.toRoute<RouteDetails>()
             } else if (backStackEntry.destination.route?.contains("Favorites") == true) {
                 backStackEntry.toRoute<Favorites>()
             } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
@@ -1,0 +1,46 @@
+package com.mbta.tid.mbta_app.android.routeDetails
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.state.getGlobalData
+import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+
+@Composable
+fun RouteDetailsView(
+    selectionId: String,
+    onOpenStopDetails: (String) -> Unit,
+    onClose: () -> Unit,
+    errorBannerViewModel: ErrorBannerViewModel,
+) {
+    val globalData = getGlobalData("RouteDetailsView.globalData")
+    val lineOrRoute = globalData?.let { RouteDetailsStopList.getLineOrRoute(selectionId, it) }
+    if (lineOrRoute == null) {
+        CircularProgressIndicator()
+        return
+    }
+
+    RouteStopListView(
+        lineOrRoute,
+        globalData,
+        onClick = { onOpenStopDetails(it.stop.id) },
+        onClose = onClose,
+        errorBannerViewModel,
+        defaultSelectedRouteId = selectionId.takeUnless { it == lineOrRoute.id },
+        rightSideContent = { _, modifier ->
+            Image(
+                painterResource(id = R.drawable.baseline_chevron_right_24),
+                contentDescription = null,
+                modifier = modifier.width(8.dp),
+                colorFilter = ColorFilter.tint(colorResource(R.color.deemphasized)),
+            )
+        },
+    )
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -1,0 +1,135 @@
+package com.mbta.tid.mbta_app.android.routeDetails
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.ErrorBanner
+import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.component.RoutePill
+import com.mbta.tid.mbta_app.android.component.RoutePillType
+import com.mbta.tid.mbta_app.android.component.SheetHeader
+import com.mbta.tid.mbta_app.android.component.StopListRow
+import com.mbta.tid.mbta_app.android.state.getRouteStops
+import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
+import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
+import com.mbta.tid.mbta_app.android.util.rememberSuspend
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+
+@Composable
+fun RouteStopListView(
+    lineOrRoute: RouteCardData.LineOrRoute,
+    globalData: GlobalResponse,
+    onClick: (RouteDetailsStopList.Entry) -> Unit,
+    onClose: () -> Unit,
+    errorBannerViewModel: ErrorBannerViewModel,
+    defaultSelectedRouteId: String? = null,
+    rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
+) {
+    val routes = lineOrRoute.allRoutes.sorted()
+    val routeIds = routes.map { it.id }
+    val parameters =
+        remember(lineOrRoute, globalData) {
+            RouteDetailsStopList.RouteParameters(lineOrRoute, globalData)
+        }
+    var selectedDirection by rememberSaveable {
+        mutableIntStateOf(parameters.availableDirections.firstOrNull() ?: 0)
+    }
+    var selectedRouteId by rememberSaveable {
+        mutableStateOf(defaultSelectedRouteId ?: routeIds.first())
+    }
+
+    val routeStops =
+        getRouteStops(selectedRouteId, selectedDirection, "RouteDetailsView.routeStopIds")
+
+    val stopList =
+        rememberSuspend(selectedRouteId, routeStops, globalData) {
+            RouteDetailsStopList.fromPieces(selectedRouteId, routeStops, globalData)
+        }
+
+    Column {
+        SheetHeader(onClose = onClose, title = lineOrRoute.name)
+        ErrorBanner(errorBannerViewModel)
+
+        DirectionPicker(
+            parameters.availableDirections,
+            parameters.directions,
+            lineOrRoute.sortRoute,
+            selectedDirection,
+            updateDirectionId = { selectedDirection = it },
+        )
+
+        if (lineOrRoute is RouteCardData.LineOrRoute.Line && routes.size > 1) {
+            Column {
+                for (route in routes) {
+                    val selected = route.id == selectedRouteId
+                    Row(
+                        Modifier.fillMaxWidth()
+                            .background(
+                                if (selected) colorResource(R.color.fill3) else Color.Transparent
+                            )
+                            .clickable { selectedRouteId = route.id }
+                            .padding(8.dp),
+                        Arrangement.spacedBy(8.dp),
+                        Alignment.CenterVertically,
+                    ) {
+                        RoutePill(route, lineOrRoute.line, RoutePillType.Fixed)
+                        Text(route.directionDestinations[selectedDirection] ?: "")
+                    }
+                }
+            }
+        }
+
+        Box(Modifier.verticalScroll(rememberScrollState())) {
+            Box(
+                Modifier.matchParentSize()
+                    .padding(horizontal = 4.dp)
+                    .haloContainer(2.dp, backgroundColor = colorResource(R.color.fill2))
+            )
+            Column {
+                if (stopList != null) {
+                    for ((index, stop) in stopList.stops.withIndex()) {
+                        StopListRow(
+                            stop.stop,
+                            onClick = { onClick(stop) },
+                            routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+                            modifier = Modifier.minimumInteractiveComponentSize(),
+                            connectingRoutes = stop.connectingRoutes,
+                            firstStop = index == 0,
+                            lastStop = index == stopList.stops.lastIndex,
+                            rightSideContent = { modifier -> rightSideContent(stop, modifier) },
+                        )
+                    }
+                } else {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
@@ -1,0 +1,83 @@
+package com.mbta.tid.mbta_app.android.state
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.mbta.tid.mbta_app.android.util.fetchApi
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+class RouteStopsFetcher(
+    private val routeStopsRepository: IRouteStopsRepository,
+    private val errorBannerRepository: IErrorBannerStateRepository,
+) {
+
+    fun getRouteStops(
+        routeId: String,
+        directionId: Int,
+        errorKey: String,
+        onSuccess: (RouteStopsResponse) -> Unit,
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            fetchApi(
+                errorBannerRepo = errorBannerRepository,
+                errorKey = errorKey,
+                getData = { routeStopsRepository.getRouteStops(routeId, directionId) },
+                onSuccess = { onSuccess(it) },
+                onRefreshAfterError = { getRouteStops(routeId, directionId, errorKey, onSuccess) },
+            )
+        }
+    }
+}
+
+class RouteStopsViewModel(
+    routeStopsRepository: IRouteStopsRepository,
+    errorBannerRepository: IErrorBannerStateRepository,
+) : ViewModel() {
+
+    private val routeStopsFetcher = RouteStopsFetcher(routeStopsRepository, errorBannerRepository)
+    private val _routeStops = MutableStateFlow<RouteStopsResponse?>(null)
+    val routeStops: StateFlow<RouteStopsResponse?> = _routeStops
+
+    fun getRouteStops(routeId: String, directionId: Int, errorKey: String) {
+        _routeStops.value = null
+        routeStopsFetcher.getRouteStops(routeId, directionId, errorKey) { _routeStops.value = it }
+    }
+
+    class Factory(
+        private val routeStopsRepository: IRouteStopsRepository,
+        private val errorBannerRepository: IErrorBannerStateRepository,
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return RouteStopsViewModel(routeStopsRepository, errorBannerRepository) as T
+        }
+    }
+}
+
+@Composable
+fun getRouteStops(
+    routeId: String,
+    directionId: Int,
+    errorKey: String,
+    routeStopsRepository: IRouteStopsRepository = koinInject(),
+    errorBannerRepository: IErrorBannerStateRepository = koinInject(),
+): RouteStopsResponse? {
+    val viewModel: RouteStopsViewModel =
+        viewModel(
+            factory = RouteStopsViewModel.Factory(routeStopsRepository, errorBannerRepository)
+        )
+
+    LaunchedEffect(routeId, directionId) { viewModel.getRouteStops(routeId, directionId, errorKey) }
+
+    return viewModel.routeStops.collectAsState(initial = null).value
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsScreen.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.analytics
 
 enum class AnalyticsScreen(val pageName: String) {
     NearbyTransit("NearbyTransitPage"),
+    RouteDetails("RouteDetailsPage"),
     TripDetails("TripDetailsPage"),
     StopDetailsFiltered("StopDetailsFilteredPage"),
     StopDetailsUnfiltered("StopDetailsUnfilteredPage"),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -14,6 +14,7 @@ import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
@@ -52,6 +53,7 @@ fun repositoriesModule(repositories: IRepositories): Module {
         single<IOnboardingRepository> { repositories.onboarding }
         single<IPinnedRoutesRepository> { repositories.pinnedRoutes }
         single<IRailRouteShapeRepository> { repositories.railRouteShapes }
+        single<IRouteStopsRepository> { repositories.routeStops }
         single<ISchedulesRepository> { repositories.schedules }
         single<ISearchResultRepository> { repositories.searchResults }
         single<ISentryRepository> { repositories.sentry }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -27,6 +27,7 @@ import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
@@ -55,6 +56,7 @@ import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
@@ -66,6 +68,7 @@ import com.mbta.tid.mbta_app.repositories.NearbyRepository
 import com.mbta.tid.mbta_app.repositories.OnboardingRepository
 import com.mbta.tid.mbta_app.repositories.PinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.RailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.RouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.SchedulesRepository
 import com.mbta.tid.mbta_app.repositories.SearchResultRepository
 import com.mbta.tid.mbta_app.repositories.SentryRepository
@@ -89,6 +92,7 @@ interface IRepositories {
     val pinnedRoutes: IPinnedRoutesRepository
     val predictions: IPredictionsRepository?
     val railRouteShapes: IRailRouteShapeRepository
+    val routeStops: IRouteStopsRepository
     val schedules: ISchedulesRepository
     val searchResults: ISearchResultRepository
     val sentry: ISentryRepository
@@ -114,6 +118,7 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val pinnedRoutes: IPinnedRoutesRepository by inject()
     override val predictions: IPredictionsRepository by inject()
     override val railRouteShapes: IRailRouteShapeRepository by inject()
+    override val routeStops: IRouteStopsRepository by inject()
     override val schedules: ISchedulesRepository by inject()
     override val searchResults: ISearchResultRepository by inject()
     override val sentry: ISentryRepository by inject()
@@ -142,6 +147,7 @@ class RealRepositories : IRepositories {
     override val pinnedRoutes = PinnedRoutesRepository()
     override val predictions = null
     override val railRouteShapes = RailRouteShapeRepository()
+    override val routeStops = RouteStopsRepository()
     override val schedules = SchedulesRepository()
     override val searchResults = SearchResultRepository()
     override val sentry = SentryRepository()
@@ -170,6 +176,7 @@ class MockRepositories : IRepositories {
     override var pinnedRoutes: IPinnedRoutesRepository = PinnedRoutesRepository()
     override var predictions: IPredictionsRepository = MockPredictionsRepository()
     override var railRouteShapes: IRailRouteShapeRepository = IdleRailRouteShapeRepository()
+    override var routeStops: IRouteStopsRepository = MockRouteStopsRepository(emptyList())
     override var schedules: ISchedulesRepository = IdleScheduleRepository()
     override var searchResults: ISearchResultRepository = IdleSearchResultRepository()
     override var sentry: ISentryRepository = MockSentryRepository()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -21,6 +21,7 @@ import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
+import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
@@ -42,6 +43,7 @@ import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -136,6 +138,7 @@ fun endToEndModule(): Module {
             // debug.
             IdleRailRouteShapeRepository()
         }
+        single<IRouteStopsRepository> { MockRouteStopsRepository(emptyList()) }
         single<ISchedulesRepository> {
             MockScheduleRepository(scheduleResponse = ScheduleResponse(objects))
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
@@ -1,0 +1,81 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+data class RouteDetailsStopList(val stops: List<Entry>) {
+    data class Entry(val stop: Stop, val connectingRoutes: List<Route>)
+
+    data class RouteParameters(
+        val availableDirections: List<Int>,
+        val directions: List<Direction>,
+    ) {
+        constructor(
+            lineOrRoute: RouteCardData.LineOrRoute,
+            globalData: GlobalResponse,
+        ) : this(
+            globalData.routePatterns.values
+                .asSequence<RoutePattern>()
+                .filter<RoutePattern> { it.routeId in lineOrRoute.allRoutes.map { it.id } }
+                .map { it.directionId }
+                .distinct()
+                .sorted()
+                .toList(),
+            listOf(0, 1).map { directionId ->
+                val name =
+                    lineOrRoute.allRoutes
+                        .map { it.directionNames[directionId] }
+                        .distinct()
+                        .singleOrNull()
+                val destination =
+                    lineOrRoute.allRoutes
+                        .map { it.directionDestinations[directionId] }
+                        .distinct()
+                        .singleOrNull()
+                Direction(name, destination, directionId)
+            },
+        )
+    }
+
+    companion object {
+        fun getLineOrRoute(
+            selectionId: String,
+            globalData: GlobalResponse,
+        ): RouteCardData.LineOrRoute? {
+            val route = globalData.getRoute(selectionId)
+            val line = globalData.getLine(selectionId) ?: globalData.getLine(route?.lineId)
+            return when {
+                line != null && line.isGrouped ->
+                    RouteCardData.LineOrRoute.Line(
+                        line,
+                        globalData.routesByLineId[line.id].orEmpty().toSet(),
+                    )
+                route != null -> RouteCardData.LineOrRoute.Route(route)
+                else -> null
+            }
+        }
+
+        suspend fun fromPieces(
+            routeId: String,
+            routeStops: RouteStopsResponse?,
+            globalData: GlobalResponse,
+        ): RouteDetailsStopList? =
+            withContext(Dispatchers.Default) {
+                if (routeStops == null) return@withContext null
+
+                val stops =
+                    routeStops.stopIds.mapNotNull { stopId ->
+                        val stop =
+                            globalData.getStop(stopId)?.resolveParent(globalData)
+                                ?: return@mapNotNull null
+                        val transferRoutes =
+                            TripDetailsStopList.getTransferRoutes(stopId, routeId, globalData)
+                        Entry(stop, transferRoutes)
+                    }
+
+                RouteDetailsStopList(stops)
+            }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/RouteStopsResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/RouteStopsResponse.kt
@@ -1,0 +1,6 @@
+package com.mbta.tid.mbta_app.model.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable data class RouteStopsResponse(@SerialName("stop_ids") val stopIds: List<String>)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
@@ -1,0 +1,53 @@
+package com.mbta.tid.mbta_app.repositories
+
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import com.mbta.tid.mbta_app.network.MobileBackendClient
+import io.ktor.client.call.body
+import io.ktor.http.path
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+interface IRouteStopsRepository {
+    suspend fun getRouteStops(routeId: String, directionId: Int): ApiResult<RouteStopsResponse>
+}
+
+class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
+    private val mobileBackendClient: MobileBackendClient by inject()
+
+    override suspend fun getRouteStops(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<RouteStopsResponse> =
+        ApiResult.runCatching {
+            mobileBackendClient
+                .get {
+                    url {
+                        path("api/route/stops")
+                        parameters.append("route_id", routeId)
+                        parameters.append("direction_id", directionId.toString())
+                    }
+                }
+                .body()
+        }
+}
+
+class MockRouteStopsRepository(
+    private val result: ApiResult<RouteStopsResponse>,
+    private val onGet: (String, Int) -> Unit = { _, _ -> },
+) : IRouteStopsRepository {
+    @DefaultArgumentInterop.Enabled
+    constructor(
+        stopIds: List<String>,
+        onGet: (String, Int) -> Unit = { _, _ -> },
+    ) : this(ApiResult.Ok(RouteStopsResponse(stopIds)), onGet)
+
+    override suspend fun getRouteStops(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<RouteStopsResponse> {
+        onGet(routeId, directionId)
+        return result
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -1,0 +1,207 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+class RouteDetailsStopListTest {
+    @Test
+    fun `RouteParameters finds available directions`() {
+        val objects = ObjectCollectionBuilder()
+        val route1 = objects.route()
+        objects.routePattern(route1) { directionId = 0 }
+        objects.routePattern(route1) { directionId = 0 }
+        objects.routePattern(route1) { directionId = 0 }
+        objects.routePattern(route1) { directionId = 0 }
+        val route2 = objects.route()
+        objects.routePattern(route2) { directionId = 0 }
+        objects.routePattern(route2) { directionId = 1 }
+        val line = objects.line()
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            listOf(0),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Route(route1),
+                    globalData,
+                )
+                .availableDirections,
+        )
+        assertEquals(
+            listOf(0, 1),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Route(route2),
+                    globalData,
+                )
+                .availableDirections,
+        )
+        assertEquals(
+            listOf(0, 1),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+                    globalData,
+                )
+                .availableDirections,
+        )
+    }
+
+    @Test
+    fun `RouteParameters finds direction info`() {
+        val objects = ObjectCollectionBuilder()
+        val route1 =
+            objects.route {
+                directionNames = listOf("East", "West")
+                directionDestinations = listOf("Here", "There")
+            }
+        val route2 =
+            objects.route {
+                directionNames = listOf("East", "West")
+                directionDestinations = listOf("Here", "Elsewhere")
+            }
+        val route3 =
+            objects.route {
+                directionNames = listOf("North", "South")
+                directionDestinations = listOf("Somewhere", "Wherever")
+            }
+        val line = objects.line()
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            listOf(Direction("East", "Here", 0), Direction("West", "There", 1)),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Route(route1),
+                    globalData,
+                )
+                .directions,
+        )
+        assertEquals(
+            listOf(Direction("East", "Here", 0), Direction("West", "Elsewhere", 1)),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Route(route2),
+                    globalData,
+                )
+                .directions,
+        )
+        assertEquals(
+            listOf(Direction("North", "Somewhere", 0), Direction("South", "Wherever", 1)),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Route(route3),
+                    globalData,
+                )
+                .directions,
+        )
+        assertEquals(
+            listOf(Direction("East", "Here", 0), Direction("West", null, 1)),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+                    globalData,
+                )
+                .directions,
+        )
+        assertEquals(
+            listOf(Direction(null, null, 0), Direction(null, null, 1)),
+            RouteDetailsStopList.RouteParameters(
+                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
+                    globalData,
+                )
+                .directions,
+        )
+    }
+
+    @Test
+    fun `getLineOrRoute gets route`() {
+        val objects = ObjectCollectionBuilder()
+        val ungroupedLine = objects.line()
+        val route1 = objects.route()
+        val route2 = objects.route()
+        val route3 = objects.route { lineId = ungroupedLine.id }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteCardData.LineOrRoute.Route(route1),
+            RouteDetailsStopList.getLineOrRoute(route1.id, globalData),
+        )
+        assertEquals(
+            RouteCardData.LineOrRoute.Route(route2),
+            RouteDetailsStopList.getLineOrRoute(route2.id, globalData),
+        )
+        assertEquals(
+            RouteCardData.LineOrRoute.Route(route3),
+            RouteDetailsStopList.getLineOrRoute(route3.id, globalData),
+        )
+    }
+
+    @Test
+    fun `getLineOrRoute gets line excluding shuttles`() {
+        val objects = ObjectCollectionBuilder()
+        val line = objects.line { id = "line-Green" }
+        val route1 = objects.route { lineId = line.id }
+        val route2 = objects.route { lineId = line.id }
+        val shuttleRoute =
+            objects.route {
+                id = "Shuttle-$id"
+                lineId = line.id
+            }
+        assertTrue(shuttleRoute.isShuttle)
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            RouteDetailsStopList.getLineOrRoute(line.id, globalData),
+        )
+    }
+
+    @Test
+    fun `getLineOrRoute gets line if route in grouped line`() {
+        val objects = ObjectCollectionBuilder()
+        val line = objects.line { id = "line-Green" }
+        val route1 = objects.route { lineId = line.id }
+        val route2 = objects.route { lineId = line.id }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            RouteDetailsStopList.getLineOrRoute(route1.id, globalData),
+        )
+        assertEquals(
+            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            RouteDetailsStopList.getLineOrRoute(route2.id, globalData),
+        )
+    }
+
+    @Test
+    fun `fromPieces finds transfer stops`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val connectingStop = objects.stop()
+        val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
+        val mainRoute = objects.route()
+        val connectingRoute = objects.route()
+        objects.routePattern(connectingRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(connectingStop.id) }
+        }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteDetailsStopList(
+                listOf(
+                    RouteDetailsStopList.Entry(mainStop, connectingRoutes = listOf(connectingRoute))
+                )
+            ),
+            RouteDetailsStopList.fromPieces(
+                mainRoute.id,
+                RouteStopsResponse(listOf(mainStop.id)),
+                globalData,
+            ),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
@@ -1,0 +1,103 @@
+package com.mbta.tid.mbta_app.repositories
+
+import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import com.mbta.tid.mbta_app.network.MobileBackendClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Url
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+
+class RouteStopsRepositoryTest : KoinTest {
+    @Test
+    fun testGetSchedule() {
+        lateinit var requestUrl: Url
+        val mockEngine = MockEngine { request ->
+            requestUrl = request.url
+            respond(
+                content =
+                    ByteReadChannel(
+                        """
+                    {
+                        "stop_ids": [
+                            "place-ogmnl",
+                            "place-mlmnl",
+                            "place-welln",
+                            "place-astao",
+                            "place-sull",
+                            "place-ccmnl",
+                            "place-north",
+                            "place-haecl",
+                            "place-state",
+                            "place-dwnxg",
+                            "place-chncl",
+                            "place-tumnl",
+                            "place-bbsta",
+                            "place-masta",
+                            "place-rugg",
+                            "place-rcmnl",
+                            "place-jaksn",
+                            "place-sbmnl",
+                            "place-grnst",
+                            "place-forhl"
+                        ]
+                    }
+                    """
+                            .trimIndent()
+                    ),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        startKoin {
+            modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
+        }
+        runBlocking {
+            val response = RouteStopsRepository().getRouteStops("Orange", 0)
+            assertEquals("/api/route/stops", requestUrl.encodedPath)
+            assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
+            assertEquals(
+                ApiResult.Ok(
+                    RouteStopsResponse(
+                        listOf(
+                            "place-ogmnl",
+                            "place-mlmnl",
+                            "place-welln",
+                            "place-astao",
+                            "place-sull",
+                            "place-ccmnl",
+                            "place-north",
+                            "place-haecl",
+                            "place-state",
+                            "place-dwnxg",
+                            "place-chncl",
+                            "place-tumnl",
+                            "place-bbsta",
+                            "place-masta",
+                            "place-rugg",
+                            "place-rcmnl",
+                            "place-jaksn",
+                            "place-sbmnl",
+                            "place-grnst",
+                            "place-forhl",
+                        )
+                    )
+                ),
+                response,
+            )
+        }
+        stopKoin()
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Route details - basic UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209816289542476?focus=true)

Correctly handles selecting either a Green Line branch or the Green Line overall from route search, since that’s complicated in a way that influences the structure overall and I had an extra day within the task points.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this works with the Green Line and with other lines. Added unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
