### PR TITLE
fix(iOS): route line alignment

### DIFF
--- a/iosApp/iosApp/ComponentViews/HaloSeparator.swift
+++ b/iosApp/iosApp/ComponentViews/HaloSeparator.swift
@@ -9,7 +9,9 @@
 import SwiftUI
 
 struct HaloSeparator: View {
+    var height: CGFloat = 1
+
     var body: some View {
-        Color.halo.frame(height: 1)
+        Color.halo.frame(height: height)
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -50,7 +50,6 @@ struct TripHeaderCard: View {
         .background(Color.fill3)
         .foregroundStyle(Color.text)
         .clipShape(RoundedRectangle(cornerRadius: 8))
-        .padding(1)
         .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
         .padding([.horizontal], 6)
         .fixedSize(horizontal: false, vertical: true)

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -52,11 +52,17 @@ struct TripStopRow: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            stopRow.background(background).overlay {
-                if targeted {
-                    Rectangle().inset(by: -1).stroke(Color.halo, lineWidth: 2)
+            stopRow
+                .background(background?.padding(.horizontal, 2))
+                .overlay {
+                    if targeted {
+                        VStack {
+                            HaloSeparator(height: 2)
+                            Spacer()
+                            HaloSeparator(height: 2)
+                        }
+                    }
                 }
-            }
             if let disruption {
                 ZStack(alignment: .leading) {
                     VStack(spacing: 0) {

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -133,6 +133,7 @@ struct TripStops: View {
                                         ColoredRouteLine(routeAccents.color).padding(.leading, 42)
                                     }
                                 }
+                                .padding(.horizontal, 6)
                                 stopList(list: collapsedStops)
                             }
                         },


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS | Fix filtered stop details route line alignment](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210100739160856?focus=true)

Fixes route line alignment and targeted stop being too big
![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 17 07 10](https://github.com/user-attachments/assets/606952dd-5f18-4fa3-8d4d-1e4d0bde49e8)
![Simulator Screenshot - iPhone 16 Pro - 2025-05-15 at 17 07 00](https://github.com/user-attachments/assets/3658a6d1-03be-4b80-8da3-d67d76204f4b)

### Testing

Manual