### PR TITLE
feat: show GL pills even if not branching

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -89,6 +89,7 @@ fun Departures(
                                     destination = formatted.headsign ?: direction.destination
                                 ),
                                 formatted.format,
+                                pillDecoration = formatted.route?.let { PillDecoration.OnRow(it) },
                             )
                         }
                         is LeafFormat.Branched -> {

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
@@ -37,6 +37,8 @@ struct RouteCardDirection: View {
             }
 
         case let .single(single):
+            let pillDecoration: PredictionRowView.PillDecoration =
+                if let route = single.route { .onRow(route: route) } else { .none }
             DirectionRowView(
                 direction: .init(
                     name: direction.name,
@@ -45,7 +47,8 @@ struct RouteCardDirection: View {
                         : single.headsign,
                     id: direction.id
                 ),
-                predictions: single.format
+                predictions: single.format,
+                pillDecoration: pillDecoration
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
@@ -20,6 +20,12 @@ sealed class LeafFormat {
 
     /** A [RouteCardData.Leaf] which only has one destination within its direction. */
     data class Single(
+        /**
+         * The route to display next to [headsign] and [format]. Only set if the
+         * [RouteCardData.Leaf] comes from a grouped line, and therefore always worth showing if
+         * set.
+         */
+        val route: Route?,
         /** The headsign to show next to [format]. Overrides [Direction.destination] if set. */
         val headsign: String?,
         val format: UpcomingFormat,
@@ -28,7 +34,7 @@ sealed class LeafFormat {
             return if (format is UpcomingFormat.Some) {
                 format.trips.map { trip ->
                     TileData(
-                        route = null,
+                        route = route,
                         headsign = null,
                         UpcomingFormat.Some(trip, format.secondaryAlert),
                         trip.trip,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/LeafFormatTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/LeafFormatTest.kt
@@ -32,6 +32,7 @@ class LeafFormatTest {
             )
         val format =
             LeafFormat.Single(
+                route = null,
                 "Overridden Headsign",
                 UpcomingFormat.Some(listOf(trip1, trip2, trip3), null),
             )
@@ -124,7 +125,8 @@ class LeafFormatTest {
     fun `Single tileData empty if no trips`() {
         val format =
             LeafFormat.Single(
-                null,
+                route = null,
+                headsign = null,
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.NoSchedulesToday),
             )
         assertEquals(emptyList(), format.tileData())
@@ -151,7 +153,8 @@ class LeafFormatTest {
                 UpcomingFormat.NoTripsFormat.ServiceEndedToday,
                 UpcomingFormat.NoTripsFormat.NoSchedulesToday,
             )) {
-            val format = LeafFormat.Single(null, UpcomingFormat.NoTrips(noTrips))
+            val format =
+                LeafFormat.Single(route = null, headsign = null, UpcomingFormat.NoTrips(noTrips))
             assertEquals(noTrips, format.noPredictionsStatus())
         }
     }
@@ -182,7 +185,8 @@ class LeafFormatTest {
                 anyEnumValue(),
                 TripInstantDisplay.Minutes(15),
             )
-        val format = LeafFormat.Single(null, UpcomingFormat.Some(trip, null))
+        val format =
+            LeafFormat.Single(route = null, headsign = null, UpcomingFormat.Some(trip, null))
         assertNull(format.noPredictionsStatus())
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -49,7 +49,11 @@ class RouteCardDataLeafTest {
         val alert = objects.alert { effect = Alert.Effect.Suspension }
 
         assertEquals(
-            LeafFormat.Single(null, UpcomingFormat.Disruption(alert, "alert-large-red-suspension")),
+            LeafFormat.Single(
+                route = null,
+                headsign = null,
+                UpcomingFormat.Disruption(alert, "alert-large-red-suspension"),
+            ),
             RouteCardData.Leaf(
                     RouteCardData.LineOrRoute.Route(route),
                     objects.stop(),
@@ -92,7 +96,8 @@ class RouteCardDataLeafTest {
         for ((route, icon) in cases) {
             assertEquals(
                 LeafFormat.Single(
-                    null,
+                    route = null,
+                    headsign = null,
                     UpcomingFormat.NoTrips(
                         UpcomingFormat.NoTripsFormat.ServiceEndedToday,
                         UpcomingFormat.SecondaryAlert(icon),
@@ -139,7 +144,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Disruption(alert, "alert-large-silver-suspension"),
             ),
             RouteCardData.Leaf(
@@ -178,7 +184,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -226,7 +233,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -264,7 +272,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                null,
+                route = null,
+                headsign = null,
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.ServiceEndedToday),
             ),
             RouteCardData.Leaf(
@@ -298,7 +307,8 @@ class RouteCardDataLeafTest {
             }
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable),
             ),
             RouteCardData.Leaf(
@@ -326,7 +336,7 @@ class RouteCardDataLeafTest {
         val route = objects.route { type = anyEnumValue() }
         val pattern = objects.routePattern(route)
         assertEquals(
-            LeafFormat.Single(null, UpcomingFormat.Loading),
+            LeafFormat.Single(route = null, headsign = null, UpcomingFormat.Loading),
             RouteCardData.Leaf(
                     RouteCardData.LineOrRoute.Route(route),
                     objects.stop(),
@@ -369,7 +379,8 @@ class RouteCardDataLeafTest {
         val upcomingTrip2 = objects.upcomingTrip(prediction2)
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -425,7 +436,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -454,7 +466,8 @@ class RouteCardDataLeafTest {
         )
         assertEquals(
             LeafFormat.Single(
-                "",
+                route = null,
+                headsign = "",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -497,7 +510,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                null,
+                route = null,
+                headsign = null,
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.NoSchedulesToday),
             ),
             RouteCardData.Leaf(
@@ -766,7 +780,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "Alewife",
+                route = null,
+                headsign = "Alewife",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -1015,6 +1030,7 @@ class RouteCardDataLeafTest {
 
         val boylston = objects.getStop("place-boyls")
         val kenmore = objects.getStop("place-kencl")
+        val reservoir = objects.getStop("place-rsmnl")
 
         val bWestbound = objects.getRoutePattern("Green-B-812-0")
         val cWestbound = objects.getRoutePattern("Green-C-832-0")
@@ -1117,6 +1133,74 @@ class RouteCardDataLeafTest {
                     )
                     .format(now, GreenLine.global)
             ),
+        )
+    }
+
+    @Test
+    fun `formats Green Line westbound at Reservoir as single`() = parametricTest {
+        val objects = GreenLine.objects()
+        val now = Clock.System.now()
+
+        val prediction1 =
+            objects.prediction {
+                departureTime = now + 3.minutes
+                trip = objects.trip(GreenLine.dWestbound)
+            }
+        val prediction2 =
+            objects.prediction {
+                departureTime = now + 5.minutes
+                trip = objects.trip(GreenLine.dWestbound)
+            }
+        val prediction3 =
+            objects.prediction {
+                departureTime = now + 10.minutes
+                trip = objects.trip(GreenLine.dWestbound)
+            }
+        val prediction4 =
+            objects.prediction {
+                departureTime = now + 15.minutes
+                trip = objects.trip(GreenLine.dWestbound)
+            }
+
+        assertEquals(
+            LeafFormat.Single(
+                GreenLine.d,
+                "Riverside",
+                UpcomingFormat.Some(
+                    listOf(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction1),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Minutes(3),
+                        ),
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction2),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Minutes(5),
+                        ),
+                    ),
+                    null,
+                ),
+            ),
+            RouteCardData.Leaf(
+                    GreenLine.lineOrRoute,
+                    GreenLine.reservoir,
+                    0,
+                    listOf(GreenLine.dWestbound),
+                    emptySet(),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                        objects.upcomingTrip(prediction4),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                )
+                .format(now, GreenLine.global),
         )
     }
 
@@ -1270,7 +1354,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "South Station",
+                route = null,
+                headsign = "South Station",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -1353,7 +1438,8 @@ class RouteCardDataLeafTest {
 
         assertEquals(
             LeafFormat.Single(
-                "Arlington Center",
+                route = null,
+                headsign = "Arlington Center",
                 UpcomingFormat.Some(
                     listOf(
                         UpcomingFormat.Some.FormattedTrip(
@@ -1537,7 +1623,8 @@ class RouteCardDataLeafTest {
 
             assertEquals(
                 LeafFormat.Single(
-                    null,
+                    route = null,
+                    headsign = null,
                     UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.ServiceEndedToday),
                 ),
                 RouteCardData.Leaf(
@@ -1667,7 +1754,8 @@ class RouteCardDataLeafTest {
 
             assertEquals(
                 LeafFormat.Single(
-                    null,
+                    route = null,
+                    headsign = null,
                     UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable),
                 ),
                 RouteCardData.Leaf(
@@ -2048,7 +2136,8 @@ class RouteCardDataLeafTest {
 
             assertEquals(
                 LeafFormat.Single(
-                    null,
+                    route = null,
+                    headsign = null,
                     UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.b)),
                 ),
                 RouteCardData.Leaf(


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | Show GL route pills in Nearby Transit card on branches](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210114621155036?focus=true)

This was indeed easy after the refactor to move the lineOrRoute into the leaf.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests in shared code and on each platform. Manually verified that pills are shown correctly on each platform.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
