### PR TITLE
ci: fix filtering for skipping platform specific tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,9 +25,9 @@ jobs:
           predicate-quantifier: 'every'
           filters: |
             android:
-              - '!iosApp'
+              - '!iosApp/**'
             ios:
-              - '!androidApp'
+              - '!androidApp/**'
     outputs:
       android: ${{ steps.changes.outputs.android == 'true' }}
       ios: ${{ steps.changes.outputs.ios == 'true' }}


### PR DESCRIPTION
### Summary

_Ticket:_ none

This piece of #993 appears to not have worked.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Can’t really be tested.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
