### PR TITLE
fix: Prevent extra trips from appearing in unfiltered stop details when navigating to filtered

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.SheetRoutes
@@ -25,7 +27,6 @@ fun StopDetailsFilteredView(
     stopId: String,
     stopFilter: StopDetailsFilter,
     tripFilter: TripDetailsFilter?,
-    routeCardData: List<RouteCardData>?,
     allAlerts: AlertsStreamDataResponse?,
     now: Instant,
     viewModel: StopDetailsViewModel,
@@ -40,6 +41,7 @@ fun StopDetailsFilteredView(
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
     val globalResponse = getGlobalData("StopDetailsView.getGlobalData")
+    val routeCardData by viewModel.routeCardData.collectAsState()
     val thisRouteCardData = routeCardData?.find { it.lineOrRoute.id == stopFilter.routeId }
     val routeStopData = thisRouteCardData?.stopData?.get(0)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.analytics.Analytics
@@ -37,8 +36,6 @@ fun StopDetailsView(
     val now by timer(updateInterval = 5.seconds)
     val analytics: Analytics = koinInject()
 
-    val routeCardData by viewModel.routeCardData.collectAsState()
-
     fun openModalAndRecord(modal: ModalRoutes) {
         openModal(modal)
         if (modal is ModalRoutes.AlertDetails) {
@@ -55,7 +52,6 @@ fun StopDetailsView(
             stopId,
             stopFilter,
             tripFilter,
-            routeCardData,
             allAlerts,
             now,
             viewModel,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Group By Direction | All trips are shown when navigating from unfiltered stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210318500071981?focus=true)

Moving the route card state into the filtered view seems to have fixed the problem, I was initially trying to do something more complicated with filtering the flow based on context, but that was causing the loading state to flicker on every filter change.

### Testing

Manually verified that extra trips no longer flash into unfiltered stop cards