### PR TITLE
feat: Elevator alert headers

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.android.util.formattedTime
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.utils.serviceDate
 import com.mbta.tid.mbta_app.utils.toBostonTime
@@ -125,6 +126,42 @@ class AlertCardTests {
         }
 
         composeTestRule.onNodeWithText("Alert header").assertIsDisplayed().performClick()
+        assertTrue { onViewDetailsClicked }
+    }
+
+    @Test
+    fun testElevatorAlertWithFacilityCard() {
+        val facility =
+            ObjectCollectionBuilder.Single.facility {
+                type = Facility.Type.Elevator
+                short_name = "Elevator name"
+            }
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                header = "Alert header"
+                effect = Alert.Effect.ElevatorClosure
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.UsingWheelchair),
+                    facility = facility.id,
+                )
+                facilities = mapOf(facility.id to facility)
+            }
+        var onViewDetailsClicked = false
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                null,
+                AlertCardSpec.Elevator,
+                color,
+                textColor,
+                { onViewDetailsClicked = true },
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("Elevator closure (Elevator name)")
+            .assertIsDisplayed()
+            .performClick()
         assertTrue { onViewDetailsClicked }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -134,7 +134,7 @@ class AlertCardTests {
         val facility =
             ObjectCollectionBuilder.Single.facility {
                 type = Facility.Type.Elevator
-                short_name = "Elevator name"
+                shortName = "Elevator name"
             }
         val alert =
             ObjectCollectionBuilder.Single.alert {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -52,6 +52,20 @@ data class FormattedAlert(
             dueToCauseRes?.let { stringResource(R.string.delays_due_to_cause, stringResource(it)) }
                 ?: stringResource(R.string.delays_unknown_reason)
 
+    private val elevatorHeader
+        @Composable
+        get() =
+            AnnotatedString(
+                alert.informedEntity
+                    .mapNotNull { alert.facilities?.get(it.facility) }
+                    .distinct()
+                    .singleOrNull()
+                    ?.shortName
+                    ?.let { facilityName ->
+                        stringResource(R.string.alert_elevator_header, facilityName)
+                    } ?: alert.header ?: effect
+            )
+
     private val summary
         @Composable
         get() =
@@ -70,8 +84,7 @@ data class FormattedAlert(
     fun alertCardHeader(spec: AlertCardSpec) =
         when (spec) {
             AlertCardSpec.Downstream -> summary ?: AnnotatedString.fromHtml(downstreamEffect)
-            AlertCardSpec.Elevator ->
-                alert.header?.let { AnnotatedString(it) } ?: AnnotatedString(effect)
+            AlertCardSpec.Elevator -> elevatorHeader
             AlertCardSpec.Delay -> AnnotatedString.fromHtml(delaysDueToCause)
             AlertCardSpec.Secondary -> summary ?: AnnotatedString.fromHtml(effect)
             else -> AnnotatedString.fromHtml(effect)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -10,6 +10,7 @@ import com.mbta.tid.mbta_app.android.component.directionNameFormatted
 import com.mbta.tid.mbta_app.android.stopDetails.AlertCardSpec
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Facility
 
 data class FormattedAlert(
     val alert: Alert,
@@ -58,6 +59,7 @@ data class FormattedAlert(
             AnnotatedString(
                 alert.informedEntity
                     .mapNotNull { alert.facilities?.get(it.facility) }
+                    .filter { it.type == Facility.Type.Elevator }
                     .distinct()
                     .singleOrNull()
                     ?.shortName

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="alert">Alerta</string>
     <string name="alert_details">Detalles de la alerta</string>
+    <string name="alert_elevator_header">Cierre del ascensor (%1$s)</string>
     <string name="alert_ended">La alerta ya no está vigente</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020desde paradas en &lt;b>%1$s&lt;/b> hasta &lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="alert">Alerte</string>
     <string name="alert_details">Détails de l’alerte</string>
+    <string name="alert_elevator_header">Fermeture de l’ascenseur (%1$s)</string>
     <string name="alert_ended">L’alerte n’est plus en vigueur</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020depuis les arrêts en direction de &lt;b>%1$s&lt;/b> jusqu’à &lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -18,6 +18,7 @@
     </plurals>
     <string name="alert">Avètisman</string>
     <string name="alert_details">Detay Avètisman</string>
+    <string name="alert_elevator_header">Fèmti asansè (%1$s)</string>
     <string name="alert_ended">Avètisman an pa aplikab ankò</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020soti nan &lt;b>%1$s&lt;/b> sispann rive nan &lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="alert">Alerta</string>
     <string name="alert_details">Detalhes do alerta</string>
+    <string name="alert_elevator_header">Fechamento de elevador (%1$s)</string>
     <string name="alert_ended">O alerta não está mais em efeito</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020de &lt;b>%1$s&lt;/b> paradas a &lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -13,6 +13,7 @@
     </plurals>
     <string name="alert">Báo động</string>
     <string name="alert_details">Chi tiết cảnh báo</string>
+    <string name="alert_elevator_header">Đóng thang máy (%1$s)</string>
     <string name="alert_ended">Cảnh báo không còn hiệu lực</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020từ các điểm dừng &lt;b>%1$s&lt;/b> đến &lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -13,6 +13,7 @@
     </plurals>
     <string name="alert">警报</string>
     <string name="alert_details">警报详情</string>
+    <string name="alert_elevator_header">电梯关停 (%1$s)</string>
     <string name="alert_ended">警报已失效</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020从&lt;b>%1$s&lt;/b>站到&lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -13,6 +13,7 @@
     </plurals>
     <string name="alert">警報</string>
     <string name="alert_details">警報詳情</string>
+    <string name="alert_elevator_header">電梯關閉 (%1$s)</string>
     <string name="alert_ended">警報已失效</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020從&lt;b>%1$s&lt;/b>站到&lt;b>%2$s&lt;/b></string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="alert">Alert</string>
     <string name="alert_details">Alert Details</string>
+    <string name="alert_elevator_header">Elevator closure (%1$s)</string>
     <string name="alert_ended">Alert is no longer in effect</string>
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s</string>
     <string name="alert_summary_location_direction_to_stop">\u0020from &lt;b>%1$s&lt;/b> stops to &lt;b>%2$s&lt;/b></string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7101,7 +7101,51 @@
       }
     },
     "Elevator closure (%1$@)" : {
-      "comment" : "    Alert header for elevator closure alerts,     the interpolated value is the short name field of the elevator facility, ex \"Elevator closure (Red Line platforms to lobby)\""
+      "comment" : "Alert header for elevator closure alerts, the interpolated value is the short name field of the elevator facility, ex \"Elevator closure (Red Line platforms to lobby)\"",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cierre del ascensor (%1$@)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fermeture de l’ascenseur (%1$@)"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fèmti asansè (%1$@)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fechamento de elevador (%1$@)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Đóng thang máy (%1$@)"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "电梯关停 (%1$@)"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "電梯關閉 (%1$@)"
+          }
+        }
+      }
     },
     "End" : {
       "comment" : "Label for the end date of a disruption",

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7100,6 +7100,9 @@
         }
       }
     },
+    "Elevator closure (%1$@)" : {
+      "comment" : "    Alert header for elevator closure alerts,     the interpolated value is the short name field of the elevator facility, ex \"Elevator closure (Red Line platforms to lobby)\""
+    },
     "End" : {
       "comment" : "Label for the end date of a disruption",
       "localizations" : {

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -257,15 +257,34 @@ struct FormattedAlert: Equatable {
         } else { nil }
     }
 
+    var elevatorHeader: AttributedString {
+        let facilities = alert.informedEntity.compactMap { entity in
+            if let facilityId = entity.facility { alert.facilities?[facilityId] } else { nil }
+        }
+        let headerString =
+            if let facility = Set(facilities).count == 1 ? facilities.first : nil,
+            let facilityName = facility.shortName {
+                String(format:
+                    NSLocalizedString(
+                        "Elevator closure (%1$@)",
+                        comment: """
+                        Alert header for elevator closure alerts, \
+                        the interpolated value is the short name field of the elevator facility, \
+                        ex "Elevator closure (Red Line platforms to lobby)"
+                        """
+                    ), facilityName)
+            } else if let header = alert.header {
+                header
+            } else {
+                effect
+            }
+        return AttributedString.tryMarkdown(headerString)
+    }
+
     func alertCardHeader(spec: AlertCardSpec) -> AttributedString {
         switch spec {
         case .downstream: summary ?? AttributedString.tryMarkdown(downstreamLabel)
-        case .elevator:
-            if let header = alert.header {
-                AttributedString.tryMarkdown(header)
-            } else {
-                AttributedString.tryMarkdown(effect)
-            }
+        case .elevator: elevatorHeader
         case .delay: AttributedString.tryMarkdown(delaysDueToCause)
         // TODO: confirm this is desired
         case .secondary: summary ?? AttributedString.tryMarkdown(effect)

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -260,7 +260,7 @@ struct FormattedAlert: Equatable {
     var elevatorHeader: AttributedString {
         let facilities = alert.informedEntity.compactMap { entity in
             if let facilityId = entity.facility { alert.facilities?[facilityId] } else { nil }
-        }
+        }.filter { $0.type == .elevator }
         let headerString =
             if let facility = Set(facilities).count == 1 ? facilities.first : nil,
             let facilityName = facility.shortName {

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -279,6 +279,41 @@ final class AlertCardTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
 
+    func testElevatorAlertWithFacilityCard() throws {
+        let objects = ObjectCollectionBuilder()
+        let facility = objects.facility { facility in
+            facility.type = .elevator
+            facility.shortName = "Elevator name"
+        }
+        let alert = objects.alert { alert in
+            alert.effect = .elevatorClosure
+            alert.header = "Elevator header"
+            alert.informedEntity(activities: [.usingWheelchair], facility: facility.id)
+            alert.facilities = [facility.id: facility]
+        }
+
+        let exp = XCTestExpectation(description: "Card pressed")
+        let sut = AlertCard(
+            alert: alert,
+            alertSummary: nil,
+            spec: .elevator,
+            color: Color.pink,
+            textColor: Color.orange,
+            onViewDetails: {
+                exp.fulfill()
+            }
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Elevator closure (Elevator name)"))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "accessibility-icon-alert"
+        }))
+        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
+            try image.actualImage().name() == "fa-circle-info"
+        }))
+        try sut.inspect().implicitAnyView().button().tap()
+        wait(for: [exp], timeout: 1)
+    }
+
     func testDelayAlertCard() throws {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -104,6 +104,7 @@ private constructor(
             activePeriod.add(Alert.ActivePeriod(start, end))
         }
 
+        @DefaultArgumentInterop.Enabled
         fun informedEntity(
             activities: List<Alert.InformedEntity.Activity>,
             directionId: Int? = null,
@@ -150,11 +151,11 @@ private constructor(
 
     class FacilityBuilder : ObjectBuilder<Facility> {
         var id = uuid()
-        var long_name: String? = null
-        var short_name: String? = null
+        var longName: String? = null
+        var shortName: String? = null
         var type: Facility.Type = Facility.Type.Other
 
-        override fun built() = Facility(id, long_name, short_name, type)
+        override fun built() = Facility(id, longName, shortName, type)
     }
 
     @DefaultArgumentInterop.Enabled
@@ -509,6 +510,9 @@ private constructor(
 
     object Single {
         fun alert(block: AlertBuilder.() -> Unit = {}) = ObjectCollectionBuilder().alert(block)
+
+        fun facility(block: FacilityBuilder.() -> Unit = {}) =
+            ObjectCollectionBuilder().facility(block)
 
         fun line(block: LineBuilder.() -> Unit = {}) = ObjectCollectionBuilder().line(block)
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
@@ -176,7 +176,7 @@ class AlertsUsecaseTest {
         val facility2 =
             objects.facility {
                 id = facility1.id
-                short_name = "New name"
+                shortName = "New name"
                 type = Facility.Type.Elevator
             }
         mockGlobalRepository.updateGlobalData(GlobalResponse(objects))


### PR DESCRIPTION
### Summary

_Ticket:_ [Update elevator alert template text [front-end changes]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210165100251910?focus=true)

Follow up to #1034 

Update elevator alert header text to use a localized template which includes the facility short name, instead of the alert header.

![Screenshot_20250602_130814](https://github.com/user-attachments/assets/3d656ed2-4fea-4b73-8882-08d60fcf0c7b)


iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for new header text