### PR TITLE
test(android): break apart some flaky tests

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
     alias(libs.plugins.compose)
     alias(libs.plugins.cycloneDx)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.mokkery)
     alias(libs.plugins.sentryGradle)
     alias(libs.plugins.serialization)
     id("check-mapbox-bridge")

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -1,0 +1,27 @@
+package com.mbta.tid.mbta_app.android.location
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class ViewportProviderTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testFollowUpdatesState() = runBlocking {
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewportProvider.isFollowingPuck = false
+        viewportProvider.isVehicleOverview = true
+
+        composeTestRule.setContent { LaunchedEffect(Unit) { viewportProvider.follow() } }
+        composeTestRule.waitUntil { viewportProvider.isFollowingPuck }
+        assertTrue(viewportProvider.isFollowingPuck)
+        assertFalse(viewportProvider.isVehicleOverview)
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -2,10 +2,9 @@ package com.mbta.tid.mbta_app.android.map
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -20,7 +19,6 @@ import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
-import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -28,8 +26,18 @@ import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import com.mbta.tid.mbta_app.utils.TestData
+import dev.mokkery.MockMode
+import dev.mokkery.answering.autofill.AutofillProvider
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -294,23 +302,44 @@ class HomeMapViewTests {
             .assertDoesNotExist()
     }
 
-    @OptIn(ExperimentalTestApi::class)
     @Test
-    @Ignore("flaky test passing locally but failing in CI")
-    fun testOverviewShownOnStopDetails(): Unit = runBlocking {
+    fun testRecenterButtonVisibilityCalledWhenOnStopDetails(): Unit = runBlocking {
         val locationManager = MockLocationDataManager()
         locationManager.hasPermission = true
-        val viewModel =
-            MapViewModel(ConfigUseCase(MockConfigRepository(), MockSentryRepository()), {})
 
-        viewModel.setGlobalResponse(GlobalResponse(objects = TestData))
+        val searchVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
         val viewportProvider = ViewportProvider(MapViewportState())
-        viewModel.loadConfig()
+
+        var updateCenterButtonVisibilityCalled = false
+
+        AutofillProvider.forMockMode.types.register(StateFlow::class) { MutableStateFlow(null) }
+
+        AutofillProvider.forMockMode.types.register(StateFlow::class) { MutableStateFlow(null) }
+
+        AutofillProvider.forMockMode.types.register(Flow::class) { MutableStateFlow(null) }
+
+        val mapVM = mock<IMapViewModel>(MockMode.autofill)
+        every { mapVM.selectedStop } returns MutableStateFlow(TestData.getStop("121"))
+        every { mapVM.configLoadAttempted } returns MutableStateFlow(true)
+        every { mapVM.showRecenterButton } returns MutableStateFlow(false)
+        every { mapVM.showTripCenterButton } returns MutableStateFlow(false)
+
+        every {
+            mapVM.updateCenterButtonVisibility(any(), locationManager, searchVM, viewportProvider)
+        } calls { updateCenterButtonVisibilityCalled = true }
+
         composeTestRule.setContent {
+            val nearbyTransitSelectingLocationState = remember { mutableStateOf(false) }
+
             HomeMapView(
                 sheetPadding = PaddingValues(0.dp),
                 lastNearbyTransitLocation = null,
-                nearbyTransitSelectingLocationState = mutableStateOf(false),
+                nearbyTransitSelectingLocationState = nearbyTransitSelectingLocationState,
                 locationDataManager = locationManager,
                 viewportProvider = viewportProvider,
                 currentNavEntry = SheetRoutes.StopDetails(TestData.getStop("121").id, null, null),
@@ -318,20 +347,13 @@ class HomeMapViewTests {
                 handleVehicleTap = {},
                 vehiclesData = emptyList(),
                 routeCardData = null,
-                viewModel = viewModel,
-                searchResultsViewModel =
-                    SearchResultsViewModel(
-                        MockAnalytics(),
-                        MockSearchResultRepository(),
-                        VisitHistoryUsecase(MockVisitHistoryRepository()),
-                    ),
+                viewModel = mapVM,
+                searchResultsViewModel = searchVM,
             )
         }
-        composeTestRule.waitUntilExactlyOneExists(
-            hasContentDescription("Recenter map on my location"),
-            timeoutMillis = 15000L,
-        )
-        composeTestRule.onNodeWithContentDescription("Recenter map on my location").assertExists()
+
+        composeTestRule.waitUntil { updateCenterButtonVisibilityCalled }
+        assertTrue(updateCenterButtonVisibilityCalled)
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/MapViewModelTests.kt
@@ -1,10 +1,19 @@
 package com.mbta.tid.mbta_app.android.map
 
+import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.ConfigResponse
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
+import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
+import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import io.github.dellisd.spatialk.geojson.Position
 import junit.framework.TestCase.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -60,5 +69,40 @@ class MapViewModelTests {
                 setHttpInterceptor = { httpInterceptorSet = true },
             )
         assertTrue { httpInterceptorSet }
+    }
+
+    @Test
+    fun testUpdateCenterButtonVisibilityWhenLocationKnownAndNotFollowing() = runBlocking {
+        val mapViewModel =
+            MapViewModel(
+                configUseCase =
+                    ConfigUseCase(
+                        MockConfigRepository(ApiResult.Error(500, "oops")),
+                        MockSentryRepository(),
+                    )
+            )
+
+        assertEquals(false, mapViewModel.showRecenterButton.value)
+
+        val searchResultsVM =
+            SearchResultsViewModel(
+                MockAnalytics(),
+                MockSearchResultRepository(),
+                VisitHistoryUsecase(MockVisitHistoryRepository()),
+            )
+
+        val locationDataManager = MockLocationDataManager()
+        locationDataManager.hasPermission = true
+        val viewportProvider = ViewportProvider(MapViewportState())
+        viewportProvider.setIsManuallyCentering(true)
+
+        mapViewModel.updateCenterButtonVisibility(
+            MockLocationDataManager.MockLocation(Position(0.0, 0.0)),
+            locationDataManager,
+            searchResultsVM,
+            viewportProvider,
+        )
+
+        assertEquals(true, mapViewModel.showRecenterButton.value)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -27,6 +27,7 @@ import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.location.IViewportProvider
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
@@ -38,7 +39,6 @@ import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.android.util.isFollowingPuck
-import com.mbta.tid.mbta_app.android.util.isRoughlyEqualTo
 import com.mbta.tid.mbta_app.map.RouteSourceData
 import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.LocationType
@@ -55,8 +55,12 @@ import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import dev.mokkery.answering.calls
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.spy
 import io.github.dellisd.spatialk.geojson.Position
-import kotlin.test.assertFalse
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -67,7 +71,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
@@ -337,7 +340,7 @@ class MapAndSheetPageTest : KoinTest {
                 currentLocation: Location?,
                 locationDataManager: LocationDataManager,
                 searchResultsViewModel: SearchResultsViewModel,
-                viewportProvider: ViewportProvider,
+                viewportProvider: IViewportProvider,
             ) {
                 TODO("Not yet implemented")
             }
@@ -433,8 +436,7 @@ class MapAndSheetPageTest : KoinTest {
     }
 
     @Test
-    @Ignore("flaky test passing locally but failing in CI")
-    fun testResetAfter1hour() = runBlocking {
+    fun testResetToFollowingAfter1hour() = runBlocking {
         val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
         val mockClock =
             object : Clock {
@@ -450,6 +452,34 @@ class MapAndSheetPageTest : KoinTest {
         val startLocation = Position(0.0, 0.0)
         val locationDataManager = MockLocationDataManager(startLocation)
         locationDataManager.hasPermission = true
+
+        val viewportProvider =
+            spy<IViewportProvider>(
+                ViewportProvider(
+                    MapViewportState(
+                        CameraState(
+                            // Specifically setting zoom so that we don't fall back to using the
+                            // default
+                            // center location. If default center is used, then since `hasPermission
+                            // = true`,
+                            // A MapEffect will also call follow and throw off the count of calls to
+                            // follow.
+                            Point.fromLngLat(sampleStop.longitude, sampleStop.latitude),
+                            EdgeInsets(0.0, 0.0, 0.0, 0.0),
+                            /* zoom = */ ViewportProvider.Companion.Defaults.zoom,
+                            /* bearing = */ 0.0,
+                            /* pitch = */ 0.0,
+                        )
+                    )
+                )
+            )
+        // setting to false so that the only calls to `follow()` will come from backgrounding.
+        // Otherwise, HomeMapView LaunchedEffect will sometimes also call `follow()` within the
+        // duration of the test and throw off the count.
+        viewportProvider.isFollowingPuck = false
+        var followCallCount = 0
+
+        everySuspend { viewportProvider.follow(any()) } calls { followCallCount += 1 }
 
         val koinApplication = testKoinApplication(builder, clock = mockClock)
         val searchResultsVM =
@@ -491,36 +521,9 @@ class MapAndSheetPageTest : KoinTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { viewportProvider.getViewportImmediate().cameraState != null }
-        val updatedCamera =
-            CameraState(Point.fromLngLat(1.1, 1.1), EdgeInsets(0.0, 0.0, 0.0, 0.0), 1.0, 0.0, 0.0)
-        viewportProvider.setIsManuallyCentering(true)
-        viewportProvider.updateCameraState(updatedCamera)
-        runBlocking {
-            viewportProvider.withViewport { viewport ->
-                viewport.setCameraOptions {
-                    center(updatedCamera.center)
-                    zoom(updatedCamera.zoom)
-                }
-            }
-        }
-        viewportProvider.setIsManuallyCentering(false)
+        composeTestRule.waitUntil() { followCallCount == 0 }
 
-        composeTestRule.waitForIdle()
-        composeTestRule.waitUntil(3000) {
-            viewportProvider
-                .getViewportImmediate()
-                .cameraState
-                ?.center
-                ?.isRoughlyEqualTo(updatedCamera.center) == true
-        }
-
-        assertTrue(
-            updatedCamera.center.isRoughlyEqualTo(
-                viewportProvider.getViewportImmediate().cameraState?.center!!
-            )
-        )
-        assertFalse(viewportProvider.isFollowingPuck)
+        assertEquals(followCallCount, 0)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
@@ -529,12 +532,7 @@ class MapAndSheetPageTest : KoinTest {
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
         composeTestRule.waitForIdle()
 
-        assertTrue(
-            updatedCamera.center.isRoughlyEqualTo(
-                viewportProvider.getViewportImmediate().cameraState?.center!!
-            )
-        )
-        assertFalse(viewportProvider.isFollowingPuck)
+        assertEquals(followCallCount, 0)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
@@ -542,18 +540,7 @@ class MapAndSheetPageTest : KoinTest {
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil(3000) {
-            !updatedCamera.center.isRoughlyEqualTo(
-                viewportProvider.getViewportImmediate().cameraState!!.center
-            ) && viewportProvider.getViewportImmediate().isFollowingPuck
-        }
-
-        assertFalse(
-            updatedCamera.center.isRoughlyEqualTo(
-                viewportProvider.getViewportImmediate().cameraState?.center!!
-            )
-        )
-        assertTrue(viewportProvider.getViewportImmediate().isFollowingPuck)
-        assertTrue(viewportProvider.isFollowingPuck)
+        composeTestRule.waitUntil() { followCallCount == 1 }
+        assertTrue(followCallCount == 1)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
@@ -72,7 +72,7 @@ constructor(
 
                 Log.i(
                     "retryableTest",
-                    "${description.displayName}: Giving up after $maxRetries failures.",
+                    "${description.displayName}: Giving up after $maxRetries attempts.",
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/retryable/RetryableComposeTestRule.kt
@@ -50,6 +50,8 @@ constructor(
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
+                var successCount = 0
+                var failureCount = 0
                 for (i in 0 until maxRetries) {
                     Log.i("retryableTest", "${description.displayName}: run ${(i + 1)}")
                     try {
@@ -58,13 +60,18 @@ constructor(
                             "retryableTest",
                             "${description.displayName}: run ${(i + 1)} succeeded.",
                         )
+                        successCount += 1
 
                         if (stopAfterSuccess) {
 
                             return
                         }
                     } catch (t: Throwable) {
-                        Log.i("retryableTest", "${description.displayName}: run ${(i + 1)} failed.")
+                        Log.i(
+                            "retryableTest",
+                            "${description.displayName}: run ${(i + 1)} failed.\n ${t.stackTraceToString()}",
+                        )
+                        failureCount += 1
                     } finally {
                         rule = ruleProvider.invoke()
                     }
@@ -72,7 +79,7 @@ constructor(
 
                 Log.i(
                     "retryableTest",
-                    "${description.displayName}: Giving up after $maxRetries attempts.",
+                    "${description.displayName}: $maxRetries attempts complete. Success: $successCount Failure: $failureCount",
                 )
             }
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -61,6 +61,7 @@ import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.appVariant
 import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.component.routeIcon
+import com.mbta.tid.mbta_app.android.location.IViewportProvider
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
@@ -88,7 +89,7 @@ fun HomeMapView(
     lastNearbyTransitLocation: Position?,
     nearbyTransitSelectingLocationState: MutableState<Boolean>,
     locationDataManager: LocationDataManager,
-    viewportProvider: ViewportProvider,
+    viewportProvider: IViewportProvider,
     currentNavEntry: SheetRoutes?,
     handleStopNavigation: (String) -> Unit,
     handleVehicleTap: (Vehicle) -> Unit,
@@ -420,6 +421,7 @@ fun HomeMapView(
 
                 MapEffect(locationDataManager.hasPermission) { map ->
                     if (locationDataManager.hasPermission && viewportProvider.isDefault()) {
+
                         viewportProvider.follow(
                             DefaultViewportTransitionOptions.Builder().maxDurationMs(0).build()
                         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/ManuallyCenteringListener.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/ManuallyCenteringListener.kt
@@ -6,9 +6,9 @@ import com.mapbox.android.gestures.StandardScaleGestureDetector
 import com.mapbox.maps.plugin.gestures.OnMoveListener
 import com.mapbox.maps.plugin.gestures.OnScaleListener
 import com.mapbox.maps.plugin.gestures.OnShoveListener
-import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.location.IViewportProvider
 
-class ManuallyCenteringListener(private val viewportProvider: ViewportProvider) :
+class ManuallyCenteringListener(private val viewportProvider: IViewportProvider) :
     OnMoveListener, OnScaleListener, OnShoveListener {
     override fun onMove(detector: MoveGestureDetector) = false
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapViewModel.kt
@@ -8,8 +8,8 @@ import androidx.lifecycle.viewModelScope
 import com.mapbox.common.HttpServiceFactory
 import com.mapbox.common.MapboxOptions
 import com.mapbox.geojson.FeatureCollection
+import com.mbta.tid.mbta_app.android.location.IViewportProvider
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
-import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.state.SearchResultsViewModel
 import com.mbta.tid.mbta_app.dependencyInjection.UsecaseDI
 import com.mbta.tid.mbta_app.map.RouteFeaturesBuilder
@@ -81,7 +81,7 @@ interface IMapViewModel {
         currentLocation: Location?,
         locationDataManager: LocationDataManager,
         searchResultsViewModel: SearchResultsViewModel,
-        viewportProvider: ViewportProvider,
+        viewportProvider: IViewportProvider,
     )
 
     fun hideCenterButtons()
@@ -209,7 +209,7 @@ open class MapViewModel(
         currentLocation: Location?,
         locationDataManager: LocationDataManager,
         searchResultsViewModel: SearchResultsViewModel,
-        viewportProvider: ViewportProvider,
+        viewportProvider: IViewportProvider,
     ) {
         setShowRecenterButton(
             locationDataManager.hasPermission &&

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -54,8 +54,8 @@ import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffoldState
 import com.mbta.tid.mbta_app.android.component.sheet.SheetValue
 import com.mbta.tid.mbta_app.android.favorites.FavoritesViewModel
+import com.mbta.tid.mbta_app.android.location.IViewportProvider
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
-import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.HomeMapView
 import com.mbta.tid.mbta_app.android.map.IMapViewModel
 import com.mbta.tid.mbta_app.android.map.MapViewModel
@@ -99,7 +99,7 @@ data class NearbyTransit(
     val nearbyTransitSelectingLocationState: MutableState<Boolean>,
     val scaffoldState: BottomSheetScaffoldState,
     val locationDataManager: LocationDataManager,
-    val viewportProvider: ViewportProvider,
+    val viewportProvider: IViewportProvider,
 ) {
     var lastNearbyTransitLocation by this.lastNearbyTransitLocationState
     var nearbyTransitSelectingLocation by this.nearbyTransitSelectingLocationState

--- a/bin/android-instrumented-test-ci.sh
+++ b/bin/android-instrumented-test-ci.sh
@@ -27,7 +27,7 @@ function retry() {
   done
 }
 
-RETRIES=3 retry ./gradlew :androidApp:connectedStagingDebugAndroidTest --no-daemon
+./gradlew :androidApp:connectedStagingDebugAndroidTest --no-daemon
 GRADLE_EXIT_CODE=$?
 
 if [ $GRADLE_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 systematic flaky test rethink](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210425090924778?focus=true)

What is this PR for?
This PR breaks apart flaky UI Tests by mocking the ViewModel and other inputs that do complicated logic. Also includes some improvements to the logging of RetryableComposeTestRule that I found useful along the way. Some light documentation of strategies for resolving flaky tests have been added to the [Test Troubleshooting doc](https://www.notion.so/mbta-downtown-crossing/Test-Troubleshooting-551faaa2f7b14fbdafa9214f63e5f816?source=copy_link#20af5d8d11ea80f5b98cd3cc43c4d8b6), but I think the muscle memory of mocking View Models as we add new UI tests will be most helpful.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran each of these tests with the RetryableComposeTestRule for 100 iterations and confirmed they did not flake. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
