### PR TITLE
fix: filter alerts by trip in filtered stop details

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -60,7 +60,7 @@ fun Departures(
                     stopData.lineOrRoute.id,
                     stopData.stop.id,
                     pinned,
-                    leaf.alertsHere.isNotEmpty(),
+                    leaf.alertsHere().isNotEmpty(),
                     stopData.lineOrRoute.type,
                     noTrips,
                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -80,11 +80,13 @@ fun StopDetailsFilteredDeparturesView(
     val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
 
     val (elevatorAlerts, alertsHere) =
-        leaf.alertsHere.partition { it.effect == Alert.Effect.ElevatorClosure }
+        leaf.alertsHere(tripId = tripFilter?.tripId).partition {
+            it.effect == Alert.Effect.ElevatorClosure
+        }
     val hasAccessibilityWarning = (elevatorAlerts.isNotEmpty() || !stop.isWheelchairAccessible)
     val pinned = pinnedRoutes.contains(lineOrRoute.id)
 
-    val downstreamAlerts: List<Alert> = leaf.alertsDownstream
+    val downstreamAlerts: List<Alert> = leaf.alertsDownstream(tripId = tripFilter?.tripId)
 
     val selectedTripIsCancelled =
         if (tripFilter != null)

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
@@ -67,7 +67,7 @@ struct RouteCardDepartures: View {
             routeId: stopData.lineOrRoute.id,
             stopId: stopData.stop.id,
             pinned: pinned,
-            alert: leaf.alertsHere.count > 0,
+            alert: leaf.alertsHere(tripId: nil).count > 0,
             routeType: stopData.lineOrRoute.type,
             noTrips: noTrips
         )

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -42,9 +42,12 @@ struct StopDetailsFilteredDepartureDetails: View {
     var isAllServiceDisrupted: Bool { leafFormat.isAllServiceDisrupted }
 
     var patternsHere: [RoutePattern] { leaf.routePatterns }
-    var alerts: [Shared.Alert] { leaf.alertsHere.filter { $0.effect != .elevatorClosure } }
-    var elevatorAlerts: [Shared.Alert] { leaf.alertsHere.filter { $0.effect == .elevatorClosure } }
-    var downstreamAlerts: [Shared.Alert] { leaf.alertsDownstream }
+    var alerts: [Shared.Alert] { leaf.alertsHere(tripId: tripFilter?.tripId).filter { $0.effect != .elevatorClosure } }
+    var elevatorAlerts: [Shared.Alert] {
+        leaf.alertsHere(tripId: tripFilter?.tripId).filter { $0.effect == .elevatorClosure }
+    }
+
+    var downstreamAlerts: [Shared.Alert] { leaf.alertsDownstream(tripId: tripFilter?.tripId) }
 
     var stop: Stop? { stopDetailsVM.global?.getStop(stopId: stopId) }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -97,7 +97,7 @@ data class RouteCardData(
         val elevatorAlerts: List<Alert>
             get() =
                 data
-                    .flatMap { it.alertsHere }
+                    .flatMap { it.alertsHere() }
                     .filter { alert -> alert.effect == Alert.Effect.ElevatorClosure }
                     .distinct()
 
@@ -112,10 +112,10 @@ data class RouteCardData(
         val routePatterns: List<RoutePattern>,
         val stopIds: Set<String>,
         val upcomingTrips: List<UpcomingTrip>,
-        val alertsHere: List<Alert>,
+        private val alertsHere: List<Alert>,
         val allDataLoaded: Boolean,
         val hasSchedulesTodayByPattern: Map<String, Boolean>,
-        val alertsDownstream: List<Alert>,
+        private val alertsDownstream: List<Alert>,
         val context: Context,
     ) {
 
@@ -166,6 +166,16 @@ data class RouteCardData(
                 it.significance < AlertSignificance.Major &&
                     it.significance >= AlertSignificance.Secondary
             } ?: alertsDownstream.firstOrNull()
+
+        fun alertsHere(tripId: String? = null) =
+            alertsHere.filter { alert ->
+                (tripId == null || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+            }
+
+        fun alertsDownstream(tripId: String? = null) =
+            alertsDownstream.filter { alert ->
+                (tripId == null || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+            }
 
         private data class PotentialService(val routeId: String, val headsign: String)
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -2161,4 +2161,50 @@ class RouteCardDataLeafTest {
                     .format(now, GreenLine.global),
             )
         }
+
+    @Test
+    fun `filters alerts by trip`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+        val stop = objects.stop()
+        val trip1 = objects.trip()
+        val trip2 = objects.trip()
+        val trip3 = objects.trip()
+        val generalAlert =
+            objects.alert { informedEntity(listOf(Alert.InformedEntity.Activity.Board)) }
+        val trip1Alert =
+            objects.alert {
+                informedEntity(listOf(Alert.InformedEntity.Activity.Board), trip = trip1.id)
+            }
+        val trip2Alert =
+            objects.alert {
+                informedEntity(listOf(Alert.InformedEntity.Activity.Board), trip = trip2.id)
+            }
+        val leaf =
+            RouteCardData.Leaf(
+                RouteCardData.LineOrRoute.Route(route),
+                stop,
+                directionId = 0,
+                routePatterns = emptyList(),
+                stopIds = emptySet(),
+                upcomingTrips = listOf(),
+                alertsHere = listOf(generalAlert, trip1Alert, trip2Alert),
+                hasSchedulesToday = true,
+                allDataLoaded = true,
+                alertsDownstream = listOf(generalAlert, trip1Alert, trip2Alert),
+                context = RouteCardData.Context.StopDetailsFiltered,
+            )
+
+        assertEquals(listOf(generalAlert, trip1Alert, trip2Alert), leaf.alertsHere(tripId = null))
+        assertEquals(listOf(generalAlert, trip1Alert), leaf.alertsHere(tripId = trip1.id))
+        assertEquals(listOf(generalAlert, trip2Alert), leaf.alertsHere(tripId = trip2.id))
+        assertEquals(listOf(generalAlert), leaf.alertsHere(tripId = trip3.id))
+        assertEquals(
+            listOf(generalAlert, trip1Alert, trip2Alert),
+            leaf.alertsDownstream(tripId = null),
+        )
+        assertEquals(listOf(generalAlert, trip1Alert), leaf.alertsDownstream(tripId = trip1.id))
+        assertEquals(listOf(generalAlert, trip2Alert), leaf.alertsDownstream(tripId = trip2.id))
+        assertEquals(listOf(generalAlert), leaf.alertsDownstream(tripId = trip3.id))
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: (Commuter Rail) delay alerts aren't filtered by trip](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210239404411192?focus=true)

I guess we just forgot to keep doing this in group by direction.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that even if the alerts from the QA were all still active, only the one that applies to the selected trip would actually appear. Added a unit test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
