### PR TITLE
chore(Android): Move VM init out of composables

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -221,6 +221,13 @@ class MapAndSheetPageTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testMapAndSheetPageDisplaysCorrectly() {
+        val searchResultsVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
+
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 CompositionLocalProvider(
@@ -245,12 +252,7 @@ class MapAndSheetPageTest : KoinTest {
                         false,
                         {},
                         {},
-                        searchResultsViewModel =
-                            SearchResultsViewModel(
-                                MockAnalytics(),
-                                MockSearchResultRepository(),
-                                VisitHistoryUsecase(MockVisitHistoryRepository()),
-                            ),
+                        searchResultsViewModel = searchResultsVM,
                         bottomBar = {},
                     )
                 }
@@ -341,6 +343,12 @@ class MapAndSheetPageTest : KoinTest {
         }
 
         val mockMapVM = MockMapVM()
+        val searchResultsVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
@@ -366,12 +374,7 @@ class MapAndSheetPageTest : KoinTest {
                         false,
                         {},
                         {},
-                        searchResultsViewModel =
-                            SearchResultsViewModel(
-                                MockAnalytics(),
-                                MockSearchResultRepository(),
-                                VisitHistoryUsecase(MockVisitHistoryRepository()),
-                            ),
+                        searchResultsViewModel = searchResultsVM,
                         bottomBar = {},
                         mapViewModel = mockMapVM,
                     )
@@ -389,6 +392,13 @@ class MapAndSheetPageTest : KoinTest {
 
     @Test
     fun testHidesMap() {
+        val searchResultsVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
+
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 CompositionLocalProvider(
@@ -413,12 +423,7 @@ class MapAndSheetPageTest : KoinTest {
                         false,
                         {},
                         {},
-                        searchResultsViewModel =
-                            SearchResultsViewModel(
-                                MockAnalytics(),
-                                MockSearchResultRepository(),
-                                VisitHistoryUsecase(MockVisitHistoryRepository()),
-                            ),
+                        searchResultsViewModel = searchResultsVM,
                         bottomBar = {},
                     )
                 }
@@ -447,6 +452,12 @@ class MapAndSheetPageTest : KoinTest {
         locationDataManager.hasPermission = true
 
         val koinApplication = testKoinApplication(builder, clock = mockClock)
+        val searchResultsVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
@@ -473,12 +484,7 @@ class MapAndSheetPageTest : KoinTest {
                         false,
                         {},
                         {},
-                        searchResultsViewModel =
-                            SearchResultsViewModel(
-                                MockAnalytics(),
-                                MockSearchResultRepository(),
-                                VisitHistoryUsecase(MockVisitHistoryRepository()),
-                            ),
+                        searchResultsViewModel = searchResultsVM,
                         bottomBar = {},
                     )
                 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewTest.kt
@@ -170,6 +170,7 @@ class MapAndSheetViewTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testNearbyTransitViewDisplaysCorrectly() {
+        val errorBannerVM = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 NearbyTransitView(
@@ -180,8 +181,7 @@ class MapAndSheetViewTest : KoinTest {
                     setSelectingLocation = {},
                     onOpenStopDetails = { _, _ -> },
                     noNearbyStopsView = {},
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerVM,
                 )
             }
         }
@@ -202,6 +202,7 @@ class MapAndSheetViewTest : KoinTest {
     @Test
     fun testNearbyTransitViewNoNearbyStops() {
         val emptyNearbyKoinApplication = testKoinApplication()
+        val errorBannerVM = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(emptyNearbyKoinApplication.koin) {
                 NearbyTransitView(
@@ -212,8 +213,7 @@ class MapAndSheetViewTest : KoinTest {
                     setSelectingLocation = {},
                     onOpenStopDetails = { _, _ -> },
                     noNearbyStopsView = { Text("This would be the no nearby stops view") },
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerVM,
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -16,13 +16,13 @@ import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
-import org.koin.compose.koinInject
 
 class RouteStopListViewTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -60,6 +60,7 @@ class RouteStopListViewTest {
             testKoinApplication(objects) {
                 routeStops = MockRouteStopsRepository(listOf(stop1.id, stop2.id, stop3.id))
             }
+        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -68,7 +69,7 @@ class RouteStopListViewTest {
                     GlobalResponse(objects),
                     onClick = clicks::add,
                     onClose = { closed = true },
-                    errorBannerViewModel = ErrorBannerViewModel(errorRepository = koinInject()),
+                    errorBannerViewModel = errorBannerVM,
                     rightSideContent = { entry, _ ->
                         Text("rightSideContent for ${entry.stop.name}")
                     },
@@ -141,6 +142,7 @@ class RouteStopListViewTest {
                         onGet = { routeId, _ -> lastSelectedRoute = routeId },
                     )
             }
+        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -149,7 +151,7 @@ class RouteStopListViewTest {
                     GlobalResponse(objects),
                     onClick = {},
                     onClose = {},
-                    errorBannerViewModel = ErrorBannerViewModel(errorRepository = koinInject()),
+                    errorBannerViewModel = errorBannerVM,
                     defaultSelectedRouteId = route2.id,
                     rightSideContent = { _, _ -> },
                 )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -50,15 +50,12 @@ class SubscribeToPredictionsTest {
         var stopIds = mutableStateOf(listOf("place-a"))
         var predictions: PredictionsStreamDataResponse? =
             PredictionsStreamDataResponse(ObjectCollectionBuilder())
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }
             val predictionsVM =
-                subscribeToPredictions(
-                    stopIds,
-                    predictionsRepo,
-                    ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
-                )
+                subscribeToPredictions(stopIds, predictionsRepo, errorBannerViewModel)
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
@@ -96,16 +93,13 @@ class SubscribeToPredictionsTest {
         var stopIds = mutableStateOf(listOf("place-a"))
         var predictions: PredictionsStreamDataResponse? =
             PredictionsStreamDataResponse(ObjectCollectionBuilder())
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 var stopIds by remember { stopIds }
                 val predictionsVM =
-                    subscribeToPredictions(
-                        stopIds,
-                        predictionsRepo,
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
-                    )
+                    subscribeToPredictions(stopIds, predictionsRepo, errorBannerViewModel)
                 predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
             }
         }
@@ -138,14 +132,11 @@ class SubscribeToPredictionsTest {
             )
 
         var predictions: PredictionsStreamDataResponse? = null
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             val predictionsVM =
-                subscribeToPredictions(
-                    emptyList(),
-                    predictionsRepo,
-                    ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
-                )
+                subscribeToPredictions(emptyList(), predictionsRepo, errorBannerViewModel)
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
@@ -170,15 +161,11 @@ class SubscribeToPredictionsTest {
             MockErrorBannerStateRepository(
                 onCheckPredictionsStale = { checkPredictionsStaleCount += 1 }
             )
+        val errorBannerViewModel = ErrorBannerViewModel(false, mockErrorRepo)
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }
-            subscribeToPredictions(
-                stopIds,
-                predictionsRepo,
-                ErrorBannerViewModel(false, mockErrorRepo),
-                1.seconds,
-            )
+            subscribeToPredictions(stopIds, predictionsRepo, errorBannerViewModel, 1.seconds)
         }
 
         composeTestRule.waitUntil(timeoutMillis = 3000) { checkPredictionsStaleCount >= 2 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -30,10 +30,11 @@ class StopDetailsPageTest : KoinTest {
         val filters = mutableStateOf(StopDetailsPageFilters("stop", null, null))
 
         var routeCardDataUpdated = false
+        val errorBannerVM = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
+
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 var filters by remember { filters }
-                val errorBannerVM = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
 
                 StopDetailsPage(
                     viewModel = viewModel,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -140,6 +140,7 @@ class StopDetailsViewTest {
             )
         )
 
+        val errorBannerVM = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
@@ -155,8 +156,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerVM,
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -207,6 +207,8 @@ class StopDetailsViewTest {
                 )
             )
         )
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
+
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember {
@@ -224,8 +226,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerViewModel,
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -281,6 +282,8 @@ class StopDetailsViewTest {
                 )
             )
         )
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
+
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
@@ -296,8 +299,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerViewModel,
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -347,6 +349,7 @@ class StopDetailsViewTest {
                 )
             )
         )
+        val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember {
@@ -364,8 +367,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel =
-                        ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                    errorBannerViewModel = errorBannerViewModel,
                     openModal = {},
                     openSheetRoute = {},
                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -166,14 +166,41 @@ private fun RefreshButton(
 @Preview
 @Composable
 private fun ErrorBannerPreviews() {
+    val vm = previewVMs()
+    LaunchedEffect(null) { vm.networkErrorVM.activate() }
+    LaunchedEffect(null) { vm.dataErrorVM.activate() }
+    LaunchedEffect(null) { vm.dataErrorDebugVM.activate() }
+    LaunchedEffect(null) { vm.staleVM.activate() }
+    LaunchedEffect(null) { vm.staleLoadingVM.activate() }
+    MyApplicationTheme {
+        Column(
+            modifier =
+                Modifier.background(MaterialTheme.colorScheme.background).padding(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            ErrorBanner(vm.networkErrorVM)
+            ErrorBanner(vm.dataErrorVM)
+            ErrorBanner(vm.dataErrorDebugVM)
+            ErrorBanner(vm.staleVM)
+            ErrorBanner(vm.staleLoadingVM)
+        }
+    }
+}
+
+data class PreviewVMs(
+    val networkErrorVM: ErrorBannerViewModel,
+    val dataErrorVM: ErrorBannerViewModel,
+    val dataErrorDebugVM: ErrorBannerViewModel,
+    val staleVM: ErrorBannerViewModel,
+    val staleLoadingVM: ErrorBannerViewModel,
+)
+
+fun previewVMs(): PreviewVMs {
     val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-    val networkErrorVM = ErrorBannerViewModel(false, networkErrorRepo)
     val dataErrorRepo =
         MockErrorBannerStateRepository(
             state = ErrorBannerState.DataError(messages = setOf("foo"), action = {})
         )
-    val dataErrorVM = ErrorBannerViewModel(false, dataErrorRepo)
-    val dataErrorDebugVM = ErrorBannerViewModel(false, dataErrorRepo)
     val staleRepo =
         MockErrorBannerStateRepository(
             state =
@@ -182,24 +209,11 @@ private fun ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val staleVM = ErrorBannerViewModel(false, staleRepo)
-    val staleLoadingVM = ErrorBannerViewModel(true, staleRepo)
-    LaunchedEffect(null) { networkErrorVM.activate() }
-    LaunchedEffect(null) { dataErrorVM.activate() }
-    LaunchedEffect(null) { dataErrorDebugVM.activate() }
-    LaunchedEffect(null) { staleVM.activate() }
-    LaunchedEffect(null) { staleLoadingVM.activate() }
-    MyApplicationTheme {
-        Column(
-            modifier =
-                Modifier.background(MaterialTheme.colorScheme.background).padding(vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            ErrorBanner(networkErrorVM)
-            ErrorBanner(dataErrorVM)
-            ErrorBanner(dataErrorDebugVM)
-            ErrorBanner(staleVM)
-            ErrorBanner(staleLoadingVM)
-        }
-    }
+    return PreviewVMs(
+        ErrorBannerViewModel(false, networkErrorRepo),
+        ErrorBannerViewModel(false, dataErrorRepo),
+        ErrorBannerViewModel(false, dataErrorRepo),
+        ErrorBannerViewModel(false, staleRepo),
+        ErrorBannerViewModel(true, staleRepo),
+    )
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -46,7 +47,8 @@ import com.mbta.tid.mbta_app.model.getAllDependencies
 fun MorePage(bottomBar: @Composable () -> Unit) {
 
     val navController = rememberNavController()
-    val viewModel = MoreViewModel(LocalContext.current, { navController.navigate("licenses") })
+    val context = LocalContext.current
+    val viewModel = viewModel { MoreViewModel(context) { navController.navigate("licenses") } }
 
     val sections by viewModel.sections.collectAsState()
     val dependencies = Dependency.getAllDependencies()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.ModalRoutes
@@ -269,6 +270,7 @@ private fun StopDetailsRoutesViewPreview() {
         )
 
     val koin = koinApplication { modules(module { single<Analytics> { MockAnalytics() } }) }
+    val errorBannerVM = viewModel { ErrorBannerViewModel(false, MockErrorBannerStateRepository()) }
 
     MyApplicationTheme {
         KoinContext(koin.koin) {
@@ -276,7 +278,7 @@ private fun StopDetailsRoutesViewPreview() {
                 stop,
                 routeCardData,
                 listOf(PillFilter.ByRoute(route1, null), PillFilter.ByRoute(route2, null)),
-                ErrorBannerViewModel(false, MockErrorBannerStateRepository()),
+                errorBannerVM,
                 showStationAccessibility = true,
                 now = now,
                 globalData,


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, follow up to #973 (which this is merging into)

The `androidx.lifecycle:lifecycle-runtime-testing` 2.9.0 upgrade seems to include some updated Android linting which marks VMs instantiated inside a composable as an error. This moves all cases where this was happening (mostly in tests and previews) outside of the composable (or wrapped in a `viewModel`).

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Tests pass