### PR TITLE
feat(Android): Add scroll separator column components

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumnTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumnTest.kt
@@ -1,0 +1,32 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class ScrollSeparatorColumnTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testSeparatorVisibility(): Unit = runBlocking {
+        composeTestRule.setContent {
+            ScrollSeparatorColumn { for (n in 1..100) Text("Content $n", Modifier.testTag("$n")) }
+        }
+        composeTestRule.onNodeWithTag("separator").assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("99").assertIsNotDisplayed()
+
+        composeTestRule.onNodeWithTag("99").performScrollTo()
+        composeTestRule.awaitIdle()
+
+        composeTestRule.onNodeWithTag("separator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("99").assertIsDisplayed()
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumnTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumnTest.kt
@@ -1,0 +1,36 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToNode
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class ScrollSeparatorLazyColumnTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testSeparatorVisibility(): Unit = runBlocking {
+        composeTestRule.setContent {
+            ScrollSeparatorLazyColumn(Modifier.testTag("column")) {
+                items((1..100).toList()) { n -> Text("Content $n", Modifier.testTag("$n")) }
+            }
+        }
+        composeTestRule.onNodeWithTag("separator").assertIsNotDisplayed()
+        composeTestRule.onNodeWithTag("99").assertIsNotDisplayed()
+
+        composeTestRule.onNodeWithTag("column").performScrollToNode(hasTestTag("99"))
+        composeTestRule.awaitIdle()
+
+        composeTestRule.onNodeWithTag("separator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("99").assertIsDisplayed()
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HaloSeparator.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HaloSeparator.kt
@@ -3,10 +3,11 @@ package com.mbta.tid.mbta_app.android.component
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
 import com.mbta.tid.mbta_app.android.R
 
 @Composable
-fun HaloSeparator(modifier: Modifier = Modifier) {
-    HorizontalDivider(modifier, color = colorResource(R.color.halo))
+fun HaloSeparator(modifier: Modifier = Modifier, color: Color = colorResource(R.color.halo)) {
+    HorizontalDivider(modifier, color = color)
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
@@ -14,10 +14,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.android.routePicker.haloColor
 
 @Composable
 fun ScrollSeparatorColumn(
@@ -26,7 +26,7 @@ fun ScrollSeparatorColumn(
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     haloColor: Color = colorResource(R.color.halo),
     scrollState: ScrollState = rememberScrollState(),
-    content: @Composable() (ColumnScope.() -> Unit),
+    content: @Composable (ColumnScope.() -> Unit),
 ) {
     Box(Modifier, Alignment.TopCenter) {
         Column(
@@ -36,7 +36,7 @@ fun ScrollSeparatorColumn(
             content,
         )
         AnimatedVisibility(scrollState.canScrollBackward, enter = fadeIn(), exit = fadeOut()) {
-            HaloSeparator(color = haloColor)
+            HaloSeparator(Modifier.testTag("separator"), haloColor)
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
@@ -1,0 +1,42 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.routePicker.haloColor
+
+@Composable
+fun ScrollSeparatorColumn(
+    modifier: Modifier = Modifier,
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(8.dp),
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    haloColor: Color = colorResource(R.color.halo),
+    scrollState: ScrollState = rememberScrollState(),
+    content: @Composable() (ColumnScope.() -> Unit),
+) {
+    Box(Modifier, Alignment.TopCenter) {
+        Column(
+            Modifier.verticalScroll(scrollState).then(modifier),
+            verticalArrangement,
+            horizontalAlignment,
+            content,
+        )
+        AnimatedVisibility(scrollState.canScrollBackward, enter = fadeIn(), exit = fadeOut()) {
+            HaloSeparator(color = haloColor)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumn.kt
@@ -1,0 +1,57 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.foundation.gestures.FlingBehavior
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberOverscrollEffect
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun ScrollSeparatorLazyColumn(
+    modifier: Modifier = Modifier,
+    state: LazyListState = rememberLazyListState(),
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    reverseLayout: Boolean = false,
+    verticalArrangement: Arrangement.Vertical =
+        if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
+    horizontalAlignment: Alignment.Horizontal = Alignment.Start,
+    flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
+    userScrollEnabled: Boolean = true,
+    overscrollEffect: OverscrollEffect? = rememberOverscrollEffect(),
+    haloColor: Color = colorResource(R.color.halo),
+    content: LazyListScope.() -> Unit,
+) {
+    Box(Modifier, Alignment.TopCenter) {
+        LazyColumn(
+            modifier = modifier,
+            state = state,
+            contentPadding = contentPadding,
+            flingBehavior = flingBehavior,
+            horizontalAlignment = horizontalAlignment,
+            verticalArrangement = verticalArrangement,
+            reverseLayout = reverseLayout,
+            userScrollEnabled = userScrollEnabled,
+            overscrollEffect = overscrollEffect,
+            content = content,
+        )
+        AnimatedVisibility(state.canScrollBackward, enter = fadeIn(), exit = fadeOut()) {
+            HaloSeparator(color = haloColor)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumn.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
@@ -51,7 +52,7 @@ fun ScrollSeparatorLazyColumn(
             content = content,
         )
         AnimatedVisibility(state.canScrollBackward, enter = fadeIn(), exit = fadeOut()) {
-            HaloSeparator(color = haloColor)
+            HaloSeparator(Modifier.testTag("separator"), haloColor)
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardList.kt
@@ -2,12 +2,12 @@ package com.mbta.tid.mbta_app.android.component.routeCard
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.component.ScrollSeparatorLazyColumn
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -26,13 +26,16 @@ fun RouteCardList(
     showStationAccessibility: Boolean,
     onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
 ) {
+    val contentPadding = PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp)
+    val verticalArrangement = Arrangement.spacedBy(14.dp)
+    val horizontalAlignment = Alignment.CenterHorizontally
     if (routeCardData == null) {
         CompositionLocalProvider(IsLoadingSheetContents provides true) {
-            LazyColumn(
-                contentPadding =
-                    PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
+            ScrollSeparatorLazyColumn(
+                contentPadding = contentPadding,
+                verticalArrangement = verticalArrangement,
+                horizontalAlignment = horizontalAlignment,
+                userScrollEnabled = false,
             ) {
                 items(5) { LoadingRouteCard() }
             }
@@ -40,10 +43,10 @@ fun RouteCardList(
     } else if (routeCardData.isEmpty()) {
         emptyView()
     } else {
-        LazyColumn(
-            contentPadding = PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
+        ScrollSeparatorLazyColumn(
+            contentPadding = contentPadding,
+            verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
         ) {
             items(routeCardData) {
                 RouteCard(


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

I did this as part of the route picker work, but putting it up as a separate PR since it's entirely standalone. This just creates scrollable columns with a HaloSeparator at the top, which only shows up when the column is scrolled, to be used on pages which have a header with the same color background as the rest of the sheet, so that the header is separated from the content, and the content doesn't get cut off abruptly by an invisible line.

![Screenshot 2025-06-11 at 11 14 07 AM](https://github.com/user-attachments/assets/6380ea90-3e82-4de4-b7ee-b92258288e66)


android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for the separator visibility behavior