### PR TITLE
fix(iOS): load empty predictions on empty stop list

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -66,7 +66,9 @@ struct NearbyTransitView: View {
             getNearby(location: newLocation, globalData: globalData)
         }
         .onChange(of: nearbyVM.nearbyState.stopIds) { [oldValue = nearbyVM.nearbyState.stopIds] newNearbyStops in
-            if Set(oldValue ?? []) != Set(newNearbyStops ?? []) {
+            let oldSet = oldValue != nil ? Set(oldValue ?? []) : nil
+            let newSet = newNearbyStops != nil ? Set(newNearbyStops ?? []) : nil
+            if oldSet != newSet {
                 getSchedule()
                 joinPredictions(newNearbyStops)
                 scrollToTop()


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1748022822010349), issue 3

#921 treats `nil` and `[]` as equivalent stop lists and skips prediction loading if the stop list loads as empty, meaning the predictions were never loading as empty outside the service area.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this works. Added a test that would’ve caught this issue to ensure that this doesn’t break in this exact way again.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
