### PR TITLE
fix(RouteCardData): Suspension at stop with stop headsigns

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -218,7 +218,6 @@ data class RouteCardData(
                 for (routePattern in routePatterns) {
                     if (
                         routePattern.isTypical() &&
-                            // TODO: Does this make sense?
                             // If this pattern is already represented under a different headsign,
                             // then we don't need to represent it separately.
                             !potentialService.values

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -178,7 +178,11 @@ data class RouteCardData(
                 (tripId == null || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
             }
 
-        private data class PotentialService(val routeId: String, val headsign: String)
+        private data class PotentialService(
+            val routeId: String,
+            val headsign: String,
+            val routePatternIds: Set<String>,
+        )
 
         /**
          * Get all routes and headsigns that might be shown for this leaf. For bus, the only
@@ -192,7 +196,8 @@ data class RouteCardData(
             representativeRoute: Route,
             globalData: GlobalResponse?,
         ): Set<PotentialService> {
-            val potentialService = mutableSetOf<PotentialService>()
+            val potentialService: MutableMap<Pair<String, String>, MutableSet<String>> =
+                mutableMapOf()
             val cutoffTime = now + 120.minutes
             val tripsUpcoming = upcomingTrips.filter { it.isUpcomingWithin(now, cutoffTime) }
             val isBus = representativeRoute.type == RouteType.BUS
@@ -200,20 +205,38 @@ data class RouteCardData(
                 if (isBus) tripsUpcoming.take(TYPICAL_LEAF_ROWS) else tripsUpcoming
             for (trip in tripsToConsider) {
                 if (trip.isUpcomingWithin(now, cutoffTime)) {
-                    potentialService.add(PotentialService(trip.trip.routeId, trip.headsign))
+                    val existingPatterns =
+                        potentialService.getOrPut(Pair(trip.trip.routeId, trip.headsign)) {
+                            mutableSetOf()
+                        }
+                    if (trip.trip.routePatternId != null) {
+                        existingPatterns.add(trip.trip.routePatternId)
+                    }
                 }
             }
             if (!isBus) {
                 for (routePattern in routePatterns) {
-                    if (routePattern.isTypical()) {
+                    if (
+                        routePattern.isTypical() &&
+                            // TODO: Does this make sense?
+                            // If this pattern is already represented under a different headsign,
+                            // then we don't need to represent it separately.
+                            !potentialService.values
+                                .flatMapTo(mutableSetOf(), { it })
+                                .contains(routePattern.id)
+                    ) {
                         val headsign =
                             globalData?.trips?.get(routePattern.representativeTripId)?.headsign
                                 ?: continue
-                        potentialService.add(PotentialService(routePattern.routeId, headsign))
+                        potentialService
+                            .getOrPut(Pair(routePattern.routeId, headsign)) { mutableSetOf() }
+                            .add(routePattern.id)
                     }
                 }
             }
             return potentialService
+                .map { (key, patternIds) -> PotentialService(key.first, key.second, patternIds) }
+                .toSet()
         }
 
         /**
@@ -245,11 +268,9 @@ data class RouteCardData(
             globalData: GlobalResponse?,
         ): Map<String, ByHeadsignData> {
             return potentialService
-                .map { (_, headsign) ->
+                .map { (_, headsign, patternIds) ->
                     val routePatterns =
-                        routePatterns.filter {
-                            globalData?.trips?.get(it.representativeTripId)?.headsign == headsign
-                        }
+                        routePatterns.filter { pattern -> patternIds.contains(pattern.id) }
 
                     val routePatternIds = routePatterns.map { it.id }.toSet()
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Group By Direction | Stop headsign disruption bug](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210356582922104?focus=true)

What is this PR for?

This PR resolves a suspension at a stop with multiple route patterns and stop headsigns would incorrectly still show upcoming service.

The cause was that we were using stop headsign to look up matching route patterns in `dataByHeadsign`, but there were no matches, and therefore no matching alerts.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally and confirmed that for the current ferry disruption, we correctly show a single suspension row for Quincy Loop. 
* Confirmed other stops w/ stop headsigns still render as expected, like CR at south station

Before & After

 ![image](https://github.com/user-attachments/assets/c3c022f1-5af4-46e2-8325-378f786336df)![image](https://github.com/user-attachments/assets/491758de-069c-4f16-b6b7-ed816725d099) 




<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
