### PR TITLE
fix(Android): Prevent global data from being reset to null on every filter change

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -107,8 +107,10 @@ class StopDetailsViewTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testStopDetailsViewDisplaysUnfilteredCorrectly() {
+        val global = GlobalResponse(builder)
         val viewModel = StopDetailsViewModel.mocked()
 
+        viewModel.setGlobalResponse(global)
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
@@ -132,7 +134,7 @@ class StopDetailsViewTest {
                                     context = RouteCardData.Context.StopDetailsUnfiltered,
                                 )
                             ),
-                            GlobalResponse(builder),
+                            global,
                         )
                     ),
                     now,
@@ -250,8 +252,10 @@ class StopDetailsViewTest {
                 header = "Elevator alert header"
             }
 
+        val global = GlobalResponse(builder)
         val viewModel = StopDetailsViewModel.mocked()
 
+        viewModel.setGlobalResponse(global)
         viewModel.setRouteCardData(
             listOf(
                 RouteCardData(
@@ -275,7 +279,7 @@ class StopDetailsViewTest {
                                     RouteCardData.Context.StopDetailsUnfiltered,
                                 )
                             ),
-                            GlobalResponse(builder),
+                            global,
                         )
                     ),
                     now,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
-import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
@@ -40,7 +39,7 @@ fun StopDetailsFilteredView(
     openSheetRoute: (SheetRoutes) -> Unit,
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
-    val globalResponse = getGlobalData("StopDetailsView.getGlobalData")
+    val globalResponse by viewModel.globalResponse.collectAsState()
     val routeCardData by viewModel.routeCardData.collectAsState()
     val thisRouteCardData = routeCardData?.find { it.lineOrRoute.id == stopFilter.routeId }
     val routeStopData = thisRouteCardData?.stopData?.get(0)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
-import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
@@ -34,7 +33,7 @@ fun StopDetailsUnfilteredView(
     openModal: (ModalRoutes) -> Unit,
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
-    val globalResponse = getGlobalData("StopDetailsView.getGlobalData")
+    val globalResponse = viewModel.globalResponse.collectAsState().value
     val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
 
     val stop: Stop? = globalResponse?.getStop(stopId)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -123,11 +123,14 @@ class StopDetailsViewModel(
 
     private val stopScheduleFetcher = ScheduleFetcher(schedulesRepository, errorBannerRepository)
 
+    private val _globalResponse = MutableStateFlow<GlobalResponse?>(null)
+    val globalResponse = _globalResponse.asStateFlow()
+
     private val _stopData = MutableStateFlow<StopData?>(null)
-    val stopData: StateFlow<StopData?> = _stopData
+    val stopData = _stopData.asStateFlow()
 
     private val _tripData = MutableStateFlow<TripData?>(null)
-    val tripData: StateFlow<TripData?> = _tripData
+    val tripData = _tripData.asStateFlow()
 
     private val _tripDetailsStopList = MutableStateFlow<TripDetailsStopList?>(null)
     // not accessible via a property since it needs extra params to be kept up to date
@@ -145,6 +148,10 @@ class StopDetailsViewModel(
             ::onJoinMessage,
             ::onPushMessage,
         )
+
+    fun setGlobalResponse(globalResponse: GlobalResponse?) {
+        _globalResponse.value = globalResponse
+    }
 
     fun loadStopDetails(stopId: String) {
         _stopData.value = StopData(stopId, null, null, false)
@@ -534,6 +541,8 @@ fun stopDetailsManagedVM(
             viewModel.leaveTripChannels()
         }
     }
+
+    LaunchedEffect(globalResponse) { viewModel.setGlobalResponse(globalResponse) }
 
     LaunchedEffect(stopId, globalResponse, stopData, filters, alertData, pinnedRoutes, now) {
         val schedules = stopData?.schedules


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | GL pill flicker in stop details departure cards](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210329839893517?focus=true)

The GL pills on filtered stop details departure tiles were disappearing every time you changed the selected trip or direction toggle. This was happening because the global data was somehow being reset to null in `Leaf.format`, which was causing the route value to be null, even though a route ID existed and the route was meant to be displayed.

This PR moves the global data into a flow in the stop details VM. We store global in the map VM, so there was some precedence for this, and it ensures that we're always using the exact same global data in `stopDetailsManagedVM` that we are in the stop details pages.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Updated tests to pass