### PR TITLE
feat(android.RouteStopListView): Collpase non-typical stops

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -1,0 +1,110 @@
+package com.mbta.tid.mbta_app.android.routeDetails
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+import com.mbta.tid.mbta_app.model.RouteType
+import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class CollapsableStopListTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testWhenOneStopJustShowsThatStop() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 =
+            objects.stop {
+                name = "Stop 1"
+                locationType = LocationType.STATION
+            }
+        var clicked = false
+        val mainRoute =
+            objects.route {
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Here", "There")
+                longName = "Mauve Line"
+                type = RouteType.HEAVY_RAIL
+            }
+        composeTestRule.setContent {
+            CollapsableStopList(
+                RouteCardData.LineOrRoute.Route(mainRoute),
+                segment =
+                    RouteDetailsStopList.Segment(
+                        listOf(RouteDetailsStopList.Entry(stop1, listOf(), listOf())),
+                        false,
+                    ),
+                onClick = { clicked = true },
+                isLastSegment = false,
+                { _, _ -> },
+            )
+        }
+
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop1.name))
+        composeTestRule.onNodeWithText("Less common stop").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("mbta_logo").assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).performClick()
+        assertTrue(clicked)
+    }
+
+    @Test
+    fun testWhenMultipleStopsCanExpandAndCollapse() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 =
+            objects.stop {
+                name = "Stop 1"
+                locationType = LocationType.STATION
+            }
+        val stop2 =
+            objects.stop {
+                name = "Stop 2"
+                locationType = LocationType.STOP
+                vehicleType = RouteType.BUS
+            }
+        val mainRoute =
+            objects.route {
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Here", "There")
+                longName = "Mauve Line"
+                type = RouteType.BUS
+            }
+        composeTestRule.setContent {
+            CollapsableStopList(
+                RouteCardData.LineOrRoute.Route(mainRoute),
+                segment =
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(stop1, listOf(), listOf()),
+                            RouteDetailsStopList.Entry(stop2, listOf(), listOf()),
+                        ),
+                        false,
+                    ),
+                onClick = {},
+                isLastSegment = false,
+                { _, _ -> },
+            )
+        }
+        composeTestRule.onNodeWithText(stop1.name).assertIsNotDisplayed()
+
+        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop1.name))
+        composeTestRule.onNodeWithTag("mbta_logo").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("stop_bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.waitUntilDoesNotExist(hasText(stop1.name))
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -43,10 +43,10 @@ class CollapsableStopListTest {
                 RouteCardData.LineOrRoute.Route(mainRoute),
                 segment =
                     RouteDetailsStopList.Segment(
-                        listOf(RouteDetailsStopList.Entry(stop1, listOf(), listOf())),
-                        false,
+                        listOf(RouteDetailsStopList.Entry(stop1, listOf(), listOf()))
                     ),
                 onClick = { clicked = true },
+                isFirstSegment = false,
                 isLastSegment = false,
                 { _, _ -> },
             )
@@ -88,10 +88,10 @@ class CollapsableStopListTest {
                         listOf(
                             RouteDetailsStopList.Entry(stop1, listOf(), listOf()),
                             RouteDetailsStopList.Entry(stop2, listOf(), listOf()),
-                        ),
-                        false,
+                        )
                     ),
                 onClick = {},
+                isFirstSegment = false,
                 isLastSegment = false,
                 { _, _ -> },
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -42,8 +42,16 @@ class RouteStopListViewTest {
                 longName = "Mauve Line"
                 type = RouteType.HEAVY_RAIL
             }
-        objects.routePattern(mainRoute) { directionId = 0 }
-        objects.routePattern(mainRoute) { directionId = 1 }
+        val pattern0 =
+            objects.routePattern(mainRoute) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop1.id, stop2.id, stop3.id) }
+            }
+        objects.routePattern(mainRoute) {
+            directionId = 1
+            typicality = RoutePattern.Typicality.Typical
+        }
         val connectingRoute =
             objects.route {
                 shortName = "32"
@@ -101,7 +109,7 @@ class RouteStopListViewTest {
 
         composeTestRule.onNodeWithText(stop2.name).performClick()
         assertEquals(
-            listOf(RouteDetailsStopList.Entry(stop2, listOf(), listOf(connectingRoute))),
+            listOf(RouteDetailsStopList.Entry(stop2, listOf(pattern0), listOf(connectingRoute))),
             clicks,
         )
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.routeDetails
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -99,7 +100,10 @@ class RouteStopListViewTest {
             .assertIsDisplayed()
 
         composeTestRule.onNodeWithText(stop2.name).performClick()
-        assertEquals(listOf(RouteDetailsStopList.Entry(stop2, listOf(connectingRoute))), clicks)
+        assertEquals(
+            listOf(RouteDetailsStopList.Entry(stop2, listOf(), listOf(connectingRoute))),
+            clicks,
+        )
 
         composeTestRule.onNodeWithContentDescription("Close").performClick()
         assertTrue(closed)
@@ -168,5 +172,69 @@ class RouteStopListViewTest {
         composeTestRule.onNodeWithText(checkNotNull(route1.directionDestinations[0])).performClick()
         composeTestRule.waitForIdle()
         assertEquals(route1.id, lastSelectedRoute)
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testCollapsesNonTypicalStops() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop { name = "Stop 1" }
+        val stop2 = objects.stop { name = "Stop 2" }
+
+        val stop3NonTypical = objects.stop { name = "Stop 3" }
+        val stop4NonTypical = objects.stop { name = "Stop 4" }
+        val mainRoute =
+            objects.route {
+                directionNames = listOf("West", "East")
+                directionDestinations = listOf("Here", "There")
+                longName = "Mauve Line"
+                type = RouteType.HEAVY_RAIL
+            }
+        val typicalPattern =
+            objects.routePattern(mainRoute) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
+            }
+
+        val deviationPattern =
+            objects.routePattern(mainRoute) {
+                directionId = 0
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip {
+                    stopIds = listOf(stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id)
+                }
+            }
+
+        val koin =
+            testKoinApplication(objects) {
+                routeStops =
+                    MockRouteStopsRepository(
+                        listOf(stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id)
+                    )
+            }
+        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                RouteStopListView(
+                    RouteCardData.LineOrRoute.Route(mainRoute),
+                    GlobalResponse(objects),
+                    onClick = {},
+                    onClose = {},
+                    errorBannerViewModel = errorBannerVM,
+                    rightSideContent = { _, _ -> },
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop1.name))
+
+        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop3NonTypical.name).assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.waitUntilExactlyOneExists(hasText(stop3NonTypical.name))
+        composeTestRule.onNodeWithText(stop4NonTypical.name).assertIsDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.component
 
 import android.content.Context
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -134,6 +135,8 @@ fun StopListRow(
                 }
                 if (stopRowStyle != StopRowStyle.StandaloneStop) {
                     RouteLine(routeAccents, stateBefore, stateAfter, targeted)
+                } else {
+                    Box(modifier = Modifier.width(20.dp).background(colorResource(R.color.key))) {}
                 }
                 Column(
                     Modifier.padding(vertical = 12.dp).padding(start = 16.dp).semantics {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
@@ -146,11 +147,13 @@ fun StopListRow(
                                 painter = painterResource(R.drawable.mbta_logo),
                                 contentDescription = null,
                                 tint = Color.Unspecified,
+                                modifier = Modifier.semantics { testTag = "mbta_logo" },
                             )
                         } else if (stop.vehicleType == RouteType.BUS) {
                             Icon(
                                 painter = painterResource(R.drawable.stop_bus),
                                 contentDescription = null,
+                                modifier = Modifier.semantics { testTag = "stop_bus" },
                                 tint = Color.Unspecified,
                             )
                         } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -80,6 +80,7 @@ fun StopListRow(
     showStationAccessibility: Boolean = false,
     targeted: Boolean = false,
     trackNumber: String? = null,
+    descriptor: @Composable () -> Unit = {},
     rightSideContent: @Composable RowScope.(Modifier) -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -174,6 +175,7 @@ fun StopListRow(
                             horizontalAlignment = Alignment.Start,
                             verticalArrangement = Arrangement.spacedBy(4.dp),
                         ) {
+                            descriptor()
                             Text(
                                 stop.name,
                                 Modifier.semantics {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -52,6 +52,13 @@ import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 
+enum class StopRowStyle {
+    FirstLineStop,
+    MidLineStop,
+    LastLineStop,
+    StandaloneStop,
+}
+
 @Composable
 fun StopListRow(
     stop: Stop,
@@ -62,9 +69,8 @@ fun StopListRow(
     alertSummaries: Map<String, AlertSummary?> = emptyMap(),
     connectingRoutes: List<Route>? = null,
     disruption: UpcomingFormat.Disruption? = null,
-    firstStop: Boolean = false,
     isTruncating: Boolean = false,
-    lastStop: Boolean = false,
+    stopRowStyle: StopRowStyle = StopRowStyle.MidLineStop,
     onOpenAlertDetails: (Alert) -> Unit = {},
     showDownstreamAlert: Boolean = false,
     showStationAccessibility: Boolean = false,
@@ -75,13 +81,13 @@ fun StopListRow(
     val context = LocalContext.current
 
     val stateBefore =
-        when {
-            firstStop -> RouteLineState.Empty
+        when (stopRowStyle) {
+            StopRowStyle.FirstLineStop -> RouteLineState.Empty
             else -> RouteLineState.Regular
         }
     val stateAfter =
         when {
-            lastStop -> RouteLineState.Empty
+            stopRowStyle == StopRowStyle.LastLineStop -> RouteLineState.Empty
             showDownstreamAlert && disruption?.alert?.effect == Alert.Effect.Shuttle ->
                 RouteLineState.Shuttle
             else -> RouteLineState.Regular
@@ -93,7 +99,7 @@ fun StopListRow(
                 .height(IntrinsicSize.Min)
                 .defaultMinSize(minHeight = 48.dp)
         ) {
-            if (!lastStop && !targeted && disruption == null) {
+            if (stopRowStyle != StopRowStyle.LastLineStop && !targeted && disruption == null) {
                 HaloSeparator(Modifier.align(Alignment.BottomCenter))
             }
             Row(
@@ -126,7 +132,9 @@ fun StopListRow(
                         )
                     }
                 }
-                RouteLine(routeAccents, stateBefore, stateAfter, targeted)
+                if (stopRowStyle != StopRowStyle.StandaloneStop) {
+                    RouteLine(routeAccents, stateBefore, stateAfter, targeted)
+                }
                 Column(
                     Modifier.padding(vertical = 12.dp).padding(start = 16.dp).semantics {
                         isTraversalGroup = true
@@ -151,7 +159,7 @@ fun StopListRow(
                                             stopAccessibilityLabel(
                                                 stop,
                                                 targeted,
-                                                firstStop,
+                                                stopRowStyle == StopRowStyle.FirstLineStop,
                                                 context,
                                             )
                                     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.component
 
 import android.content.Context
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -18,11 +17,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
@@ -49,7 +50,9 @@ import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 
@@ -136,7 +139,23 @@ fun StopListRow(
                 if (stopRowStyle != StopRowStyle.StandaloneStop) {
                     RouteLine(routeAccents, stateBefore, stateAfter, targeted)
                 } else {
-                    Box(modifier = Modifier.width(20.dp).background(colorResource(R.color.key))) {}
+                    Row(modifier = Modifier.width(20.dp)) {
+                        if (stop.locationType == LocationType.STATION) {
+                            Icon(
+                                painter = painterResource(R.drawable.mbta_logo),
+                                contentDescription = null,
+                                tint = Color.Unspecified,
+                            )
+                        } else if (stop.vehicleType == RouteType.BUS) {
+                            Icon(
+                                painter = painterResource(R.drawable.stop_bus),
+                                contentDescription = null,
+                                tint = Color.Unspecified,
+                            )
+                        } else {
+                            StopDot(routeAccents, false)
+                        }
+                    }
                 }
                 Column(
                     Modifier.padding(vertical = 12.dp).padding(start = 16.dp).semantics {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.StopListRow
-import com.mbta.tid.mbta_app.android.component.StopRowStyle
+import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -48,6 +48,7 @@ fun CollapsableStopList(
     lineOrRoute: RouteCardData.LineOrRoute,
     segment: RouteDetailsStopList.Segment,
     onClick: (RouteDetailsStopList.Entry) -> Unit,
+    isFirstSegment: Boolean = false,
     isLastSegment: Boolean = false,
     rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
 ) {
@@ -63,7 +64,7 @@ fun CollapsableStopList(
             modifier =
                 Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
             connectingRoutes = stop.connectingRoutes,
-            stopRowStyle = StopRowStyle.StandaloneStop,
+            stopPlacement = StopPlacement(isFirstSegment, isLastSegment, false),
             descriptor = {
                 Text(stringResource(R.string.less_common_stop), style = Typography.footnote)
             },
@@ -87,13 +88,13 @@ fun CollapsableStopList(
                             fadeIn(animationSpec = tween(500)) togetherWith
                                 fadeOut(animationSpec = tween(500))
                         },
-                    ) {
+                    ) { stopsExpanded ->
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Center,
                             modifier = Modifier.padding(start = 22.dp).width(20.dp),
                         ) {
-                            if (it) {
+                            if (stopsExpanded) {
                                 Icon(
                                     painterResource(R.drawable.fa_caret_right),
                                     contentDescription = null,
@@ -138,7 +139,7 @@ fun CollapsableStopList(
             }
 
             if (stopsExpanded) {
-                segment.stops.map { stop ->
+                segment.stops.forEachIndexed { index, stop ->
                     StopListRow(
                         stop.stop,
                         onClick = { onClick(stop) },
@@ -147,7 +148,12 @@ fun CollapsableStopList(
                             Modifier.minimumInteractiveComponentSize()
                                 .background(colorResource(R.color.fill1)),
                         connectingRoutes = stop.connectingRoutes,
-                        stopRowStyle = StopRowStyle.StandaloneStop,
+                        stopPlacement =
+                            StopPlacement(
+                                isFirstSegment && index == 0,
+                                isLastSegment && index == segment.stops.lastIndex,
+                                false,
+                            ),
                         rightSideContent = { modifier -> rightSideContent(stop, modifier) },
                     )
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -1,0 +1,150 @@
+package com.mbta.tid.mbta_app.android.routeDetails
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.HaloSeparator
+import com.mbta.tid.mbta_app.android.component.StopListRow
+import com.mbta.tid.mbta_app.android.component.StopRowStyle
+import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+
+@Composable
+fun CollapsableStopList(
+    lineOrRoute: RouteCardData.LineOrRoute,
+    segment: RouteDetailsStopList.Segment,
+    onClick: (RouteDetailsStopList.Entry) -> Unit,
+    isLastSegment: Boolean = false,
+    rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
+) {
+
+    var stopsExpanded by rememberSaveable { mutableStateOf(false) }
+
+    if (segment.stops.size == 1) {
+        val stop = segment.stops.first()
+        StopListRow(
+            stop.stop,
+            onClick = { onClick(stop) },
+            routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+            modifier =
+                Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
+            connectingRoutes = stop.connectingRoutes,
+            stopRowStyle = StopRowStyle.StandaloneStop,
+            descriptor = { Text("Less common stop", style = Typography.footnote) },
+            rightSideContent = { modifier -> rightSideContent(stop, modifier) },
+        )
+    } else {
+        Column {
+            Column(Modifier.padding(horizontal = 6.dp)) {
+                Row(
+                    Modifier.height(IntrinsicSize.Min)
+                        // TODO: Click label
+                        .clickable() { stopsExpanded = !stopsExpanded }
+                        // TODO: Content description
+                        .padding(horizontal = 10.dp)
+                        .defaultMinSize(minHeight = 48.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    AnimatedContent(
+                        stopsExpanded,
+                        transitionSpec = {
+                            fadeIn(animationSpec = tween(500)) togetherWith
+                                fadeOut(animationSpec = tween(500))
+                        },
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center,
+                            modifier = Modifier.padding(start = 22.dp).width(20.dp),
+                        ) {
+                            if (it) {
+                                Icon(
+                                    painterResource(R.drawable.fa_caret_right),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(12.dp).rotate(90f),
+                                    tint = colorResource(R.color.deemphasized),
+                                )
+                            } else {
+                                Icon(
+                                    painterResource(R.drawable.fa_caret_right),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(12.dp),
+                                    tint = colorResource(R.color.deemphasized),
+                                )
+                            }
+                        }
+                    }
+                    Column(
+                        modifier =
+                            Modifier.weight(1f)
+                                .padding(vertical = 12.dp)
+                                .padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            "${segment.stops.size} less common stops",
+                            color = colorResource(R.color.text),
+                            style = Typography.body,
+                        )
+                        Text(
+                            "Only served at certain times of day",
+                            color = colorResource(R.color.deemphasized),
+                            style = Typography.footnote,
+                        )
+                    }
+                }
+
+                if (!isLastSegment) {
+                    HaloSeparator()
+                }
+            }
+
+            if (stopsExpanded) {
+                segment.stops.map { stop ->
+                    StopListRow(
+                        stop.stop,
+                        onClick = { onClick(stop) },
+                        routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+                        modifier =
+                            Modifier.minimumInteractiveComponentSize()
+                                .background(colorResource(R.color.fill1)),
+                        connectingRoutes = stop.connectingRoutes,
+                        stopRowStyle = StopRowStyle.StandaloneStop,
+                        rightSideContent = { modifier -> rightSideContent(stop, modifier) },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
@@ -61,7 +64,9 @@ fun CollapsableStopList(
                 Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
             connectingRoutes = stop.connectingRoutes,
             stopRowStyle = StopRowStyle.StandaloneStop,
-            descriptor = { Text("Less common stop", style = Typography.footnote) },
+            descriptor = {
+                Text(stringResource(R.string.less_common_stop), style = Typography.footnote)
+            },
             rightSideContent = { modifier -> rightSideContent(stop, modifier) },
         )
     } else {
@@ -113,12 +118,14 @@ fun CollapsableStopList(
                         verticalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         Text(
-                            "${segment.stops.size} less common stops",
+                            AnnotatedString.fromHtml(
+                                stringResource(R.string.less_common_stops, segment.stops.size)
+                            ),
                             color = colorResource(R.color.text),
                             style = Typography.body,
                         )
                         Text(
-                            "Only served at certain times of day",
+                            stringResource(R.string.only_served_at_certain_times),
                             color = colorResource(R.color.deemphasized),
                             style = Typography.footnote,
                         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -191,20 +191,17 @@ fun CollapsableStopList(
 
     if (segment.stops.size == 1) {
         val stop = segment.stops.first()
-        Column() {
-            Text("Less common stop", style = Typography.footnote)
-            StopListRow(
-                stop.stop,
-                onClick = { onClick(stop) },
-                routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
-                modifier =
-                    Modifier.minimumInteractiveComponentSize()
-                        .background(colorResource(R.color.fill1)),
-                connectingRoutes = stop.connectingRoutes,
-                stopRowStyle = StopRowStyle.StandaloneStop,
-                rightSideContent = { modifier -> rightSideContent(stop, modifier) },
-            )
-        }
+        StopListRow(
+            stop.stop,
+            onClick = { onClick(stop) },
+            routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+            modifier =
+                Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
+            connectingRoutes = stop.connectingRoutes,
+            stopRowStyle = StopRowStyle.StandaloneStop,
+            descriptor = { Text("Less common stop", style = Typography.footnote) },
+            rightSideContent = { modifier -> rightSideContent(stop, modifier) },
+        )
     } else {
         Column(Modifier.padding(horizontal = 6.dp)) {
             Row(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -184,8 +185,8 @@ fun CollapsableStopList(
 
     if (segment.stops.size == 1) {
         val stop = segment.stops.first()
-        Column {
-            Text("Less common stop")
+        Column(modifier = Modifier.haloContainer(1.dp, borderRadius = 0.dp)) {
+            Text("Less common stop", style = Typography.footnote)
             StopListRow(
                 stop.stop,
                 onClick = { onClick(stop) },
@@ -205,8 +206,9 @@ fun CollapsableStopList(
             // TODO: Click label
             .clickable() { stopsExpanded = !stopsExpanded }
             // TODO: Content description
-            .padding(horizontal = 12.dp)
-            .defaultMinSize(minHeight = 48.dp),
+            .padding(horizontal = 16.dp)
+            .defaultMinSize(minHeight = 48.dp)
+            .haloContainer(1.dp, borderRadius = 0.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         AnimatedContent(
@@ -217,7 +219,8 @@ fun CollapsableStopList(
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(start = 22.dp).width(20.dp),
             ) {
                 if (it) {
                     Icon(
@@ -236,7 +239,10 @@ fun CollapsableStopList(
                 }
             }
         }
-        Column(modifier = Modifier.weight(1f)) {
+        Column(
+            modifier = Modifier.weight(1f).padding(vertical = 12.dp).padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
             Text(
                 "${segment.stops.size} less common stops",
                 color = colorResource(R.color.text),
@@ -244,8 +250,8 @@ fun CollapsableStopList(
             )
             Text(
                 "Only served at certain times of day",
-                color = colorResource(R.color.text),
-                style = Typography.body,
+                color = colorResource(R.color.deemphasized),
+                style = Typography.footnote,
             )
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -114,7 +114,7 @@ fun RouteStopListView(
             )
             Column {
                 if (stopList != null) {
-                    for ((index, stop) in stopList.stops.withIndex()) {
+                    for ((index, stop) in stopList.segments.flatMap { it.stops }.withIndex()) {
                         StopListRow(
                             stop.stop,
                             onClick = { onClick(stop) },
@@ -122,7 +122,7 @@ fun RouteStopListView(
                             modifier = Modifier.minimumInteractiveComponentSize(),
                             connectingRoutes = stop.connectingRoutes,
                             firstStop = index == 0,
-                            lastStop = index == stopList.stops.lastIndex,
+                            lastStop = index == stopList.segments.flatMap { it.stops }.lastIndex,
                             rightSideContent = { modifier -> rightSideContent(stop, modifier) },
                         )
                     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -1,28 +1,18 @@
 package com.mbta.tid.mbta_app.android.routeDetails
 
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -34,15 +24,12 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
-import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.android.component.SheetHeader
@@ -51,7 +38,6 @@ import com.mbta.tid.mbta_app.android.component.StopRowStyle
 import com.mbta.tid.mbta_app.android.state.getRouteStops
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
-import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -173,111 +159,6 @@ fun RouteStopListView(
                 } else {
                     CircularProgressIndicator()
                 }
-            }
-        }
-    }
-}
-
-@Composable
-fun CollapsableStopList(
-    lineOrRoute: RouteCardData.LineOrRoute,
-    segment: RouteDetailsStopList.Segment,
-    onClick: (RouteDetailsStopList.Entry) -> Unit,
-    isLastSegment: Boolean = false,
-    rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
-) {
-
-    var stopsExpanded by rememberSaveable { mutableStateOf(false) }
-
-    if (segment.stops.size == 1) {
-        val stop = segment.stops.first()
-        StopListRow(
-            stop.stop,
-            onClick = { onClick(stop) },
-            routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
-            modifier =
-                Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
-            connectingRoutes = stop.connectingRoutes,
-            stopRowStyle = StopRowStyle.StandaloneStop,
-            descriptor = { Text("Less common stop", style = Typography.footnote) },
-            rightSideContent = { modifier -> rightSideContent(stop, modifier) },
-        )
-    } else {
-        Column(Modifier.padding(horizontal = 6.dp)) {
-            Row(
-                Modifier.height(IntrinsicSize.Min)
-                    // TODO: Click label
-                    .clickable() { stopsExpanded = !stopsExpanded }
-                    // TODO: Content description
-                    .padding(horizontal = 10.dp)
-                    .defaultMinSize(minHeight = 48.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                AnimatedContent(
-                    stopsExpanded,
-                    transitionSpec = {
-                        fadeIn(animationSpec = tween(500)) togetherWith
-                            fadeOut(animationSpec = tween(500))
-                    },
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.Center,
-                        modifier = Modifier.padding(start = 22.dp).width(20.dp),
-                    ) {
-                        if (it) {
-                            Icon(
-                                painterResource(R.drawable.fa_caret_right),
-                                contentDescription = null,
-                                modifier = Modifier.size(12.dp).rotate(90f),
-                                tint = colorResource(R.color.deemphasized),
-                            )
-                        } else {
-                            Icon(
-                                painterResource(R.drawable.fa_caret_right),
-                                contentDescription = null,
-                                modifier = Modifier.size(12.dp),
-                                tint = colorResource(R.color.deemphasized),
-                            )
-                        }
-                    }
-                }
-                Column(
-                    modifier =
-                        Modifier.weight(1f).padding(vertical = 12.dp).padding(horizontal = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                ) {
-                    Text(
-                        "${segment.stops.size} less common stops",
-                        color = colorResource(R.color.text),
-                        style = Typography.body,
-                    )
-                    Text(
-                        "Only served at certain times of day",
-                        color = colorResource(R.color.deemphasized),
-                        style = Typography.footnote,
-                    )
-                }
-            }
-
-            if (!isLastSegment) {
-                HaloSeparator()
-            }
-        }
-
-        if (stopsExpanded) {
-            segment.stops.map { stop ->
-                StopListRow(
-                    stop.stop,
-                    onClick = { onClick(stop) },
-                    routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
-                    modifier =
-                        Modifier.minimumInteractiveComponentSize()
-                            .background(colorResource(R.color.fill1)),
-                    connectingRoutes = stop.connectingRoutes,
-                    stopRowStyle = StopRowStyle.StandaloneStop,
-                    rightSideContent = { modifier -> rightSideContent(stop, modifier) },
-                )
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -34,7 +34,7 @@ import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.StopListRow
-import com.mbta.tid.mbta_app.android.component.StopRowStyle
+import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.state.getRouteStops
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
@@ -116,21 +116,18 @@ fun RouteStopListView(
             )
             Column {
                 if (stopList != null) {
-                    stopList.segments.withIndex().map { (segmentIndex, segment) ->
+                    stopList.segments.forEachIndexed { segmentIndex, segment ->
                         if (segment.isTypical) {
 
-                            segment.stops.withIndex().map { (stopIndex, stop) ->
-                                val stopRowStyle =
-                                    if (segmentIndex == 0 && stopIndex == 0) {
-                                        StopRowStyle.FirstLineStop
-                                    } else if (
-                                        segmentIndex == stopList.segments.lastIndex &&
-                                            stopIndex == segment.stops.lastIndex
-                                    ) {
-                                        StopRowStyle.LastLineStop
-                                    } else {
-                                        StopRowStyle.MidLineStop
-                                    }
+                            segment.stops.forEachIndexed { stopIndex, stop ->
+                                val stopPlacement =
+                                    StopPlacement(
+                                        isFirst = segmentIndex == 0 && stopIndex == 0,
+                                        isLast =
+                                            segmentIndex == stopList.segments.lastIndex &&
+                                                stopIndex == segment.stops.lastIndex,
+                                        includeLineDiagram = true,
+                                    )
 
                                 StopListRow(
                                     stop.stop,
@@ -138,7 +135,7 @@ fun RouteStopListView(
                                     routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
                                     modifier = Modifier.minimumInteractiveComponentSize(),
                                     connectingRoutes = stop.connectingRoutes,
-                                    stopRowStyle = stopRowStyle,
+                                    stopPlacement = stopPlacement,
                                     rightSideContent = { modifier ->
                                         rightSideContent(stop, modifier)
                                     },
@@ -150,6 +147,7 @@ fun RouteStopListView(
                                 lineOrRoute,
                                 segment,
                                 onClick,
+                                segmentIndex == 0,
                                 segmentIndex == stopList.segments.lastIndex,
                             ) { stop, modifier ->
                                 rightSideContent(stop, modifier)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.StopListRow
-import com.mbta.tid.mbta_app.android.component.StopRowStyle
+import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.component.UpcomingTripView
 import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
@@ -64,12 +64,7 @@ fun TripStopRow(
         alertSummaries = alertSummaries,
         connectingRoutes = stop.routes,
         disruption = disruption,
-        stopRowStyle =
-            when {
-                firstStop -> StopRowStyle.FirstLineStop
-                lastStop -> StopRowStyle.LastLineStop
-                else -> StopRowStyle.MidLineStop
-            },
+        stopPlacement = StopPlacement(firstStop, lastStop, true),
         isTruncating = stop.isTruncating,
         onOpenAlertDetails = onOpenAlertDetails,
         showDownstreamAlert = showDownstreamAlert,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.StopListRow
+import com.mbta.tid.mbta_app.android.component.StopRowStyle
 import com.mbta.tid.mbta_app.android.component.UpcomingTripView
 import com.mbta.tid.mbta_app.android.component.UpcomingTripViewState
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
@@ -63,9 +64,13 @@ fun TripStopRow(
         alertSummaries = alertSummaries,
         connectingRoutes = stop.routes,
         disruption = disruption,
-        firstStop = firstStop,
+        stopRowStyle =
+            when {
+                firstStop -> StopRowStyle.FirstLineStop
+                lastStop -> StopRowStyle.LastLineStop
+                else -> StopRowStyle.MidLineStop
+            },
         isTruncating = stop.isTruncating,
-        lastStop = lastStop,
         onOpenAlertDetails = onOpenAlertDetails,
         showDownstreamAlert = showDownstreamAlert,
         showStationAccessibility = showStationAccessibility,

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -160,6 +160,7 @@
     <string name="is_stops_away_from">%1$s está a %2$d parada(s) antes de %3$s</string>
     <string name="later_today">más tarde hoy</string>
     <string name="less_common_stop">Parada menos común</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> paradas menos comunes</string>
     <string name="live">En vivo</string>
     <string name="loading">Cargando…</string>
     <string name="location_not_available_yet">Ubicación no disponible aún</string>

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -159,6 +159,7 @@
     <string name="inbound">Entrante</string>
     <string name="is_stops_away_from">%1$s está a %2$d parada(s) antes de %3$s</string>
     <string name="later_today">más tarde hoy</string>
+    <string name="less_common_stop">Parada menos común</string>
     <string name="live">En vivo</string>
     <string name="loading">Cargando…</string>
     <string name="location_not_available_yet">Ubicación no disponible aún</string>
@@ -215,6 +216,7 @@
     <string name="onboarding_map_display_header">Establecer preferencia de visualización del mapa</string>
     <string name="onboarding_station_accessibility_body">Al suscribirse, podemos mostrarle qué estaciones son inaccesibles o tienen cierres de ascensores.</string>
     <string name="onboarding_station_accessibility_header">Establecer preferencia de información de accesibilidad de la estación</string>
+    <string name="only_served_at_certain_times">Sólo se sirve en determinados momentos del día.</string>
     <string name="open_for_more_arrivals">Abierto para más llegadas</string>
     <string name="other_link_privacy_policy">Política de privacidad</string>
     <string name="other_link_source_code">Ver código fuente en Github</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -159,6 +159,7 @@
     <string name="inbound">En direction du centre</string>
     <string name="is_stops_away_from">%1$s est à %2$d arrêts de %3$s</string>
     <string name="later_today">plus tard aujourd’hui</string>
+    <string name="less_common_stop">Arrêt moins courant</string>
     <string name="live">En temps réel</string>
     <string name="loading">Chargement...</string>
     <string name="location_not_available_yet">La localisation n’est pas encore disponible</string>
@@ -215,6 +216,7 @@
     <string name="onboarding_map_display_header">Définir les préférences d’affichage de la carte</string>
     <string name="onboarding_station_accessibility_body">En vous inscrivant, nous pouvons vous montrer quelles stations sont inaccessibles ou dont les ascenseurs sont fermés.</string>
     <string name="onboarding_station_accessibility_header">Définir les préférences d’informations sur l’accessibilité de la station</string>
+    <string name="only_served_at_certain_times">Servi uniquement à certains moments de la journée</string>
     <string name="open_for_more_arrivals">Ouvert pour plus d’arrivées</string>
     <string name="other_link_privacy_policy">Politique de confidentialité</string>
     <string name="other_link_source_code">Voir la source sur Github</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -160,6 +160,7 @@
     <string name="is_stops_away_from">%1$s est à %2$d arrêts de %3$s</string>
     <string name="later_today">plus tard aujourd’hui</string>
     <string name="less_common_stop">Arrêt moins courant</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> arrêts moins courants</string>
     <string name="live">En temps réel</string>
     <string name="loading">Chargement...</string>
     <string name="location_not_available_yet">La localisation n’est pas encore disponible</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -169,6 +169,7 @@
     <string name="is_stops_away_from">%1$s nan %2$d arè parapò ak %3$s</string>
     <string name="later_today">pita jodi a</string>
     <string name="less_common_stop">Mwens komen sispann</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> mwens arè komen</string>
     <string name="live">An dirèk</string>
     <string name="loading">Chajman...</string>
     <string name="location_not_available_yet">Pozisyon poko disponib</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -168,6 +168,7 @@
     <string name="inbound">Antran</string>
     <string name="is_stops_away_from">%1$s nan %2$d arè parapò ak %3$s</string>
     <string name="later_today">pita jodi a</string>
+    <string name="less_common_stop">Mwens komen sispann</string>
     <string name="live">An dirèk</string>
     <string name="loading">Chajman...</string>
     <string name="location_not_available_yet">Pozisyon poko disponib</string>
@@ -224,6 +225,7 @@
     <string name="onboarding_map_display_header">Mete preferans ou pou montre kat la</string>
     <string name="onboarding_station_accessibility_body">Lè ou enskri, nou ka montre w ki estasyon ki pa aksesib oswa kote yo fèmen asansè yo.</string>
     <string name="onboarding_station_accessibility_header">Mete preferans ou pou enfòmasyon sou aksè estasyon yo</string>
+    <string name="only_served_at_certain_times">Yo sèvi sèlman nan sèten lè nan jounen an</string>
     <string name="open_for_more_arrivals">Ouvri pou plis arive</string>
     <string name="other_link_privacy_policy">Règleman sou Vi Prive</string>
     <string name="other_link_source_code">Gade sous sou Github</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -159,6 +159,7 @@
     <string name="inbound">Entrada</string>
     <string name="is_stops_away_from">%1$s está a %2$d paradas de %3$s</string>
     <string name="later_today">mais tarde hoje</string>
+    <string name="less_common_stop">Parada menos comum</string>
     <string name="live">Ao vivo</string>
     <string name="loading">Carregando...</string>
     <string name="location_not_available_yet">Localização ainda não disponível</string>
@@ -215,6 +216,7 @@
     <string name="onboarding_map_display_header">Definir preferência de exibição do mapa</string>
     <string name="onboarding_station_accessibility_body">Ao ativar, podemos mostrar quais estações estão inacessíveis ou com elevadores fechados.</string>
     <string name="onboarding_station_accessibility_header">Definir preferência de informações de acessibilidade da estação</string>
+    <string name="only_served_at_certain_times">Servido apenas em determinados horários do dia</string>
     <string name="open_for_more_arrivals">Aberto para mais chegadas</string>
     <string name="other_link_privacy_policy">Política de Privacidade</string>
     <string name="other_link_source_code">Exibir origem no GitHub</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -160,6 +160,7 @@
     <string name="is_stops_away_from">%1$s está a %2$d paradas de %3$s</string>
     <string name="later_today">mais tarde hoje</string>
     <string name="less_common_stop">Parada menos comum</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> paradas menos comuns</string>
     <string name="live">Ao vivo</string>
     <string name="loading">Carregando...</string>
     <string name="location_not_available_yet">Localização ainda não disponível</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -153,6 +153,7 @@
     <string name="inbound">Đến</string>
     <string name="is_stops_away_from">%1$s cách %3$s %2$d điểm dừng</string>
     <string name="later_today">trong ngày hôm nay</string>
+    <string name="less_common_stop">Điểm dừng ít phổ biến hơn</string>
     <string name="live">Trực tiếp</string>
     <string name="loading">Đang tải...</string>
     <string name="location_not_available_yet">Vị trí chưa có sẵn</string>
@@ -209,6 +210,7 @@
     <string name="onboarding_map_display_header">Đặt tùy chọn hiển thị bản đồ</string>
     <string name="onboarding_station_accessibility_body">Bằng cách chọn tham gia, chúng tôi có thể cho bạn biết ga nào không thể tiếp cận được hoặc có thang máy bị đóng.</string>
     <string name="onboarding_station_accessibility_header">Đặt tùy chọn thông tin về khả năng tiếp cận ga</string>
+    <string name="only_served_at_certain_times">Chỉ phục vụ vào một số thời điểm nhất định trong ngày</string>
     <string name="open_for_more_arrivals">Mở cửa đón thêm khách đến</string>
     <string name="other_link_privacy_policy">Chính sách bảo mật</string>
     <string name="other_link_source_code">Xem nguồn trên Github</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -154,6 +154,7 @@
     <string name="is_stops_away_from">%1$s cách %3$s %2$d điểm dừng</string>
     <string name="later_today">trong ngày hôm nay</string>
     <string name="less_common_stop">Điểm dừng ít phổ biến hơn</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> các điểm dừng ít phổ biến hơn</string>
     <string name="live">Trực tiếp</string>
     <string name="loading">Đang tải...</string>
     <string name="location_not_available_yet">Vị trí chưa có sẵn</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -154,6 +154,7 @@
     <string name="is_stops_away_from">%1$s距离%3$s还有%2$d站</string>
     <string name="later_today">今天晚些时候</string>
     <string name="less_common_stop">不太常见的停站</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> 不常见站点</string>
     <string name="live">实时</string>
     <string name="loading">正在加载……</string>
     <string name="location_not_available_yet">定位服务暂不可用</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -153,6 +153,7 @@
     <string name="inbound">进站</string>
     <string name="is_stops_away_from">%1$s距离%3$s还有%2$d站</string>
     <string name="later_today">今天晚些时候</string>
+    <string name="less_common_stop">不太常见的停站</string>
     <string name="live">实时</string>
     <string name="loading">正在加载……</string>
     <string name="location_not_available_yet">定位服务暂不可用</string>
@@ -209,6 +210,7 @@
     <string name="onboarding_map_display_header">设置地图显示首选项</string>
     <string name="onboarding_station_accessibility_body">通过选择加入，我们可以向您显示哪些车站不适合轮椅通行或电梯关闭。</string>
     <string name="onboarding_station_accessibility_header">设置车站无障碍信息首选项</string>
+    <string name="only_served_at_certain_times">仅在一天中的特定时间供应</string>
     <string name="open_for_more_arrivals">开启获得更多到站信息</string>
     <string name="other_link_privacy_policy">隐私政策</string>
     <string name="other_link_source_code">在 Github 上查看源代码</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -154,6 +154,7 @@
     <string name="is_stops_away_from">%1$s距離%3$s還有%2$d站</string>
     <string name="later_today">今天晚些時候</string>
     <string name="less_common_stop">較不常見的停站</string>
+    <string name="less_common_stops">&lt;b>%1$d&lt;/b> 不常見站點</string>
     <string name="live">即時</string>
     <string name="loading">正在載入……</string>
     <string name="location_not_available_yet">位置尚未確定</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -153,6 +153,7 @@
     <string name="inbound">進站</string>
     <string name="is_stops_away_from">%1$s距離%3$s還有%2$d站</string>
     <string name="later_today">今天晚些時候</string>
+    <string name="less_common_stop">較不常見的停站</string>
     <string name="live">即時</string>
     <string name="loading">正在載入……</string>
     <string name="location_not_available_yet">位置尚未確定</string>
@@ -209,6 +210,7 @@
     <string name="onboarding_map_display_header">設定地圖顯示首選項</string>
     <string name="onboarding_station_accessibility_body">透過選擇加入，我們可以向您顯示哪些車站不適合輪椅通行或電梯關閉。</string>
     <string name="onboarding_station_accessibility_header">設定車站無障礙資訊首選項</string>
+    <string name="only_served_at_certain_times">不太常见的停站</string>
     <string name="open_for_more_arrivals">開啟獲得更多到站資訊</string>
     <string name="other_link_privacy_policy">隱私政策</string>
     <string name="other_link_source_code">在 Github 上查看原始碼</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -161,7 +161,7 @@
     <string name="is_stops_away_from">%1$s is %2$d stops away from %3$s</string>
     <string name="later_today">later today</string>
     <string name="less_common_stop">Less common stop</string>
-    <string name="less_common_stops">&lt;b&gt;%1$d&lt;/b&gt;  less common stops</string>
+    <string name="less_common_stops">&lt;b&gt;%1$d&lt;/b&gt; less common stops</string>
     <string name="live">Live</string>
     <string name="loading" tools:ignore="TypographyEllipsis">Loading...</string>
     <string name="location_not_available_yet">Location not available yet</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="inbound">Inbound</string>
     <string name="is_stops_away_from">%1$s is %2$d stops away from %3$s</string>
     <string name="later_today">later today</string>
+    <string name="less_common_stop">Less common stop</string>
+    <string name="less_common_stops">&lt;b&gt;%1$d&lt;/b&gt;  less common stops</string>
     <string name="live">Live</string>
     <string name="loading" tools:ignore="TypographyEllipsis">Loading...</string>
     <string name="location_not_available_yet">Location not available yet</string>
@@ -217,6 +219,7 @@
     <string name="onboarding_map_display_header">Set map display preference</string>
     <string name="onboarding_station_accessibility_body">By opting in, we can show you which stations are inaccessible or have elevator closures.</string>
     <string name="onboarding_station_accessibility_header">Set station accessibility info preference</string>
+    <string name="only_served_at_certain_times">Only served at certain times of day</string>
     <string name="open_for_more_arrivals">Open for more arrivals</string>
     <string name="other_link_privacy_policy">Privacy Policy</string>
     <string name="other_link_source_code">View Source on GitHub</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -408,6 +408,60 @@
         }
       }
     },
+    "**%1$ld** less common stops" : {
+      "comment" : "Header for a list of stops that vehicles don't always stop at for a given route",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%1$ld** less common stops"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** paradas menos comunes"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** arrêts moins courants"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** mwens arè komen"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** paradas menos comuns"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** các điểm dừng ít phổ biến hơn"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** 不常见站点"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$ld** 不常見站點"
+          }
+        }
+      }
+    },
     "**%ld** affected stops" : {
       "comment" : "The number of stops affected by an alert",
       "localizations" : {
@@ -9760,6 +9814,60 @@
         }
       }
     },
+    "Less common stop" : {
+      "comment" : "Descriptor in a list of all stops on a route for a single stop that a vehicle doesn't stop at on every trip",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Less common stop"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Parada menos común"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Arrêt moins courant"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Mwens komen sispann"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Parada menos comum"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Điểm dừng ít phổ biến hơn"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "不太常见的停站"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "較不常見的停站"
+          }
+        }
+      }
+    },
     "Lists remaining stops" : {
       "comment" : "Screen reader hint explaining what happens when 'x stops away'\nis selected (open an accordion listing those stops)",
       "localizations" : {
@@ -11537,6 +11645,60 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "準時"
+          }
+        }
+      }
+    },
+    "Only served at certain times of day" : {
+      "comment" : "Explainer text for \"Less common stops\" that vehicles don't always stop at",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only served at certain times of day"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sólo se sirve en determinados momentos del día."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Servi uniquement à certains moments de la journée"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yo sèvi sèlman nan sèten lè nan jounen an"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Servido apenas em determinados horários do dia"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chỉ phục vụ vào một số thời điểm nhất định trong ngày"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "仅在一天中的特定时间供应"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "不太常见的停站"
           }
         }
       }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
@@ -13,7 +13,9 @@ data class RouteDetailsStopList(val segments: List<Segment>) {
         val patterns: List<RoutePattern>,
         val connectingRoutes: List<Route>,
     ) {
-        val minTypicality = patterns.minOf { it.typicality ?: RoutePattern.Typicality.Typical }
+        private val minTypicality =
+            patterns.minOfOrNull { it.typicality ?: RoutePattern.Typicality.Typical }
+                ?: RoutePattern.Typicality.Typical
         val isTypical = minTypicality == RoutePattern.Typicality.Typical
     }
 
@@ -98,9 +100,9 @@ data class RouteDetailsStopList(val segments: List<Segment>) {
                     entry ->
                     if (wipSegment == null) {
                         Pair(acc, Segment(listOf(entry), entry.isTypical))
-                    } else if (entry.isTypical && wipSegment.stops.last().isTypical) {
-                        // adding to existing typical segment
-                        Pair(acc, Segment(wipSegment.stops.plus(entry), true))
+                    } else if (entry.isTypical == wipSegment.stops.last().isTypical) {
+                        // typicality match - continue building wip segment
+                        Pair(acc, Segment(wipSegment.stops.plus(entry), entry.isTypical))
                     } else {
                         // typicality change - start a new segment
                         Pair(acc.plus(wipSegment), Segment(listOf(entry), entry.isTypical))

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -84,13 +84,20 @@ data class GlobalResponse(
             null
         }
 
-    fun getTypicalRoutesFor(stopId: String): List<Route> {
+    fun getPatternsFor(stopId: String): List<RoutePattern> {
         val stop = stops[stopId] ?: return emptyList()
         val stopIds = stop.childStopIds + listOf(stopId)
         val patternIds = stopIds.flatMap { patternIdsByStop[it] ?: emptyList() }
-        return patternIds
-            .mapNotNull {
-                val routePattern = routePatterns[it] ?: return@mapNotNull null
+        return patternIds.mapNotNull { routePatterns[it] }
+    }
+
+    fun getPatternsFor(stopId: String, routeId: String): List<RoutePattern> {
+        return getPatternsFor(stopId).filter { it.routeId == routeId }
+    }
+
+    fun getTypicalRoutesFor(stopId: String): List<Route> {
+        return getPatternsFor(stopId)
+            .mapNotNull { routePattern ->
                 if (routePattern.typicality != RoutePattern.Typicality.Typical) {
                     return@mapNotNull null
                 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -184,7 +184,14 @@ class RouteDetailsStopListTest {
         val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
         val mainRoute = objects.route()
         val connectingRoute = objects.route()
-        val pattern =
+
+        val mainPattern =
+            objects.routePattern(mainRoute) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(mainStop.id) }
+            }
+
+        val connectingPattern =
             objects.routePattern(connectingRoute) {
                 typicality = RoutePattern.Typicality.Typical
                 representativeTrip { stopIds = listOf(connectingStop.id) }
@@ -200,10 +207,9 @@ class RouteDetailsStopListTest {
                             RouteDetailsStopList.Entry(
                                 mainStop,
                                 connectingRoutes = listOf(connectingRoute),
-                                patterns = listOf(),
+                                patterns = listOf(mainPattern),
                             )
-                        ),
-                        true,
+                        )
                     )
                 )
             ),
@@ -287,8 +293,7 @@ class RouteDetailsStopListTest {
                                         patternNonTypical1,
                                     ),
                             ),
-                        ),
-                        true,
+                        )
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -302,8 +307,7 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
                             ),
-                        ),
-                        false,
+                        )
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -312,8 +316,7 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
                             )
-                        ),
-                        true,
+                        )
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -322,8 +325,7 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
                             )
-                        ),
-                        false,
+                        )
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -332,8 +334,7 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical1, patternNonTypical1),
                             )
-                        ),
-                        true,
+                        )
                     ),
                 )
             ),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -184,22 +184,172 @@ class RouteDetailsStopListTest {
         val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
         val mainRoute = objects.route()
         val connectingRoute = objects.route()
-        objects.routePattern(connectingRoute) {
-            typicality = RoutePattern.Typicality.Typical
-            representativeTrip { stopIds = listOf(connectingStop.id) }
-        }
+        val pattern =
+            objects.routePattern(connectingRoute) {
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(connectingStop.id) }
+            }
 
         val globalData = GlobalResponse(objects)
 
         assertEquals(
             RouteDetailsStopList(
                 listOf(
-                    RouteDetailsStopList.Entry(mainStop, connectingRoutes = listOf(connectingRoute))
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                mainStop,
+                                connectingRoutes = listOf(connectingRoute),
+                                patterns = listOf(),
+                            )
+                        ),
+                        true,
+                    )
                 )
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 RouteStopsResponse(listOf(mainStop.id)),
+                globalData,
+            ),
+        )
+    }
+
+    @Test
+    fun `fromPieces breaks segments by typicality`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val stop0 = objects.stop { id = "stop0" }
+        val stop1 = objects.stop { id = "stop1" }
+        val stop2NonTypical = objects.stop { id = "stop2NonTypical" }
+        val stop3NonTypical = objects.stop { id = "stop3NonTypical" }
+        val stop4 = objects.stop { id = "stop4" }
+        val stop5NonTypical = objects.stop { id = "stop5NonTypical" }
+        val stop6 = objects.stop { id = "stop6" }
+
+        val mainRoute = objects.route()
+        val patternTypical0 =
+            objects.routePattern(mainRoute) {
+                id = "typical_0"
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop4.id) }
+            }
+
+        val patternTypical1 =
+            objects.routePattern(mainRoute) {
+                id = "typical_1"
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop6.id) }
+            }
+
+        val patternNonTypical0 =
+            objects.routePattern(mainRoute) {
+                id = "non_typical_0"
+                typicality = RoutePattern.Typicality.Atypical
+                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop2NonTypical.id) }
+            }
+
+        val patternNonTypical1 =
+            objects.routePattern(mainRoute) {
+                id = "non_typical_1"
+                typicality = RoutePattern.Typicality.Deviation
+                representativeTrip {
+                    stopIds =
+                        listOf(stop0.id, stop1.id, stop3NonTypical.id, stop5NonTypical.id, stop6.id)
+                }
+            }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteDetailsStopList(
+                listOf(
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop0,
+                                connectingRoutes = listOf(),
+                                patterns =
+                                    listOf(
+                                        patternTypical0,
+                                        patternTypical1,
+                                        patternNonTypical0,
+                                        patternNonTypical1,
+                                    ),
+                            ),
+                            RouteDetailsStopList.Entry(
+                                stop1,
+                                connectingRoutes = listOf(),
+                                patterns =
+                                    listOf(
+                                        patternTypical0,
+                                        patternTypical1,
+                                        patternNonTypical0,
+                                        patternNonTypical1,
+                                    ),
+                            ),
+                        ),
+                        true,
+                    ),
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop2NonTypical,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternNonTypical0),
+                            ),
+                            RouteDetailsStopList.Entry(
+                                stop3NonTypical,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternNonTypical1),
+                            ),
+                        ),
+                        false,
+                    ),
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop4,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternTypical0),
+                            )
+                        ),
+                        true,
+                    ),
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop5NonTypical,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternNonTypical1),
+                            )
+                        ),
+                        false,
+                    ),
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop6,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternTypical1, patternNonTypical1),
+                            )
+                        ),
+                        true,
+                    ),
+                )
+            ),
+            RouteDetailsStopList.fromPieces(
+                mainRoute.id,
+                RouteStopsResponse(
+                    listOf(
+                        stop0.id,
+                        stop1.id,
+                        stop2NonTypical.id,
+                        stop3NonTypical.id,
+                        stop4.id,
+                        stop5NonTypical.id,
+                        stop6.id,
+                    )
+                ),
                 globalData,
             ),
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Collapse non-typical bus stops](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210389717064826?focus=true)

What is this PR for?
* Collapses non-typical stops in the route list. Leaves some placeholders for improving the accessibility VoiceOver behavior after further discussion with design - will make a ticket to follow up on that.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests
* Ran locally 
![image](https://github.com/user-attachments/assets/d047d2f1-414f-438c-a392-08042d9c9b5e)
![image](https://github.com/user-attachments/assets/2fe59f02-7428-48f3-946c-b574ba9ca6ff)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
