### PR TITLE
fix: try to show time if exit not blocked by downstream alert

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -131,7 +131,7 @@ class TripDetailsViewTest {
 
         objects.alert {
             cause = Alert.Cause.Parade
-            effect = Alert.Effect.Shuttle
+            effect = Alert.Effect.StopClosure
             activePeriod(now.minus(5.minutes), now.plus(30.minutes))
             informedEntity(
                 activities =
@@ -182,6 +182,6 @@ class TripDetailsViewTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(downstreamStop.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Shuttle Bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop Closed").assertIsDisplayed()
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -37,7 +37,18 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
 
         fun format(trip: Trip, now: Instant, routeType: RouteType): UpcomingFormat? {
             if (disruption != null) {
-                return disruption
+                // ignore activities on platforms since they may be wrong or they may be correct in
+                // a way that doesn’t match how service is being run
+                if (isTruncating) {
+                    // if the alert represents a truncation of service, either this is the first
+                    // stop of the alert and we want to show its arrival time or this is a later
+                    // stop in the alert and it was discarded in splitForTarget so this was never
+                    // called
+                } else {
+                    // if the alert does not represent a truncation of service (e.g. stop closure),
+                    // we do want to replace the time with the alert
+                    return disruption
+                }
             }
 
             return UpcomingFormat.Some(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -35,6 +35,11 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
 
         fun activeElevatorAlerts(now: Instant) = elevatorAlerts.filter { it.isActive(now) }
 
+        /**
+         * Gets the time to display for this entry, or an alert to be displayed instead.
+         *
+         * @return [disruption], an [UpcomingFormat.Some] with a single entry, or null
+         */
         fun format(trip: Trip, now: Instant, routeType: RouteType): UpcomingFormat? {
             if (disruption != null) {
                 // ignore activities on platforms since they may be wrong or they may be correct in


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: display arrival time at shuttle boundary if possible to exit](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210239404411208?focus=true)

Easy after #986.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the disruption no longer displays instead of predictions for the current Orange Line shuttle.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
