### PR TITLE
feat: Increase default shete detent

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
@@ -227,7 +227,7 @@ private fun StandardBottomSheet(
                             SheetValue.Hidden at layoutHeight
                         }
                         SheetValue.Small at layoutHeight - smallHeightPx
-                        SheetValue.Medium at layoutHeight / 2
+                        SheetValue.Medium at (layoutHeight * 0.4).toFloat()
                         SheetValue.Large at 0f
                     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -33,6 +34,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -65,6 +67,7 @@ import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
 import com.mbta.tid.mbta_app.android.stopDetails.stopDetailsManagedVM
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
+import com.mbta.tid.mbta_app.android.util.plus
 import com.mbta.tid.mbta_app.android.util.rememberPrevious
 import com.mbta.tid.mbta_app.android.util.stateJsonSaver
 import com.mbta.tid.mbta_app.android.util.timer
@@ -132,6 +135,10 @@ fun MapAndSheetPage(
     val previousNavEntry: SheetRoutes? = rememberPrevious(currentNavEntry)
 
     val (pinnedRoutes) = managePinnedRoutes()
+
+    var searchBarHeight: Dp? by rememberSaveable() { mutableStateOf(null) }
+
+    val density = LocalDensity.current
 
     val now by timer(updateInterval = 5.seconds)
 
@@ -475,6 +482,7 @@ fun MapAndSheetPage(
                 ::handleRouteNavigation,
                 searchFocusRequester,
                 searchResultsViewModel,
+                onBarGloballyPositioned = {},
             ) {
                 SheetContent(
                     Modifier.padding(top = if (showSearchBar) 94.dp else 0.dp)
@@ -487,8 +495,6 @@ fun MapAndSheetPage(
                 sheetDragHandle = { DragHandle() },
                 sheetContent = {
                     var sheetHeight by remember { mutableStateOf(0.dp) }
-                    val density = LocalDensity.current
-
                     Box(
                         modifier =
                             Modifier.onGloballyPositioned {
@@ -529,9 +535,21 @@ fun MapAndSheetPage(
                     ::handleRouteNavigation,
                     searchFocusRequester,
                     searchResultsViewModel,
+                    onBarGloballyPositioned = { layoutCoordinates ->
+                        Log.i("KB", "ON Globally positiononed ${layoutCoordinates.size.height}")
+                        with(density) { searchBarHeight = layoutCoordinates.size.height.toDp() }
+                    },
                 ) {
                     HomeMapView(
-                        sheetPadding = sheetPadding,
+                        sheetPadding =
+                            sheetPadding.plus(
+                                PaddingValues(
+                                    start = 0.dp,
+                                    end = 0.dp,
+                                    top = (searchBarHeight ?: 0.dp),
+                                    bottom = 0.dp,
+                                )
+                            ),
                         lastNearbyTransitLocation = nearbyTransit.lastNearbyTransitLocation,
                         nearbyTransitSelectingLocationState =
                             nearbyTransit.nearbyTransitSelectingLocationState,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlay.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,6 +57,7 @@ fun SearchBarOverlay(
     onRouteNavigation: (routeId: String) -> Unit,
     inputFieldFocusRequester: FocusRequester,
     searchResultsVm: SearchResultsViewModel,
+    onBarGloballyPositioned: (LayoutCoordinates) -> Unit,
     content: @Composable () -> Unit,
 ) {
     var searchInputState by rememberSaveable { mutableStateOf("") }
@@ -120,7 +123,10 @@ fun SearchBarOverlay(
                                         backgroundColor = colorResource(R.color.fill3),
                                     )
                                     .fillMaxWidth()
-                                    .focusRequester(inputFieldFocusRequester),
+                                    .focusRequester(inputFieldFocusRequester)
+                                    .onGloballyPositioned { layoutCoordinates ->
+                                        onBarGloballyPositioned(layoutCoordinates)
+                                    },
                             onSearch = {},
                             leadingIcon = {
                                 Icon(

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -397,7 +397,7 @@ struct ContentView: View {
          Only update this if we're less than half way up the users screen. Otherwise,
          the entire map is blocked by the sheet anyway, so it doesn't need to respond to height changes
          */
-        guard newSheetHeight < (UIScreen.main.bounds.height / 2) else { return }
+        guard newSheetHeight < (UIScreen.main.bounds.height * PresentationDetent.MEDIUM_DETENT_FRACTION) else { return }
         sheetHeight = newSheetHeight - 55
     }
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -132,7 +132,7 @@ struct ContentView: View {
         }
     }
 
-    @State var selectedDetent: PresentationDetent = .halfScreen
+    @State var selectedDetent: PresentationDetent = .medium
     @State var visibleNearbySheet: SheetNavigationStackEntry = .nearby
     @State private var showingLocationPermissionAlert = false
 
@@ -286,7 +286,7 @@ struct ContentView: View {
                         GeometryReader { proxy in
                             VStack {
                                 navSheetContents
-                                    .presentationDetents([.small, .halfScreen, .almostFull], selection: $selectedDetent)
+                                    .presentationDetents([.small, .medium, .almostFull], selection: $selectedDetent)
                                     .interactiveDismissDisabled()
                                     .modifier(AllowsBackgroundInteraction())
                             }
@@ -301,7 +301,7 @@ struct ContentView: View {
                                 },
                                 content: coverContents
                             )
-                            .onChange(of: sheetItemId) { _ in selectedDetent = .halfScreen }
+                            .onChange(of: sheetItemId) { _ in selectedDetent = .medium }
                             .onAppear { recordSheetHeight(proxy.size.height) }
                             .onChange(of: proxy.size.height) { newValue in recordSheetHeight(newValue) }
                         }
@@ -403,7 +403,7 @@ struct ContentView: View {
 
     struct AllowsBackgroundInteraction: ViewModifier {
         func body(content: Content) -> some View {
-            content.presentationBackgroundInteraction(.enabled(upThrough: .halfScreen))
+            content.presentationBackgroundInteraction(.enabled(upThrough: .medium))
         }
     }
 }

--- a/iosApp/iosApp/Utils/PresentationDetentExtension.swift
+++ b/iosApp/iosApp/Utils/PresentationDetentExtension.swift
@@ -10,8 +10,10 @@ import SwiftUI
 import UIKit
 
 extension PresentationDetent {
+    static let MEDIUM_DETENT_FRACTION = 0.6
+
     static let small = Self.height(150)
-    static let medium = Self.fraction(0.6)
+    static let medium = Self.fraction(MEDIUM_DETENT_FRACTION)
     static let almostFull = Self.custom(AlmostFull.self)
 }
 

--- a/iosApp/iosApp/Utils/PresentationDetentExtension.swift
+++ b/iosApp/iosApp/Utils/PresentationDetentExtension.swift
@@ -11,7 +11,7 @@ import UIKit
 
 extension PresentationDetent {
     static let small = Self.height(150)
-    static let halfScreen = Self.fraction(0.5)
+    static let medium = Self.fraction(0.6)
     static let almostFull = Self.custom(AlmostFull.self)
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Change default sheet detent](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210002409672378?focus=true)

What is this PR for?
This PR increases the default sheet detent on both iOS & android. On android, it also accounts for the height of the search bar when centering the location puck on the available map space.

It didn't seem trivial to account for the status bar, so checking with design if we want the % changed.


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran on both iOS & android, checked sheet height looks as expected and puck centered on android.
* Confirming these match design's expectations

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->

![image](https://github.com/user-attachments/assets/01c9f385-7d2c-4da7-b5b2-cfc67ef7507e)
![image](https://github.com/user-attachments/assets/5b0e50b6-2d21-4804-80a2-f80497c9376a)

