### PR TITLE
fix(android.HomeMapView): Default to current location if location permissions enabled

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -129,7 +129,8 @@ class ViewportProvider(var viewport: MapViewportState, isManuallyCentering: Bool
         animateTo(stop.position.toMapbox())
     }
 
-    fun isDefault() = viewport.cameraState?.center?.isRoughlyEqualTo(Defaults.center) == true
+    // if camera state's center is null, then treat it like it is at the default center
+    fun isDefault() = viewport.cameraState?.center?.isRoughlyEqualTo(Defaults.center) != false
 
     fun animateTo(
         coordinates: Point,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Current location not centered on app launch](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210226994170857?focus=true)

What is this PR for?
Ensures that on startup with location permissions enabled, the map defaults to your current location

* This seems to have  been caused by a change in Mapbox [11.12.0](https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md#11120-may-7-2025), but I can't quite pinpoint what from the changelog would do it. This was not an issue in 11.11.0

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally with permissions enabled and confirmed I am immediately brought to my current location
* Ran locally with permissions disabled and then enabled them. Confirmed I am brought to my current location

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
