### PR TITLE
feat: Show delayed CR predictions with schedule

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -155,6 +155,28 @@ class UpcomingTripViewTest {
     }
 
     @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithSchedule() {
+        val predictionInstant = Instant.fromEpochSeconds(1722535384)
+        val predictionShortTime = formatTime(predictionInstant)
+
+        val scheduleInstant = Instant.fromEpochSeconds(1722535784)
+        val scheduleShortTime = formatTime(scheduleInstant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.TimeWithSchedule(predictionInstant, scheduleInstant)
+                )
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(predictionInstant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("arriving at $predictionShortTime", substring = true)
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+    }
+
+    @Test
     fun testUpcomingTripViewWithSomeScheduleTime() {
         val instant = Instant.fromEpochSeconds(1722535384)
         val shortTime = formatTime(instant)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -225,6 +225,38 @@ fun UpcomingTripView(
                             style = Typography.footnoteSemibold,
                         )
                     }
+                is TripInstantDisplay.TimeWithSchedule ->
+                    Column(modifier, horizontalAlignment = Alignment.End) {
+                        WithRealtimeIndicator(
+                            modifier.then(maxAlphaModifier),
+                            hideRealtimeIndicators,
+                        ) {
+                            Text(
+                                formatTime(state.trip.predictionTime),
+                                Modifier.semantics {
+                                        contentDescription =
+                                            UpcomingTripAccessibilityFormatters.predictedTimeLabel(
+                                                context,
+                                                time = formatTime(state.trip.predictionTime),
+                                                isFirst,
+                                                vehicleType,
+                                            )
+                                    }
+                                    .placeholderIfLoading(),
+                                textAlign = TextAlign.End,
+                                style =
+                                    if (state.trip.headline) Typography.headlineSemibold
+                                    else Typography.footnoteSemibold,
+                            )
+                        }
+                        Text(
+                            formatTime(state.trip.scheduledTime),
+                            color = LocalContentColor.current.copy(alpha = min(maxTextAlpha, 0.6f)),
+                            textAlign = TextAlign.End,
+                            textDecoration = TextDecoration.LineThrough,
+                            style = Typography.footnoteSemibold,
+                        )
+                    }
                 is TripInstantDisplay.ScheduleTime ->
                     Text(
                         formatTime(state.trip.scheduledTime),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
@@ -30,6 +30,7 @@ fun TripInstantDisplay.containsWrappableText() =
         TripInstantDisplay.Now -> false
         is TripInstantDisplay.Time -> false
         is TripInstantDisplay.TimeWithStatus -> true
+        is TripInstantDisplay.TimeWithSchedule -> false
         is TripInstantDisplay.Minutes -> false
         is TripInstantDisplay.ScheduleTime -> false
         is TripInstantDisplay.ScheduleMinutes -> false

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -115,6 +115,25 @@ struct UpcomingTripView: View {
                         .opacity(min(0.6, maxTextAlpha))
                         .multilineTextAlignment(.trailing)
                 }
+            case let .timeWithSchedule(format):
+                VStack(alignment: .trailing, spacing: 0) {
+                    Text(Date(instant: format.predictionTime), style: .time)
+                        .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
+                        .realtime(hideIndicator: hideRealtimeIndicators)
+                        .opacity(min(1.0, maxTextAlpha))
+                        .accessibilityLabel(isFirst
+                            ? accessibilityFormatters.distantFutureFirst(
+                                date: format.predictionTime.toNSDate(),
+                                vehicleText: routeType?.typeText(isOnly: isOnly) ?? ""
+                            )
+                            : accessibilityFormatters
+                            .distantFutureOther(date: format.predictionTime.toNSDate()))
+                    Text(Date(instant: format.scheduledTime), style: .time)
+                        .font(Typography.footnoteSemibold)
+                        .opacity(min(0.6, maxTextAlpha))
+                        .strikethrough()
+                        .multilineTextAlignment(.trailing)
+                }
             case let .minutes(format):
                 PredictionText(minutes: format.minutes)
                     .realtime(hideIndicator: hideRealtimeIndicators)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -636,6 +636,52 @@ class TripInstantDisplayTest {
     }
 
     @Test
+    fun `time with schedule early`() = parametricTest {
+        val now = Clock.System.now()
+        val predictionTime = now + 2.minutes
+        val scheduleTime = now + 5.minutes
+        val prediction =
+            ObjectCollectionBuilder.Single.prediction { departureTime = predictionTime }
+
+        val schedule = ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime }
+
+        assertEquals(
+            TripInstantDisplay.TimeWithSchedule(predictionTime, scheduleTime, true),
+            TripInstantDisplay.from(
+                prediction,
+                schedule,
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now,
+                context = TripInstantDisplay.Context.StopDetailsFiltered,
+            ),
+        )
+    }
+
+    @Test
+    fun `time with schedule late`() = parametricTest {
+        val now = Clock.System.now()
+        val predictionTime = now + 2.minutes
+        val scheduleTime = now - 5.minutes
+        val prediction =
+            ObjectCollectionBuilder.Single.prediction { departureTime = predictionTime }
+
+        val schedule = ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime }
+
+        assertEquals(
+            TripInstantDisplay.TimeWithSchedule(predictionTime, scheduleTime, true),
+            TripInstantDisplay.from(
+                prediction,
+                schedule,
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now,
+                context = TripInstantDisplay.Context.StopDetailsFiltered,
+            ),
+        )
+    }
+
+    @Test
     fun `minutes less than 20 outside trip details`() = parametricTest {
         val now = Clock.System.now()
         val context = nonTripDetails()


### PR DESCRIPTION
### Summary

_Ticket:_ [Display commuter rail scheduled times](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210112078012937?focus=true)

Show scheduled times with a strikethrough below the predicted time if they are not the same for CR (and ferry when we get predictions). Waiting on design for an updated screen reader string for this, will include that as a follow up if necessary, or add to this PR if it comes in soon.

![Simulator Screenshot - iPhone 16 - 2025-06-04 at 16 01 04](https://github.com/user-attachments/assets/91ef6b5d-0219-4d92-bbd2-89f96ef25800) ![Screenshot_20250605_110340](https://github.com/user-attachments/assets/05420da2-052a-4af4-9523-b0bb23cb001a)



iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for the new type of trip display, and the Android composable. We can't test this on iOS because ViewInspector doesn't support testing formatted time strings.