### PR TITLE
fix(Android): Move filtered/unfiltered state to VM

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -111,7 +111,7 @@ class StopDetailsViewTest {
         val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setGlobalResponse(global)
-        viewModel.setRouteCardData(
+        viewModel.setUnfilteredRouteCardData(
             listOf(
                 RouteCardData(
                     lineOrRoute,
@@ -179,34 +179,26 @@ class StopDetailsViewTest {
     fun testStopDetailsViewDisplaysFilteredCorrectly() {
         val viewModel = StopDetailsViewModel.mocked()
 
-        viewModel.setRouteCardData(
-            listOf(
-                RouteCardData(
-                    lineOrRoute,
-                    listOf(
-                        RouteCardData.RouteStopData(
-                            route,
-                            stop,
-                            listOf(
-                                RouteCardData.Leaf(
-                                    lineOrRoute,
-                                    stop,
-                                    directionId = 0,
-                                    listOf(routePatternOne),
-                                    setOf(stop.id),
-                                    listOf(UpcomingTrip(trip, prediction)),
-                                    alertsHere = emptyList(),
-                                    allDataLoaded = false,
-                                    hasSchedulesToday = true,
-                                    alertsDownstream = emptyList(),
-                                    context = RouteCardData.Context.StopDetailsUnfiltered,
-                                )
-                            ),
-                            GlobalResponse(builder),
-                        )
-                    ),
-                    now,
-                )
+        viewModel.setFilteredRouteStopData(
+            RouteCardData.RouteStopData(
+                route,
+                stop,
+                listOf(
+                    RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
+                        directionId = 0,
+                        listOf(routePatternOne),
+                        setOf(stop.id),
+                        listOf(UpcomingTrip(trip, prediction)),
+                        alertsHere = emptyList(),
+                        allDataLoaded = false,
+                        hasSchedulesToday = true,
+                        alertsDownstream = emptyList(),
+                        context = RouteCardData.Context.StopDetailsFiltered,
+                    )
+                ),
+                GlobalResponse(builder),
             )
         )
         val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())
@@ -256,7 +248,7 @@ class StopDetailsViewTest {
         val viewModel = StopDetailsViewModel.mocked()
 
         viewModel.setGlobalResponse(global)
-        viewModel.setRouteCardData(
+        viewModel.setUnfilteredRouteCardData(
             listOf(
                 RouteCardData(
                     lineOrRoute,
@@ -323,34 +315,26 @@ class StopDetailsViewTest {
 
         val viewModel = StopDetailsViewModel.mocked()
 
-        viewModel.setRouteCardData(
-            listOf(
-                RouteCardData(
-                    lineOrRoute,
-                    listOf(
-                        RouteCardData.RouteStopData(
-                            route,
-                            stop,
-                            listOf(
-                                RouteCardData.Leaf(
-                                    lineOrRoute,
-                                    stop,
-                                    directionId = 0,
-                                    listOf(routePatternOne),
-                                    setOf(stop.id),
-                                    listOf(UpcomingTrip(trip, prediction)),
-                                    alertsHere = listOf(alert),
-                                    allDataLoaded = false,
-                                    hasSchedulesToday = true,
-                                    alertsDownstream = emptyList(),
-                                    RouteCardData.Context.StopDetailsUnfiltered,
-                                )
-                            ),
-                            GlobalResponse(builder),
-                        )
-                    ),
-                    now,
-                )
+        viewModel.setFilteredRouteStopData(
+            RouteCardData.RouteStopData(
+                route,
+                stop,
+                listOf(
+                    RouteCardData.Leaf(
+                        lineOrRoute,
+                        stop,
+                        directionId = 0,
+                        listOf(routePatternOne),
+                        setOf(stop.id),
+                        listOf(UpcomingTrip(trip, prediction)),
+                        alertsHere = listOf(alert),
+                        allDataLoaded = false,
+                        hasSchedulesToday = true,
+                        alertsDownstream = emptyList(),
+                        RouteCardData.Context.StopDetailsFiltered,
+                    )
+                ),
+                GlobalResponse(builder),
             )
         )
         val errorBannerViewModel = ErrorBannerViewModel(false, MockErrorBannerStateRepository())

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -40,16 +40,14 @@ fun StopDetailsFilteredView(
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
     val globalResponse by viewModel.globalResponse.collectAsState()
-    val routeCardData by viewModel.routeCardData.collectAsState()
-    val thisRouteCardData = routeCardData?.find { it.lineOrRoute.id == stopFilter.routeId }
-    val routeStopData = thisRouteCardData?.stopData?.get(0)
+    val routeStopData by viewModel.filteredRouteStopData.collectAsState()
 
-    if (routeStopData != null) {
+    routeStopData?.let {
         StopDetailsFilteredPickerView(
             stopId = stopId,
             stopFilter = stopFilter,
             tripFilter = tripFilter,
-            routeStopData = routeStopData,
+            routeStopData = it,
             allAlerts = allAlerts,
             global = globalResponse,
             now = now,
@@ -64,8 +62,8 @@ fun StopDetailsFilteredView(
             openModal = openModal,
             openSheetRoute = openSheetRoute,
         )
-    } else {
-        Loading(
+    }
+        ?: Loading(
             stopId,
             stopFilter,
             tripFilter,
@@ -75,7 +73,6 @@ fun StopDetailsFilteredView(
             errorBannerViewModel,
             globalResponse,
         )
-    }
 }
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -40,7 +40,7 @@ fun StopDetailsUnfilteredView(
 
     val analytics: Analytics = koinInject()
 
-    val routeCardData = viewModel.routeCardData.collectAsState().value
+    val routeCardData = viewModel.unfilteredRouteCardData.collectAsState().value
 
     val onTapRoutePill = { pillFilter: PillFilter ->
         analytics.tappedRouteFilter(pillFilter.id, stopId)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.jvm.JvmName
 import kotlin.math.max
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -1134,6 +1135,15 @@ data class RouteCardData(
         }
     }
 }
+
+@JvmName("optionalHasContext")
+fun List<RouteCardData>?.hasContext(context: RouteCardData.Context): Boolean =
+    this?.hasContext(context) == true
+
+fun List<RouteCardData>.hasContext(context: RouteCardData.Context): Boolean =
+    this.any {
+        it.stopData.any { stopData -> stopData.data.any { leaf -> leaf.context == context } }
+    }
 
 fun List<RouteCardData>.sort(
     distanceFrom: Position?,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Group By Direction | All trips are shown when navigating from unfiltered stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210318500071981?focus=true)

This is a follow up to #1005, which didn't actually fix the problem. This is closer to the initial approach I was trying, but instead of using filtered flows entirely within the VM, I introduced flows that the `stopDetailsManagedVM` handles updating when the `routeId` or `routeCardData` change. This prevents the extra null init values, and allows us to remember the unfiltered route card data even after navigating into and back from a route filter, minimizing loading states.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Manual testing to check that the extra trips really don't show up, updated existing tests to pass.
