### PR TITLE
feat(DepartureTile): Wrap long headsigns

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
@@ -61,7 +63,8 @@ fun DepartureTile(
                 onClick = onTap,
             )
             .heightIn(min = 56.dp)
-            .widthIn(max = 195.dp)
+            .width(IntrinsicSize.Max)
+            .sizeIn(maxWidth = 195.dp)
             .fillMaxHeight()
             .haloContainer(
                 borderWidth = 2.dp,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -2,15 +2,16 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -59,7 +60,7 @@ fun DepartureTile(
                 onClick = onTap,
             )
             .heightIn(min = 56.dp)
-            .width(IntrinsicSize.Max)
+            .widthIn(max = 195.dp)
             .haloContainer(
                 borderWidth = 2.dp,
                 outlineColor = if (isSelected) colorResource(R.color.halo) else Color.Transparent,
@@ -118,7 +119,13 @@ private fun DepartureTilePreview() {
     val trip3 = objects.trip()
 
     MyApplicationTheme {
-        Row(Modifier.background(Color.fromHex("00843D")).padding(16.dp)) {
+        Row(
+            Modifier.background(Color.fromHex("00843D"))
+                .padding(16.dp)
+                .horizontalScroll(rememberScrollState())
+                .padding(horizontal = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
             DepartureTile(
                 TileData(
                     route1,
@@ -165,7 +172,7 @@ private fun DepartureTilePreview() {
             DepartureTile(
                 TileData(
                     routeB,
-                    "Government Center",
+                    "Really long headsign that should be broken onto multiple lines",
                     UpcomingFormat.Some(
                         listOf(
                             UpcomingFormat.Some.FormattedTrip(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
@@ -61,6 +62,7 @@ fun DepartureTile(
             )
             .heightIn(min = 56.dp)
             .widthIn(max = 195.dp)
+            .fillMaxHeight()
             .haloContainer(
                 borderWidth = 2.dp,
                 outlineColor = if (isSelected) colorResource(R.color.halo) else Color.Transparent,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
@@ -290,7 +292,9 @@ private fun DepartureTiles(
 ) {
     val coroutineScope = rememberCoroutineScope()
     Row(
-        Modifier.horizontalScroll(scrollState).padding(horizontal = 10.dp),
+        Modifier.horizontalScroll(scrollState)
+            .padding(horizontal = 10.dp)
+            .height(IntrinsicSize.Max),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         for (tileData in tiles) {

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -20,16 +20,44 @@ struct DepartureTile: View {
         case onPrediction(route: Route)
     }
 
+    // Store the size that the tile should be for text to wrap properly.
+    // In order for wrapped text not to get cut off in the horizontal ScrollView, we need to set the fixed width
+    // rather than just using `maxWidth` (see https://stackoverflow.com/a/75331082)
+    // Calculating the size based on an approach taken in
+    // https://nilcoalescing.com/blog/AdaptiveLayoutsWithViewThatFits/#expandable-text-with-line-limit
+    // the ideal width is measured on the background in the initial render, then used on subsequent renders.
+    @State var computedMultilineSize: CGSize? = nil
+
     var body: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
                 if let headsign = data.headsign {
-                    Text(headsign)
-                        .font(Typography.footnoteSemibold)
-                        .multilineTextAlignment(.leading)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .border(Color.red, width: 1)
+                    if let computedMultilineSize {
+                        Text(headsign)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .frame(width: computedMultilineSize.width)
+                            .font(Typography.footnoteSemibold)
+                            .multilineTextAlignment(.leading)
+                    } else {
+                        Text(headsign)
+                            .lineLimit(1)
+                            .frame(maxWidth: 195)
+                            .font(Typography.footnoteSemibold)
+                            .multilineTextAlignment(.leading)
+                            .background {
+                                Text(headsign).fixedSize(horizontal: false, vertical: true)
+                                    .font(Typography.footnoteSemibold)
+                                    .background(
+                                        GeometryReader { geo in
+                                            Color.clear.onAppear {
+                                                computedMultilineSize = geo.size
+                                            }
+                                        }
+                                    ).hidden()
+                            }
+                    }
                 }
+
                 HStack(spacing: 0) {
                     if case let .onPrediction(route) = pillDecoration {
                         RoutePill(route: route, type: .flex)
@@ -37,14 +65,11 @@ struct DepartureTile: View {
                     }
                     TripStatus(predictions: data.formatted)
                 }
-            }.frame(maxHeight: .infinity)
-                .border(Color.orange, width: 1)
+            }
         }
-        .frame(maxHeight: .infinity)
-        .frame(maxWidth: 195, minHeight: 56, maxHeight: .infinity)
-        .padding(.vertical, 10)
         .padding(.horizontal, 10)
-        .border(Color.cyan, width: 1)
+        .padding(.vertical, 10)
+        .frame(maxWidth: 195, minHeight: 56, maxHeight: .infinity)
         .background(isSelected ? Color.fill3 : Color.deselectedToggle2.opacity(0.6))
         .foregroundStyle(isSelected ? Color.text : Color.deselectedToggleText)
         .clipShape(.rect(cornerRadius: 8))

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -27,6 +27,8 @@ struct DepartureTile: View {
                     Text(headsign)
                         .font(Typography.footnoteSemibold)
                         .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .border(Color.red, width: 1)
                 }
                 HStack(spacing: 0) {
                     if case let .onPrediction(route) = pillDecoration {
@@ -35,11 +37,14 @@ struct DepartureTile: View {
                     }
                     TripStatus(predictions: data.formatted)
                 }
-            }
+            }.frame(maxHeight: .infinity)
+                .border(Color.orange, width: 1)
         }
-        .padding(.horizontal, 10)
+        .frame(maxHeight: .infinity)
+        .frame(maxWidth: 195, minHeight: 56, maxHeight: .infinity)
         .padding(.vertical, 10)
-        .frame(minHeight: 56)
+        .padding(.horizontal, 10)
+        .border(Color.cyan, width: 1)
         .background(isSelected ? Color.fill3 : Color.deselectedToggle2.opacity(0.6))
         .foregroundStyle(isSelected ? Color.text : Color.deselectedToggleText)
         .clipShape(.rect(cornerRadius: 8))

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -119,45 +119,46 @@ struct StopDetailsFilteredDepartureDetails: View {
                         .onChange(of: tripFilter) { filter in if let filter { view.scrollTo(filter.tripId) } }
                 }
             }
-            alertCards
+            /*
+             alertCards
 
-            if isAllServiceDisrupted {
-                EmptyView()
-            } else if let noPredictionsStatus {
-                StopDetailsNoTripCard(
-                    status: noPredictionsStatus,
-                    accentColor: routeColor,
-                    routeType: routeType,
-                    hideMaps: stopDetailsVM.hideMaps
-                )
-                .accessibilityHeading(.h3)
-                .accessibilityFocused($selectedDepartureFocus, equals: cardFocusId)
-            } else if selectedTripIsCancelled {
-                StopDetailsIconCard(
-                    accentColor: routeColor,
-                    details: Text(
-                        "This trip has been cancelled. We’re sorry for the inconvenience.",
-                        comment: "Explanation for a cancelled trip on stop details"
-                    ),
-                    header: Text(
-                        "Trip cancelled",
-                        comment: "Header for a cancelled trip card on stop details"
-                    ),
-                    icon: routeSlashIcon(routeType)
-                )
-                .accessibilityHeading(.h4)
-            } else {
-                TripDetailsView(
-                    tripFilter: tripFilter,
-                    stopId: stopId,
-                    now: now,
-                    errorBannerVM: errorBannerVM,
-                    nearbyVM: nearbyVM,
-                    mapVM: mapVM,
-                    stopDetailsVM: stopDetailsVM,
-                    onOpenAlertDetails: { alert in getAlertDetailsHandler(alert.id, spec: .downstream)() }
-                )
-            }
+             if isAllServiceDisrupted {
+                 EmptyView()
+             } else if let noPredictionsStatus {
+                 StopDetailsNoTripCard(
+                     status: noPredictionsStatus,
+                     accentColor: routeColor,
+                     routeType: routeType,
+                     hideMaps: stopDetailsVM.hideMaps
+                 )
+                 .accessibilityHeading(.h3)
+                 .accessibilityFocused($selectedDepartureFocus, equals: cardFocusId)
+             } else if selectedTripIsCancelled {
+                 StopDetailsIconCard(
+                     accentColor: routeColor,
+                     details: Text(
+                         "This trip has been cancelled. We’re sorry for the inconvenience.",
+                         comment: "Explanation for a cancelled trip on stop details"
+                     ),
+                     header: Text(
+                         "Trip cancelled",
+                         comment: "Header for a cancelled trip card on stop details"
+                     ),
+                     icon: routeSlashIcon(routeType)
+                 )
+                 .accessibilityHeading(.h4)
+             } else {
+                 TripDetailsView(
+                     tripFilter: tripFilter,
+                     stopId: stopId,
+                     now: now,
+                     errorBannerVM: errorBannerVM,
+                     nearbyVM: nearbyVM,
+                     mapVM: mapVM,
+                     stopDetailsVM: stopDetailsVM,
+                     onOpenAlertDetails: { alert in getAlertDetailsHandler(alert.id, spec: .downstream)() }
+                 )
+             }*/
         }
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
@@ -217,45 +218,57 @@ struct StopDetailsFilteredDepartureDetails: View {
         }
     }
 
+    @State var scrollViewHeight: CGFloat = .zero
+
+    struct TileText: Identifiable, Equatable {
+        let id: Int
+        let text: String
+    }
+
     @ViewBuilder
-    func departureTiles(_ view: ScrollViewProxy) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: 0) {
-                ForEach(tiles, id: \.id) { tileData in
-                    DepartureTile(
-                        data: tileData,
-                        onTap: {
-                            nearbyVM.navigationStack.lastTripDetailsFilter = .init(
-                                tripId: tileData.upcoming.trip.id,
-                                vehicleId: tileData.upcoming.prediction?.vehicleId,
-                                stopSequence: tileData.upcoming.stopSequence,
-                                selectionLock: false
-                            )
-                            analytics.tappedDeparture(
-                                routeId: leaf.lineOrRoute.id,
-                                stopId: leaf.stop.id,
-                                pinned: pinned,
-                                alert: alerts.count > 0,
-                                routeType: leaf.lineOrRoute.type,
-                                noTrips: nil
-                            )
-                            view.scrollTo(tileData.id)
-                        },
-                        pillDecoration: pillDecoration(tileData: tileData),
-                        isSelected: tileData.isSelected(tripFilter: tripFilter)
-                    ).frame(maxHeight: .infinity)
-                        .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
-                        .padding(.horizontal, 4)
-                }
+    func departureTiles(_: ScrollViewProxy) -> some View {
+        HScrollableContent(
+            [TileText(id: 1, text: "THIS TEXT IS REALLY LONG AND SHOULD SCROLL PLS WORK"),
+             TileText(id: 2, text: "short txt")],
+            buildView: { tileText, _ in
+                Text(tileText.text)
+                    .frame(maxWidth: 195)
+                    .lineLimit(5)
             }
+        )
 
-            .padding(.horizontal, 12)
-            .padding(.vertical, 1)
-            .frame(maxHeight: .infinity)
-            .border(Color.green, width: 1)
+        /*  ForEach(tiles, id: \.id) { _ in
 
-        }.fixedSize(horizontal: false, vertical: true)
-            .border(Color.blue, width: 1)
+             /** DepartureTile(
+              data: tileData,
+              onTap: {
+              nearbyVM.navigationStack.lastTripDetailsFilter = .init(
+              tripId: tileData.upcoming.trip.id,
+              vehicleId: tileData.upcoming.prediction?.vehicleId,
+              stopSequence: tileData.upcoming.stopSequence,
+              selectionLock: false
+              )
+              analytics.tappedDeparture(
+              routeId: leaf.lineOrRoute.id,
+              stopId: leaf.stop.id,
+              pinned: pinned,
+              alert: alerts.count > 0,
+              routeType: leaf.lineOrRoute.type,
+              noTrips: nil
+              )
+              view.scrollTo(tileData.id)
+              },
+              pillDecoration: pillDecoration(tileData: tileData),
+              isSelected: tileData.isSelected(tripFilter: tripFilter)
+              ).frame(maxHeight: .infinity)
+              .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
+              .padding(.horizontal, 4)
+              */
+         }*/
+
+        .padding(.horizontal, 12)
+        .padding(.vertical, 1)
+        .border(Color.green, width: 1)
     }
 
     private func setAlertSummaries(_ alertSummaryParams: AlertSummaryParams) {
@@ -365,6 +378,104 @@ struct StopDetailsFilteredDepartureDetails: View {
                     }
                 }
             }.padding(.horizontal, 16)
+        }
+    }
+}
+
+struct SizePreferenceKey: PreferenceKey {
+    static var defaultValue: CGSize = .zero
+    static func reduce(value _: inout CGSize, nextValue _: () -> CGSize) {}
+}
+
+// https://medium.com/@santhoshudaya95/building-a-custom-horizontal-scrollable-view-in-swiftui-hscrollablecontent-6ac27afb396a
+
+struct HScrollableContent<Content, T>: View where Content: View, T: Identifiable, T: Equatable {
+    @Namespace private var contentAnimationNameSpace
+    @Binding var selectionValue: Int
+    private let buildView: (T, Int) -> Content
+    private let spacing: CGFloat
+    private let containerSpace: CGFloat
+    private let showsIndicators: Bool
+    private let scrollToCenter: Bool
+    private let shouldLoadViewLazy: Bool
+    private let contents: [T]
+    private let alignment: VerticalAlignment
+    private let scrollDisabled: Bool
+    @State var scrollViewHeight: CGFloat = .zero
+
+    init(
+        _ contents: [T],
+        selection: Binding<Int> = .constant(0),
+        spacing: CGFloat = .zero,
+        containerSpace: CGFloat = .zero,
+        alignment: VerticalAlignment = .top,
+        showsIndicators: Bool = false,
+        scrollToCenter: Bool = false,
+        shouldLoadViewLazy: Bool = true,
+        scrollDisabled: Bool = false,
+        @ViewBuilder buildView: @escaping (T, Int) -> Content
+    ) {
+        self.contents = contents
+        self.spacing = spacing
+        self.containerSpace = containerSpace
+        self.alignment = alignment
+        self.showsIndicators = showsIndicators
+        self.scrollToCenter = scrollToCenter
+        self.shouldLoadViewLazy = shouldLoadViewLazy
+        _selectionValue = selection
+        self.scrollDisabled = scrollDisabled
+        self.buildView = buildView
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: showsIndicators) {
+                LazyHStack(alignment: alignment, spacing: spacing) {
+                    buildContent(contents: contents)
+                }
+                .padding(.horizontal, containerSpace)
+                .onChange(of: selectionValue) { _ in
+                    if scrollToCenter {
+                        withAnimation {
+                            proxy.scrollTo(contents[selectionValue].id, anchor: .center)
+                        }
+                    }
+                }
+            }
+            .frame(height: scrollViewHeight != .zero ? scrollViewHeight : nil)
+            .scrollDisabled(scrollDisabled)
+        }
+    }
+
+    @ViewBuilder
+    func buildContent(contents: [T]) -> some View {
+        ForEach(Array(contents.enumerated()), id: \.element.id) { index, content in
+            buildView(content, index)
+                .id(content.id)
+                .fixedSize()
+                .onAppear {
+                    if contents.count - 1 == index {}
+                }
+                .background(
+                    GeometryReader { geometry in
+                        Color.clear
+                            .preference(key: SizePreferenceKey.self, value: geometry.size)
+                    }
+                )
+                .onPreferenceChange(SizePreferenceKey.self) { height in
+                    if height.height > scrollViewHeight {
+                        scrollViewHeight = height.height
+                    }
+                }
+        }
+        paginationLoader()
+    }
+
+    @ViewBuilder
+    private func paginationLoader() -> some View {
+        VStack {
+            Spacer()
+            Spacer()
         }
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -119,46 +119,45 @@ struct StopDetailsFilteredDepartureDetails: View {
                         .onChange(of: tripFilter) { filter in if let filter { view.scrollTo(filter.tripId) } }
                 }
             }
-            /*
-             alertCards
+            alertCards
 
-             if isAllServiceDisrupted {
-                 EmptyView()
-             } else if let noPredictionsStatus {
-                 StopDetailsNoTripCard(
-                     status: noPredictionsStatus,
-                     accentColor: routeColor,
-                     routeType: routeType,
-                     hideMaps: stopDetailsVM.hideMaps
-                 )
-                 .accessibilityHeading(.h3)
-                 .accessibilityFocused($selectedDepartureFocus, equals: cardFocusId)
-             } else if selectedTripIsCancelled {
-                 StopDetailsIconCard(
-                     accentColor: routeColor,
-                     details: Text(
-                         "This trip has been cancelled. We’re sorry for the inconvenience.",
-                         comment: "Explanation for a cancelled trip on stop details"
-                     ),
-                     header: Text(
-                         "Trip cancelled",
-                         comment: "Header for a cancelled trip card on stop details"
-                     ),
-                     icon: routeSlashIcon(routeType)
-                 )
-                 .accessibilityHeading(.h4)
-             } else {
-                 TripDetailsView(
-                     tripFilter: tripFilter,
-                     stopId: stopId,
-                     now: now,
-                     errorBannerVM: errorBannerVM,
-                     nearbyVM: nearbyVM,
-                     mapVM: mapVM,
-                     stopDetailsVM: stopDetailsVM,
-                     onOpenAlertDetails: { alert in getAlertDetailsHandler(alert.id, spec: .downstream)() }
-                 )
-             }*/
+            if isAllServiceDisrupted {
+                EmptyView()
+            } else if let noPredictionsStatus {
+                StopDetailsNoTripCard(
+                    status: noPredictionsStatus,
+                    accentColor: routeColor,
+                    routeType: routeType,
+                    hideMaps: stopDetailsVM.hideMaps
+                )
+                .accessibilityHeading(.h3)
+                .accessibilityFocused($selectedDepartureFocus, equals: cardFocusId)
+            } else if selectedTripIsCancelled {
+                StopDetailsIconCard(
+                    accentColor: routeColor,
+                    details: Text(
+                        "This trip has been cancelled. We’re sorry for the inconvenience.",
+                        comment: "Explanation for a cancelled trip on stop details"
+                    ),
+                    header: Text(
+                        "Trip cancelled",
+                        comment: "Header for a cancelled trip card on stop details"
+                    ),
+                    icon: routeSlashIcon(routeType)
+                )
+                .accessibilityHeading(.h4)
+            } else {
+                TripDetailsView(
+                    tripFilter: tripFilter,
+                    stopId: stopId,
+                    now: now,
+                    errorBannerVM: errorBannerVM,
+                    nearbyVM: nearbyVM,
+                    mapVM: mapVM,
+                    stopDetailsVM: stopDetailsVM,
+                    onOpenAlertDetails: { alert in getAlertDetailsHandler(alert.id, spec: .downstream)() }
+                )
+            }
         }
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
@@ -218,57 +217,42 @@ struct StopDetailsFilteredDepartureDetails: View {
         }
     }
 
-    @State var scrollViewHeight: CGFloat = .zero
-
-    struct TileText: Identifiable, Equatable {
-        let id: Int
-        let text: String
-    }
-
     @ViewBuilder
-    func departureTiles(_: ScrollViewProxy) -> some View {
-        HScrollableContent(
-            [TileText(id: 1, text: "THIS TEXT IS REALLY LONG AND SHOULD SCROLL PLS WORK"),
-             TileText(id: 2, text: "short txt")],
-            buildView: { tileText, _ in
-                Text(tileText.text)
-                    .frame(maxWidth: 195)
-                    .lineLimit(5)
+    func departureTiles(_ view: ScrollViewProxy) -> some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .top, spacing: 0) {
+                ForEach(tiles, id: \.id) { tileData in
+                    DepartureTile(
+                        data: tileData,
+                        onTap: {
+                            nearbyVM.navigationStack.lastTripDetailsFilter = .init(
+                                tripId: tileData.upcoming.trip.id,
+                                vehicleId: tileData.upcoming.prediction?.vehicleId,
+                                stopSequence: tileData.upcoming.stopSequence,
+                                selectionLock: false
+                            )
+                            analytics.tappedDeparture(
+                                routeId: leaf.lineOrRoute.id,
+                                stopId: leaf.stop.id,
+                                pinned: pinned,
+                                alert: alerts.count > 0,
+                                routeType: leaf.lineOrRoute.type,
+                                noTrips: nil
+                            )
+                            view.scrollTo(tileData.id)
+                        },
+                        pillDecoration: pillDecoration(tileData: tileData),
+                        isSelected: tileData.isSelected(tripFilter: tripFilter)
+                    )
+                    .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
+                    .padding(.horizontal, 4)
+                }
             }
-        )
 
-        /*  ForEach(tiles, id: \.id) { _ in
-
-             /** DepartureTile(
-              data: tileData,
-              onTap: {
-              nearbyVM.navigationStack.lastTripDetailsFilter = .init(
-              tripId: tileData.upcoming.trip.id,
-              vehicleId: tileData.upcoming.prediction?.vehicleId,
-              stopSequence: tileData.upcoming.stopSequence,
-              selectionLock: false
-              )
-              analytics.tappedDeparture(
-              routeId: leaf.lineOrRoute.id,
-              stopId: leaf.stop.id,
-              pinned: pinned,
-              alert: alerts.count > 0,
-              routeType: leaf.lineOrRoute.type,
-              noTrips: nil
-              )
-              view.scrollTo(tileData.id)
-              },
-              pillDecoration: pillDecoration(tileData: tileData),
-              isSelected: tileData.isSelected(tripFilter: tripFilter)
-              ).frame(maxHeight: .infinity)
-              .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
-              .padding(.horizontal, 4)
-              */
-         }*/
-
-        .padding(.horizontal, 12)
-        .padding(.vertical, 1)
-        .border(Color.green, width: 1)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 1)
+            .fixedSize(horizontal: false, vertical: true)
+        }
     }
 
     private func setAlertSummaries(_ alertSummaryParams: AlertSummaryParams) {
@@ -378,104 +362,6 @@ struct StopDetailsFilteredDepartureDetails: View {
                     }
                 }
             }.padding(.horizontal, 16)
-        }
-    }
-}
-
-struct SizePreferenceKey: PreferenceKey {
-    static var defaultValue: CGSize = .zero
-    static func reduce(value _: inout CGSize, nextValue _: () -> CGSize) {}
-}
-
-// https://medium.com/@santhoshudaya95/building-a-custom-horizontal-scrollable-view-in-swiftui-hscrollablecontent-6ac27afb396a
-
-struct HScrollableContent<Content, T>: View where Content: View, T: Identifiable, T: Equatable {
-    @Namespace private var contentAnimationNameSpace
-    @Binding var selectionValue: Int
-    private let buildView: (T, Int) -> Content
-    private let spacing: CGFloat
-    private let containerSpace: CGFloat
-    private let showsIndicators: Bool
-    private let scrollToCenter: Bool
-    private let shouldLoadViewLazy: Bool
-    private let contents: [T]
-    private let alignment: VerticalAlignment
-    private let scrollDisabled: Bool
-    @State var scrollViewHeight: CGFloat = .zero
-
-    init(
-        _ contents: [T],
-        selection: Binding<Int> = .constant(0),
-        spacing: CGFloat = .zero,
-        containerSpace: CGFloat = .zero,
-        alignment: VerticalAlignment = .top,
-        showsIndicators: Bool = false,
-        scrollToCenter: Bool = false,
-        shouldLoadViewLazy: Bool = true,
-        scrollDisabled: Bool = false,
-        @ViewBuilder buildView: @escaping (T, Int) -> Content
-    ) {
-        self.contents = contents
-        self.spacing = spacing
-        self.containerSpace = containerSpace
-        self.alignment = alignment
-        self.showsIndicators = showsIndicators
-        self.scrollToCenter = scrollToCenter
-        self.shouldLoadViewLazy = shouldLoadViewLazy
-        _selectionValue = selection
-        self.scrollDisabled = scrollDisabled
-        self.buildView = buildView
-    }
-
-    var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: showsIndicators) {
-                LazyHStack(alignment: alignment, spacing: spacing) {
-                    buildContent(contents: contents)
-                }
-                .padding(.horizontal, containerSpace)
-                .onChange(of: selectionValue) { _ in
-                    if scrollToCenter {
-                        withAnimation {
-                            proxy.scrollTo(contents[selectionValue].id, anchor: .center)
-                        }
-                    }
-                }
-            }
-            .frame(height: scrollViewHeight != .zero ? scrollViewHeight : nil)
-            .scrollDisabled(scrollDisabled)
-        }
-    }
-
-    @ViewBuilder
-    func buildContent(contents: [T]) -> some View {
-        ForEach(Array(contents.enumerated()), id: \.element.id) { index, content in
-            buildView(content, index)
-                .id(content.id)
-                .fixedSize()
-                .onAppear {
-                    if contents.count - 1 == index {}
-                }
-                .background(
-                    GeometryReader { geometry in
-                        Color.clear
-                            .preference(key: SizePreferenceKey.self, value: geometry.size)
-                    }
-                )
-                .onPreferenceChange(SizePreferenceKey.self) { height in
-                    if height.height > scrollViewHeight {
-                        scrollViewHeight = height.height
-                    }
-                }
-        }
-        paginationLoader()
-    }
-
-    @ViewBuilder
-    private func paginationLoader() -> some View {
-        VStack {
-            Spacer()
-            Spacer()
         }
     }
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -243,16 +243,19 @@ struct StopDetailsFilteredDepartureDetails: View {
                         },
                         pillDecoration: pillDecoration(tileData: tileData),
                         isSelected: tileData.isSelected(tripFilter: tripFilter)
-                    )
-                    .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
-                    .padding(.horizontal, 4)
+                    ).frame(maxHeight: .infinity)
+                        .accessibilityFocused($selectedDepartureFocus, equals: tileData.id)
+                        .padding(.horizontal, 4)
                 }
             }
 
             .padding(.horizontal, 12)
             .padding(.vertical, 1)
-            .fixedSize(horizontal: false, vertical: true)
-        }
+            .frame(maxHeight: .infinity)
+            .border(Color.green, width: 1)
+
+        }.fixedSize(horizontal: false, vertical: true)
+            .border(Color.blue, width: 1)
     }
 
     private func setAlertSummaries(_ alertSummaryParams: AlertSummaryParams) {


### PR DESCRIPTION
### Summary

_Ticket:_ [Set max width for departure tiles](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210239404411202?focus=true)

What is this PR for?
This PR ensures that long headsigns are wrapped in departure tiles so that they are more readable and it is more obvious you can scroll. 

This was easier on android than iOS, and I don't _love_ where I landed on iOS. The use of a `ScrollView` seems to affect how the ideal height of the tile is calculated, and I had a hard time getting the text to both wrap and be visible without this workaround. Please let me know if you have any other ideas / solutions here! Some discussed in [this thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1747405439129889)

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran on iOS & android, confirmed long headsigns wrapped and short headsigns are still short.
![image](https://github.com/user-attachments/assets/d84814c4-9caf-4e95-bcf8-fa17986f90ad)
![image](https://github.com/user-attachments/assets/72444db5-1d5d-48b2-be53-f83c86caba16)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
