### PR TITLE
feat(android): UI Test rule to retry individual test

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
@@ -1,0 +1,126 @@
+package com.mbta.tid.mbta_app.android.retryable
+
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.AndroidComposeUiTestEnvironment
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.IdlingResource
+import androidx.compose.ui.test.MainTestClock
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Density
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Utils for marking tests as retryable
+ *
+ * A mix of the RetryableComposeTestRule from https://github.com/androidx/androidx/pull/574 and the
+ * Retry AnnotationClass from
+ * https://euryperez.dev/how-to-retry-your-instrumented-tests-in-android-e60581114826
+ */
+const val DEFAULT_RETRIES = 3
+
+/**
+ * An implementation of [ComposeTestRule] that will correctly reset itself in-between test retries.
+ *
+ * This is necessary because there is currently no ability to reset the
+ * [AndroidComposeUiTestEnvironment] in the standard [AndroidComposeTestRule].
+ *
+ * @param ruleProvider Function to create the underlying ComposeTestRule rule, defaults to
+ *   [createEmptyComposeRule]
+ */
+class RetryableComposeTestRule
+constructor(
+    val maxRetries: Int = DEFAULT_RETRIES,
+    val stopAfterSuccess: Boolean = true,
+    private val ruleProvider: () -> ComposeContentTestRule = ::createComposeRule,
+) : ComposeContentTestRule {
+    private var rule: ComposeContentTestRule = ruleProvider.invoke()
+
+    override val density: Density
+        get() = rule.density
+
+    override val mainClock: MainTestClock
+        get() = rule.mainClock
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                for (i in 0 until maxRetries) {
+                    System.out.println("${description.displayName}: run ${(i + 1)}")
+                    try {
+                        rule.apply(base, description).evaluate()
+
+                        if (stopAfterSuccess) {
+                            return
+                        }
+                    } catch (t: Throwable) {
+                        Log.i("retryableTest", "${description.displayName}: run ${(i + 1)} failed.")
+                    } finally {
+                        rule = ruleProvider.invoke()
+                    }
+                }
+
+                Log.i(
+                    "retryableTest",
+                    "${description.displayName}: Giving up after $maxRetries failures.",
+                )
+            }
+        }
+    }
+
+    override suspend fun awaitIdle() = rule.awaitIdle()
+
+    override fun onAllNodes(
+        matcher: SemanticsMatcher,
+        useUnmergedTree: Boolean,
+    ): SemanticsNodeInteractionCollection = rule.onAllNodes(matcher, useUnmergedTree)
+
+    override fun onNode(
+        matcher: SemanticsMatcher,
+        useUnmergedTree: Boolean,
+    ): SemanticsNodeInteraction = rule.onNode(matcher, useUnmergedTree)
+
+    override fun registerIdlingResource(idlingResource: IdlingResource) =
+        rule.registerIdlingResource(idlingResource)
+
+    override fun <T> runOnIdle(action: () -> T): T = rule.runOnIdle(action)
+
+    override fun <T> runOnUiThread(action: () -> T): T = rule.runOnUiThread(action)
+
+    override fun setContent(composable: @Composable () -> Unit) {
+        rule.setContent(composable)
+    }
+
+    override fun unregisterIdlingResource(idlingResource: IdlingResource) =
+        rule.unregisterIdlingResource(idlingResource)
+
+    override fun waitForIdle() = rule.waitForIdle()
+
+    override fun waitUntil(timeoutMillis: Long, condition: () -> Boolean) =
+        rule.waitUntil(timeoutMillis, condition)
+
+    @ExperimentalTestApi
+    override fun waitUntilAtLeastOneExists(matcher: SemanticsMatcher, timeoutMillis: Long) {
+        rule.waitUntilAtLeastOneExists(matcher, timeoutMillis)
+    }
+
+    @ExperimentalTestApi
+    override fun waitUntilDoesNotExist(matcher: SemanticsMatcher, timeoutMillis: Long) {
+        rule.waitUntilDoesNotExist(matcher, timeoutMillis)
+    }
+
+    @ExperimentalTestApi
+    override fun waitUntilExactlyOneExists(matcher: SemanticsMatcher, timeoutMillis: Long) {
+        rule.waitUntilExactlyOneExists(matcher, timeoutMillis)
+    }
+
+    @ExperimentalTestApi
+    override fun waitUntilNodeCount(matcher: SemanticsMatcher, count: Int, timeoutMillis: Long) {
+        rule.waitUntilNodeCount(matcher, count, timeoutMillis)
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
@@ -54,8 +54,13 @@ constructor(
                     Log.i("retryableTest", "${description.displayName}: run ${(i + 1)}")
                     try {
                         rule.apply(base, description).evaluate()
+                        Log.i(
+                            "retryableTest",
+                            "${description.displayName}: run ${(i + 1)} succeeded.",
+                        )
 
                         if (stopAfterSuccess) {
+
                             return
                         }
                     } catch (t: Throwable) {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
@@ -51,7 +51,7 @@ constructor(
         return object : Statement() {
             override fun evaluate() {
                 for (i in 0 until maxRetries) {
-                    System.out.println("${description.displayName}: run ${(i + 1)}")
+                    Log.i("retryableTest", "${description.displayName}: run ${(i + 1)}")
                     try {
                         rule.apply(base, description).evaluate()
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 systematic flaky test rethink](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210425090924778?focus=true)

What is this PR for?
Adds a retryable rule, useful for testing flaky tests locally and handling one-off flaky tests. Goes along with [WIP flaky test troubleshooting doc](https://www.notion.so/mbta-downtown-crossing/Test-Troubleshooting-551faaa2f7b14fbdafa9214f63e5f816?source=copy_link#20af5d8d11ea80f5b98cd3cc43c4d8b6)

Limitations:
* Logs about retry attempts are only visible when viewing Logcat locally and cannot be accessed from CI.

Next steps:
* Remove reties at the test suite level and add retries to a few specific flaky tests
* Try restructuring the known flaky tests to remove flakiness.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added a simple flaky test that checked if a randomly selected integer was less than 3. Ran using the new RetryableComposeTestRule and confirmed in the logs that the test was retried as expected
![image](https://github.com/user-attachments/assets/4365a00d-7609-4a07-95df-db075df178ba)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
