### PR TITLE
feat: hide irrelevant bus stops in layer

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -45,6 +45,7 @@ import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -295,6 +296,7 @@ class MapAndSheetPageTest : KoinTest {
             override val configLoadAttempted: StateFlow<Boolean> = MutableStateFlow(value = false)
             override val globalMapData: Flow<GlobalMapData?> = MutableStateFlow(value = null)
             override val selectedStop: StateFlow<Stop?> = MutableStateFlow(value = null)
+            override val stopFilter: StateFlow<StopDetailsFilter?> = MutableStateFlow(value = null)
             override val showRecenterButton: StateFlow<Boolean> = MutableStateFlow(value = false)
             override val showTripCenterButton: StateFlow<Boolean> = MutableStateFlow(value = false)
             var loadConfigCalledCount = 0
@@ -311,10 +313,7 @@ class MapAndSheetPageTest : KoinTest {
 
             override suspend fun refreshRouteLineData(globalMapData: GlobalMapData?) {}
 
-            override suspend fun refreshStopFeatures(
-                selectedStop: Stop?,
-                globalMapData: GlobalMapData?,
-            ) {}
+            override suspend fun refreshStopFeatures(globalMapData: GlobalMapData?) {}
 
             override suspend fun setAlertsData(alertsData: AlertsStreamDataResponse?) {}
 
@@ -323,6 +322,10 @@ class MapAndSheetPageTest : KoinTest {
             override fun setSelectedVehicle(selectedVehicle: Vehicle?) {}
 
             override fun setSelectedStop(stop: Stop?) {
+                TODO("Not yet implemented")
+            }
+
+            override fun setStopFilter(stopFilter: StopDetailsFilter?) {
                 TODO("Not yet implemented")
             }
 

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -94,9 +94,14 @@ struct HomeMapView: View {
             }
             .onChange(of: mapVM.routeSourceData) { _ in
                 updateRouteSource()
+                if let layerManager = mapVM.layerManager {
+                    addLayers(layerManager)
+                }
             }
-            .onChange(of: mapVM.stopSourceData) { _ in
-                updateStopSource()
+            .onChange(of: mapVM.stopLayerState) { _ in
+                if let layerManager = mapVM.layerManager {
+                    addLayers(layerManager)
+                }
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
             .onChange(of: viewportProvider.isManuallyCentering) { isManuallyCentering in

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -170,7 +170,7 @@ extension HomeMapView {
     }
 
     func handleStopDetailsChange(_ stop: Stop, _ filter: StopDetailsFilter?) {
-        mapVM.stopSourceData = .init(selectedStopId: stop.id)
+        mapVM.stopLayerState = .init(selectedStopId: stop.id, stopFilter: filter)
         viewportProvider.animateTo(coordinates: stop.coordinate)
 
         Task {

--- a/iosApp/iosApp/ViewModels/MapViewModel.swift
+++ b/iosApp/iosApp/ViewModels/MapViewModel.swift
@@ -14,7 +14,7 @@ import Shared
 class MapViewModel: ObservableObject {
     @Published var selectedVehicle: Vehicle?
     @Published var routeSourceData: [MapFriendlyRouteResponse.RouteWithSegmentedShapes] = []
-    @Published var stopSourceData: StopSourceData = .init()
+    @Published var stopLayerState: StopLayerGenerator.State = .init()
     @Published var stopMapData: StopMapResponse?
     @Published var allRailSourceData: [MapFriendlyRouteResponse.RouteWithSegmentedShapes] = []
     @Published var globalData: GlobalResponse?
@@ -82,7 +82,6 @@ class MapViewModel: ObservableObject {
 
     private func getStopFeatures(globalMapData: GlobalMapData) async throws -> MapboxMaps.FeatureCollection {
         try await StopFeaturesBuilder.shared.buildCollection(
-            stopData: stopSourceData,
             globalMapData: globalMapData,
             routeSourceDetails: snappedStopRouteSources
         ).toMapbox()

--- a/iosApp/iosAppTests/Mocks/MockLayerManager.swift
+++ b/iosApp/iosAppTests/Mocks/MockLayerManager.swift
@@ -38,9 +38,9 @@ class MockLayerManager: IMapLayerManager {
 
     func addLayers(
         routes _: [MapFriendlyRouteResponse.RouteWithSegmentedShapes],
+        state _: StopLayerGenerator.State,
         globalResponse _: GlobalResponse,
-        colorScheme: ColorScheme,
-        recreate _: Bool = false
+        colorScheme: ColorScheme
     ) {
         currentScheme = colorScheme
         addLayersCallback()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapTestDataHelper.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapTestDataHelper.kt
@@ -25,6 +25,7 @@ object MapTestDataHelper {
             stopAlewife,
             mapOf(MapStopRoute.RED to listOf(routeRed), MapStopRoute.BUS to listOf(route67)),
             listOf(MapStopRoute.RED, MapStopRoute.BUS),
+            mapOf(routeRed.id to setOf(0, 1), route67.id to setOf(0, 1)),
             true,
             null,
         )
@@ -37,6 +38,7 @@ object MapTestDataHelper {
             stop = stopDavis,
             routes = mapOf(MapStopRoute.RED to listOf(routeRed)),
             routeTypes = listOf(MapStopRoute.RED),
+            routeDirections = mapOf(routeRed.id to setOf(0, 1)),
             isTerminal = false,
             alerts = null,
         )
@@ -48,6 +50,7 @@ object MapTestDataHelper {
             stopPorter,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
             listOf(MapStopRoute.RED),
+            mapOf(routeRed.id to setOf(0, 1)),
             false,
             null,
         )
@@ -59,6 +62,7 @@ object MapTestDataHelper {
             stopHarvard,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
             listOf(MapStopRoute.RED),
+            mapOf(routeRed.id to setOf(0, 1)),
             false,
             null,
         )
@@ -70,6 +74,7 @@ object MapTestDataHelper {
             stopCentral,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
             listOf(MapStopRoute.RED),
+            mapOf(routeRed.id to setOf(0, 1)),
             false,
             null,
         )
@@ -83,6 +88,7 @@ object MapTestDataHelper {
             stopAssembly,
             mapOf(MapStopRoute.ORANGE to listOf(routeOrange)),
             listOf(MapStopRoute.ORANGE),
+            mapOf(routeOrange.id to setOf(0, 1)),
             false,
             null,
         )
@@ -94,6 +100,7 @@ object MapTestDataHelper {
             stopSullivan,
             mapOf(MapStopRoute.ORANGE to listOf(routeOrange)),
             listOf(MapStopRoute.ORANGE),
+            mapOf(routeOrange.id to setOf(0, 1)),
             false,
             null,
         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.map
 
-import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.map.style.Feature
 import com.mbta.tid.mbta_app.map.style.FeatureCollection
 import com.mbta.tid.mbta_app.map.style.FeatureProperty
@@ -17,15 +16,10 @@ import kotlinx.coroutines.withContext
 
 data class StopFeatureData(val stop: MapStop, val feature: Feature)
 
-data class StopSourceData
-@DefaultArgumentInterop.Enabled
-constructor(val filteredStopIds: List<String>? = null, val selectedStopId: String? = null)
-
 object StopFeaturesBuilder {
     val stopSourceId = "stop-source"
 
     val propIdKey = FeatureProperty<String>("id")
-    val propIsSelectedKey = FeatureProperty<Boolean>("isSelected")
     val propIsTerminalKey = FeatureProperty<Boolean>("isTerminal")
     // Map routes is an array of MapStopRoute enum names
     val propMapRoutesKey = FeatureProperty<List<String>>("mapRoutes")
@@ -35,25 +29,20 @@ object StopFeaturesBuilder {
     val propServiceStatusKey = FeatureProperty<Map<String, String>>("serviceStatus")
     val propSortOrderKey = FeatureProperty<Number>("sortOrder")
 
+    /** Routes and directions are stored as "<route id>/<direction id>". */
+    val propAllRouteDirectionsKey = FeatureProperty<List<String>>("allRouteDirections")
+
     suspend fun buildCollection(
-        stopData: StopSourceData,
         globalMapData: GlobalMapData?,
         routeSourceDetails: List<RouteSourceData>,
-    ) = buildCollection(stopData, globalMapData?.mapStops.orEmpty(), routeSourceDetails)
+    ) = buildCollection(globalMapData?.mapStops.orEmpty(), routeSourceDetails)
 
     internal suspend fun buildCollection(
-        stopData: StopSourceData,
         stops: Map<String, MapStop>,
         routeSourceDetails: List<RouteSourceData>,
     ): FeatureCollection =
         withContext(Dispatchers.Default) {
-            val filteredStops =
-                if (stopData.filteredStopIds != null) {
-                    stops.filter { stopData.filteredStopIds.contains(it.key) }
-                } else {
-                    stops
-                }
-            val stopFeatures = generateStopFeatures(stopData, filteredStops, routeSourceDetails)
+            val stopFeatures = generateStopFeatures(stops, routeSourceDetails)
             buildCollection(stopFeatures = stopFeatures)
         }
 
@@ -62,20 +51,17 @@ object StopFeaturesBuilder {
     }
 
     private fun generateStopFeatures(
-        stopData: StopSourceData,
         stops: Map<String, MapStop>,
         routeSourceDetails: List<RouteSourceData>,
     ): List<StopFeatureData> {
         val touchedStopIds: MutableSet<String> = mutableSetOf()
-        val routeStops =
-            generateRouteAssociatedStops(stopData, stops, routeSourceDetails, touchedStopIds)
-        val otherStops = generateRemainingStops(stopData, stops, touchedStopIds)
+        val routeStops = generateRouteAssociatedStops(stops, routeSourceDetails, touchedStopIds)
+        val otherStops = generateRemainingStops(stops, touchedStopIds)
         return otherStops + routeStops
     }
 
     @OptIn(ExperimentalTurfApi::class)
     private fun generateRouteAssociatedStops(
-        stopData: StopSourceData,
         stops: Map<String, MapStop>,
         routeSourceDetails: List<RouteSourceData>,
         touchedStopIds: MutableSet<String>,
@@ -96,8 +82,7 @@ object StopFeaturesBuilder {
                     touchedStopIds.add(stop.id)
                     return@mapNotNull StopFeatureData(
                         stop = mapStop,
-                        feature =
-                            generateStopFeature(mapStop, stopData, overrideLocation = snappedCoord),
+                        feature = generateStopFeature(mapStop, overrideLocation = snappedCoord),
                     )
                 }
             }
@@ -105,7 +90,6 @@ object StopFeaturesBuilder {
     }
 
     private fun generateRemainingStops(
-        stopData: StopSourceData,
         stops: Map<String, MapStop>,
         touchedStopIds: MutableSet<String>,
     ): List<StopFeatureData> {
@@ -122,54 +106,54 @@ object StopFeaturesBuilder {
             touchedStopIds.add(stop.id)
             return@mapNotNull StopFeatureData(
                 stop = mapStop,
-                feature = generateStopFeature(mapStop, stopData),
+                feature = generateStopFeature(mapStop),
             )
         }
     }
 
-    private fun generateStopFeature(
-        mapStop: MapStop,
-        stopData: StopSourceData,
-        overrideLocation: Position? = null,
-    ): Feature {
+    private fun generateStopFeature(mapStop: MapStop, overrideLocation: Position? = null): Feature {
         val stop = mapStop.stop
         return Feature(
             id = stop.id,
             geometry = Point(overrideLocation ?: stop.position),
-            properties = generateStopFeatureProperties(mapStop, stopData),
+            properties = generateStopFeatureProperties(mapStop),
         )
     }
 
-    private fun generateStopFeatureProperties(mapStop: MapStop, stopData: StopSourceData) =
-        buildFeatureProperties {
-            val stop = mapStop.stop
-            put(propIdKey, stop.id)
-            put(propNameKey, stop.name)
-            put(propIsSelectedKey, stop.id == stopData.selectedStopId)
-            put(propIsTerminalKey, mapStop.isTerminal)
-            put(propMapRoutesKey, mapStop.routeTypes.map { it.name })
-            put(
-                propRouteIdsKey,
-                mapStop.routes
-                    .map { (routeType, routes) -> Pair(routeType.name, routes.map { it.id }) }
-                    .toMap(),
-            )
-            put(
-                propServiceStatusKey,
-                mapStop.alerts
-                    .orEmpty()
-                    .map { (routeType, alertState) -> Pair(routeType.name, alertState.name) }
-                    .toMap(),
-            )
+    private fun generateStopFeatureProperties(mapStop: MapStop) = buildFeatureProperties {
+        val stop = mapStop.stop
+        put(propIdKey, stop.id)
+        put(propNameKey, stop.name)
+        put(propIsTerminalKey, mapStop.isTerminal)
+        put(propMapRoutesKey, mapStop.routeTypes.map { it.name })
+        put(
+            propRouteIdsKey,
+            mapStop.routes
+                .map { (routeType, routes) -> Pair(routeType.name, routes.map { it.id }) }
+                .toMap(),
+        )
+        put(
+            propServiceStatusKey,
+            mapStop.alerts
+                .orEmpty()
+                .map { (routeType, alertState) -> Pair(routeType.name, alertState.name) }
+                .toMap(),
+        )
+        put(
+            propAllRouteDirectionsKey,
+            mapStop.routeDirections.flatMap { (routeId, directions) ->
+                directions.map { "$routeId/$it" }
+            },
+        )
 
-            // The symbolSortKey must be ascending, so higher priority icons need higher values.
-            // This takes the ordinal of the top route and makes it negative. If there are no routes
-            // it's set to the total number of route types so that the weird routeless stop is below
-            // everything else, and if it has multiple route types, it's set to positive 1 to put
-            // the route container above everything else.
-            val topRouteOrdinal =
-                if (mapStop.routeTypes.isEmpty()) (MapStopRoute.entries.size)
-                else mapStop.routeTypes[0].ordinal
-            put(propSortOrderKey, if (mapStop.routeTypes.count() > 1) 1 else -topRouteOrdinal)
-        }
+        // The symbolSortKey must be ascending, so higher priority icons need higher values.
+        // This takes the ordinal of the top route and makes it negative. If there are no routes
+        // it's set to the total number of route types so that the weird routeless stop is below
+        // everything else, and if it has multiple route types, it's set to positive 1 to put
+        // the route container above everything else.
+        val topRouteOrdinal =
+            if (mapStop.routeTypes.isEmpty()) (MapStopRoute.entries.size)
+            else mapStop.routeTypes[0].ordinal
+        put(propSortOrderKey, if (mapStop.routeTypes.count() > 1) 1 else -topRouteOrdinal)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
@@ -173,6 +173,17 @@ sealed interface Exp<T> : MapboxStyleObject {
                 }
             }
 
+        fun <T> let(vararg bindings: LetVariable.Binding<*>, body: Exp<T>): Exp<T> =
+            op("let") {
+                for (binding in bindings) {
+                    add(binding.variable.name)
+                    add(binding.value)
+                }
+                add(body)
+            }
+
+        fun <T> `var`(variable: LetVariable<T>): Exp<T> = op("var", Exp(variable.name))
+
         fun concat(vararg values: Exp<String>): Exp<String> = op("concat", *values)
 
         fun downcase(value: Exp<String>): Exp<String> = op("downcase", value)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LetVariable.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LetVariable.kt
@@ -1,0 +1,7 @@
+package com.mbta.tid.mbta_app.map.style
+
+data class LetVariable<T>(val name: String) {
+    infix fun boundTo(value: Exp<T>) = Binding(this, value)
+
+    data class Binding<T>(val variable: LetVariable<T>, val value: Exp<T>)
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -26,7 +26,6 @@ class StopFeaturesBuilderTest {
 
         val collection =
             StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(selectedStopId = null),
                 stops =
                     mapOf(
                         stop1.id to
@@ -34,6 +33,7 @@ class StopFeaturesBuilderTest {
                                 stop = stop1,
                                 routes = emptyMap(),
                                 routeTypes = listOf(MapStopRoute.BLUE),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -42,6 +42,7 @@ class StopFeaturesBuilderTest {
                                 stop = stop2,
                                 routes = emptyMap(),
                                 routeTypes = listOf(MapStopRoute.GREEN),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -55,6 +56,7 @@ class StopFeaturesBuilderTest {
                                         MapStopRoute.MATTAPAN,
                                         MapStopRoute.BUS,
                                     ),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -63,6 +65,7 @@ class StopFeaturesBuilderTest {
                                 stop = stop4,
                                 routes = emptyMap(),
                                 routeTypes = listOf(MapStopRoute.BUS),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -71,6 +74,7 @@ class StopFeaturesBuilderTest {
                                 stop = stop5,
                                 routes = emptyMap(),
                                 routeTypes = listOf(MapStopRoute.BUS),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -79,6 +83,7 @@ class StopFeaturesBuilderTest {
                                 stop = stop6,
                                 routes = emptyMap(),
                                 routeTypes = listOf(MapStopRoute.BUS),
+                                routeDirections = emptyMap(),
                                 isTerminal = false,
                                 alerts = null,
                             ),
@@ -107,11 +112,7 @@ class StopFeaturesBuilderTest {
                 alertsByStop = emptyMap(),
             )
         val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(),
-                stops = stops,
-                routeSourceDetails = routeLines,
-            )
+            StopFeaturesBuilder.buildCollection(stops = stops, routeSourceDetails = routeLines)
         val snappedStopCoordinates =
             Position(latitude = 42.3961623851223, longitude = -71.14129664101432)
 
@@ -123,71 +124,6 @@ class StopFeaturesBuilderTest {
     }
 
     @Test
-    fun `selected stop has prop set`() = runBlocking {
-        val objects = TestData.clone()
-        val selectedStop = objects.getStop("place-alfcl")
-        val otherStop = objects.getStop("place-davis")
-
-        val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(selectedStopId = selectedStop.id),
-                stops =
-                    mapOf(selectedStop.id to selectedStop, otherStop.id to otherStop).mapValues {
-                        (_, stop) ->
-                        MapStop(
-                            stop = stop,
-                            routes = mapOf(MapStopRoute.RED to listOf(MapTestDataHelper.routeRed)),
-                            routeTypes = listOf(MapStopRoute.RED),
-                            isTerminal = false,
-                            alerts = null,
-                        )
-                    },
-                routeSourceDetails = emptyList(),
-            )
-
-        assertEquals(2, collection.features.size)
-
-        val selectedFeature = collection.features.find { it.id == selectedStop.id }
-        val otherFeature = collection.features.find { it.id == otherStop.id }
-        assertNotNull(selectedFeature)
-        assertEquals(true, selectedFeature.properties[StopFeaturesBuilder.propIsSelectedKey])
-
-        assertEquals(false, otherFeature?.properties?.get(StopFeaturesBuilder.propIsSelectedKey))
-    }
-
-    @Test
-    fun `filtered stop ids`(): Unit = runBlocking {
-        val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData =
-                    StopSourceData(
-                        filteredStopIds = listOf(MapTestDataHelper.stopAlewife.id),
-                        selectedStopId = null,
-                    ),
-                stops =
-                    mapOf(
-                            MapTestDataHelper.stopAlewife.id to MapTestDataHelper.stopAlewife,
-                            MapTestDataHelper.stopDavis.id to MapTestDataHelper.stopDavis,
-                        )
-                        .mapValues { (_, stop) ->
-                            MapStop(
-                                stop = stop,
-                                routes =
-                                    mapOf(MapStopRoute.RED to listOf(MapTestDataHelper.routeRed)),
-                                routeTypes = listOf(MapStopRoute.RED),
-                                isTerminal = false,
-                                alerts = null,
-                            )
-                        },
-                routeSourceDetails = emptyList(),
-            )
-
-        assertEquals(1, collection.features.size)
-
-        assertNotNull(collection.features.find { it.id == MapTestDataHelper.stopAlewife.id })
-    }
-
-    @Test
     fun `stops features have service status`() = runBlocking {
         val objects = MapTestDataHelper.objects
 
@@ -195,7 +131,6 @@ class StopFeaturesBuilderTest {
 
         val collection =
             StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(),
                 stops =
                     mapOf(
                         "70061" to
@@ -204,6 +139,8 @@ class StopFeaturesBuilderTest {
                                 routes =
                                     mapOf(MapStopRoute.RED to listOf(MapTestDataHelper.routeRed)),
                                 routeTypes = listOf(MapStopRoute.RED),
+                                routeDirections =
+                                    mapOf(MapTestDataHelper.routeRed.id to setOf(0, 1)),
                                 isTerminal = true,
                                 alerts = null,
                             ),
@@ -213,6 +150,8 @@ class StopFeaturesBuilderTest {
                                 routes =
                                     mapOf(MapStopRoute.RED to listOf(MapTestDataHelper.routeRed)),
                                 routeTypes = listOf(MapStopRoute.RED),
+                                routeDirections =
+                                    mapOf(MapTestDataHelper.routeRed.id to setOf(0, 1)),
                                 isTerminal = true,
                                 alerts = mapOf(MapStopRoute.RED to StopAlertState.Shuttle),
                             ),
@@ -224,6 +163,8 @@ class StopFeaturesBuilderTest {
                                         MapStopRoute.ORANGE to listOf(MapTestDataHelper.routeOrange)
                                     ),
                                 routeTypes = listOf(MapStopRoute.ORANGE),
+                                routeDirections =
+                                    mapOf(MapTestDataHelper.routeOrange.id to setOf(0, 1)),
                                 isTerminal = false,
                                 alerts = mapOf(MapStopRoute.ORANGE to StopAlertState.Suspension),
                             ),
@@ -266,11 +207,7 @@ class StopFeaturesBuilderTest {
                 alertsByStop = emptyMap(),
             )
         val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(),
-                stops = stops,
-                routeSourceDetails = routeLines,
-            )
+            StopFeaturesBuilder.buildCollection(stops = stops, routeSourceDetails = routeLines)
 
         assertEquals(4, collection.features.size)
         val assemblyFeature =
@@ -302,11 +239,7 @@ class StopFeaturesBuilderTest {
             )
 
         val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(),
-                stops = stops,
-                routeSourceDetails = emptyList(),
-            )
+            StopFeaturesBuilder.buildCollection(stops = stops, routeSourceDetails = emptyList())
 
         assertEquals(2, collection.features.size)
         val assemblyFeature =
@@ -330,11 +263,7 @@ class StopFeaturesBuilderTest {
             )
 
         val collection =
-            StopFeaturesBuilder.buildCollection(
-                stopData = StopSourceData(),
-                stops = stops,
-                routeSourceDetails = emptyList(),
-            )
+            StopFeaturesBuilder.buildCollection(stops = stops, routeSourceDetails = emptyList())
 
         assertEquals(2, collection.features.size)
         val alewifeFeature = collection.features.find { it.id == MapTestDataHelper.stopAlewife.id }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
@@ -1,9 +1,15 @@
 package com.mbta.tid.mbta_app.map
 
 import com.mbta.tid.mbta_app.map.style.evaluate
+import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.MapStop
 import com.mbta.tid.mbta_app.model.MapStopRoute
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopAlertState
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,7 +18,8 @@ import kotlinx.coroutines.runBlocking
 class StopLayerGeneratorTest {
     @Test
     fun `stop layers are created`() = runBlocking {
-        val stopLayers = StopLayerGenerator.createStopLayers(ColorPalette.light)
+        val stopLayers =
+            StopLayerGenerator.createStopLayers(ColorPalette.light, StopLayerGenerator.State())
 
         assertEquals(11, stopLayers.size)
         assertEquals(StopLayerGenerator.stopTouchTargetLayerId, stopLayers[0].id)
@@ -44,6 +51,16 @@ class StopLayerGeneratorTest {
                         TestData.getRoute("CR-Newburyport"),
                     ),
             )
+        val routeDirections =
+            mapOf(
+                "Orange" to setOf(0, 1),
+                "Green-D" to setOf(0, 1),
+                "Green-E" to setOf(0, 1),
+                "CR-Fitchburg" to setOf(0, 1),
+                "CR-Haverhill" to setOf(0, 1),
+                "CR-Lowell" to setOf(0, 1),
+                "CR-Newburyport" to setOf(0, 1),
+            )
 
         val mapStops =
             mapOf(
@@ -53,6 +70,7 @@ class StopLayerGeneratorTest {
                         routes = routes,
                         routeTypes =
                             listOf(MapStopRoute.ORANGE, MapStopRoute.GREEN, MapStopRoute.COMMUTER),
+                        routeDirections = routeDirections,
                         isTerminal = true,
                         alerts =
                             mapOf(
@@ -64,12 +82,10 @@ class StopLayerGeneratorTest {
                     )
             )
 
-        val feature =
-            StopFeaturesBuilder.buildCollection(StopSourceData(), mapStops, emptyList())
-                .features
-                .single()
+        val feature = StopFeaturesBuilder.buildCollection(mapStops, emptyList()).features.single()
 
-        val stopLayers = StopLayerGenerator.createStopLayers(ColorPalette.light)
+        val stopLayers =
+            StopLayerGenerator.createStopLayers(ColorPalette.light, StopLayerGenerator.State())
 
         val busLayer = stopLayers[1]
         val busAlertLayer = stopLayers[2]
@@ -80,6 +96,7 @@ class StopLayerGeneratorTest {
         val alertLayer0 = stopLayers[7]
         val alertLayer1 = stopLayers[8]
         val alertLayer2 = stopLayers[9]
+        val selectedPinLayer = stopLayers[10]
 
         assertEquals("", busLayer.iconImage!!.evaluate(feature.properties, zoom = 14.0))
         assertEquals("", busLayer.textField!!.evaluate(feature.properties, zoom = 14.0))
@@ -116,5 +133,109 @@ class StopLayerGeneratorTest {
             alertLayer1.iconImage!!.evaluate(feature.properties, zoom = 14.0),
         )
         assertEquals("", alertLayer2.iconImage!!.evaluate(feature.properties, zoom = 14.0))
+        assertEquals("", selectedPinLayer.iconImage!!.evaluate(feature.properties, zoom = 14.0))
+    }
+
+    @Test
+    fun `state selected stop applies correctly`() = runBlocking {
+        val mapStops =
+            mapOf(
+                MapTestDataHelper.stopAlewife.id to MapTestDataHelper.mapStopAlewife,
+                MapTestDataHelper.stopAssembly.id to MapTestDataHelper.mapStopAssembly,
+            )
+        val features = StopFeaturesBuilder.buildCollection(mapStops, emptyList()).features
+
+        val alewifeFeature = features.first { it.id == MapTestDataHelper.stopAlewife.id }
+        val assemblyFeature = features.first { it.id == MapTestDataHelper.stopAssembly.id }
+
+        val stopLayers =
+            StopLayerGenerator.createStopLayers(
+                ColorPalette.light,
+                StopLayerGenerator.State(selectedStopId = alewifeFeature.id),
+            )
+
+        val selectedPinLayer = stopLayers[10]
+
+        assertEquals(
+            StopIcons.stopPinIcon,
+            selectedPinLayer.iconImage!!.evaluate(alewifeFeature.properties, zoom = 14.0),
+        )
+        assertEquals(
+            "",
+            selectedPinLayer.iconImage!!.evaluate(assemblyFeature.properties, zoom = 14.0),
+        )
+    }
+
+    @Test
+    fun `state stop details filter applies correctly`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val subwayRoute =
+            objects.route {
+                id = "Orange"
+                type = RouteType.HEAVY_RAIL
+            }
+        val selectedBusRoute = objects.route { type = RouteType.BUS }
+        val otherBusRoute = objects.route { type = RouteType.BUS }
+        val busAndSubwayStop = objects.stop()
+        val wrongRouteBusStop = objects.stop()
+        val wrongDirectionBusStop = objects.stop()
+        val rightBusStop = objects.stop()
+
+        objects.routePattern(subwayRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(busAndSubwayStop.id) }
+        }
+        objects.routePattern(selectedBusRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            directionId = 0
+            representativeTrip { stopIds = listOf(rightBusStop.id) }
+        }
+        objects.routePattern(selectedBusRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            directionId = 1
+            representativeTrip { stopIds = listOf(wrongDirectionBusStop.id) }
+        }
+        objects.routePattern(otherBusRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(busAndSubwayStop.id, wrongRouteBusStop.id) }
+        }
+
+        val globalMapData = GlobalMapData(GlobalResponse(objects), emptyMap())
+        val features = StopFeaturesBuilder.buildCollection(globalMapData, emptyList()).features
+        val busAndSubwayStopFeature = features.first { it.id == busAndSubwayStop.id }
+        val wrongRouteBusStopFeature = features.first { it.id == wrongRouteBusStop.id }
+        val wrongDirectionBusStopFeature = features.first { it.id == wrongDirectionBusStop.id }
+        val rightBusStopFeature = features.first { it.id == rightBusStop.id }
+
+        val stopLayers =
+            StopLayerGenerator.createStopLayers(
+                ColorPalette.light,
+                StopLayerGenerator.State(
+                    stopFilter = StopDetailsFilter(routeId = selectedBusRoute.id, directionId = 0)
+                ),
+            )
+        val stopLayer = stopLayers.first { it.id == StopLayerGenerator.stopLayerId }
+
+        assertEquals(
+            true,
+            stopLayer.filter!!.evaluate(busAndSubwayStopFeature.properties, zoom = 13.0),
+        )
+        assertEquals(
+            false,
+            stopLayer.filter!!.evaluate(wrongRouteBusStopFeature.properties, zoom = 13.0),
+        )
+        assertEquals(
+            true,
+            stopLayer.filter!!.evaluate(wrongRouteBusStopFeature.properties, zoom = 16.0),
+        )
+        assertEquals(
+            false,
+            stopLayer.filter!!.evaluate(wrongDirectionBusStopFeature.properties, zoom = 13.0),
+        )
+        assertEquals(
+            true,
+            stopLayer.filter!!.evaluate(wrongDirectionBusStopFeature.properties, zoom = 16.0),
+        )
+        assertEquals(true, stopLayer.filter!!.evaluate(rightBusStopFeature.properties, zoom = 13.0))
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
@@ -1,17 +1,22 @@
 package com.mbta.tid.mbta_app.map.style
 
 import kotlin.jvm.JvmName
+import kotlin.math.ln
+import kotlin.math.pow
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
 private fun JSONValue.toKotlin(): JsonElement =
     when (this) {
@@ -22,11 +27,43 @@ private fun JSONValue.toKotlin(): JsonElement =
         is JSONValue.String -> JsonPrimitive(this.data)
     }
 
-private data class EvaluationContext(val featureProperties: FeatureProperties, val zoom: Double) {
+private data class EvaluationContext(
+    val featureProperties: FeatureProperties,
+    val zoom: Double,
+    val letBindings: Map<String, JsonElement> = emptyMap(),
+) {
     fun evaluate(json: JsonElement): JsonElement {
         return if (json is JsonArray) {
             when (val operator = (json.firstOrNull() as? JsonPrimitive)?.contentOrNull) {
+                "array" -> {
+                    val type = if (json.size > 2) evaluate(json[1]).jsonPrimitive.content else null
+                    val size = if (json.size == 4) evaluate(json[2]).jsonPrimitive.int else null
+                    val value = evaluate(json.last()).jsonArray
+                    when (type) {
+                        "boolean" -> value.forEach { checkNotNull(it.jsonPrimitive.booleanOrNull) }
+                        "number" ->
+                            value.forEach {
+                                checkNotNull(
+                                    it.jsonPrimitive.longOrNull ?: it.jsonPrimitive.doubleOrNull
+                                )
+                            }
+                        "string" -> value.forEach { check(it.jsonPrimitive.isString) }
+                        null -> {}
+                        else -> throw IllegalArgumentException("can’t have array of type $type")
+                    }
+                    when (size) {
+                        null -> {}
+                        else -> check(value.size == size)
+                    }
+                    value
+                }
                 "boolean" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.boolean)
+                "image" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.content)
+                "literal" -> json[1]
+                "number" ->
+                    evaluate(json[1]).also {
+                        checkNotNull(it.jsonPrimitive.longOrNull ?: it.jsonPrimitive.doubleOrNull)
+                    }
                 "string" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.content)
                 "at" -> {
                     val index = evaluate(json[1]).jsonPrimitive.int
@@ -49,6 +86,17 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                         JsonPrimitive(evaluate(json[2]).jsonObject.containsKey(property))
                     }
                 }
+                "in" -> {
+                    val needle = evaluate(json[1])
+                    val haystack = evaluate(json[2])
+                    if (haystack is JsonArray) {
+                        JsonPrimitive(haystack.contains(needle))
+                    } else {
+                        JsonPrimitive(
+                            haystack.jsonPrimitive.content.contains(needle.jsonPrimitive.content)
+                        )
+                    }
+                }
                 "length" ->
                     when (val target = evaluate(json[1])) {
                         is JsonArray -> JsonPrimitive(target.size)
@@ -56,7 +104,35 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                         else -> throw IllegalArgumentException("can't take length of $target")
                     }
                 "!" -> JsonPrimitive(!evaluate(json[1]).jsonPrimitive.boolean)
+                "!=" -> JsonPrimitive(evaluate(json[1]) != evaluate(json[2]))
+                "<" -> {
+                    val lhs = evaluate(json[1])
+                    val rhs = evaluate(json[2])
+                    if (lhs.jsonPrimitive.isString) {
+                        JsonPrimitive(lhs.jsonPrimitive.content < rhs.jsonPrimitive.content)
+                    } else {
+                        JsonPrimitive(lhs.jsonPrimitive.double < rhs.jsonPrimitive.double)
+                    }
+                }
+                "<=" -> {
+                    val lhs = evaluate(json[1])
+                    val rhs = evaluate(json[2])
+                    if (lhs.jsonPrimitive.isString) {
+                        JsonPrimitive(lhs.jsonPrimitive.content <= rhs.jsonPrimitive.content)
+                    } else {
+                        JsonPrimitive(lhs.jsonPrimitive.double <= rhs.jsonPrimitive.double)
+                    }
+                }
                 "==" -> JsonPrimitive(evaluate(json[1]) == evaluate(json[2]))
+                ">" -> {
+                    val lhs = evaluate(json[1])
+                    val rhs = evaluate(json[2])
+                    if (lhs.jsonPrimitive.isString) {
+                        JsonPrimitive(lhs.jsonPrimitive.content > rhs.jsonPrimitive.content)
+                    } else {
+                        JsonPrimitive(lhs.jsonPrimitive.double > rhs.jsonPrimitive.double)
+                    }
+                }
                 ">=" -> {
                     val lhs = evaluate(json[1])
                     val rhs = evaluate(json[2])
@@ -77,6 +153,82 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                     }
                     evaluate(json.last())
                 }
+                "match" -> {
+                    val input = evaluate(json[1])
+                    for ((case, output) in json.drop(2).dropLast(1).windowed(size = 2, step = 2)) {
+                        // case must be literal or list of literals so don’t evaluate
+                        val matches = if (case is JsonArray) case.contains(input) else case == input
+                        if (matches) {
+                            return evaluate(output)
+                        }
+                    }
+                    evaluate(json.last())
+                }
+                "interpolate" -> {
+                    data class Stop(val stop: Double, val value: Double)
+                    val interpolationSpec = json[1].jsonArray
+                    val interpolationFunction: (Double, Double, Double) -> Double =
+                        when (interpolationSpec[0].jsonPrimitive.content) {
+                            "linear" -> ({ t, v0, v1 -> v0 * (1 - t) + v1 * t })
+                            "exponential" -> {
+                                val base = evaluate(interpolationSpec[1]).jsonPrimitive.double
+                                { t, v0, v1 ->
+                                    // this may not be quite how Mapbox implements it, but if we
+                                    // have v = C * base ^ (k * t), then that means
+                                    // v0 = C * base ^ 0
+                                    // C = v0
+                                    // v1 = C * base ^ k
+                                    // v1 = v0 * base ^ k
+                                    // v1/v0 = base ^ k
+                                    // ln (v1/v0) = ln (base ^ k)
+                                    // ln v1 - ln v0 = k ln base
+                                    // k = (ln v1 - ln v0) / ln base
+                                    val k = (ln(v1) - ln(v0)) / ln(base)
+                                    v0 * base.pow(k * t)
+                                }
+                            }
+                            else ->
+                                throw IllegalArgumentException(
+                                    "interpolate with spec $interpolationSpec not implemented in ExpEval"
+                                )
+                        }
+                    val input = evaluate(json[2]).jsonPrimitive.double
+                    val stops =
+                        json.drop(3).windowed(size = 2, step = 2).map { (stop, outputExp) ->
+                            // stop must be literal so don’t evaluate
+                            val output =
+                                checkNotNull(evaluate(outputExp).jsonPrimitive.doubleOrNull) {
+                                    "interpolate with non-number output not implemented in ExpEval"
+                                }
+                            Stop(stop.jsonPrimitive.double, output)
+                        }
+                    val stopPairs =
+                        (listOf(null) + stops + listOf(null)).windowed(size = 2, step = 1)
+                    for ((stopBelow, stopAbove) in stopPairs) {
+                        if (
+                            input == stopBelow?.stop ||
+                                (stopBelow != null && stopAbove == null && input < stopBelow.stop)
+                        )
+                            return JsonPrimitive(stopBelow.value)
+                        if (
+                            input == stopAbove?.stop ||
+                                (stopAbove != null && stopBelow == null && input > stopAbove.stop)
+                        )
+                            return JsonPrimitive(stopAbove.value)
+                        if (
+                            stopBelow != null &&
+                                stopAbove != null &&
+                                input > stopBelow.stop &&
+                                input < stopAbove.stop
+                        ) {
+                            val t = (input - stopBelow.stop) / (stopAbove.stop - stopBelow.stop)
+                            val v0 = stopBelow.value
+                            val v1 = stopAbove.value
+                            return JsonPrimitive(interpolationFunction(t, v0, v1))
+                        }
+                    }
+                    throw IllegalStateException("interpolate stops not exhaustive somehow")
+                }
                 "step" -> {
                     val input = evaluate(json[1]).jsonPrimitive.double
                     var previousOutput = evaluate(json[2])
@@ -84,7 +236,22 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                         if (input < evaluate(stopInput).jsonPrimitive.double) break
                         previousOutput = evaluate(stopOutput)
                     }
-                    return previousOutput
+                    previousOutput
+                }
+                "let" -> {
+                    val bindings = this.letBindings.toMutableMap()
+                    for ((nameExp, valueExp) in
+                        json.drop(1).dropLast(1).windowed(size = 2, step = 2)) {
+                        val name = evaluate(nameExp)
+                        val value = evaluate(valueExp)
+                        bindings[name.jsonPrimitive.content] = value
+                    }
+                    val childContext = this.copy(letBindings = bindings)
+                    childContext.evaluate(json.last())
+                }
+                "var" -> {
+                    val name = evaluate(json[1])
+                    letBindings.getValue(name.jsonPrimitive.content)
                 }
                 "concat" ->
                     JsonPrimitive(
@@ -95,13 +262,13 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                         }
                     )
                 "downcase" -> JsonPrimitive(evaluate(json[1]).jsonPrimitive.content.lowercase())
+                "*" ->
+                    JsonPrimitive(
+                        json.drop(1).map { evaluate(it).jsonPrimitive.double }.reduce(Double::times)
+                    )
                 "zoom" -> JsonPrimitive(zoom)
-                "array",
                 "collator",
                 "format",
-                "image",
-                "literal",
-                "number",
                 "number-format",
                 "object",
                 "to-boolean",
@@ -116,23 +283,13 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                 "line-progress",
                 "properties",
                 "config",
-                "in",
                 "index-of",
                 "measure-light",
                 "slice",
-                "!=",
-                "<",
-                "<=",
-                ">",
                 "coalesce",
-                "match",
                 "within",
-                "interpolate",
                 "interpolate-hcl",
                 "interpolate-lab",
-                "let",
-                "var",
-                "downcase",
                 "is-supported-script",
                 "resolved-locale",
                 "upcase",
@@ -142,7 +299,6 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
                 "rgba",
                 "to-rgba",
                 "-",
-                "*",
                 "/",
                 "%",
                 "^",
@@ -178,6 +334,12 @@ private data class EvaluationContext(val featureProperties: FeatureProperties, v
             json
         }
     }
+}
+
+@JvmName("evaluateString")
+fun Exp<Boolean>.evaluate(featureProperties: FeatureProperties, zoom: Double): Boolean {
+    val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
+    return result.jsonPrimitive.boolean
 }
 
 @JvmName("evaluateResolvedImage")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
@@ -336,7 +336,7 @@ private data class EvaluationContext(
     }
 }
 
-@JvmName("evaluateString")
+@JvmName("evaluateBoolean")
 fun Exp<Boolean>.evaluate(featureProperties: FeatureProperties, zoom: Double): Boolean {
     val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
     return result.jsonPrimitive.boolean


### PR DESCRIPTION
### Summary

_Ticket:_ [Omit bus stops on unselected routes below zoom 15](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210277504456915?focus=true)

An alternative approach to #1031 that feels more responsive.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the bus stops disappear and reappear as called for. Added new unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
