### PR TITLE
fix(ioS.RouteCardDirection): Accessibility input labels include headsigns

### DIFF
--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
@@ -34,22 +34,31 @@ struct RouteCardDirection: View {
                         pillDecoration: pillDecoration
                     )
                 }
-            }
+            }.accessibilityElement(children: .combine)
+                .accessibilityInputLabels(Set([
+                    DirectionLabel.directionNameFormatted(direction),
+                    direction.destination,
+                ] +
+                    Set(branched.branchRows.map(\.headsign)))
+                    .compactMap { text in if let text { Text(text) } else { nil }})
 
         case let .single(single):
             let pillDecoration: PredictionRowView.PillDecoration =
                 if let route = single.route { .onDirectionDestination(route: route) } else { .none }
+            let destination = single.headsign == nil || single.headsign?.isEmpty == true
+                ? direction.destination
+                : single.headsign
             DirectionRowView(
                 direction: .init(
                     name: direction.name,
-                    destination: single.headsign == nil || single.headsign?.isEmpty == true
-                        ? direction.destination
-                        : single.headsign,
+                    destination: destination,
                     id: direction.id
                 ),
                 predictions: single.format,
                 pillDecoration: pillDecoration
-            )
+            ).accessibilityElement(children: .combine)
+                .accessibilityInputLabels(Set([DirectionLabel.directionNameFormatted(direction), destination])
+                    .compactMap { text in if let text { Text(text) } else { nil }})
         }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Group By Direction | Voice Control hints for route card](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210344414645468?focus=true)

What is this PR for?

This PR adds accessibilityInputLabels to the new RouteCard so that users can continue to say "Tap Alewife" or "Tap Braintree" to click into the row, rather than having to say "Tap Outbound" then select from all the visible outbound rows available. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing
What testing have you done?
* Ran locally for both Voice Control & Voice Over. Confirmed that I could say "Tap [direction]", "Tap [destination]", or "Tap [headsign]". Looks like the OS has built-in shorthand for long headsigns, where you can just say "Tap [first word of headsign]". 

I'd definitely appreciate a second set of eyes & ears running this manually though. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
