### PR TITLE
chore: add changelog links where dependabot doesn’t pull changelogs automatically

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,26 @@
 [versions]
 accompanist = "0.37.3"
+# changelog: https://developer.android.com/jetpack/androidx/releases/compose-material3
 android-material3 = "1.3.2"
+# changelog: https://developer.android.com/jetpack/androidx/releases/activity
 androidx-activityCompose = "1.9.1"
+# changelog: https://developer.android.com/jetpack/androidx/releases/navigation
 androidx-navigationCompose = "2.9.0"
+# changelog: https://developer.android.com/jetpack/androidx/releases/test
 androidx-test-monitor = "1.7.2"
 androidx-test-rules = "1.6.1"
+# changelog: https://developer.android.com/build/releases/past-releases
 agp = "8.7.2"
-# see https://developer.android.com/develop/ui/compose/bom/bom-mapping
-# and https://developer.android.com/jetpack/androidx/releases/compose for release notes
+# bom: https://developer.android.com/develop/ui/compose/bom/bom-mapping
+# changelog: https://developer.android.com/jetpack/androidx/releases/compose
 compose-bom = "2025.05.00"
 compose-placeholder-material3= "1.0.11"
 compose-shimmer= "1.3.2"
+# changelog: https://github.com/CycloneDX/cyclonedx-gradle-plugin/releases
 cyclonedx = "2.3.0"
+# changelog: https://developer.android.com/jetpack/androidx/releases/datastore
 datastorePreferencesCore = "1.1.6"
+# bom/changelog: https://firebase.google.com/support/release-notes/android
 firebase-bom = "33.13.0"
 kotlin = "2.1.20"
 javaphoenixclient = "1.3.1"
@@ -22,6 +30,7 @@ kotlinpoet = "2.2.0"
 kotlinxCoroutinesCore = "1.10.2"
 kotlinxDatetime = "0.6.2"
 ktor = "3.1.3"
+# changelog: https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md
 mapbox = "11.12.0"
 mapboxTurf = "7.4.0"
 mokkery = "2.7.2"
@@ -34,6 +43,7 @@ skie = "0.10.2-preview.2.1.20"
 spatialk = "0.3.0"
 spotless = "7.0.3"
 turbine = "1.2.0"
+# changelog: https://developer.android.com/jetpack/androidx/releases/lifecycle
 lifecycleRuntimeTesting = "2.9.0"
 
 [libraries]


### PR DESCRIPTION
### Summary

_Ticket:_ none

Sometimes, Dependabot knows how to track down the changelog for dependencies it’s updating, and that’s nice. Other times, we need to hunt down the release notes ourselves, mostly in the Android standard library but sometimes on dependencies that just don’t have that working for whatever reason; for those, it seems like it’d be nice to have a link right there in the diff context, like we already do for the Jetpack Compose BOM.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Not testable.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
