### PR TITLE
feat: set up deep linking

### DIFF
--- a/androidApp/src/devOrange/AndroidManifest.xml
+++ b/androidApp/src/devOrange/AndroidManifest.xml
@@ -2,5 +2,28 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <application
         android:label="MBTA Go Dev Orange"
-        tools:replace="android:label" />
+        tools:replace="android:label">
+        <activity android:name=".MainActivity" tools:node="merge">
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="dev-green.mbtace.com" />
+                <data android:pathPrefix="/go" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="dev-blue.mbtace.com" />
+                <data android:pathPrefix="/go" />
+            </intent-filter>
+        </activity>
+    </application>
 </manifest>

--- a/androidApp/src/devOrange/AndroidManifest.xml
+++ b/androidApp/src/devOrange/AndroidManifest.xml
@@ -11,28 +11,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="dev-green.mbtace.com" />
-                <data android:pathPrefix="/go" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" />
-                <data android:host="dev-blue.mbtace.com" />
-                <data android:pathPrefix="/go" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" />
                 <data android:host="mobile-app-backend-dev-orange.mbtace.com" />
-                <data android:pathPrefix="/go" />
             </intent-filter>
         </activity>
     </application>

--- a/androidApp/src/devOrange/AndroidManifest.xml
+++ b/androidApp/src/devOrange/AndroidManifest.xml
@@ -32,6 +32,7 @@
 
                 <data android:scheme="https" />
                 <data android:host="mobile-app-backend-dev-orange.mbtace.com" />
+                <data android:pathPrefix="/go" />
             </intent-filter>
         </activity>
     </application>

--- a/androidApp/src/devOrange/AndroidManifest.xml
+++ b/androidApp/src/devOrange/AndroidManifest.xml
@@ -24,6 +24,15 @@
                 <data android:host="dev-blue.mbtace.com" />
                 <data android:pathPrefix="/go" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="mobile-app-backend-dev-orange.mbtace.com" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/androidApp/src/devOrange/AndroidManifest.xml
+++ b/androidApp/src/devOrange/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <application
         android:label="MBTA Go Dev Orange"
         tools:replace="android:label">
-        <activity android:name=".MainActivity" tools:node="merge">
+        <activity android:name=".MainActivity" android:exported="true" tools:node="merge">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -53,6 +53,7 @@ class MainActivity : ComponentActivity() {
         val deepLinkUri = intent.data?.takeIf { intent.action == Intent.ACTION_VIEW }
         when {
             deepLinkUri?.path == "/go" -> {}
+            deepLinkUri?.path == "/" -> {}
             deepLinkUri != null -> {
                 Log.w("MainActivity", "Unhandled deep link URI $deepLinkUri")
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -52,7 +52,6 @@ class MainActivity : ComponentActivity() {
 
         val deepLinkUri = intent.data?.takeIf { intent.action == Intent.ACTION_VIEW }
         when {
-            deepLinkUri?.path == "/go" -> {}
             deepLinkUri?.path == "/" -> {}
             deepLinkUri != null -> {
                 Log.w("MainActivity", "Unhandled deep link URI $deepLinkUri")

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android
 
+import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
@@ -48,6 +49,15 @@ class MainActivity : ComponentActivity() {
                     )
                 },
         )
+
+        val deepLinkUri = intent.data?.takeIf { intent.action == Intent.ACTION_VIEW }
+        when {
+            deepLinkUri?.path == "/go" -> {}
+            deepLinkUri != null -> {
+                Log.w("MainActivity", "Unhandled deep link URI $deepLinkUri")
+            }
+            else -> {}
+        }
 
         setContent {
             MyApplicationTheme {

--- a/androidApp/src/prod/AndroidManifest.xml
+++ b/androidApp/src/prod/AndroidManifest.xml
@@ -9,26 +9,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="mbta.com" />
-                <data android:pathPrefix="/go" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" />
-                <data android:host="www.mbta.com" />
-                <data android:pathPrefix="/go" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" />
                 <data android:host="mobile-app-backend.mbtace.com" />
             </intent-filter>
         </activity>

--- a/androidApp/src/prod/AndroidManifest.xml
+++ b/androidApp/src/prod/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
     <application tools:node="merge">
-        <activity android:name=".MainActivity" tools:node="merge">
+        <activity android:name=".MainActivity" android:exported="true" tools:node="merge">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/androidApp/src/prod/AndroidManifest.xml
+++ b/androidApp/src/prod/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
-    <application
-        android:label="MBTA Go Staging"
-        tools:replace="android:label">
+    <application tools:node="merge">
         <activity android:name=".MainActivity" tools:node="merge">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -11,7 +9,17 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="dev.mbtace.com" />
+                <data android:host="mbta.com" />
+                <data android:pathPrefix="/go" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="www.mbta.com" />
                 <data android:pathPrefix="/go" />
             </intent-filter>
         </activity>

--- a/androidApp/src/prod/AndroidManifest.xml
+++ b/androidApp/src/prod/AndroidManifest.xml
@@ -22,6 +22,15 @@
                 <data android:host="www.mbta.com" />
                 <data android:pathPrefix="/go" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="mobile-app-backend.mbtace.com" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/androidApp/src/staging/AndroidManifest.xml
+++ b/androidApp/src/staging/AndroidManifest.xml
@@ -14,6 +14,15 @@
                 <data android:host="dev.mbtace.com" />
                 <data android:pathPrefix="/go" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="mobile-app-backend-staging.mbtace.com" />
+            </intent-filter>
         </activity>
     </application>
 </manifest>

--- a/androidApp/src/staging/AndroidManifest.xml
+++ b/androidApp/src/staging/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <application
         android:label="MBTA Go Staging"
         tools:replace="android:label">
-        <activity android:name=".MainActivity" tools:node="merge">
+        <activity android:name=".MainActivity" android:exported="true" tools:node="merge">
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 

--- a/androidApp/src/staging/AndroidManifest.xml
+++ b/androidApp/src/staging/AndroidManifest.xml
@@ -11,16 +11,6 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="dev.mbtace.com" />
-                <data android:pathPrefix="/go" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="https" />
                 <data android:host="mobile-app-backend-staging.mbtace.com" />
             </intent-filter>
         </activity>

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             return false
         }
 
-        if components.path == "/go" || components.path == "/" {
+        if components.path == "/" {
             // just opening app, let default route happen
             return true
         } else {

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -31,7 +31,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             return false
         }
 
-        if components.path == "/go" {
+        if components.path == "/go" || components.path == "/" {
             // just opening app, let default route happen
             return true
         } else {

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -17,11 +17,34 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         FirebaseApp.configure()
         return true
     }
+
+    /// from https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app
+    func application(
+        _: UIApplication,
+        continue userActivity: NSUserActivity,
+        restorationHandler _: @escaping ([any UIUserActivityRestoring]?) -> Void
+    ) -> Bool {
+        // Get URL components from the incoming user activity.
+        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+              let incomingURL = userActivity.webpageURL,
+              let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+            return false
+        }
+
+        if components.path == "/go" {
+            // just opening app, let default route happen
+            return true
+        } else {
+            // unhandled path
+            debugPrint("Unhandled deep link URI", components)
+            return false
+        }
+    }
 }
 
 @main
 struct IOSApp: App {
-    // register app delegate for Firebase setup
+    // register app delegate for Firebase setup and deep linking
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
 
     // When running unit tests or previews, don't mount the entire app which makes real API requests.

--- a/iosApp/iosApp/iosApp-dev-orange.entitlements
+++ b/iosApp/iosApp/iosApp-dev-orange.entitlements
@@ -5,8 +5,6 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:mobile-app-backend-dev-orange.mbtace.com</string>
-		<string>applinks:dev-blue.mbtace.com</string>
-		<string>applinks:dev-green.mbtace.com</string>
 	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/iosApp-dev-orange.entitlements
+++ b/iosApp/iosApp/iosApp-dev-orange.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:dev-blue.mbtace.com</string>
+		<string>applinks:dev-green.mbtace.com</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/iosApp/iosApp-dev-orange.entitlements
+++ b/iosApp/iosApp/iosApp-dev-orange.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:mobile-app-backend-dev-orange.mbtace.com</string>
 		<string>applinks:dev-blue.mbtace.com</string>
 		<string>applinks:dev-green.mbtace.com</string>
 	</array>

--- a/iosApp/iosApp/iosApp-prod.entitlements
+++ b/iosApp/iosApp/iosApp-prod.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:mbta.com</string>
+		<string>applinks:www.mbta.com</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/iosApp/iosApp-prod.entitlements
+++ b/iosApp/iosApp/iosApp-prod.entitlements
@@ -6,6 +6,7 @@
 	<array>
 		<string>applinks:mbta.com</string>
 		<string>applinks:www.mbta.com</string>
+		<string>applinks:mobile-app-backend.mbtace.com</string>
 	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/iosApp-prod.entitlements
+++ b/iosApp/iosApp/iosApp-prod.entitlements
@@ -4,8 +4,6 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:mbta.com</string>
-		<string>applinks:www.mbta.com</string>
 		<string>applinks:mobile-app-backend.mbtace.com</string>
 	</array>
 </dict>

--- a/iosApp/iosApp/iosApp-staging.entitlements
+++ b/iosApp/iosApp/iosApp-staging.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:dev.mbtace.com</string>
+		<string>applinks:mobile-app-backend-staging.mbtace.com</string>
 	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/iosApp-staging.entitlements
+++ b/iosApp/iosApp/iosApp-staging.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:dev.mbtace.com</string>
+	</array>
+</dict>
+</plist>

--- a/iosApp/iosApp/iosApp-staging.entitlements
+++ b/iosApp/iosApp/iosApp-staging.entitlements
@@ -4,7 +4,6 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:dev.mbtace.com</string>
 		<string>applinks:mobile-app-backend-staging.mbtace.com</string>
 	</array>
 </dict>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -133,13 +133,16 @@ targets:
         DevOrange:
           ASSETCATALOG_COMPILER_APPICON_NAME: AppIconDevOrange
           BUNDLE_NAME: MBTA Go Dev Orange
+          CODE_SIGN_ENTITLEMENTS: iosApp/iosApp-dev-orange.entitlements
           PRODUCT_BUNDLE_IDENTIFIER: com.mbta.tid.mbtaapp.devorange
         Staging:
           ASSETCATALOG_COMPILER_APPICON_NAME: AppIconStaging
           BUNDLE_NAME: MBTA Go Staging
+          CODE_SIGN_ENTITLEMENTS: iosApp/iosApp-staging.entitlements
           PRODUCT_BUNDLE_IDENTIFIER: com.mbta.tid.mbtaapp.staging
         Prod:
           BUNDLE_NAME: MBTA Go
+          CODE_SIGN_ENTITLEMENTS: iosApp/iosApp-prod.entitlements
           PRODUCT_BUNDLE_IDENTIFIER: com.mbta.tid.mbtaapp
     postBuildScripts:
       - name: Configure Build Variables


### PR DESCRIPTION
### Summary

_Ticket:_ [Create link that opens the app if you have it installed and the store otherwise](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209949928014406?focus=true)

Sets up `/` as a deep link to open the app with no particular route.

Should work in the backend environments that https://github.com/mbta/mobile_app_backend/pull/318 is running in.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the iOS and Android versions should open when linked to from dotcom.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
