### PR TITLE
ci: really fix filtering for skipping platform specific tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,14 +41,14 @@ jobs:
     permissions:
       contents: read
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android == 'true' }}
     uses: ./.github/workflows/test-android.yaml
   test-ios:
     name: Test for iOS
     permissions:
       contents: read
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.ios }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.ios == 'true' }}
     uses: ./.github/workflows/test-ios.yaml
     secrets:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
@@ -61,7 +61,7 @@ jobs:
       contents: read
       pull-requests: write
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android }}
+    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android == 'true' }}
     uses: ./.github/workflows/build-android.yaml
     with:
       build-type: "Debug"


### PR DESCRIPTION
### Summary

_Ticket:_ none

As can be seen in [this run](https://github.com/mbta/mobile_app/actions/runs/15145766015) of #1008, even now that the path filtering has been fixed in #1006, the conditions are broken. I am not sure if this will actually work, but if it does, then I will cry.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Can’t really be tested.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
