### PR TITLE
feat: Add facilities data to alerts

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
+import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
+import com.mbta.tid.mbta_app.usecases.AlertsUsecase
 import kotlin.test.assertEquals
 import org.junit.Assert
 import org.junit.Rule
@@ -30,9 +32,10 @@ class SubscribeToAlertsTest {
         var connectCount = 0
         val alertsStreamDataResponse = AlertsStreamDataResponse(builder)
         val alertsRepo = MockAlertsRepository(alertsStreamDataResponse, { connectCount += 1 })
+        val alertsUsecase = AlertsUsecase(alertsRepo, MockGlobalRepository())
 
         var actualData: AlertsStreamDataResponse? = null
-        composeRule.setContent { actualData = subscribeToAlerts(alertsRepo) }
+        composeRule.setContent { actualData = subscribeToAlerts(alertsUsecase) }
         composeRule.waitUntil { connectCount == 1 }
         composeRule.waitUntil { alertsStreamDataResponse == actualData }
         assertEquals(alertsStreamDataResponse, actualData)
@@ -59,12 +62,13 @@ class SubscribeToAlertsTest {
                 { connectCount += 1 },
                 { disconnectCount += 1 },
             )
+        val alertsUsecase = AlertsUsecase(alertsRepo, MockGlobalRepository())
 
         var actualData: AlertsStreamDataResponse? = null
 
         composeRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
-                actualData = subscribeToAlerts(alertsRepo)
+                actualData = subscribeToAlerts(alertsUsecase)
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 koin-junit4 = { module = "io.insert-koin:koin-test-junit4" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -44,7 +44,7 @@ class NearbyViewModel: ObservableObject {
 
     @Published var selectingLocation = false
 
-    private let alertsRepository: IAlertsRepository
+    private let alertsUsecase: AlertsUsecase
     private let errorBannerRepository: IErrorBannerStateRepository
     private let nearbyRepository: INearbyRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
@@ -57,7 +57,7 @@ class NearbyViewModel: ObservableObject {
         navigationStack: [SheetNavigationStackEntry] = [],
         showDebugMessages: Bool = false,
         showStationAccessibility: Bool = false,
-        alertsRepository: IAlertsRepository = RepositoryDI().alerts,
+        alertsUsecase: AlertsUsecase = UsecaseDI().alertsUsecase,
         errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner,
         nearbyRepository: INearbyRepository = RepositoryDI().nearby,
         visitHistoryUsecase: VisitHistoryUsecase = UsecaseDI().visitHistoryUsecase,
@@ -70,7 +70,7 @@ class NearbyViewModel: ObservableObject {
         self.showDebugMessages = showDebugMessages
         self.showStationAccessibility = showStationAccessibility
 
-        self.alertsRepository = alertsRepository
+        self.alertsUsecase = alertsUsecase
         self.errorBannerRepository = errorBannerRepository
         self.nearbyRepository = nearbyRepository
         self.visitHistoryUsecase = visitHistoryUsecase
@@ -254,7 +254,7 @@ class NearbyViewModel: ObservableObject {
     }
 
     func joinAlertsChannel() {
-        alertsRepository.connect { outcome in
+        alertsUsecase.connect { outcome in
             DispatchQueue.main.async { [weak self] in
                 if case let .ok(result) = onEnum(of: outcome) {
                     self?.alerts = result.data
@@ -264,7 +264,7 @@ class NearbyViewModel: ObservableObject {
     }
 
     func leaveAlertsChannel() {
-        alertsRepository.disconnect()
+        alertsUsecase.disconnect()
     }
 }
 

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -70,7 +70,12 @@ final class ContentViewTests: XCTestCase {
         joinAlertsExp.expectedFulfillmentCount = 1
         joinAlertsExp.assertForOverFulfill = true
 
-        let fakeNearbyVM: NearbyViewModel = .init(alertsRepository: CallbackAlertsRepository(connectExp: joinAlertsExp))
+        let fakeNearbyVM: NearbyViewModel = .init(
+            alertsUsecase: AlertsUsecase(
+                alertsRepository: CallbackAlertsRepository(connectExp: joinAlertsExp),
+                globalRepository: MockGlobalRepository()
+            )
+        )
 
         let sut = withDefaultEnvironmentObjects(sut: ContentView(contentVM: .init(), nearbyVM: fakeNearbyVM),
                                                 socketProvider: SocketProvider(socket: MockSocket()))
@@ -84,9 +89,12 @@ final class ContentViewTests: XCTestCase {
 
     func testLeavesAlertsAfterBackgrounding() throws {
         let leavesAlertsExp = expectation(description: "Alerts channel left")
-
-        let fakeNearbyVM: NearbyViewModel = .init(alertsRepository:
-            CallbackAlertsRepository(disconnectExp: leavesAlertsExp))
+        let fakeNearbyVM: NearbyViewModel = .init(
+            alertsUsecase: AlertsUsecase(
+                alertsRepository: CallbackAlertsRepository(disconnectExp: leavesAlertsExp),
+                globalRepository: MockGlobalRepository()
+            )
+        )
 
         let sut = withDefaultEnvironmentObjects(sut: ContentView(contentVM: .init(), nearbyVM: fakeNearbyVM),
                                                 socketProvider: SocketProvider(socket: MockSocket()))

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -86,6 +86,7 @@ kotlin {
             dependencies {
                 implementation(libs.koin.test)
                 implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.ktor.client.mock)
                 implementation(libs.okio.fakefilesystem)
                 implementation(libs.turbine)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -26,6 +26,7 @@ import com.mbta.tid.mbta_app.repositories.ITripRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
 import com.mbta.tid.mbta_app.repositories.IVisitHistoryRepository
+import com.mbta.tid.mbta_app.usecases.AlertsUsecase
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
@@ -79,6 +80,7 @@ fun repositoriesModule(repositories: IRepositories): Module {
         repositories.vehicles?.let { vehiclesRepo -> factory<IVehiclesRepository> { vehiclesRepo } }
         single<IVisitHistoryRepository> { repositories.visitHistory }
         single<IFavoritesRepository> { repositories.favorites }
+        single { AlertsUsecase(get(), get()) }
         single { ConfigUseCase(get(), get()) }
         single { FeaturePromoUseCase(get(), get()) }
         single { TogglePinnedRouteUsecase(get()) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.dependencyInjection
 
+import com.mbta.tid.mbta_app.usecases.AlertsUsecase
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
@@ -8,6 +9,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class UsecaseDI : KoinComponent {
+    val alertsUsecase: AlertsUsecase by inject()
     val configUsecase: ConfigUseCase by inject()
     val featurePromoUsecase: FeaturePromoUseCase by inject()
     val toggledPinnedRouteUsecase: TogglePinnedRouteUsecase by inject()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -54,6 +54,7 @@ import com.mbta.tid.mbta_app.repositories.MockTripRepository
 import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
 import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
+import com.mbta.tid.mbta_app.usecases.AlertsUsecase
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
@@ -151,6 +152,7 @@ fun endToEndModule(): Module {
         single<IVehicleRepository> { MockVehicleRepository() }
         single<IVehiclesRepository> { MockVehiclesRepository() }
         single<IVisitHistoryRepository> { MockVisitHistoryRepository() }
+        single { AlertsUsecase(get(), get()) }
         single { ConfigUseCase(get(), get()) }
         single { FeaturePromoUseCase(get(), get()) }
         single { TogglePinnedRouteUsecase(get()) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -23,6 +23,9 @@ data class Alert(
     val lifecycle: Lifecycle,
     val severity: Int,
     @SerialName("updated_at") val updatedAt: Instant,
+    // This field is not parsed from the Alert object from the backend, it is injected from
+    // global data in the AlertsUsecase if any informed entities apply to a facility.
+    val facilities: Map<String, Facility>? = null,
 ) : BackendObject {
     init {
         // This is done on init to avoid having to pass it in for any call to format an ActivePeriod

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Facility.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Facility.kt
@@ -1,0 +1,34 @@
+package com.mbta.tid.mbta_app.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Facility(
+    override val id: String,
+    @SerialName("long_name") val longName: String? = null,
+    @SerialName("short_name") val shortName: String? = null,
+    val type: Type = Type.Other,
+) : BackendObject {
+    @Serializable
+    enum class Type {
+        @SerialName("bike_storage") BikeStorage,
+        @SerialName("bridge_plate") BridgePlate,
+        @SerialName("electric_car_chargers") ElectricCarChargers,
+        @SerialName("elevated_subplatform") ElevatedSubplatform,
+        @SerialName("elevator") Elevator,
+        @SerialName("escalator") Escalator,
+        @SerialName("fare_media_assistance_facility") FareMediaAssistanceFacility,
+        @SerialName("fare_media_assistant") FareMediaAssistant,
+        @SerialName("fare_vending_machine") FareVendingMachine,
+        @SerialName("fare_vending_retailer") FareVendingRetailer,
+        @SerialName("fully_elevated_platform") FullyElevatedPlatform,
+        @SerialName("other") Other,
+        @SerialName("parking_area") ParkingArea,
+        @SerialName("pick_drop") PickDrop,
+        @SerialName("portable_boarding_lift") PortableBoardingLift,
+        @SerialName("ramp") Ramp,
+        @SerialName("taxi_stand") TaxiStand,
+        @SerialName("ticket_window") TicketWindow,
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -23,6 +23,7 @@ import kotlinx.datetime.Instant
 class ObjectCollectionBuilder
 private constructor(
     val alerts: MutableMap<String, Alert>,
+    val facilities: MutableMap<String, Facility>,
     val lines: MutableMap<String, Line>,
     val predictions: MutableMap<String, Prediction>,
     val routes: MutableMap<String, Route>,
@@ -36,6 +37,7 @@ private constructor(
     constructor() :
         this(
             alerts = mutableMapOf(),
+            facilities = mutableMapOf(),
             lines = mutableMapOf(),
             predictions = mutableMapOf(),
             routes = mutableMapOf(),
@@ -50,6 +52,7 @@ private constructor(
     fun clone() =
         ObjectCollectionBuilder(
             alerts = alerts.toMutableMap(),
+            facilities = facilities.toMutableMap(),
             lines = lines.toMutableMap(),
             predictions = predictions.toMutableMap(),
             routes = routes.toMutableMap(),
@@ -68,6 +71,7 @@ private constructor(
     fun put(`object`: BackendObject) {
         when (`object`) {
             is Alert -> alerts[`object`.id] = `object`
+            is Facility -> facilities[`object`.id] = `object`
             is Line -> lines[`object`.id] = `object`
             is Prediction -> predictions[`object`.id] = `object`
             is Route -> routes[`object`.id] = `object`
@@ -94,6 +98,7 @@ private constructor(
         var lifecycle = Alert.Lifecycle.New
         var severity = 0
         var updatedAt = Instant.fromEpochMilliseconds(0)
+        var facilities: Map<String, Facility>? = null
 
         fun activePeriod(start: Instant, end: Instant?) {
             activePeriod.add(Alert.ActivePeriod(start, end))
@@ -135,12 +140,27 @@ private constructor(
                 lifecycle,
                 severity,
                 updatedAt,
+                facilities,
             )
     }
 
     fun alert(block: AlertBuilder.() -> Unit) = build(AlertBuilder(), block)
 
     fun getAlert(id: String) = alerts.getValue(id)
+
+    class FacilityBuilder : ObjectBuilder<Facility> {
+        var id = uuid()
+        var long_name: String? = null
+        var short_name: String? = null
+        var type: Facility.Type = Facility.Type.Other
+
+        override fun built() = Facility(id, long_name, short_name, type)
+    }
+
+    @DefaultArgumentInterop.Enabled
+    fun facility(block: FacilityBuilder.() -> Unit = {}) = build(FacilityBuilder(), block)
+
+    fun getFacility(id: String) = facilities.getValue(id)
 
     class LineBuilder : ObjectBuilder<Line> {
         var id = uuid()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -11,6 +11,19 @@ data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
     fun getAlert(alertId: String) = alerts[alertId]
 
     fun isEmpty() = alerts.isEmpty()
+
+    fun injectFacilities(globalResponse: GlobalResponse?): AlertsStreamDataResponse =
+        globalResponse?.let { global ->
+            AlertsStreamDataResponse(
+                alerts.mapValues { (_, alert) ->
+                    val facilities =
+                        alert.informedEntity
+                            .mapNotNull { entity -> global.getFacility(entity.facility) }
+                            .associateBy { it.id }
+                    if (facilities.isEmpty()) alert else alert.copy(facilities = facilities)
+                }
+            )
+        } ?: this
 }
 
 fun AlertsStreamDataResponse?.isNullOrEmpty() = this == null || this.isEmpty()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.model.response
 
 import com.mbta.tid.mbta_app.kdTree.KdTree
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -15,6 +16,7 @@ import kotlinx.serialization.Transient
 
 @Serializable
 data class GlobalResponse(
+    internal val facilities: Map<String, Facility>,
     internal val lines: Map<String, Line>,
     @SerialName("pattern_ids_by_stop") internal val patternIdsByStop: Map<String, List<String>>,
     internal val routes: Map<String, Route>,
@@ -25,6 +27,7 @@ data class GlobalResponse(
     constructor(
         objects: ObjectCollectionBuilder
     ) : this(
+        objects.facilities,
         objects.lines,
         objects.routePatterns
             .flatMap {
@@ -43,6 +46,7 @@ data class GlobalResponse(
         objects: ObjectCollectionBuilder,
         patternIdsByStop: Map<String, List<String>>,
     ) : this(
+        objects.facilities,
         objects.lines,
         patternIdsByStop,
         objects.routes,
@@ -66,6 +70,8 @@ data class GlobalResponse(
     /** lines with their associated non-shuttle routes */
     internal val routesByLineId: Map<String, List<Route>> =
         routes.values.filter { it.lineId != null && !it.isShuttle }.groupBy { it.lineId!! }
+
+    fun getFacility(facilityId: String?) = facilities[facilityId]
 
     fun getRoute(routeId: String?) = routes[routeId]
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.path
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -45,7 +46,15 @@ constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) :
     @DefaultArgumentInterop.Enabled
     constructor(
         response: GlobalResponse =
-            GlobalResponse(emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), emptyMap()),
+            GlobalResponse(
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+                emptyMap(),
+            ),
         onGet: () -> Unit = {},
     ) : this(ApiResult.Ok(response), onGet)
 
@@ -60,6 +69,10 @@ constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) :
     override suspend fun getGlobalData(): ApiResult<GlobalResponse> {
         onGet()
         return result
+    }
+
+    fun updateGlobalData(newGlobal: GlobalResponse?) {
+        state.update { newGlobal }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
@@ -1,0 +1,52 @@
+package com.mbta.tid.mbta_app.usecases
+
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.IAlertsRepository
+import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+
+class AlertsUsecase(
+    private val alertsRepository: IAlertsRepository,
+    globalRepository: IGlobalRepository,
+    private val globalUpdateDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : KoinComponent {
+
+    private var lastOkResult: ApiResult.Ok<AlertsStreamDataResponse>? = null
+    private var globalState = globalRepository.state
+    private var globalUpdateJob: Job? = null
+
+    fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
+        fun injectAndReceive(result: ApiResult<AlertsStreamDataResponse>) {
+            val injectedResult =
+                if (result is ApiResult.Ok) {
+                    lastOkResult = result
+                    result.copy(result.data.injectFacilities(globalState.value))
+                } else result
+            onReceive(injectedResult)
+        }
+        alertsRepository.connect(::injectAndReceive)
+
+        globalUpdateJob?.cancel()
+        globalUpdateJob =
+            CoroutineScope(globalUpdateDispatcher).launch {
+                globalState.collect { global ->
+                    lastOkResult?.let { result ->
+                        onReceive(result.copy(result.data.injectFacilities(global)))
+                    }
+                }
+            }
+    }
+
+    fun disconnect() {
+        alertsRepository.disconnect()
+        globalUpdateJob?.cancel()
+        globalUpdateJob = null
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.usecases
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
@@ -12,7 +13,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 
-class AlertsUsecase(
+class AlertsUsecase
+@DefaultArgumentInterop.Enabled
+constructor(
     private val alertsRepository: IAlertsRepository,
     globalRepository: IGlobalRepository,
     private val globalUpdateDispatcher: CoroutineDispatcher = Dispatchers.IO,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponseTest.kt
@@ -1,0 +1,62 @@
+package com.mbta.tid.mbta_app.model.response
+
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Facility
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class AlertsStreamDataResponseTest {
+    @Test
+    fun `provided global facilities data is injected into alerts`() {
+        val objects = ObjectCollectionBuilder()
+        val facility = objects.facility { type = Facility.Type.Elevator }
+        val alert =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility.id,
+                )
+            }
+
+        val alertData = AlertsStreamDataResponse(objects)
+        assertEquals(alert, alertData.getAlert(alert.id))
+
+        val injectedData = alertData.injectFacilities(GlobalResponse(objects))
+        assertNotEquals(alertData, injectedData)
+        assertNotEquals(alert, injectedData.getAlert(alert.id))
+        assertEquals(facility, injectedData.getAlert(alert.id)?.facilities?.get(facility.id))
+    }
+
+    @Test
+    fun `alert data is passed through unchanged if global data is null`() {
+        val objects = ObjectCollectionBuilder()
+        val alert = objects.alert {}
+
+        val alertData = AlertsStreamDataResponse(objects)
+        assertEquals(alert, alertData.getAlert(alert.id))
+
+        val injectedData = alertData.injectFacilities(null)
+        assertEquals(alertData, injectedData)
+    }
+
+    @Test
+    fun `isNullOrEmpty is true when null or empty`() {
+        val nullResponse: AlertsStreamDataResponse? = null
+        assertTrue(nullResponse.isNullOrEmpty())
+
+        val emptyResponse = AlertsStreamDataResponse(emptyMap())
+        assertTrue(emptyResponse.isNullOrEmpty())
+    }
+
+    @Test
+    fun `isNullOrEmpty is false when alerts exist`() {
+        val objects = ObjectCollectionBuilder()
+        objects.alert {}
+        val alertData = AlertsStreamDataResponse(objects)
+        assertFalse(alertData.isNullOrEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.model.Facility
+import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -44,7 +46,24 @@ class GlobalRepositoryTest : KoinTest {
                     ByteReadChannel(
                         """
 {
-  "lines": {},
+  "facilities": {
+    "808": {
+      "id": "808",
+      "type": "elevator",
+      "long_name": "Park Street Elevator 808 (Red Line center platform to Government Center & North platform, Winter Street Concourse)",
+      "short_name": "Red Line center platform to Government Center & North platform, Winter Street Concourse"
+    }
+  },
+  "lines": {
+    "line-Green": {
+      "id": "line-Green",
+      "color": "00843D",
+      "long_name": "Green Line",
+      "short_name": "",
+      "sort_order": 10032,
+      "text_color": "FFFFFF"
+    }
+  },
   "routes": {
     "Shuttle-AirportGovernmentCenterLocal": {
       "id": "Shuttle-AirportGovernmentCenterLocal",
@@ -131,6 +150,24 @@ class GlobalRepositoryTest : KoinTest {
             val repo = GlobalRepository()
             assertNull(repo.state.value)
             val response = repo.getGlobalData()
+            val facility =
+                Facility(
+                    id = "808",
+                    longName =
+                        "Park Street Elevator 808 (Red Line center platform to Government Center & North platform, Winter Street Concourse)",
+                    shortName =
+                        "Red Line center platform to Government Center & North platform, Winter Street Concourse",
+                    type = Facility.Type.Elevator,
+                )
+            val line =
+                Line(
+                    id = "line-Green",
+                    color = "00843D",
+                    longName = "Green Line",
+                    shortName = "",
+                    sortOrder = 10032,
+                    textColor = "FFFFFF",
+                )
             val route =
                 Route(
                     id = "Shuttle-AirportGovernmentCenterLocal",
@@ -177,8 +214,8 @@ class GlobalRepositoryTest : KoinTest {
                 )
             val expectedResponse =
                 GlobalResponse(
-                    facilities = emptyMap(),
-                    lines = emptyMap(),
+                    facilities = mapOf("808" to facility),
+                    lines = mapOf("line-Green" to line),
                     patternIdsByStop = mapOf("3992" to listOf("230-3-1", "230-5-1")),
                     routes = mapOf("Shuttle-AirportGovernmentCenterLocal" to route),
                     routePatterns = mapOf("39-3-0" to routePattern),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -177,6 +177,7 @@ class GlobalRepositoryTest : KoinTest {
                 )
             val expectedResponse =
                 GlobalResponse(
+                    facilities = emptyMap(),
                     lines = emptyMap(),
                     patternIdsByStop = mapOf("3992" to listOf("230-3-1", "230-5-1")),
                     routes = mapOf("Shuttle-AirportGovernmentCenterLocal" to route),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
@@ -1,0 +1,195 @@
+package com.mbta.tid.mbta_app.usecases
+
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Facility
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.IdleGlobalRepository
+import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
+import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class AlertsUsecaseTest {
+    @Test
+    fun `connect with successful alerts response and existing global state`() {
+        val objects = ObjectCollectionBuilder()
+        val facility = objects.facility { type = Facility.Type.Elevator }
+        val alert =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility.id,
+                )
+            }
+
+        val alertResponse = AlertsStreamDataResponse(objects)
+        val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(alertResponse)
+        val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
+
+        var result: ApiResult<AlertsStreamDataResponse>? = null
+
+        usecase.connect { result = it }
+
+        assertNotNull(result)
+        assertTrue(result is ApiResult.Ok)
+        assertEquals(
+            facility,
+            (result as ApiResult.Ok<AlertsStreamDataResponse>)
+                .data
+                .getAlert(alert.id)
+                ?.facilities
+                ?.get(facility.id),
+        )
+    }
+
+    @Test
+    fun `global data is still injected when alert data changes`() {
+        val objects = ObjectCollectionBuilder()
+        val facility = objects.facility { type = Facility.Type.Elevator }
+        val alert1 =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility.id,
+                )
+            }
+
+        val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
+
+        var result: ApiResult<AlertsStreamDataResponse>? = null
+
+        usecase.connect { result = it }
+
+        assertNotNull(result)
+        assertTrue(result is ApiResult.Ok)
+        assertEquals(
+            facility,
+            (result as ApiResult.Ok<AlertsStreamDataResponse>)
+                .data
+                .getAlert(alert1.id)
+                ?.facilities
+                ?.get(facility.id),
+        )
+
+        val alert2 =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility.id,
+                )
+            }
+        mockAlertsRepository.receiveResult(ApiResult.Ok(AlertsStreamDataResponse(objects)))
+        assertEquals(
+            facility,
+            (result as ApiResult.Ok<AlertsStreamDataResponse>)
+                .data
+                .getAlert(alert2.id)
+                ?.facilities
+                ?.get(facility.id),
+        )
+    }
+
+    @Test
+    fun `error responses are passed through`() {
+        val mockGlobalRepository = IdleGlobalRepository()
+        val mockAlertsRepository = MockAlertsRepository(ApiResult.Error(message = "Error"))
+        val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
+
+        var result: ApiResult<AlertsStreamDataResponse>? = null
+
+        usecase.connect { result = it }
+
+        assertNotNull(result)
+        assertTrue(result is ApiResult.Error)
+        assertEquals("Error", (result as ApiResult.Error<AlertsStreamDataResponse>).message)
+    }
+
+    @Test
+    fun `alerts are passed through when global data is null`() {
+        val objects = ObjectCollectionBuilder()
+        val alert = objects.alert {}
+
+        val mockGlobalRepository = IdleGlobalRepository()
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
+
+        var result: ApiResult<AlertsStreamDataResponse>? = null
+
+        usecase.connect { result = it }
+
+        assertNotNull(result)
+        assertTrue(result is ApiResult.Ok)
+        val okResult = (result as ApiResult.Ok<AlertsStreamDataResponse>)
+        assertEquals(alert, okResult.data.getAlert(alert.id))
+        assertNull(okResult.data.getAlert(alert.id)?.facilities)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `alerts are updated when global data is updated`() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val facility1 = objects.facility { type = Facility.Type.Elevator }
+        val alert =
+            objects.alert {
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility1.id,
+                )
+            }
+        val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val usecase =
+            AlertsUsecase(
+                mockAlertsRepository,
+                mockGlobalRepository,
+                StandardTestDispatcher(testScheduler),
+            )
+
+        var result: ApiResult<AlertsStreamDataResponse>? = null
+
+        usecase.connect { result = it }
+
+        assertNotNull(result)
+        assertTrue(result is ApiResult.Ok)
+        assertEquals(
+            facility1,
+            (result as ApiResult.Ok<AlertsStreamDataResponse>)
+                .data
+                .getAlert(alert.id)
+                ?.facilities
+                ?.get(facility1.id),
+        )
+
+        val facility2 =
+            objects.facility {
+                id = facility1.id
+                short_name = "New name"
+                type = Facility.Type.Elevator
+            }
+        mockGlobalRepository.updateGlobalData(GlobalResponse(objects))
+
+        advanceUntilIdle()
+
+        assertEquals(
+            facility2,
+            (result as ApiResult.Ok<AlertsStreamDataResponse>)
+                .data
+                .getAlert(alert.id)
+                ?.facilities
+                ?.get(facility2.id),
+        )
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ First piece of [Update elevator alert template text [front-end changes]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210165100251910?focus=true)

This adds `Facility` objects to the frontend, and adds a usecase layer to wrap the alert stream, which injects facility data from the global response directly into the alerts which reference a facility in their informed entities.

We took this approach since we want to use the facility data in `FormattedAlert`, where it would be annoying to prop drill global data everywhere it's used.

### Testing

Existing tests pass, added unit tests for the new usecase.