### PR TITLE
ci: run empty job instead of skipping if platform not changed

### DIFF
--- a/.github/workflows/build-android.yaml
+++ b/.github/workflows/build-android.yaml
@@ -18,6 +18,11 @@ on:
       sentry-environment:
         required: true
         type: string
+      skip-everything:
+        description: "Skips all the individual steps so the job passes quickly"
+        required: false
+        default: false
+        type: boolean
     secrets:
       AWS_ROLE_ARN:
         required: false
@@ -49,7 +54,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        if: ${{ !inputs.skip-everything }}
       - uses: ./.github/actions/setup
+        if: ${{ !inputs.skip-everything }}
         with:
           for: android-build
           aws-role: ${{ secrets.AWS_ROLE_ARN }}
@@ -57,6 +64,7 @@ jobs:
           gcp-service-account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Lowercase build parameters
         id: lowercase
+        if: ${{ !inputs.skip-everything }}
         run: |
           # https://stackoverflow.com/a/12487455
           buildType="${{ inputs.build-type }}"
@@ -64,6 +72,7 @@ jobs:
           flavor="${{ inputs.flavor }}"
           echo "flavor=${flavor,}" | tee -a "$GITHUB_OUTPUT"
       - name: Build Android app
+        if: ${{ !inputs.skip-everything }}
         env:
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
           GOOGLE_APP_ID_ANDROID: ${{ secrets.GOOGLE_APP_ID_ANDROID }}
@@ -77,18 +86,18 @@ jobs:
         run: |
           bundle exec fastlane android build flavor:${{ inputs.flavor }} build_type:${{ inputs.build-type }}
       - uses: actions/upload-artifact@v4
-        if: ${{ inputs.deploy }}
+        if: ${{ inputs.deploy && !inputs.skip-everything }}
         with:
           name: android-apk
           path: androidApp/build/outputs/apk/${{ steps.lowercase.outputs.flavor }}/${{ steps.lowercase.outputs.build-type }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ steps.lowercase.outputs.build-type }}.apk
       - uses: actions/upload-artifact@v4
-        if: ${{ inputs.deploy }}
+        if: ${{ inputs.deploy && !inputs.skip-everything }}
         with:
           name: android-aab
           path: androidApp/build/outputs/bundle/${{ steps.lowercase.outputs.flavor }}${{ inputs.build-type }}/androidApp-${{ steps.lowercase.outputs.flavor }}-${{ steps.lowercase.outputs.build-type }}.aab
   deploy-android:
     name: Upload to Google Play
-    if: ${{ inputs.deploy }}
+    if: ${{ inputs.deploy && !inputs.skip-everything }}
     needs:
       - build-android
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,15 +41,17 @@ jobs:
     permissions:
       contents: read
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android == 'true' }}
     uses: ./.github/workflows/test-android.yaml
+    with:
+      skip-everything: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.android == 'false' }}
   test-ios:
     name: Test for iOS
     permissions:
       contents: read
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.ios == 'true' }}
     uses: ./.github/workflows/test-ios.yaml
+    with:
+      skip-everything: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.ios == 'false' }}
     secrets:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
@@ -61,13 +63,13 @@ jobs:
       contents: read
       pull-requests: write
     needs: check-changes
-    if: ${{ github.event_name != 'pull_request' || needs.check-changes.outputs.android == 'true' }}
     uses: ./.github/workflows/build-android.yaml
     with:
       build-type: "Debug"
       deploy: false
       flavor: "Staging"
       sentry-environment: "debug"
+      skip-everything: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.android == 'false' }}
     secrets:
       FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
       GOOGLE_APP_ID_ANDROID: ${{ secrets.GOOGLE_APP_ID_ANDROID_STAGING }}

--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -2,6 +2,12 @@ name: Android tests
 
 on:
   workflow_call:
+    inputs:
+      skip-everything:
+        description: "Skips all the individual steps so the job passes quickly"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   test-android:
@@ -11,21 +17,26 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        if: ${{ !inputs.skip-everything }}
       - uses: ./.github/actions/setup
+        if: ${{ !inputs.skip-everything }}
         with:
           for: android-test
       - run: ./gradlew spotlessCheck
+        if: ${{ !inputs.skip-everything }}
       - name: shared checks & unit tests
         run: ./gradlew shared:check
+        if: ${{ !inputs.skip-everything }}
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && !inputs.skip-everything
         with:
           name: android-shared-reports
           path: shared/build/reports
       - name: android checks & unit tests
         run: ./gradlew androidApp:check
+        if: ${{ !inputs.skip-everything }}
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && !inputs.skip-everything
         with:
           name: android-android-reports
           path: androidApp/build/reports
@@ -46,7 +57,9 @@ jobs:
           #   arch: x86_64
     steps:
       - uses: actions/checkout@v4
+        if: ${{ !inputs.skip-everything }}
       - uses: ./.github/actions/setup
+        if: ${{ !inputs.skip-everything }}
         with:
           for: android-test
       # full setup including AVD snapshot caching from https://github.com/ReactiveCircus/android-emulator-runner/blob/a3dcdb348bb02349cd939d168a74e31a9094b7f0/README.md
@@ -55,8 +68,10 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+        if: ${{ !inputs.skip-everything }}
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2
+        if: ${{ !inputs.skip-everything }}
         timeout-minutes: 30
         with:
           api-level: ${{ matrix.api-level }}
@@ -66,7 +81,7 @@ jobs:
           disable-animations: true
           script: ./bin/android-instrumented-test-ci.sh
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && !inputs.skip-everything
         with:
           name: android-connected-reports-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
           path: androidApp/build/reports

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -2,6 +2,12 @@ name: iOS tests
 
 on:
   workflow_call:
+    inputs:
+      skip-everything:
+        description: "Skips all the individual steps so the job passes quickly"
+        required: false
+        default: false
+        type: boolean
     secrets:
       SENTRY_DSN:
         required: true
@@ -18,10 +24,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        if: ${{ !inputs.skip-everything }}
       - uses: ./.github/actions/setup
+        if: ${{ !inputs.skip-everything }}
         with:
           for: ios-test
       - name: Install CocoaPods dependencies
+        if: ${{ !inputs.skip-everything }}
         run: |
           ./gradlew :shared:generateDummyFramework
           pushd iosApp
@@ -29,15 +38,17 @@ jobs:
           popd
           bundle exec ./gradlew :shared:podInstallSyntheticIos
       - name: shared checks & unit tests
+        if: ${{ !inputs.skip-everything }}
         run: ./gradlew shared:iosSimulatorArm64Test shared:iosX64Test
         env:
           GH_TOKEN: ${{ github.token }}
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && !inputs.skip-everything
         with:
           name: ios-shared-reports
           path: shared/build/reports
       - name: Add build environment variables
+        if: ${{ !inputs.skip-everything }}
         run: |
           {
             echo "export SENTRY_DSN=${SENTRY_DSN}"
@@ -51,11 +62,12 @@ jobs:
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
           GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
       - name: Run emulator tests
+        if: ${{ !inputs.skip-everything }}
         run: |
           bundle exec fastlane ios test \
             xcodebuild_formatter:"xcbeautify --renderer github-actions"
       - uses: actions/upload-artifact@v4
-        if: failure()
+        if: failure() && !inputs.skip-everything
         with:
           name: ios-ios-results
           path: fastlane/test_output/*


### PR DESCRIPTION
### Summary

_Ticket:_ none

#1009 went slightly too far, because you can’t skip required jobs, and if they aren’t required then the merge queue doesn’t care if they fail. Hopefully, skipping all the steps within the job will get us everything we want. Have I mentioned lately that I don’t think GitHub Actions is very good?

### Testing

`actionlint` doesn’t seem to spot any issues with this, for whatever that’s worth.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
