### PR TITLE
fix(Android): Disappearing vehicle pucks

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -449,11 +449,12 @@ fun HomeMapView(
                     ViewAnnotation(
                         options =
                             viewAnnotationOptions {
-                                selected(isSelected)
+                                priority(if (isSelected) 1 else 0)
                                 geometry(Point.fromLngLat(vehicle.longitude, vehicle.latitude))
                                 annotationAnchor { anchor(ViewAnnotationAnchor.CENTER) }
                                 allowOverlap(true)
                                 allowOverlapWithPuck(true)
+                                ignoreCameraPadding(true)
                                 visible(
                                     zoomLevel >= StopLayerGenerator.stopZoomThreshold || isSelected
                                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -204,7 +204,8 @@ fun MapAndSheetPage(
                 when (currentNavEntry) {
                     is SheetRoutes.StopDetails -> currentNavEntry.stopFilter
                     else -> null
-                }
+                },
+            routeCardData = routeCardData,
         )
 
     var searchExpanded by rememberSaveable { mutableStateOf(false) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ kotlinxCoroutinesCore = "1.10.2"
 kotlinxDatetime = "0.6.2"
 ktor = "3.1.3"
 # changelog: https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md
-mapbox = "11.12.0"
+mapbox = "11.12.2"
 mapboxTurf = "7.4.0"
 mokkery = "2.8.0"
 okhttp = "4.12.0"


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Fix: missing vehicle pucks](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210444251184038?focus=true)

I was having some trouble reproducing this, so I added 3 separate changes that could make some difference.
* Upgraded mapbox from 11.12.0 to 11.12.2 (there was a [view annotation fix](https://github.com/mapbox/mapbox-maps-android/releases/tag/v11.12.2) in there)
* Add `ignoreCameraPadding(true)` to the annotations so that they always stay visible to the edges of the screen
* Filter out irrelevant GL vehicles when you're on a branch, so that vehicles on parallel branches aren't shown on the map (we already do this on iOS but forgot to ever add it on Android)

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a new unit test for the parallel line filtering