### PR TITLE
fix(iOS): Mapbox attribution positioning

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -18,7 +18,9 @@ struct ContentView: View {
 
     @ObservedObject var contentVM: ContentViewModel
 
-    @State private var sheetHeight: CGFloat = UIScreen.main.bounds.height / 2
+    @State private var contentHeight: CGFloat = UIScreen.current?.bounds.height ?? 0
+    @State private var sheetHeight: CGFloat = (UIScreen.current?.bounds.height ?? 0) * PresentationDetent
+        .mediumDetentFraction
     @StateObject var errorBannerVM = ErrorBannerViewModel()
     @StateObject var nearbyVM = NearbyViewModel()
     @StateObject var mapVM = MapViewModel()
@@ -42,8 +44,12 @@ struct ContentView: View {
     }
 
     var body: some View {
-        VStack {
-            contents
+        GeometryReader { proxy in
+            VStack {
+                contents
+            }
+            .onAppear { contentHeight = proxy.size.height }
+            .onChange(of: proxy.size.height) { contentHeight = $0 }
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .onAppear {
@@ -412,8 +418,8 @@ struct ContentView: View {
          Only update this if we're less than half way up the users screen. Otherwise,
          the entire map is blocked by the sheet anyway, so it doesn't need to respond to height changes
          */
-        guard newSheetHeight < (UIScreen.main.bounds.height * PresentationDetent.mediumDetentFraction) else { return }
-        sheetHeight = newSheetHeight - 55
+        guard newSheetHeight < ((contentHeight - 8) * PresentationDetent.mediumDetentFraction) else { return }
+        sheetHeight = newSheetHeight
     }
 
     private func updateTabBarVisibility(_: SelectedTab) {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -19,8 +19,8 @@ struct ContentView: View {
     @ObservedObject var contentVM: ContentViewModel
 
     @State private var contentHeight: CGFloat = UIScreen.current?.bounds.height ?? 0
-    @State private var sheetHeight: CGFloat = (UIScreen.current?.bounds.height ?? 0) * PresentationDetent
-        .mediumDetentFraction
+    @State private var sheetHeight: CGFloat =
+        (UIScreen.current?.bounds.height ?? 0) * PresentationDetent.mediumDetentFraction
     @StateObject var errorBannerVM = ErrorBannerViewModel()
     @StateObject var nearbyVM = NearbyViewModel()
     @StateObject var mapVM = MapViewModel()

--- a/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
+++ b/iosApp/iosApp/Pages/Map/AnnotatedMap.swift
@@ -51,7 +51,7 @@ struct AnnotatedMap: View {
             .ornamentOptions(.init(
                 scaleBar: .init(visibility: .hidden),
                 compass: .init(visibility: .hidden),
-                attributionButton: .init(margins: .init(x: 0, y: 8))
+                attributionButton: .init(margins: .init(x: -3, y: 6))
             ))
             .onLayerTapGesture(StopLayerGenerator.shared.stopLayerId, perform: handleTapStopLayer)
             .onLayerTapGesture(StopLayerGenerator.shared.stopTouchTargetLayerId, perform: handleTapStopLayer)
@@ -65,7 +65,7 @@ struct AnnotatedMap: View {
                     handleStyleLoaded()
                 }
             }
-            .additionalSafeAreaInsets(.bottom, sheetHeight + 8)
+            .additionalSafeAreaInsets(.bottom, sheetHeight)
             .additionalSafeAreaInsets(.top, 20)
             .ignoresSafeArea(.all)
             .accessibilityIdentifier("transitMap")

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -207,7 +207,7 @@ struct HomeMapView: View {
         VStack {
             Image(.mapNearbyLocationCursor)
             Spacer()
-                .frame(height: sheetHeight - 12)
+                .frame(height: sheetHeight - 20)
         }
     }
 

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -35,8 +35,7 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
-            .vStack()
+        try sut.inspect().find(ContentView.self).find(ViewType.GeometryReader.self)
             .callOnChange(newValue: ScenePhase.background)
         wait(for: [disconnectedExpectation], timeout: 5)
     }
@@ -55,12 +54,11 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
-            .vStack()
+        try sut.inspect().find(ContentView.self).find(ViewType.GeometryReader.self)
             .callOnChange(newValue: ScenePhase.background)
         wait(for: [disconnectedExpectation], timeout: 1)
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
-            .vStack().callOnChange(newValue: ScenePhase.active)
+        try sut.inspect().find(ContentView.self).find(ViewType.GeometryReader.self)
+            .callOnChange(newValue: ScenePhase.active)
         wait(for: [connectedExpectation], timeout: 1)
     }
 
@@ -82,8 +80,8 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
-            .vStack().callOnChange(newValue: ScenePhase.active)
+        try sut.inspect().find(ContentView.self).find(ViewType.GeometryReader.self)
+            .callOnChange(newValue: ScenePhase.active)
         wait(for: [joinAlertsExp], timeout: 5)
     }
 
@@ -101,7 +99,7 @@ final class ContentViewTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView().vStack()
+        try sut.inspect().find(ContentView.self).find(ViewType.GeometryReader.self)
             .callOnChange(newValue: ScenePhase.background)
         wait(for: [leavesAlertsExp], timeout: 5)
     }
@@ -131,8 +129,7 @@ final class ContentViewTests: XCTestCase {
 
         let newConfig: ApiResult<ConfigResponse>? = ApiResultOk(data: .init(mapboxPublicToken: "FAKE_TOKEN"))
 
-        try sut.inspect().implicitAnyView().view(ContentView.self).implicitAnyView()
-            .vStack()
+        try sut.inspect().implicitAnyView().find(ContentView.self).find(ViewType.GeometryReader.self)
             .callOnChange(newValue: newConfig)
         wait(for: [tokenConfigExpectation], timeout: 5)
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [ Fix Mapbox attribution](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1210440278891490?focus=true)

The position wasn't updated properly when we changed the sheet detent. This should better handle any future detent ratio changes, and stops using the deprecated `UIScreen.main.bounds`, which was giving a number that didn't line up with the actual rendered content height. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Tested on an simulated iPhone 16 and an iPhone 13 mini to check that it works on different screen sizes. Also took screenshots and measured pixel lengths between the attribution logo/info button and borders to get consistent padding.
