### PR TITLE
fix(Android): prevent sheet size change from interrupting map transition

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -5,6 +5,10 @@ import java.io.StringReader
 import java.util.Locale
 import java.util.Properties
 
+// To use debug signing keys and skip Sentry uploads for an easier time debugging
+// performance-sensitive issues, turn this on.
+val runLocalReleaseBuild = false
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.compose)
@@ -19,7 +23,7 @@ sentry {
     // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
     // This enables source context, allowing you to see your source
     // code as part of your stack traces in Sentry.
-    includeSourceContext = true
+    includeSourceContext = !runLocalReleaseBuild
 
     org = "mbtace"
     projectName = "mobile_app_android"
@@ -44,7 +48,14 @@ android {
     }
     lint { disable.add("NullSafeMutableLiveData") }
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
-    buildTypes { getByName("release") { isMinifyEnabled = false } }
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            if (runLocalReleaseBuild) {
+                signingConfig = signingConfigs.getByName("debug")
+            }
+        }
+    }
     flavorDimensions += "environment"
     productFlavors {
         create("devOrange") {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -322,6 +322,7 @@ class HomeMapViewTests {
                     ),
             )
         }
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithContentDescription("Recenter map on my location").assertExists()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -66,6 +66,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.junit.Rule
@@ -491,21 +492,29 @@ class MapAndSheetPageTest : KoinTest {
             }
         }
 
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { viewportProvider.getViewportImmediate().cameraState != null }
         val updatedCamera =
             CameraState(Point.fromLngLat(1.1, 1.1), EdgeInsets(0.0, 0.0, 0.0, 0.0), 1.0, 0.0, 0.0)
         viewportProvider.setIsManuallyCentering(true)
         viewportProvider.updateCameraState(updatedCamera)
-        viewportProvider.viewport.setCameraOptions {
-            center(updatedCamera.center)
-            zoom(updatedCamera.zoom)
+        runBlocking {
+            viewportProvider.withViewport { viewport ->
+                viewport.setCameraOptions {
+                    center(updatedCamera.center)
+                    zoom(updatedCamera.zoom)
+                }
+            }
         }
         viewportProvider.setIsManuallyCentering(false)
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { viewportProvider.viewport.cameraState != null }
+        composeTestRule.waitUntil { viewportProvider.getViewportImmediate().cameraState != null }
 
         assertTrue(
-            updatedCamera.center.isRoughlyEqualTo(viewportProvider.viewport.cameraState?.center!!)
+            updatedCamera.center.isRoughlyEqualTo(
+                viewportProvider.getViewportImmediate().cameraState?.center!!
+            )
         )
         assertFalse(viewportProvider.isFollowingPuck)
 
@@ -517,7 +526,9 @@ class MapAndSheetPageTest : KoinTest {
         composeTestRule.waitForIdle()
 
         assertTrue(
-            updatedCamera.center.isRoughlyEqualTo(viewportProvider.viewport.cameraState?.center!!)
+            updatedCamera.center.isRoughlyEqualTo(
+                viewportProvider.getViewportImmediate().cameraState?.center!!
+            )
         )
         assertFalse(viewportProvider.isFollowingPuck)
 
@@ -528,13 +539,17 @@ class MapAndSheetPageTest : KoinTest {
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
         composeTestRule.waitForIdle()
         composeTestRule.waitUntil {
-            !updatedCamera.center.isRoughlyEqualTo(viewportProvider.viewport.cameraState!!.center)
+            !updatedCamera.center.isRoughlyEqualTo(
+                viewportProvider.getViewportImmediate().cameraState!!.center
+            )
         }
 
         assertFalse(
-            updatedCamera.center.isRoughlyEqualTo(viewportProvider.viewport.cameraState?.center!!)
+            updatedCamera.center.isRoughlyEqualTo(
+                viewportProvider.getViewportImmediate().cameraState?.center!!
+            )
         )
-        assertTrue(viewportProvider.viewport.isFollowingPuck)
+        assertTrue(viewportProvider.getViewportImmediate().isFollowingPuck)
         assertTrue(viewportProvider.isFollowingPuck)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -264,7 +264,9 @@ class ViewportProvider(
         isFollowingPuck = savedNearbyTransitViewport?.isFollowingPuck ?: false
         isVehicleOverview = false
         isAnimating = true
-        withViewport { viewport -> savedNearbyTransitViewport?.restoreOn(viewport) }
+        animateViewport { viewport, completionListener ->
+            savedNearbyTransitViewport?.restoreOn(viewport, completionListener)
+        }
         isAnimating = false
         savedNearbyTransitViewport = null
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -76,6 +76,7 @@ import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 @Composable
@@ -151,7 +152,7 @@ fun HomeMapView(
         return false
     }
 
-    fun positionViewportToStop() {
+    suspend fun positionViewportToStop() {
         if (selectedStop != null) {
             viewportProvider.stopCenter(selectedStop!!)
             viewModel.updateCenterButtonVisibility(
@@ -308,7 +309,7 @@ fun HomeMapView(
                         alignment = Alignment.BottomEnd,
                     )
                 },
-                mapViewportState = viewportProvider.viewport,
+                mapViewportState = viewportProvider.getViewportImmediate(),
                 mapState = mapState,
                 style = {
                     MapStyle(
@@ -494,7 +495,7 @@ fun HomeMapView(
             Column(recenterContainerModifier, Arrangement.spacedBy(16.dp)) {
                 if (showRecenterButton) {
                     RecenterButton(
-                        onClick = { viewportProvider.follow() },
+                        onClick = { coroutineScope.launch { viewportProvider.follow() } },
                         modifier = Modifier.padding(horizontal = 16.dp),
                     )
                 }
@@ -506,11 +507,13 @@ fun HomeMapView(
                             TripCenterButton(
                                 routeType = routeType,
                                 onClick = {
-                                    viewportProvider.vehicleOverview(
-                                        selectedVehicle,
-                                        selectedStop,
-                                        density,
-                                    )
+                                    coroutineScope.launch {
+                                        viewportProvider.vehicleOverview(
+                                            selectedVehicle,
+                                            selectedStop,
+                                            density,
+                                        )
+                                    }
                                 },
                                 modifier = Modifier.padding(horizontal = 16.dp),
                             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,13 +29,15 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.Typography
+import kotlinx.coroutines.launch
 
 @Composable
 fun NoNearbyStopsView(
     hideMaps: Boolean,
     onOpenSearch: () -> Unit,
-    onPanToDefaultCenter: () -> Unit,
+    onPanToDefaultCenter: suspend () -> Unit,
 ) {
+    val coroutineScope = rememberCoroutineScope()
     Column(
         modifier =
             Modifier.clip(RoundedCornerShape(8.dp))
@@ -83,7 +86,7 @@ fun NoNearbyStopsView(
         }
         if (!hideMaps) {
             OutlinedButton(
-                onClick = onPanToDefaultCenter,
+                onClick = { coroutineScope.launch { onPanToDefaultCenter() } },
                 modifier = Modifier.requiredHeightIn(min = 48.dp),
                 shape = RoundedCornerShape(8.dp),
                 border = BorderStroke(1.dp, colorResource(R.color.key)),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -123,6 +123,7 @@ fun MapAndSheetPage(
 
     val viewModel: NearbyTransitTabViewModel = viewModel()
 
+    val coroutineScope = rememberCoroutineScope()
     val navController = rememberNavController()
 
     val currentNavBackStackEntry by
@@ -298,7 +299,7 @@ fun MapAndSheetPage(
             if (timeSinceBackground > 1.hours) {
                 navigateToEntrypoint()
                 if (nearbyTransit.locationDataManager.hasPermission) {
-                    nearbyTransit.viewportProvider.follow()
+                    coroutineScope.launch { nearbyTransit.viewportProvider.follow() }
                 }
             }
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -63,7 +63,7 @@ fun NearbyTransitPage(
         }
     }
 
-    fun panToDefaultCenter() {
+    suspend fun panToDefaultCenter() {
         nearbyTransit.viewportProvider.isManuallyCentering = true
         nearbyTransit.viewportProvider.isFollowingPuck = false
         nearbyTransit.viewportProvider.animateTo(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/MapboxUtil.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.android.util
 
 import com.mapbox.geojson.Point
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mapbox.maps.plugin.viewport.CompletionListener
 import com.mapbox.maps.plugin.viewport.ViewportStatus
 import com.mapbox.maps.plugin.viewport.data.FollowPuckViewportStateOptions
 import com.mapbox.maps.plugin.viewport.state.FollowPuckViewportState
@@ -11,8 +11,10 @@ import io.github.dellisd.spatialk.geojson.Position
 import kotlin.math.pow
 import kotlin.math.round
 
-@OptIn(MapboxExperimental::class)
-fun MapViewportState.followPuck(zoom: Double? = null) {
+fun MapViewportState.followPuck(
+    zoom: Double? = null,
+    completionListener: CompletionListener? = null,
+) {
     this.transitionToFollowPuckState(
         followPuckViewportStateOptions =
             FollowPuckViewportStateOptions.Builder()
@@ -21,7 +23,8 @@ fun MapViewportState.followPuck(zoom: Double? = null) {
                     pitch(null)
                     zoom(zoom)
                 }
-                .build()
+                .build(),
+        completionListener = completionListener,
     )
 }
 
@@ -34,7 +37,6 @@ val MapViewportState.isFollowingPuck: Boolean
             null -> false
         }
 
-@OptIn(MapboxExperimental::class)
 val MapViewportState.isOverview: Boolean
     get() =
         when (val status = this.mapViewportStatus) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ViewportSnapshot.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ViewportSnapshot.kt
@@ -2,10 +2,9 @@ package com.mbta.tid.mbta_app.android.util
 
 import com.mapbox.maps.CameraOptions
 import com.mapbox.maps.CameraState
-import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mapbox.maps.plugin.viewport.CompletionListener
 
-@OptIn(MapboxExperimental::class)
 class ViewportSnapshot(val isFollowingPuck: Boolean?, val camera: CameraState?) {
     constructor(
         mapViewportState: MapViewportState
@@ -14,13 +13,17 @@ class ViewportSnapshot(val isFollowingPuck: Boolean?, val camera: CameraState?) 
         camera = mapViewportState.cameraState,
     )
 
-    fun restoreOn(mapViewportState: MapViewportState) {
+    fun restoreOn(mapViewportState: MapViewportState, completionListener: CompletionListener) {
         if (this.isFollowingPuck == true) {
-            mapViewportState.followPuck(zoom = camera?.zoom)
+            mapViewportState.followPuck(
+                zoom = camera?.zoom,
+                completionListener = completionListener,
+            )
         } else if (camera != null) {
             mapViewportState.easeTo(
                 CameraOptions.Builder().zoom(camera.zoom).center(camera.center).build(),
                 animationOptions = MapAnimationDefaults.options,
+                completionListener = completionListener,
             )
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1748022822010349)

It’s a little bit annoying that `setSheetPadding` can’t just allow the transition to continue, but I think making all the transitions `suspend` so we actually know when they’re finished is a good thing in its own right.

### Testing

Checked that the issues with map animation don’t appear in local release builds where they used to. (One that might be easier to reproduce on purpose is to pan far away from your location, and then recenter and immediately adjust the sheet size. Before this change, resizing the sheet interrupts the recenter animation so the camera gets stuck part of the way back; after this change, the recenter animation finishes fine.)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
