### PR TITLE
refactor: move more logic into TripDetailsStopList.Entry.format

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -28,16 +28,17 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Stop Name" }
+        val trip = objects.trip()
         val vehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.InTransitTo
-                tripId = ""
+                tripId = trip.id
             }
         val route = objects.route {}
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
                 "",
                 TripRouteAccents(route),
@@ -53,12 +54,13 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
+        val trip = objects.trip()
 
         val vehicleState =
             mutableStateOf<Vehicle>(
                 objects.vehicle {
                     currentStatus = Vehicle.CurrentStatus.InTransitTo
-                    tripId = ""
+                    tripId = trip.id
                 }
             )
         val route = objects.route {}
@@ -66,7 +68,7 @@ class TripHeaderCardTest {
         composeTestRule.setContent {
             val vehicle: Vehicle by vehicleState
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
                 "",
                 TripRouteAccents(route),
@@ -79,7 +81,7 @@ class TripHeaderCardTest {
         val incomingVehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.IncomingAt
-                tripId = ""
+                tripId = trip.id
             }
 
         vehicleState.value = incomingVehicle
@@ -89,7 +91,7 @@ class TripHeaderCardTest {
         val stoppedVehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
-                tripId = ""
+                tripId = trip.id
             }
 
         vehicleState.value = stoppedVehicle
@@ -104,10 +106,11 @@ class TripHeaderCardTest {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Stop Name" }
         val route = objects.route {}
+        val trip = objects.trip()
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "selected",
+                trip,
                 TripHeaderSpec.FinishingAnotherTrip,
                 "",
                 TripRouteAccents(route),
@@ -125,9 +128,10 @@ class TripHeaderCardTest {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Stop Name" }
         val route = objects.route {}
+        val trip = objects.trip()
 
         composeTestRule.setContent {
-            TripHeaderCard("selected", TripHeaderSpec.NoVehicle, "", TripRouteAccents(route), now)
+            TripHeaderCard(trip, TripHeaderSpec.NoVehicle, "", TripRouteAccents(route), now)
         }
         composeTestRule
             .onNodeWithText("Location not available yet", useUnmergedTree = true)
@@ -140,11 +144,12 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
+        val trip = objects.trip()
 
         val vehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
-                tripId = ""
+                tripId = trip.id
                 stopId = stop.id
             }
 
@@ -152,7 +157,7 @@ class TripHeaderCardTest {
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
                 stop.id,
                 TripRouteAccents(route),
@@ -171,6 +176,7 @@ class TripHeaderCardTest {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop {}
         val route = objects.route {}
+        val trip = objects.trip()
 
         val predictionDeparture = now.plus(5.minutes)
 
@@ -178,7 +184,7 @@ class TripHeaderCardTest {
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
 
-                tripId = ""
+                tripId = trip.id
                 stopId = stop.id
                 currentStopSequence = 0
             }
@@ -186,7 +192,7 @@ class TripHeaderCardTest {
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(
                     vehicle,
                     stop,
@@ -196,7 +202,6 @@ class TripHeaderCardTest {
                         disruption = null,
                         schedule = null,
                         prediction = prediction,
-                        predictionStop = stop,
                         vehicle = vehicle,
                         routes = listOf(),
                     ),
@@ -232,6 +237,7 @@ class TripHeaderCardTest {
                 parentStationId = stop.id
             }
         val route = objects.route { type = RouteType.COMMUTER_RAIL }
+        val trip = objects.trip()
 
         val predictionDeparture = now.plus(5.minutes)
 
@@ -239,7 +245,7 @@ class TripHeaderCardTest {
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
 
-                tripId = ""
+                tripId = trip.id
                 stopId = stop.id
                 currentStopSequence = 0
             }
@@ -251,7 +257,7 @@ class TripHeaderCardTest {
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(
                     vehicle,
                     stop,
@@ -281,15 +287,20 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Stop Name" }
+        val trip = objects.trip()
 
         val scheduledTime = now.plus(5.minutes)
-        val route = objects.route {}
+        val route = objects.route { type = RouteType.COMMUTER_RAIL }
 
-        val schedule = objects.schedule { departureTime = scheduledTime }
+        val schedule =
+            objects.schedule {
+                this.trip = trip
+                departureTime = scheduledTime
+            }
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.Scheduled(
                     stop,
                     TripDetailsStopList.Entry(
@@ -298,7 +309,6 @@ class TripHeaderCardTest {
                         disruption = null,
                         schedule = schedule,
                         prediction = null,
-                        predictionStop = null,
                         vehicle = null,
                         routes = listOf(),
                     ),
@@ -364,12 +374,17 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "stop" }
-        val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.IncomingAt }
+        val trip = objects.trip()
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.IncomingAt
+                tripId = trip.id
+            }
         val route = objects.route { type = RouteType.BUS }
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
                 stop.id,
                 TripRouteAccents(route),
@@ -400,7 +415,12 @@ class TripHeaderCardTest {
                 vehicleType = RouteType.COMMUTER_RAIL
                 parentStationId = stop.id
             }
-        val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
+        val trip = objects.trip()
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                tripId = trip.id
+            }
         val route = objects.route { type = RouteType.COMMUTER_RAIL }
         val prediction =
             objects.prediction {
@@ -410,7 +430,7 @@ class TripHeaderCardTest {
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(
                     vehicle,
                     stop,
@@ -448,14 +468,19 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "stop" }
-        val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.IncomingAt }
+        val trip = objects.trip()
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.IncomingAt
+                tripId = trip.id
+            }
         val route = objects.route { type = RouteType.BUS }
 
         val otherStop = objects.stop { name = "other stop" }
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.VehicleOnTrip(vehicle, otherStop, null, false),
                 stop.id,
                 TripRouteAccents(route),
@@ -476,13 +501,18 @@ class TripHeaderCardTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "stop" }
-        val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.IncomingAt }
+        val trip = objects.trip()
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.IncomingAt
+                tripId = trip.id
+            }
         val route = objects.route { type = RouteType.BUS }
         val schedule = objects.schedule { departureTime = now.plus(5.minutes) }
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.Scheduled(
                     stop,
                     TripDetailsStopList.Entry(
@@ -491,8 +521,7 @@ class TripHeaderCardTest {
                         disruption = null,
                         schedule = schedule,
                         prediction = null,
-                        predictionStop = null,
-                        vehicle = null,
+                        vehicle = vehicle,
                         routes = listOf(),
                     ),
                 ),
@@ -517,13 +546,18 @@ class TripHeaderCardTest {
         val stop = objects.stop { name = "stop" }
         val other = objects.stop { name = "other stop" }
 
-        val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.IncomingAt }
+        val trip = objects.trip()
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.IncomingAt
+                tripId = trip.id
+            }
         val route = objects.route { type = RouteType.BUS }
         val schedule = objects.schedule { departureTime = now.plus(5.minutes) }
 
         composeTestRule.setContent {
             TripHeaderCard(
-                "",
+                trip,
                 TripHeaderSpec.Scheduled(
                     other,
                     TripDetailsStopList.Entry(
@@ -532,8 +566,7 @@ class TripHeaderCardTest {
                         disruption = null,
                         schedule = schedule,
                         prediction = null,
-                        predictionStop = null,
-                        vehicle = null,
+                        vehicle = vehicle,
                         routes = listOf(),
                     ),
                 ),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -37,6 +37,7 @@ class TripStopRowTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Worcester" }
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route()
@@ -49,10 +50,10 @@ class TripStopRowTest {
                     null,
                     schedule,
                     prediction,
-                    stop,
-                    null,
-                    listOf(route),
+                    vehicle = null,
+                    routes = listOf(route),
                 ),
+                trip,
                 now,
                 onTapLink = {},
                 onOpenAlertDetails = {},
@@ -70,6 +71,7 @@ class TripStopRowTest {
             LocalDateTime.parse("2025-01-24T15:37:39").toInstant(TimeZone.currentSystemDefault())
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop()
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route()
@@ -82,10 +84,10 @@ class TripStopRowTest {
                     null,
                     schedule,
                     prediction,
-                    stop,
-                    null,
-                    listOf(route),
+                    vehicle = null,
+                    routes = listOf(route),
                 ),
+                trip,
                 now,
                 onTapLink = {},
                 onOpenAlertDetails = {},
@@ -109,6 +111,7 @@ class TripStopRowTest {
                 vehicleType = RouteType.COMMUTER_RAIL
                 parentStationId = stop.id
             }
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route { type = RouteType.COMMUTER_RAIL }
@@ -121,10 +124,11 @@ class TripStopRowTest {
                     null,
                     schedule,
                     prediction,
-                    platformStop,
-                    null,
-                    listOf(route),
+                    predictionStop = platformStop,
+                    vehicle = null,
+                    routes = listOf(route),
                 ),
+                trip,
                 now,
                 onTapLink = {},
                 onOpenAlertDetails = {},
@@ -142,6 +146,7 @@ class TripStopRowTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "stop" }
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route()
@@ -153,9 +158,8 @@ class TripStopRowTest {
                 null,
                 schedule,
                 prediction,
-                stop,
-                null,
-                listOf(route),
+                vehicle = null,
+                routes = listOf(route),
             )
 
         var selected by mutableStateOf(false)
@@ -164,6 +168,7 @@ class TripStopRowTest {
         composeTestRule.setContent {
             TripStopRow(
                 stopEntry,
+                trip,
                 now,
                 onTapLink = {},
                 onOpenAlertDetails = {},
@@ -195,6 +200,7 @@ class TripStopRowTest {
         val now = Clock.System.now()
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Worcester" }
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route()
@@ -206,15 +212,15 @@ class TripStopRowTest {
                 null,
                 schedule,
                 prediction,
-                stop,
-                null,
-                listOf(route),
+                vehicle = null,
+                routes = listOf(route),
             )
         var linkTappedWith: TripDetailsStopList.Entry? = null
 
         composeTestRule.setContent {
             TripStopRow(
                 entry,
+                trip,
                 now,
                 onTapLink = { linkTappedWith = it },
                 onOpenAlertDetails = {},
@@ -241,6 +247,7 @@ class TripStopRowTest {
                 name = "Boylston"
                 wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE
             }
+        val trip = objects.trip()
         val schedule = objects.schedule { departureTime = now + 5.seconds }
         val prediction = objects.prediction(schedule) { departureTime = now + 6.seconds }
         val route = objects.route()
@@ -252,16 +259,16 @@ class TripStopRowTest {
                 null,
                 schedule,
                 prediction,
-                stop,
-                null,
-                listOf(route),
-                elevatorAlerts,
+                vehicle = null,
+                routes = listOf(route),
+                elevatorAlerts = elevatorAlerts,
             )
 
         var testEntry by mutableStateOf(entry(inaccessibleStop))
         composeTestRule.setContent {
             TripStopRow(
                 testEntry,
+                trip,
                 now,
                 onTapLink = {},
                 onOpenAlertDetails = {},
@@ -308,6 +315,7 @@ class TripStopRowTest {
                 AlertSummary.Timeframe.Tomorrow,
             )
 
+        val trip = objects.trip()
         val entry =
             TripDetailsStopList.Entry(
                 stop,
@@ -315,7 +323,6 @@ class TripStopRowTest {
                 UpcomingFormat.Disruption(alert, MapStopRoute.ORANGE),
                 schedule = null,
                 prediction = null,
-                predictionStop = null,
                 vehicle = null,
                 routes = emptyList(),
             )
@@ -323,6 +330,7 @@ class TripStopRowTest {
         composeTestRule.setContent {
             TripStopRow(
                 entry,
+                trip,
                 now,
                 {},
                 {},

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -74,7 +74,7 @@ class TripStopsTest {
 
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     TripDetailsStopList.Entry(
                         stop1,
@@ -82,9 +82,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule1,
                         prediction1,
-                        stop1,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop2,
@@ -92,9 +91,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3Target,
@@ -102,9 +100,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule3,
                         prediction3,
-                        stop3Target,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop4,
@@ -112,9 +109,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule4,
                         prediction4,
-                        stop4,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop5,
@@ -122,9 +118,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule5,
                         prediction5,
-                        stop5,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
             )
@@ -195,7 +190,7 @@ class TripStopsTest {
 
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     TripDetailsStopList.Entry(
                         stop1,
@@ -203,9 +198,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule1,
                         prediction1,
-                        stop1,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop2,
@@ -213,9 +207,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3,
@@ -223,9 +216,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule3,
                         prediction3,
-                        stop3,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
             )
@@ -297,13 +289,12 @@ class TripStopsTest {
                 disruption = null,
                 schedule1,
                 prediction1,
-                stop1,
-                vehicle,
-                listOf(route),
+                vehicle = vehicle,
+                routes = listOf(route),
             )
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     firstStop,
                     TripDetailsStopList.Entry(
@@ -312,9 +303,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
                 startTerminalEntry = firstStop,
@@ -388,13 +378,12 @@ class TripStopsTest {
                 disruption = null,
                 schedule1,
                 prediction1,
-                stop1,
-                vehicle,
-                listOf(route),
+                vehicle = vehicle,
+                routes = listOf(route),
             )
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     firstStop,
                     TripDetailsStopList.Entry(
@@ -403,9 +392,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3,
@@ -413,9 +401,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule3,
                         prediction3,
-                        stop3,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
                 startTerminalEntry = firstStop,
@@ -487,7 +474,7 @@ class TripStopsTest {
 
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     TripDetailsStopList.Entry(
                         stop1,
@@ -495,9 +482,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule1,
                         prediction1,
-                        stop1,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop2Target,
@@ -505,9 +491,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2Target,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3,
@@ -515,9 +500,8 @@ class TripStopsTest {
                         disruption = UpcomingFormat.Disruption(alert, null),
                         schedule3,
                         prediction3,
-                        stop3,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
             )
@@ -597,7 +581,7 @@ class TripStopsTest {
 
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     TripDetailsStopList.Entry(
                         stop1,
@@ -605,9 +589,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule1,
                         prediction1,
-                        stop1,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop2Target,
@@ -615,9 +598,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2Target,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3,
@@ -625,9 +607,8 @@ class TripStopsTest {
                         disruption = UpcomingFormat.Disruption(alert, null),
                         schedule3,
                         prediction3,
-                        stop3,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
             )
@@ -707,7 +688,7 @@ class TripStopsTest {
 
         val stops =
             TripDetailsStopList(
-                trip.id,
+                trip,
                 listOf(
                     TripDetailsStopList.Entry(
                         stop1,
@@ -715,9 +696,8 @@ class TripStopsTest {
                         disruption = UpcomingFormat.Disruption(alert, null),
                         schedule1,
                         prediction1,
-                        stop1,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop2Target,
@@ -725,9 +705,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule2,
                         prediction2,
-                        stop2Target,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                     TripDetailsStopList.Entry(
                         stop3,
@@ -735,9 +714,8 @@ class TripStopsTest {
                         disruption = null,
                         schedule3,
                         prediction3,
-                        stop3,
-                        vehicle,
-                        listOf(route),
+                        vehicle = vehicle,
+                        routes = listOf(route),
                     ),
                 ),
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -302,8 +302,7 @@ class StopDetailsViewModel(
                         globalResponse != null
                 ) {
                     TripDetailsStopList.fromPieces(
-                        tripFilter.tripId,
-                        tripData.trip.directionId,
+                        tripData.trip,
                         tripData.tripSchedules,
                         tripData.tripPredictions,
                         tripData.vehicle,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -24,6 +24,7 @@ import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -106,7 +107,7 @@ fun TripDetailsView(
             }
 
         TripDetailsView(
-            tripId,
+            tripData.trip,
             headerSpec,
             onHeaderTap,
             ::onTapStop,
@@ -124,7 +125,7 @@ fun TripDetailsView(
     } else {
         val placeholderTripInfo = LoadingPlaceholders.tripDetailsInfo()
         val placeholderTripStops = placeholderTripInfo.stops
-        val placeholderTripId = placeholderTripInfo.vehicle.tripId ?: ""
+        val placeholderTripId = placeholderTripInfo.trip.id
 
         val placeholderHeaderSpec =
             TripHeaderSpec.getSpec(
@@ -139,7 +140,7 @@ fun TripDetailsView(
         CompositionLocalProvider(IsLoadingSheetContents provides true) {
             Column(modifier = modifier.loadingShimmer()) {
                 TripDetailsView(
-                    placeholderTripId,
+                    placeholderTripInfo.trip,
                     placeholderHeaderSpec,
                     null,
                     onTapStop = {},
@@ -160,7 +161,7 @@ fun TripDetailsView(
 
 @Composable
 private fun TripDetailsView(
-    tripId: String,
+    trip: Trip,
     headerSpec: TripHeaderSpec?,
     onHeaderTap: (() -> Unit)?,
     onTapStop: (TripDetailsStopList.Entry) -> Unit,
@@ -186,7 +187,7 @@ private fun TripDetailsView(
             }
         }
         Column(Modifier.zIndex(1F)) {
-            TripHeaderCard(tripId, headerSpec, stopId, routeAccents, now, onTap = onHeaderTap)
+            TripHeaderCard(trip, headerSpec, stopId, routeAccents, now, onTap = onHeaderTap)
         }
         Column(Modifier.offset(y = (-16).dp)) {
             TripStops(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -49,6 +49,7 @@ import com.mbta.tid.mbta_app.model.AlertSignificance
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
@@ -74,6 +75,7 @@ fun TripStops(
 ) {
     val context = LocalContext.current
 
+    val trip = stops.trip
     val splitStops: TripDetailsStopList.TargetSplit =
         remember(targetId, stops, stopSequence, global) {
             stops.splitForTarget(targetId, stopSequence, global)
@@ -127,6 +129,7 @@ fun TripStops(
                 if (firstStop != null) {
                     TripStopRow(
                         stop = firstStop,
+                        trip,
                         now,
                         onTapLink,
                         onOpenAlertDetails,
@@ -208,6 +211,7 @@ fun TripStops(
                         HaloUnderRouteLine(routeAccents.color)
                         StopList(
                             list = collapsedStops,
+                            trip,
                             lastStopSequence,
                             now,
                             onTapLink,
@@ -235,6 +239,7 @@ fun TripStops(
                 }
                 TripStopRow(
                     stop = target,
+                    trip,
                     now,
                     onTapLink,
                     onOpenAlertDetails,
@@ -251,6 +256,7 @@ fun TripStops(
             }
             StopList(
                 splitStops.followingStops,
+                trip,
                 lastStopSequence,
                 now,
                 onTapLink,
@@ -277,6 +283,7 @@ private fun HaloUnderRouteLine(color: Color) {
 @Composable
 private fun StopList(
     list: List<TripDetailsStopList.Entry>,
+    trip: Trip,
     lastStopSequence: Int?,
     now: Instant,
     onTapLink: (TripDetailsStopList.Entry) -> Unit,
@@ -289,6 +296,7 @@ private fun StopList(
     for (stop in list) {
         TripStopRow(
             stop,
+            trip,
             now,
             onTapLink,
             onOpenAlertDetails,
@@ -325,7 +333,7 @@ private fun TripStopsPreview() {
     val alert = objects.alert { effect = Alert.Effect.Shuttle }
     val stopList =
         TripDetailsStopList(
-            trip.id,
+            trip,
             stops.mapIndexed { index, stop ->
                 TripDetailsStopList.Entry(
                     stop,
@@ -336,7 +344,6 @@ private fun TripStopsPreview() {
                         else null,
                     schedule = null,
                     prediction = objects.prediction { departureTime = now + (2 * index).minutes },
-                    predictionStop = null,
                     vehicle = null,
                     routes = emptyList(),
                 )

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -20,7 +20,7 @@ enum TripHeaderSpec {
 // swiftlint:disable:next type_body_length
 struct TripHeaderCard: View {
     let spec: TripHeaderSpec
-    let tripId: String
+    let trip: Trip
     let targetId: String
     let routeAccents: TripRouteAccents
     let onTap: (() -> Void)?
@@ -126,7 +126,7 @@ struct TripHeaderCard: View {
     @ViewBuilder private func vehicleDescription(
         _ vehicle: Vehicle, _ stop: Stop, _ entry: TripDetailsStopList.Entry?, _ atTerminal: Bool
     ) -> some View {
-        if vehicle.tripId == tripId {
+        if vehicle.tripId == trip.id {
             VStack(alignment: .leading, spacing: 2) {
                 VStack(alignment: .leading, spacing: 2) {
                     vehicleStatusDescription(vehicle.currentStatus, atTerminal)
@@ -304,14 +304,15 @@ struct TripHeaderCard: View {
         default: nil
         }
         guard let entry else { return nil }
-        if let disruption = entry.disruption {
-            return .disruption(.init(alert: disruption.alert), iconName: disruption.iconName)
-        } else {
-            let formatted = entry.format(now: now.toKotlinInstant(), routeType: routeAccents.type)
-            return switch onEnum(of: formatted) {
-            case .hidden, .skipped: nil
-            default: .some(formatted)
-            }
+        guard let formatted = entry.format(trip: trip, now: now.toKotlinInstant(), routeType: routeAccents.type)
+        else { return nil }
+        switch onEnum(of: formatted) {
+        case let .disruption(disruption): return .disruption(
+                .init(alert: disruption.alert),
+                iconName: disruption.iconName
+            )
+        case let .some(some): return .some(some.trips[0].format)
+        default: return nil
         }
     }
 }
@@ -350,7 +351,7 @@ struct TripVehicleCard_Previews: PreviewProvider {
         List {
             TripHeaderCard(
                 spec: .vehicle(vehicle, stop, nil, false),
-                tripId: trip.id,
+                trip: trip,
                 targetId: "",
                 routeAccents: TripRouteAccents(route: red),
                 onTap: nil,

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct TripStopRow: View {
     var stop: TripDetailsStopList.Entry
+    var trip: Trip
     var now: Instant
     var onTapLink: (TripDetailsStopList.Entry) -> Void
     var onOpenAlertDetails: (Shared.Alert) -> Void
@@ -126,12 +127,14 @@ struct TripStopRow: View {
                                     }
                                 }
                                 Spacer()
-                                UpcomingTripView(
-                                    prediction: upcomingTripViewState,
-                                    routeType: routeAccents.type,
-                                    hideRealtimeIndicators: true,
-                                    maxTextAlpha: 0.6
-                                ).foregroundStyle(Color.text)
+                                if let upcomingTripViewState {
+                                    UpcomingTripView(
+                                        prediction: upcomingTripViewState,
+                                        routeType: routeAccents.type,
+                                        hideRealtimeIndicators: true,
+                                        maxTextAlpha: 0.6
+                                    ).foregroundStyle(Color.text)
+                                }
 
                                 // Adding the accessibility description into the stop label rather than on the
                                 // accessibility icon so that it is clear which stop it is associated with
@@ -251,17 +254,22 @@ struct TripStopRow: View {
         }
     }
 
-    var upcomingTripViewState: UpcomingTripView.State {
-        if let disruption = stop.disruption {
-            .disruption(.init(alert: disruption.alert), iconName: disruption.iconName)
-        } else {
-            .some(stop.format(now: now, routeType: routeAccents.type))
+    var upcomingTripViewState: UpcomingTripView.State? {
+        guard let formatted = stop.format(trip: trip, now: now, routeType: routeAccents.type) else { return nil }
+        switch onEnum(of: formatted) {
+        case let .disruption(disruption): return .disruption(
+                .init(alert: disruption.alert),
+                iconName: disruption.iconName
+            )
+        case let .some(some): return .some(some.trips[0].format)
+        default: return nil
         }
     }
 }
 
 #Preview {
     let objects = ObjectCollectionBuilder()
+    let trip = objects.trip { _ in }
     let now = Date.now
     VStack {
         TripStopRow(
@@ -274,7 +282,6 @@ struct TripStopRow: View {
                 disruption: nil,
                 schedule: nil,
                 prediction: objects.prediction { $0.status = "Stopped 5 stops away" },
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [
                     objects.route { route in
@@ -289,6 +296,7 @@ struct TripStopRow: View {
                     },
                 ]
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -306,7 +314,6 @@ struct TripStopRow: View {
                 disruption: nil,
                 schedule: nil,
                 prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [
                     objects.route { route in
@@ -321,6 +328,7 @@ struct TripStopRow: View {
                     },
                 ]
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -350,6 +358,7 @@ struct TripStopRow: View {
                     },
                 ]
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -367,6 +376,7 @@ struct TripStopRow: View {
 
 #Preview("Disruptions") {
     let objects = ObjectCollectionBuilder()
+    let trip = objects.trip { _ in }
     let now = Date.now
     ZStack {
         Color.fill3.padding(6)
@@ -382,7 +392,6 @@ struct TripStopRow: View {
                     ),
                     schedule: nil,
                     prediction: objects.prediction { $0.status = "Stopped 5 stops away" },
-                    predictionStop: nil,
                     vehicle: nil,
                     routes: [
                         objects.route { route in
@@ -397,6 +406,7 @@ struct TripStopRow: View {
                         },
                     ]
                 ),
+                trip: trip,
                 now: now.toKotlinInstant(),
                 onTapLink: { _ in },
                 onOpenAlertDetails: { _ in },
@@ -415,7 +425,6 @@ struct TripStopRow: View {
                     disruption: nil,
                     schedule: nil,
                     prediction: objects.prediction { $0.departureTime = (now + 5 * 60).toKotlinInstant() },
-                    predictionStop: nil,
                     vehicle: nil,
                     routes: [
                         objects.route { route in
@@ -430,6 +439,7 @@ struct TripStopRow: View {
                         },
                     ]
                 ),
+                trip: trip,
                 now: now.toKotlinInstant(),
                 onTapLink: { _ in },
                 onOpenAlertDetails: { _ in },
@@ -454,6 +464,7 @@ struct TripStopRow: View {
                     routes: [],
                     elevatorAlerts: []
                 ),
+                trip: trip,
                 now: now.toKotlinInstant(),
                 onTapLink: { _ in },
                 onOpenAlertDetails: { _ in },

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -75,6 +75,7 @@ struct TripStops: View {
         ForEach(list, id: \.stopSequence) { stop in
             TripStopRow(
                 stop: stop,
+                trip: stops.trip,
                 now: now.toKotlinInstant(),
                 onTapLink: onTapLink,
                 onOpenAlertDetails: onOpenAlertDetails,
@@ -110,6 +111,7 @@ struct TripStops: View {
                 if showFirstStopSeparately, let firstStop = splitStops.firstStop {
                     TripStopRow(
                         stop: firstStop,
+                        trip: stops.trip,
                         now: now.toKotlinInstant(),
                         onTapLink: onTapLink,
                         onOpenAlertDetails: onOpenAlertDetails,
@@ -185,6 +187,7 @@ struct TripStops: View {
                     // it's already displayed in the trip header
                     TripStopRow(
                         stop: target,
+                        trip: stops.trip,
                         now: now.toKotlinInstant(),
                         onTapLink: onTapLink,
                         onOpenAlertDetails: onOpenAlertDetails,
@@ -229,7 +232,7 @@ struct TripStops: View {
     let alertStartIndex = 7
     let alert = objects.alert { $0.effect = .shuttle }
     let stopList = TripDetailsStopList(
-        tripId: trip.id,
+        trip: trip,
         stops: stops.enumerated().map { index, stop in
             .init(
                 stop: stop,
@@ -239,7 +242,6 @@ struct TripStops: View {
                 schedule: nil,
                 prediction: objects
                     .prediction { $0.departureTime = (now + TimeInterval(2 * 60 * index)).toKotlinInstant() },
-                predictionStop: nil,
                 vehicle: nil,
                 routes: []
             )

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -317,7 +317,7 @@ final class TripDetailsViewTests: XCTestCase {
 
         sut.onTapStop(stop: TripDetailsStopList.Entry(
             stop: targetStop, stopSequence: 0,
-            disruption: nil, schedule: nil, prediction: nil, predictionStop: nil,
+            disruption: nil, schedule: nil, prediction: nil,
             vehicle: nil, routes: [], elevatorAlerts: []
         ))
         XCTAssertEqual(nearbyVM.navigationStack, [oldNavEntry, newNavEntry])

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -21,13 +21,14 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "Stop Name" }
+        let trip = objects.trip { _ in }
         let vehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .inTransitTo
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
         }
         let sut = TripHeaderCard(
             spec: .vehicle(vehicle, stop, nil, false),
-            tripId: "",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -41,14 +42,15 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
 
         let inTransitVehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .inTransitTo
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
         }
         let inTransitSut = TripHeaderCard(
             spec: .vehicle(inTransitVehicle, stop, nil, false),
-            tripId: "",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -58,11 +60,11 @@ final class TripHeaderCardTests: XCTestCase {
 
         let incomingVehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .incomingAt
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
         }
         let incomingSut = TripHeaderCard(
             spec: .vehicle(incomingVehicle, stop, nil, false),
-            tripId: "",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -72,11 +74,11 @@ final class TripHeaderCardTests: XCTestCase {
 
         let stoppedVehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .stoppedAt
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
         }
         let stoppedSut = TripHeaderCard(
             spec: .vehicle(stoppedVehicle, stop, nil, false),
-            tripId: "",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -89,10 +91,11 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "Stop Name" }
+        let trip = objects.trip { _ in }
 
         let sut = TripHeaderCard(
             spec: .finishingAnotherTrip,
-            tripId: "selected",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -106,10 +109,11 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "Stop Name" }
+        let trip = objects.trip { _ in }
 
         let sut = TripHeaderCard(
             spec: .noVehicle,
-            tripId: "selected",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -123,16 +127,16 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .stoppedAt
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
             vehicle.stopId = stop.id
         }
         let targeted = TripHeaderCard(
             spec: .vehicle(vehicle, stop, nil, false),
-
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: nil,
@@ -145,8 +149,7 @@ final class TripHeaderCardTests: XCTestCase {
 
         let notTargeted = TripHeaderCard(
             spec: .vehicle(vehicle, stop, nil, false),
-
-            tripId: "",
+            trip: trip,
             targetId: "",
             routeAccents: .init(),
             onTap: nil,
@@ -162,10 +165,11 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .stoppedAt
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
             vehicle.stopId = stop.id
             vehicle.currentStopSequence = 0
         }
@@ -180,12 +184,11 @@ final class TripHeaderCardTests: XCTestCase {
                 disruption: nil,
                 schedule: nil,
                 prediction: prediction,
-                predictionStop: nil,
                 vehicle: vehicle,
                 routes: [],
                 elevatorAlerts: []
             ), true),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: nil,
@@ -208,10 +211,11 @@ final class TripHeaderCardTests: XCTestCase {
             platformStop.vehicleType = .commuterRail
             platformStop.parentStationId = stop.id
         }
+        let trip = objects.trip { _ in }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .stoppedAt
-            vehicle.tripId = ""
+            vehicle.tripId = trip.id
             vehicle.stopId = stop.id
             vehicle.currentStopSequence = 0
         }
@@ -233,7 +237,7 @@ final class TripHeaderCardTests: XCTestCase {
                 routes: [],
                 elevatorAlerts: []
             ), true),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(route: route),
             onTap: nil,
@@ -247,6 +251,7 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "Stop Name" }
+        let trip = objects.trip { _ in }
 
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5 * 60).toKotlinInstant()
@@ -259,12 +264,11 @@ final class TripHeaderCardTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule,
                 prediction: nil,
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [],
                 elevatorAlerts: []
             )),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: nil,
@@ -283,6 +287,7 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
 
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5 * 60).toKotlinInstant()
@@ -297,12 +302,11 @@ final class TripHeaderCardTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule,
                 prediction: nil,
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [],
                 elevatorAlerts: []
             )),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: { tapExpectation.fulfill() },
@@ -320,10 +324,11 @@ final class TripHeaderCardTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "stop" }
+        let trip = objects.trip { _ in }
 
         let withTap = TripHeaderCard(
             spec: .finishingAnotherTrip,
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: {},
@@ -336,7 +341,7 @@ final class TripHeaderCardTests: XCTestCase {
 
         let withoutTap = TripHeaderCard(
             spec: .finishingAnotherTrip,
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: nil,
@@ -349,11 +354,12 @@ final class TripHeaderCardTests: XCTestCase {
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.currentStatus = .incomingAt
+            vehicle.tripId = trip.id
         }
 
         let withVehicleAtStop = TripHeaderCard(
             spec: .vehicle(vehicle, stop, nil, false),
-            tripId: "", targetId: stop.id,
+            trip: trip, targetId: stop.id,
             routeAccents: .init(type: .bus),
             onTap: {},
             now: now
@@ -367,7 +373,7 @@ final class TripHeaderCardTests: XCTestCase {
         }
         let withVehicleAtOtherStop = TripHeaderCard(
             spec: .vehicle(vehicle, otherStop, nil, false),
-            tripId: "", targetId: stop.id,
+            trip: trip, targetId: stop.id,
             routeAccents: .init(type: .bus),
             onTap: {},
             now: now
@@ -386,12 +392,11 @@ final class TripHeaderCardTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule,
                 prediction: nil,
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [],
                 elevatorAlerts: []
             )),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: {},
@@ -408,12 +413,11 @@ final class TripHeaderCardTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule,
                 prediction: nil,
-                predictionStop: nil,
                 vehicle: nil,
                 routes: [],
                 elevatorAlerts: []
             )),
-            tripId: "",
+            trip: trip,
             targetId: stop.id,
             routeAccents: .init(),
             onTap: {},
@@ -425,6 +429,7 @@ final class TripHeaderCardTests: XCTestCase {
 
         let boardingVehicle = objects.vehicle { boardingVehicle in
             boardingVehicle.currentStatus = .stoppedAt
+            boardingVehicle.tripId = trip.id
         }
         let coreCRStop = objects.stop { stop in
             stop.name = "North Station"
@@ -443,7 +448,7 @@ final class TripHeaderCardTests: XCTestCase {
                     prediction.stopId = platformStop.id
                 }, predictionStop: platformStop, vehicle: boardingVehicle, routes: [], elevatorAlerts: []
             ), false),
-            tripId: "", targetId: coreCRStop.id,
+            trip: trip, targetId: coreCRStop.id,
             routeAccents: .init(type: .commuterRail),
             onTap: {},
             now: now

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -21,6 +21,7 @@ final class TripStopRowTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -32,9 +33,10 @@ final class TripStopRowTests: XCTestCase {
         let sut = TripStopRow(
             stop: .init(
                 stop: stop, stopSequence: 0, disruption: nil,
-                schedule: schedule, prediction: prediction, predictionStop: nil,
+                schedule: schedule, prediction: prediction,
                 vehicle: nil, routes: [route], elevatorAlerts: []
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -49,6 +51,7 @@ final class TripStopRowTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -60,9 +63,10 @@ final class TripStopRowTests: XCTestCase {
         let sut = TripStopRow(
             stop: .init(
                 stop: stop, stopSequence: 0, disruption: nil,
-                schedule: schedule, prediction: prediction, predictionStop: nil,
+                schedule: schedule, prediction: prediction,
                 vehicle: nil, routes: [route], elevatorAlerts: []
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -82,6 +86,7 @@ final class TripStopRowTests: XCTestCase {
             platformStop.vehicleType = .commuterRail
             platformStop.parentStationId = stop.id
         }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -97,6 +102,7 @@ final class TripStopRowTests: XCTestCase {
                 schedule: schedule, prediction: prediction, predictionStop: platformStop,
                 vehicle: nil, routes: [route], elevatorAlerts: []
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -112,6 +118,7 @@ final class TripStopRowTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -123,9 +130,10 @@ final class TripStopRowTests: XCTestCase {
         let targeted = TripStopRow(
             stop: .init(
                 stop: stop, stopSequence: 0, disruption: nil,
-                schedule: schedule, prediction: prediction, predictionStop: nil,
+                schedule: schedule, prediction: prediction,
                 vehicle: nil, routes: [route], elevatorAlerts: []
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -141,9 +149,10 @@ final class TripStopRowTests: XCTestCase {
         let notTargeted = TripStopRow(
             stop: .init(
                 stop: stop, stopSequence: 0, disruption: nil,
-                schedule: schedule, prediction: prediction, predictionStop: nil,
+                schedule: schedule, prediction: prediction,
                 vehicle: nil, routes: [route], elevatorAlerts: []
             ),
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -160,6 +169,7 @@ final class TripStopRowTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { stop in stop.name = "stop" }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -170,12 +180,13 @@ final class TripStopRowTests: XCTestCase {
 
         let stopEntry = TripDetailsStopList.Entry(
             stop: stop, stopSequence: 0, disruption: nil,
-            schedule: schedule, prediction: prediction, predictionStop: nil,
+            schedule: schedule, prediction: prediction,
             vehicle: nil, routes: [route], elevatorAlerts: []
         )
 
         let basicRow = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -186,6 +197,7 @@ final class TripStopRowTests: XCTestCase {
 
         let selectedRow = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -197,6 +209,7 @@ final class TripStopRowTests: XCTestCase {
 
         let firstRow = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -208,6 +221,7 @@ final class TripStopRowTests: XCTestCase {
 
         let selectedFirstRow = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -228,6 +242,7 @@ final class TripStopRowTests: XCTestCase {
             stop.name = "stop"
             stop.wheelchairBoarding = .inaccessible
         }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -238,12 +253,13 @@ final class TripStopRowTests: XCTestCase {
 
         let stopEntry = TripDetailsStopList.Entry(
             stop: stop, stopSequence: 0, disruption: nil,
-            schedule: schedule, prediction: prediction, predictionStop: nil,
+            schedule: schedule, prediction: prediction,
             vehicle: nil, routes: [route], elevatorAlerts: []
         )
 
         let row = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -262,6 +278,7 @@ final class TripStopRowTests: XCTestCase {
             stop.name = "stop"
             stop.wheelchairBoarding = .accessible
         }
+        let trip = objects.trip { _ in }
         let schedule = objects.schedule { schedule in
             schedule.departureTime = now.addingTimeInterval(5).toKotlinInstant()
         }
@@ -272,7 +289,7 @@ final class TripStopRowTests: XCTestCase {
 
         let stopEntry = TripDetailsStopList.Entry(
             stop: stop, stopSequence: 0, disruption: nil,
-            schedule: schedule, prediction: prediction, predictionStop: nil,
+            schedule: schedule, prediction: prediction,
             vehicle: nil, routes: [route], elevatorAlerts: [objects.alert {
                 $0.activePeriod(
                     start: Date.now.addingTimeInterval(-20 * 60).toKotlinInstant(),
@@ -283,6 +300,7 @@ final class TripStopRowTests: XCTestCase {
 
         let row = TripStopRow(
             stop: stopEntry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },
@@ -298,6 +316,7 @@ final class TripStopRowTests: XCTestCase {
         let now = Date.now
         let objects = ObjectCollectionBuilder()
         let stop = objects.stop { _ in }
+        let trip = objects.trip { _ in }
         let route = objects.route { _ in }
         let alert = objects.alert { $0.effect = .shuttle }
         let summary = AlertSummary(
@@ -313,13 +332,13 @@ final class TripStopRowTests: XCTestCase {
             disruption: .init(alert: alert, mapStopRoute: .orange),
             schedule: nil,
             prediction: nil,
-            predictionStop: nil,
             vehicle: nil,
             routes: []
         )
 
         let sut = TripStopRow(
             stop: entry,
+            trip: trip,
             now: now.toKotlinInstant(),
             onTapLink: { _ in },
             onOpenAlertDetails: { _ in },

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -65,30 +65,30 @@ final class TripStopsTests: XCTestCase {
         let schedule5 = makeSchedule(stop: stop5)
         let prediction5 = makePrediction(schedule: schedule5)
 
-        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+        let stops = TripDetailsStopList(trip: trip, stops: [
             .init(
                 stop: stop1, stopSequence: 1, disruption: nil,
-                schedule: schedule1, prediction: prediction1, predictionStop: nil,
+                schedule: schedule1, prediction: prediction1,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop2, stopSequence: 2, disruption: nil,
-                schedule: schedule2, prediction: prediction2, predictionStop: nil,
+                schedule: schedule2, prediction: prediction2,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop3Target, stopSequence: 3, disruption: nil,
-                schedule: schedule3, prediction: prediction3, predictionStop: nil,
+                schedule: schedule3, prediction: prediction3,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop4, stopSequence: 4, disruption: nil,
-                schedule: schedule4, prediction: prediction4, predictionStop: nil,
+                schedule: schedule4, prediction: prediction4,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop5, stopSequence: 5, disruption: nil,
-                schedule: schedule5, prediction: prediction5, predictionStop: nil,
+                schedule: schedule5, prediction: prediction5,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
         ])
@@ -158,20 +158,20 @@ final class TripStopsTests: XCTestCase {
         let schedule3 = makeSchedule(stop: stop3)
         let prediction3 = makePrediction(schedule: schedule3)
 
-        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+        let stops = TripDetailsStopList(trip: trip, stops: [
             .init(
                 stop: stop1, stopSequence: 1, disruption: nil,
-                schedule: schedule1, prediction: prediction1, predictionStop: nil,
+                schedule: schedule1, prediction: prediction1,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop2, stopSequence: 2, disruption: nil,
-                schedule: schedule2, prediction: prediction2, predictionStop: nil,
+                schedule: schedule2, prediction: prediction2,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
             .init(
                 stop: stop3, stopSequence: 3, disruption: nil,
-                schedule: schedule3, prediction: prediction3, predictionStop: nil,
+                schedule: schedule3, prediction: prediction3,
                 vehicle: vehicle, routes: [route], elevatorAlerts: []
             ),
         ])
@@ -239,16 +239,16 @@ final class TripStopsTests: XCTestCase {
 
         let firstStop: TripDetailsStopList.Entry = .init(
             stop: stop1, stopSequence: 1, disruption: nil,
-            schedule: schedule1, prediction: prediction1, predictionStop: nil,
+            schedule: schedule1, prediction: prediction1,
             vehicle: vehicle, routes: [route], elevatorAlerts: []
         )
         let stops = TripDetailsStopList(
-            tripId: trip.id,
+            trip: trip,
             stops: [
                 firstStop,
                 .init(
                     stop: stop2, stopSequence: 2, disruption: nil,
-                    schedule: schedule2, prediction: prediction2, predictionStop: nil,
+                    schedule: schedule2, prediction: prediction2,
                     vehicle: vehicle, routes: [route], elevatorAlerts: []
                 ),
             ],
@@ -319,21 +319,21 @@ final class TripStopsTests: XCTestCase {
 
         let firstStop: TripDetailsStopList.Entry = .init(
             stop: stop1, stopSequence: 1, disruption: nil,
-            schedule: schedule1, prediction: prediction1, predictionStop: nil,
+            schedule: schedule1, prediction: prediction1,
             vehicle: vehicle, routes: [route], elevatorAlerts: []
         )
         let stops = TripDetailsStopList(
-            tripId: trip.id,
+            trip: trip,
             stops: [
                 firstStop,
                 .init(
                     stop: stop2, stopSequence: 2, disruption: nil,
-                    schedule: schedule2, prediction: prediction2, predictionStop: nil,
+                    schedule: schedule2, prediction: prediction2,
                     vehicle: vehicle, routes: [route], elevatorAlerts: []
                 ),
                 .init(
                     stop: stop3, stopSequence: 3, disruption: nil,
-                    schedule: schedule3, prediction: prediction3, predictionStop: nil,
+                    schedule: schedule3, prediction: prediction3,
                     vehicle: vehicle, routes: [route], elevatorAlerts: []
                 ),
             ],
@@ -405,14 +405,13 @@ final class TripStopsTests: XCTestCase {
         let schedule3 = makeSchedule(stop: stop3)
         let prediction3 = makePrediction(schedule: schedule3)
 
-        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+        let stops = TripDetailsStopList(trip: trip, stops: [
             .init(
                 stop: stop1,
                 stopSequence: 1,
                 disruption: nil,
                 schedule: schedule1,
                 prediction: prediction1,
-                predictionStop: stop1,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -422,7 +421,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule2,
                 prediction: prediction2,
-                predictionStop: stop2Target,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -432,7 +430,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: .init(alert: alert, mapStopRoute: nil),
                 schedule: schedule3,
                 prediction: prediction3,
-                predictionStop: stop3,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -504,14 +501,13 @@ final class TripStopsTests: XCTestCase {
         let schedule3 = makeSchedule(stop: stop3)
         let prediction3 = makePrediction(schedule: schedule3)
 
-        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+        let stops = TripDetailsStopList(trip: trip, stops: [
             .init(
                 stop: stop1,
                 stopSequence: 1,
                 disruption: nil,
                 schedule: schedule1,
                 prediction: prediction1,
-                predictionStop: stop1,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -521,7 +517,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule2,
                 prediction: prediction2,
-                predictionStop: stop2Target,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -531,7 +526,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: .init(alert: alert, mapStopRoute: nil),
                 schedule: schedule3,
                 prediction: prediction3,
-                predictionStop: stop3,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -603,14 +597,13 @@ final class TripStopsTests: XCTestCase {
         let schedule3 = makeSchedule(stop: stop3)
         let prediction3 = makePrediction(schedule: schedule3)
 
-        let stops = TripDetailsStopList(tripId: trip.id, stops: [
+        let stops = TripDetailsStopList(trip: trip, stops: [
             .init(
                 stop: stop1,
                 stopSequence: 1,
                 disruption: .init(alert: alert, mapStopRoute: nil),
                 schedule: schedule1,
                 prediction: prediction1,
-                predictionStop: stop1,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -620,7 +613,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule2,
                 prediction: prediction2,
-                predictionStop: stop2Target,
                 vehicle: vehicle,
                 routes: [route]
             ),
@@ -630,7 +622,6 @@ final class TripStopsTests: XCTestCase {
                 disruption: nil,
                 schedule: schedule3,
                 prediction: prediction3,
-                predictionStop: stop3,
                 vehicle: vehicle,
                 routes: [route]
             ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -103,6 +103,7 @@ object LoadingPlaceholders {
 
     data class TripDetailsInfo(
         val stops: TripDetailsStopList,
+        val trip: Trip,
         val vehicle: Vehicle,
         val vehicleStop: Stop,
         val route: Route,
@@ -136,7 +137,7 @@ object LoadingPlaceholders {
             }
         return TripDetailsInfo(
             TripDetailsStopList(
-                trip.id,
+                trip,
                 (1..8).map { sequence ->
                     val stop = objects.stop { name = "Loading" }
                     val prediction =
@@ -152,12 +153,12 @@ object LoadingPlaceholders {
                         disruption = null,
                         schedule = null,
                         prediction,
-                        predictionStop = null,
-                        vehicle,
-                        listOf(otherRoute),
+                        vehicle = vehicle,
+                        routes = listOf(otherRoute),
                     )
                 },
             ),
+            trip,
             vehicle,
             vehicleStop,
             route,


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: display arrival time at shuttle boundary if possible to exit](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210239404411208?focus=true)

Whatever approach we wind up taking will involve refining the logic of how we decide whether to use the disruption or the formatted time, so it’ll be helpful to have one home for that logic rather than two.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
