### PR TITLE
fix: Only use typical patterns to determine direction toggle destinations

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -702,7 +702,9 @@ data class RouteCardData(
                                             lineOrRoute.directions(
                                                 globalData,
                                                 stop,
-                                                patternsForStop.allPatterns,
+                                                patternsForStop.allPatterns.filter {
+                                                    it.isTypical()
+                                                },
                                             )
                                         stop.id to
                                             RouteStopDataBuilder(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -549,7 +549,10 @@ class RouteCardDataTest {
 
             val railPattern =
                 objects.routePattern(railRoute) {
-                    representativeTrip { headsign = "Boston College" }
+                    representativeTrip {
+                        headsign = "Boston College"
+                        typicality = RoutePattern.Typicality.Typical
+                    }
                 }
             val shuttlePattern =
                 objects.routePattern(shuttleRoute) {
@@ -667,11 +670,22 @@ class RouteCardDataTest {
                 directionDestinations = listOf("Riverside", "Union Sq")
             }
 
-        val bWestPattern = objects.routePattern(bRoute) {}
-        val bEastPattern = objects.routePattern(bRoute) { directionId = 1 }
-        val cWestPattern = objects.routePattern(cRoute) {}
-        val cEastPattern = objects.routePattern(cRoute) { directionId = 1 }
-        val dWestPattern = objects.routePattern(dRoute) {}
+        val bWestPattern =
+            objects.routePattern(bRoute) { typicality = RoutePattern.Typicality.Typical }
+        val bEastPattern =
+            objects.routePattern(bRoute) {
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val cWestPattern =
+            objects.routePattern(cRoute) { typicality = RoutePattern.Typicality.Typical }
+        val cEastPattern =
+            objects.routePattern(cRoute) {
+                directionId = 1
+                typicality = RoutePattern.Typicality.Typical
+            }
+        val dWestPattern =
+            objects.routePattern(dRoute) { typicality = RoutePattern.Typicality.Typical }
 
         val global =
             GlobalResponse(


### PR DESCRIPTION
### Summary

_Ticket:_ [Group by Direction | GL direction labels not always working](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210318010176378?focus=true)

Destination labels in the direction toggle were blank on the trunk past Gov Ctr. This was happening because the atypical GL B and C patterns were included in the list sent to `Direction.getDirectionsForLine`, and would resolve to their branch destinations rather to the grouped destinations, and since they didn't match the grouped destination, none of them would be shown.

### Testing

Checked that all branches and trunk stops on the GL show expected destinations, updated existing tests