### PR TITLE
fix(ios.StopDetailsFilteredDepartureDetails): Preserve accessibility focus on tile

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -180,7 +180,7 @@ fun MapAndSheetPage(
     val tileScrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(previousNavEntry) {
+    LaunchedEffect(currentNavEntry) {
         if (
             previousNavEntry is SheetRoutes.StopDetails &&
                 currentNavEntry is SheetRoutes.StopDetails &&

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -150,8 +150,9 @@ fun StopDetailsFilteredDeparturesView(
     }
 
     LaunchedEffect(tripFilter) {
-        if (tripFilter != null) {
-            bringIntoViewRequesters[tripFilter.tripId]?.bringIntoView()
+        val selectedTileId = tileData.firstOrNull { it.isSelected(tripFilter) }?.id
+        if (selectedTileId != null) {
+            bringIntoViewRequesters[selectedTileId]?.bringIntoView()
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -176,7 +176,7 @@ struct StopDetailsFilteredDepartureDetails: View {
         .onChange(of: noPredictionsStatus) { status in handleViewportForStatus(status) }
         .onChange(of: selectedTripIsCancelled) { if $0 { setViewportToStop() } }
         .onChange(of: tripFilter) { tripFilter in
-            selectedDepartureFocus = tiles.first { $0.id == tripFilter?.tripId }?.id ?? cardFocusId
+            selectedDepartureFocus = tiles.first { $0.tripId == tripFilter?.tripId }?.id ?? cardFocusId
         }
         .onChange(of: leaf) { leaf in
             leafFormat = leaf.format(now: now.toKotlinInstant(), globalData: stopDetailsVM.global)
@@ -226,7 +226,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                         data: tileData,
                         onTap: {
                             nearbyVM.navigationStack.lastTripDetailsFilter = .init(
-                                tripId: tileData.upcoming.trip.id,
+                                tripId: tileData.tripId,
                                 vehicleId: tileData.upcoming.prediction?.vehicleId,
                                 stopSequence: tileData.upcoming.stopSequence,
                                 selectionLock: false

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -115,8 +115,15 @@ struct StopDetailsFilteredDepartureDetails: View {
                 if !isAllServiceDisrupted, !tiles.isEmpty {
                     departureTiles(view)
                         .dynamicTypeSize(...DynamicTypeSize.accessibility3)
-                        .onAppear { if let id = tripFilter?.tripId { view.scrollTo(id) } }
-                        .onChange(of: tripFilter) { filter in if let filter { view.scrollTo(filter.tripId) } }
+                        .onAppear { if let id = tiles.first(where: { $0.isSelected(tripFilter: tripFilter) })?.id {
+                            view.scrollTo(id)
+                        }
+                        }
+                        .onChange(of: tripFilter) { filter in
+                            if let id = tiles.first(where: { $0.isSelected(tripFilter: filter) })?.id {
+                                view.scrollTo(id)
+                            }
+                        }
                 }
             }
             alertCards

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -176,7 +176,7 @@ struct StopDetailsFilteredDepartureDetails: View {
         .onChange(of: noPredictionsStatus) { status in handleViewportForStatus(status) }
         .onChange(of: selectedTripIsCancelled) { if $0 { setViewportToStop() } }
         .onChange(of: tripFilter) { tripFilter in
-            selectedDepartureFocus = tiles.first { $0.tripId == tripFilter?.tripId }?.id ?? cardFocusId
+            selectedDepartureFocus = tiles.first { $0.isSelected(tripFilter: tripFilter) }?.id ?? cardFocusId
         }
         .onChange(of: leaf) { leaf in
             leafFormat = leaf.format(now: now.toKotlinInstant(), globalData: stopDetailsVM.global)
@@ -226,7 +226,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                         data: tileData,
                         onTap: {
                             nearbyVM.navigationStack.lastTripDetailsFilter = .init(
-                                tripId: tileData.tripId,
+                                tripId: tileData.upcoming.trip.id,
                                 vehicleId: tileData.upcoming.prediction?.vehicleId,
                                 stopSequence: tileData.upcoming.stopSequence,
                                 selectionLock: false

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -14,6 +14,7 @@ data class TileData(
     val upcoming: UpcomingTrip,
 ) {
     val id: String = upcoming.id
+    val tripId = upcoming.trip.id
 
     fun isSelected(tripFilter: TripDetailsFilter?): Boolean =
         upcoming.trip.id == tripFilter?.tripId &&

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -14,7 +14,6 @@ data class TileData(
     val upcoming: UpcomingTrip,
 ) {
     val id: String = upcoming.id
-    val tripId = upcoming.trip.id
 
     fun isSelected(tripFilter: TripDetailsFilter?): Boolean =
         upcoming.trip.id == tripFilter?.tripId &&


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix VO focus when navigating to filtered stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210322015597203?focus=true)

What is this PR for?
* Ensure we always focus on the first selected tile. This was a regression introduced by https://github.com/mbta/mobile_app/pull/952 when the id for an `UpcomingTrip` changed.
* Also includes android fixed discussed at dev check-in for resetting scroll position when changing direction

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally on iOS and confirmed that VO correctly focused on the first tile when coming from any view. 
    * Thought about writing a ViewInspector test, but [accessibilityFocused](https://github.com/nalexn/ViewInspector/blob/0.10.2/readiness.md) is not yet implemented 
* Ran on android and confirm tile scroll position resets to the start of the list when the direction filter changes


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
