### PR TITLE
build: upgrade Xcode and SwiftPM dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -125,7 +125,7 @@ runs:
       if: steps.settings.outputs.xcode == 'true'
       shell: bash
       run: |
-        sudo xcode-select --switch /Applications/Xcode_16.2.app/Contents/Developer
+        sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer
     - name: Generate Xcode project
       if: steps.settings.outputs.xcode == 'true'
       shell: bash

--- a/.github/workflows/build-ios.yaml
+++ b/.github/workflows/build-ios.yaml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   build-ios:
     name: Build for iOS
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     permissions:
       id-token: write
       contents: read
@@ -97,7 +97,7 @@ jobs:
     if: ${{ inputs.deploy }}
     needs:
       - build-ios
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   test-ios:
     name: Test for iOS
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     permissions:
       contents: read
     steps:

--- a/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iosApp/iosApp.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "fbd463894af94d90eb4d6a4e54080459a8179519",
-        "version" : "11.12.0"
+        "revision" : "45d327fcbe7793747295346c2209ad419bdead74",
+        "version" : "11.14.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "70a7857886f065a40486a7607268781c49db04ae",
+        "version" : "2.0.0"
       }
     },
     {
@@ -33,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "f7460ea630bddf172115c28493ae8b3798d95ce3",
-        "version" : "11.12.0"
+        "revision" : "406f72d0d5e9445fd1cf782db3e9e338cee2bed4",
+        "version" : "11.14.0"
       }
     },
     {
@@ -96,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-common-ios.git",
       "state" : {
-        "revision" : "316a4f97bcf45aaae632327b69fac545cc38e42f",
-        "version" : "24.12.0"
+        "revision" : "cfbe00b0ad27bbc4c38d6406ebb4c92762e61650",
+        "version" : "24.12.2"
       }
     },
     {
@@ -105,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-core-maps-ios.git",
       "state" : {
-        "revision" : "853cfc3c431d42291e1c4a0d550fc8cf6ea90015",
-        "version" : "11.12.0"
+        "revision" : "6194dc70689363eb6518203365dd2ac11126280e",
+        "version" : "11.12.2"
       }
     },
     {
@@ -114,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mapbox/mapbox-maps-ios.git",
       "state" : {
-        "revision" : "c141954157c3aaf09bc1bc3d233239666421b96e",
-        "version" : "11.12.0"
+        "revision" : "a122234e3c7af92f875eaadee03dbccd35c7cbc8",
+        "version" : "11.12.2"
       }
     },
     {
@@ -141,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -150,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
-        "version" : "1.29.0"
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
       }
     },
     {
@@ -186,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector",
       "state" : {
-        "revision" : "788e7879d38a839c4e348ab0762dcc0364e646a2",
-        "version" : "0.10.1"
+        "revision" : "a6fcac8485bc8f57b2d2b55bb6d97138e8659e4b",
+        "version" : "0.10.2"
       }
     }
   ],

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -76,13 +76,13 @@ settingGroups:
 packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
-    from: 11.1.0
+    from: 11.14.0
   MapboxMaps:
     url: https://github.com/mapbox/mapbox-maps-ios.git
-    from: 11.3.0
+    from: 11.12.2
   swift-collections:
     url: https://github.com/apple/swift-collections.git
-    from: 1.1.1
+    from: 1.2.0
   SwiftPhoenixClient:
     url: https://github.com/davidstump/SwiftPhoenixClient
     from: 5.3.5
@@ -91,7 +91,7 @@ packages:
     from: 1.5.1
   ViewInspector:
     url: https://github.com/nalexn/ViewInspector
-    from: 0.10.0
+    from: 0.10.2
 targets:
   iosApp:
     type: application


### PR DESCRIPTION
### Summary

_Ticket:_ none

Since the ViewInspector fix for Xcode 16.3 has been shipped, we can now upgrade to that version, which might be enough to unblock #922.

### Testing

Checked that the tests pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
