### PR TITLE
build(iOS): add a Fastlane lane for repairing provisioning profiles

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,6 +155,42 @@ platform :ios do
     get_provisioning_profile(app_identifier: app_identifier(options[:scheme]), output_path: 'iosApp/secrets')
   end
 
+  desc <<~DESC.chomp
+    Repairs provisioning profiles related to the app.
+
+    This is the fix for "Provisioning Profile '...' is not valid, skipping this one..."
+    and for "No profile for team '...' matching '...' found: Xcode couldn't find any provisioning profiles matching '...'".
+  DESC
+  lane :repair_provisioning_profiles do |_options|
+    # Unfortunately, `sigh repair` at the command line does not accept filtering, and there are
+    # provisioning profiles in the account that we don't own, so we need our own copy of this code.
+    # from https://github.com/fastlane/fastlane/blob/master/sigh/lib/sigh/repair.rb
+    require 'spaceship'
+    UI.message("Provisioning profile repair doesn't work with App Store Connect, you'll need to " \
+               'provide your credentials directly')
+    Spaceship.login(nil, nil)
+    Spaceship.select_team
+    UI.message('Successfully logged in')
+
+    # Select all 'Invalid' or 'Expired' provisioning profiles
+    broken_profiles = Spaceship.provisioning_profile.all.find_all do |profile|
+      %w[Invalid Expired].include?(profile.status) and profile.name.include?('com.mbta.tid.mbtaapp')
+    end
+
+    if broken_profiles.count.zero?
+      UI.success('All provisioning profiles are valid, nothing to do')
+    else
+      UI.success("Going to repair #{broken_profiles.count} provisioning profiles")
+
+      broken_profiles.each do |profile|
+        UI.message("Repairing profile '#{profile.name}'...")
+        profile.repair!
+      end
+
+      UI.success("Successfully repaired #{broken_profiles.count} provisioning profiles")
+    end
+  end
+
   desc 'Run tests'
   lane :test do |options|
     run_tests(

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -60,6 +60,17 @@ Load downloaded code signing certificates
 
 Check certificate and provisioning configuration
 
+### ios repair_provisioning_profiles
+
+```sh
+[bundle exec] fastlane ios repair_provisioning_profiles
+```
+
+Repairs provisioning profiles related to the app.
+
+This is the fix for "Provisioning Profile '...' is not valid, skipping this one..."
+and for "No profile for team '...' matching '...' found: Xcode couldn't find any provisioning profiles matching '...'".
+
 ### ios test
 
 ```sh


### PR DESCRIPTION
### Summary

_Ticket:_ none

If the issue we ran into today comes back, this would probably fix it; the changes I made to the `sigh repair` command that actually worked were a little different and a little less straightforward to use, so I’m only mostly certain that this will work when we eventually need it to.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that with nothing to do this doesn’t do anything. It is hard to fake a situation where this needs to do something, so we just have to hope that it’ll work, although it Seems Like It Should™.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
