### PR TITLE
feat: handle typical branches in route details

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -126,7 +126,7 @@ fun RouteStopListView(
                                         isLast =
                                             segmentIndex == stopList.segments.lastIndex &&
                                                 stopIndex == segment.stops.lastIndex,
-                                        includeLineDiagram = true,
+                                        includeLineDiagram = segment.hasRouteLine,
                                     )
 
                                 StopListRow(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -209,7 +209,8 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(connectingRoute),
                                 patterns = listOf(mainPattern),
                             )
-                        )
+                        ),
+                        hasRouteLine = true,
                     )
                 )
             ),
@@ -236,6 +237,7 @@ class RouteDetailsStopListTest {
         val patternTypical0 =
             objects.routePattern(mainRoute) {
                 id = "typical_0"
+                sortOrder = 0
                 typicality = RoutePattern.Typicality.Typical
                 representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop4.id) }
             }
@@ -243,6 +245,7 @@ class RouteDetailsStopListTest {
         val patternTypical1 =
             objects.routePattern(mainRoute) {
                 id = "typical_1"
+                sortOrder = 1
                 typicality = RoutePattern.Typicality.Typical
                 representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop6.id) }
             }
@@ -293,7 +296,8 @@ class RouteDetailsStopListTest {
                                         patternNonTypical1,
                                     ),
                             ),
-                        )
+                        ),
+                        hasRouteLine = true,
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -307,7 +311,8 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
                             ),
-                        )
+                        ),
+                        hasRouteLine = false,
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -316,7 +321,8 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
                             )
-                        )
+                        ),
+                        hasRouteLine = true,
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -325,7 +331,8 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
                             )
-                        )
+                        ),
+                        hasRouteLine = false,
                     ),
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -334,7 +341,8 @@ class RouteDetailsStopListTest {
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical1, patternNonTypical1),
                             )
-                        )
+                        ),
+                        hasRouteLine = false,
                     ),
                 )
             ),


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Route details non-GL branching](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210389717064824?focus=true)

As discussed in standup today, this is better than nothing and worth keeping. #1050 was a great foundation to build on.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that the behavior is as discussed on the Red Line and defensible for a few branching Commuter Rail routes. Adjusted the unit test from #1050 since it has typical branching too.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
