### PR TITLE
fix(RouteCardData.potentialService): Evaluate all upcoming trips for bus in unfiltered stop details

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -195,6 +195,7 @@ data class RouteCardData(
             now: Instant,
             representativeRoute: Route,
             globalData: GlobalResponse?,
+            context: Context,
         ): Set<PotentialService> {
             val potentialService: MutableMap<Pair<String, String>, MutableSet<String>> =
                 mutableMapOf()
@@ -202,7 +203,8 @@ data class RouteCardData(
             val tripsUpcoming = upcomingTrips.filter { it.isUpcomingWithin(now, cutoffTime) }
             val isBus = representativeRoute.type == RouteType.BUS
             val tripsToConsider =
-                if (isBus) tripsUpcoming.take(TYPICAL_LEAF_ROWS) else tripsUpcoming
+                if (isBus && context == Context.NearbyTransit) tripsUpcoming.take(TYPICAL_LEAF_ROWS)
+                else tripsUpcoming
             for (trip in tripsToConsider) {
                 if (trip.isUpcomingWithin(now, cutoffTime)) {
                     val existingPatterns =
@@ -456,7 +458,7 @@ data class RouteCardData(
 
         fun format(now: Instant, globalData: GlobalResponse?): LeafFormat {
             val representativeRoute = this.lineOrRoute.sortRoute
-            val potentialService = potentialService(now, representativeRoute, globalData)
+            val potentialService = potentialService(now, representativeRoute, globalData, context)
 
             // If we are dealing with a line, then we should show the route alongside the
             // UpcomingTripFormat

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -203,8 +203,9 @@ data class RouteCardData(
             val tripsUpcoming = upcomingTrips.filter { it.isUpcomingWithin(now, cutoffTime) }
             val isBus = representativeRoute.type == RouteType.BUS
             val tripsToConsider =
-                if (isBus && context == Context.StopDetailsFiltered) tripsUpcoming
-                else tripsUpcoming.take(TYPICAL_LEAF_ROWS)
+                if (isBus && context != Context.StopDetailsFiltered)
+                    tripsUpcoming.take(TYPICAL_LEAF_ROWS)
+                else tripsUpcoming
 
             for (trip in tripsToConsider) {
                 if (trip.isUpcomingWithin(now, cutoffTime)) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -203,8 +203,9 @@ data class RouteCardData(
             val tripsUpcoming = upcomingTrips.filter { it.isUpcomingWithin(now, cutoffTime) }
             val isBus = representativeRoute.type == RouteType.BUS
             val tripsToConsider =
-                if (isBus && context == Context.NearbyTransit) tripsUpcoming.take(TYPICAL_LEAF_ROWS)
-                else tripsUpcoming
+                if (isBus && context == Context.StopDetailsFiltered) tripsUpcoming
+                else tripsUpcoming.take(TYPICAL_LEAF_ROWS)
+
             for (trip in tripsToConsider) {
                 if (trip.isUpcomingWithin(now, cutoffTime)) {
                     val existingPatterns =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -1478,6 +1478,95 @@ class RouteCardDataLeafTest {
     }
 
     @Test
+    fun `formats bus as non-branching in StopDetailsFiltered even if next two trips match`() {
+        val objects = `87`.objects()
+        val now = Clock.System.now()
+
+        val prediction1 =
+            objects.prediction {
+                departureTime = now + 3.minutes
+                trip = objects.trip(`87`.outboundTypical)
+            }
+        val prediction2 =
+            objects.prediction {
+                departureTime = now + 12.minutes
+                trip = objects.trip(`87`.outboundTypical)
+            }
+        val prediction3 =
+            objects.prediction {
+                departureTime = now + 35.minutes
+                trip = objects.trip(`87`.outboundDeviation)
+            }
+
+        assertEquals(
+            wipeBranchUUID(
+                LeafFormat.Branched(
+                    branchRows =
+                        listOf(
+                            LeafFormat.Branched.BranchRow(
+                                null,
+                                "Arlington Center",
+                                UpcomingFormat.Some(
+                                    UpcomingFormat.Some.FormattedTrip(
+                                        objects.upcomingTrip(prediction1),
+                                        RouteType.BUS,
+                                        TripInstantDisplay.Minutes(3),
+                                    ),
+                                    null,
+                                ),
+                            ),
+                            LeafFormat.Branched.BranchRow(
+                                null,
+                                "Arlington Center",
+                                UpcomingFormat.Some(
+                                    UpcomingFormat.Some.FormattedTrip(
+                                        objects.upcomingTrip(prediction2),
+                                        RouteType.BUS,
+                                        TripInstantDisplay.Minutes(12),
+                                    ),
+                                    null,
+                                ),
+                            ),
+                            LeafFormat.Branched.BranchRow(
+                                null,
+                                "Clarendon Hill",
+                                UpcomingFormat.Some(
+                                    UpcomingFormat.Some.FormattedTrip(
+                                        objects.upcomingTrip(prediction3),
+                                        RouteType.BUS,
+                                        TripInstantDisplay.Minutes(35),
+                                    ),
+                                    null,
+                                ),
+                            ),
+                        ),
+                    null,
+                )
+            ),
+            wipeBranchUUID(
+                RouteCardData.Leaf(
+                        `87`.lineOrRoute,
+                        objects.stop(),
+                        0,
+                        listOf(`87`.outboundTypical, `87`.outboundDeviation),
+                        emptySet(),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3),
+                        ),
+                        emptyList(),
+                        allDataLoaded = true,
+                        hasSchedulesToday = true,
+                        emptyList(),
+                        RouteCardData.Context.StopDetailsFiltered,
+                    )
+                    .format(now, `87`.global)
+            ),
+        )
+    }
+
+    @Test
     fun `formats bus as branching if next trips differ and only shows 2 trips`() = parametricTest {
         val objects = `87`.objects()
         val now = Clock.System.now()


### PR DESCRIPTION

### Summary

_Ticket:_ No ticket, based on [report in slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1748627972953529)

What is this PR for?

We are sometimes unexpectedly treating the 15 as unbranched and always showing a headsign of "St Peter's Square" even for "Fields Corner" trips. This seems to only occur if the next two trips are both heading to "St Peter's Square". 

We want to only look at the first two bus trips to determine whether to use branching rules in nearby transit, but in filtered stop details, we should look at all trips.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added a unit test
* Ran locally and confirmed I see other headsigns for the 15, even when the next 2 trips are both to "St Peter's Square"
![image](https://github.com/user-attachments/assets/72a7ffd9-95c7-4fdf-8ee8-4deb3c369e98)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
