### PR TITLE
feat: create Molecule FavoritesViewModel

### DIFF
--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -3,4 +3,7 @@ package com.mbta.tid.mbta_app.viewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
-actual fun viewModelModule() = module { viewModelOf(::SearchViewModel) }
+actual fun viewModelModule() = module {
+    viewModelOf(::FavoritesViewModel)
+    viewModelOf(::SearchViewModel)
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -82,3 +82,5 @@ data class PredictionsByStopJoinResponse(
         val empty = PredictionsByStopJoinResponse(emptyMap(), emptyMap(), emptyMap())
     }
 }
+
+fun PredictionsByStopJoinResponse?.orEmpty() = this ?: PredictionsByStopJoinResponse.empty

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -1,0 +1,186 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
+import io.github.dellisd.spatialk.geojson.Position
+import kotlinx.coroutines.flow.Flow
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class FavoritesViewModel(private val favoritesUsecases: FavoritesUsecases) :
+    MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>() {
+    sealed interface Event {
+        data object ReloadFavorites : Event
+
+        data class SetActive(val active: Boolean, val isReturningFromBackground: Boolean?) : Event
+
+        data class SetAlerts(val alerts: AlertsStreamDataResponse?) : Event
+
+        data class SetLocation(val location: Position?) : Event
+
+        data class SetNow(val now: Instant) : Event
+    }
+
+    data class State(
+        val favorites: Set<RouteStopDirection>?,
+        val isReturningFromBackground: Boolean,
+        val routeCardData: List<RouteCardData>?,
+        val staticRouteCardData: List<RouteCardData>?,
+    ) {
+        constructor() : this(null, false, null, null)
+    }
+
+    @Composable
+    override fun runLogic(events: Flow<Event>): State {
+        var favorites: Set<RouteStopDirection>? by remember { mutableStateOf(null) }
+        var isReturningFromBackground: Boolean by remember { mutableStateOf(false) }
+        var routeCardData: List<RouteCardData>? by remember { mutableStateOf(null) }
+        var staticRouteCardData: List<RouteCardData>? by remember { mutableStateOf(null) }
+
+        var active: Boolean by remember { mutableStateOf(true) }
+        var alerts: AlertsStreamDataResponse? by remember { mutableStateOf(null) }
+        var location: Position? by remember { mutableStateOf(null) }
+        var now: Instant by remember { mutableStateOf(Clock.System.now()) }
+
+        val globalData = getGlobalData("FavoritesViewModel.getGlobalData")
+        val stopIds =
+            remember(favorites, globalData) {
+                val stops = favorites?.mapNotNull { globalData?.getStop(it.stop) }
+                stops?.flatMap { stop ->
+                    stop.childStopIds.filter { globalData?.stops?.containsKey(it) ?: false } +
+                        stop.id
+                }
+            }
+        val schedules = getSchedules(stopIds, "FavoritesViewModel.getSchedules")
+        val predictions = subscribeToPredictions(stopIds, active)
+
+        LaunchedEffect(Unit) { favorites = favoritesUsecases.getRouteStopDirectionFavorites() }
+
+        LaunchedEffect(Unit) {
+            events.collect { event ->
+                when (event) {
+                    Event.ReloadFavorites ->
+                        favorites = favoritesUsecases.getRouteStopDirectionFavorites()
+                    is Event.SetActive -> {
+                        active = event.active
+                        event.isReturningFromBackground?.let { isReturningFromBackground = it }
+                    }
+                    is Event.SetAlerts -> alerts = event.alerts
+                    is Event.SetLocation -> location = event.location
+                    is Event.SetNow -> now = event.now
+                }
+            }
+        }
+
+        LaunchedEffect(predictions) {
+            if (predictions != null) {
+                isReturningFromBackground = false
+            }
+        }
+
+        LaunchedEffect(
+            stopIds,
+            globalData,
+            location,
+            schedules,
+            predictions,
+            alerts,
+            now,
+            favorites,
+        ) {
+            if (stopIds == null || globalData == null || location == null) {
+                routeCardData = null
+            } else if (stopIds.isEmpty()) {
+                routeCardData = emptyList()
+            } else {
+                val loadedRouteCardData =
+                    RouteCardData.routeCardsForStopList(
+                        stopIds,
+                        globalData,
+                        location,
+                        schedules,
+                        predictions,
+                        alerts,
+                        now,
+                        emptySet(),
+                        RouteCardData.Context.Favorites,
+                    )
+                routeCardData = filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
+            }
+        }
+
+        LaunchedEffect(stopIds, globalData, favorites) {
+            if (stopIds == null || globalData == null) {
+                staticRouteCardData = null
+            } else if (stopIds.isEmpty()) {
+                staticRouteCardData = emptyList()
+            } else {
+                val loadedRouteCardData =
+                    RouteCardData.routeCardsForStaticStopList(
+                        stopIds,
+                        globalData,
+                        RouteCardData.Context.Favorites,
+                    )
+                staticRouteCardData =
+                    filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
+            }
+        }
+
+        return State(favorites, isReturningFromBackground, routeCardData, staticRouteCardData)
+    }
+
+    val models
+        get() = internalModels
+
+    fun reloadFavorites() = fireEvent(Event.ReloadFavorites)
+
+    @DefaultArgumentInterop.Enabled
+    fun setActive(active: Boolean, isReturningFromBackground: Boolean? = null) =
+        fireEvent(Event.SetActive(active, isReturningFromBackground))
+
+    fun setAlerts(alerts: AlertsStreamDataResponse?) = fireEvent(Event.SetAlerts(alerts))
+
+    fun setLocation(location: Position?) = fireEvent(Event.SetLocation(location))
+
+    fun setNow(now: Instant) = fireEvent(Event.SetNow(now))
+
+    companion object {
+        fun filterRouteAndDirection(
+            routeCardData: List<RouteCardData>?,
+            global: GlobalResponse,
+            favorites: Set<RouteStopDirection>?,
+        ): List<RouteCardData>? {
+            return routeCardData
+                ?.map { data ->
+                    val filteredStopData =
+                        data.stopData
+                            .map { stopData ->
+                                val filteredLeafData =
+                                    stopData.data.filter { leafData ->
+                                        val routeStopDirection =
+                                            RouteStopDirection(
+                                                leafData.lineOrRoute.id,
+                                                leafData.stop.resolveParent(global).id,
+                                                leafData.directionId,
+                                            )
+                                        favorites?.contains(routeStopDirection) == true
+                                    }
+                                stopData.copy(data = filteredLeafData)
+                            }
+                            .filter { it.data.isNotEmpty() }
+                    data.copy(stopData = filteredStopData)
+                }
+                ?.filter { it.stopData.any { it.data.isNotEmpty() } }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/fetchApi.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/fetchApi.kt
@@ -1,0 +1,34 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+
+/**
+ * If `getData` returns an `ApiResultOk`, clears any preexisting data error in `errorKey` in
+ * `errorBannerRepo` and calls `onSuccess`. If `getData` returns an `ApiResultError` or throws, sets
+ * an error in `errorKey` in `errorBannerRepo` with the given `onRefreshAfterError`.
+ */
+suspend fun <T : Any> fetchApi(
+    errorBannerRepo: IErrorBannerStateRepository,
+    errorKey: String,
+    getData: suspend () -> ApiResult<T>,
+    onSuccess: suspend (T) -> Unit = {},
+    onRefreshAfterError: () -> Unit,
+) {
+    val result: ApiResult<T> =
+        try {
+            getData()
+        } catch (e: Exception) {
+            ApiResult.Error(code = null, message = e.message ?: "")
+        }
+    when (result) {
+        is ApiResult.Error -> {
+            println("fetchApi error: API request $errorKey failed: $result")
+            errorBannerRepo.setDataError(key = errorKey, action = onRefreshAfterError)
+        }
+        is ApiResult.Ok -> {
+            errorBannerRepo.clearDataError(key = errorKey)
+            onSuccess(result.data)
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/getGlobalData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/getGlobalData.kt
@@ -1,0 +1,48 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
+
+private fun fetchGlobalData(
+    errorKey: String,
+    errorBannerRepository: IErrorBannerStateRepository,
+    globalRepository: IGlobalRepository,
+    onSuccess: (GlobalResponse) -> Unit,
+) {
+    CoroutineScope(Dispatchers.IO).launch {
+        fetchApi(
+            errorBannerRepo = errorBannerRepository,
+            errorKey = errorKey,
+            getData = { globalRepository.getGlobalData() },
+            onSuccess = onSuccess,
+            onRefreshAfterError = {
+                fetchGlobalData(errorKey, errorBannerRepository, globalRepository, onSuccess)
+            },
+        )
+    }
+}
+
+@Composable
+fun getGlobalData(
+    errorKey: String,
+    globalRepository: IGlobalRepository = koinInject(),
+    errorBannerRepository: IErrorBannerStateRepository = koinInject(),
+): GlobalResponse? {
+    var globalResponse: GlobalResponse? by remember { mutableStateOf(null) }
+    LaunchedEffect(null) {
+        fetchGlobalData(errorKey, errorBannerRepository, globalRepository) { globalResponse = it }
+    }
+    return globalResponse
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/getSchedules.kt
@@ -1,0 +1,65 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+import org.koin.compose.koinInject
+
+private fun fetchSchedules(
+    stopIds: List<String>,
+    errorKey: String,
+    errorBannerRepository: IErrorBannerStateRepository,
+    schedulesRepository: ISchedulesRepository,
+    onSuccess: (ScheduleResponse) -> Unit,
+) {
+    CoroutineScope(Dispatchers.IO).launch {
+        fetchApi(
+            errorBannerRepo = errorBannerRepository,
+            errorKey = errorKey,
+            getData = { schedulesRepository.getSchedule(stopIds, Clock.System.now()) },
+            onSuccess = onSuccess,
+            onRefreshAfterError = {
+                fetchSchedules(
+                    stopIds,
+                    errorKey,
+                    errorBannerRepository,
+                    schedulesRepository,
+                    onSuccess,
+                )
+            },
+        )
+    }
+}
+
+@Composable
+fun getSchedules(
+    stopIds: List<String>?,
+    errorKey: String,
+    schedulesRepository: ISchedulesRepository = koinInject(),
+    errorBannerRepository: IErrorBannerStateRepository = koinInject(),
+): ScheduleResponse? {
+    var result: ScheduleResponse? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(stopIds) {
+        if (stopIds != null) {
+            fetchSchedules(stopIds, errorKey, errorBannerRepository, schedulesRepository) {
+                result = it
+            }
+        } else {
+            result = ScheduleResponse(emptyList(), emptyMap())
+        }
+    }
+
+    return result
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/subscribeToPredictions.kt
@@ -1,0 +1,84 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.orEmpty
+import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
+import org.koin.compose.koinInject
+
+@Composable
+fun subscribeToPredictions(
+    stopIds: List<String>?,
+    active: Boolean,
+    errorBannerRepository: IErrorBannerStateRepository = koinInject(),
+    predictionsRepository: IPredictionsRepository = koinInject(),
+): PredictionsStreamDataResponse? {
+    var predictions: PredictionsByStopJoinResponse? by remember { mutableStateOf(null) }
+
+    fun onJoin(message: ApiResult<PredictionsByStopJoinResponse>) {
+        when (message) {
+            is ApiResult.Ok -> predictions = message.data
+            is ApiResult.Error -> println("Predictions stream failed to join: ${message.message}")
+        }
+    }
+
+    fun onMessage(message: ApiResult<PredictionsByStopMessageResponse>) {
+        when (message) {
+            is ApiResult.Ok -> predictions = predictions.orEmpty().mergePredictions(message.data)
+            is ApiResult.Error ->
+                println("Predictions stream failed on message: ${message.message}")
+        }
+    }
+
+    DisposableEffect(stopIds, active) {
+        if (stopIds != null && active) {
+            predictionsRepository.connectV2(stopIds, onJoin = ::onJoin, onMessage = ::onMessage)
+        }
+        onDispose { predictionsRepository.disconnect() }
+    }
+
+    LaunchedEffect(predictions) {
+        val lastUpdated = predictionsRepository.lastUpdated
+        if (lastUpdated != null) {
+            errorBannerRepository.checkPredictionsStale(
+                predictionsLastUpdated = lastUpdated,
+                predictionQuantity = predictions?.predictionQuantity() ?: 0,
+                action = {
+                    predictionsRepository.disconnect()
+                    if (stopIds != null && active) {
+                        predictionsRepository.connectV2(
+                            stopIds,
+                            onJoin = ::onJoin,
+                            onMessage = ::onMessage,
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    // when becoming active, if predictions should be forgotten, reset predictions
+    LaunchedEffect(active) {
+        if (
+            active &&
+                predictions != null &&
+                predictionsRepository.shouldForgetPredictions(
+                    predictions?.predictionQuantity() ?: 0
+                )
+        ) {
+            predictions = null
+        }
+    }
+
+    return predictions?.toPredictionsStreamDataResponse()
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -1,0 +1,321 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import app.cash.turbine.test
+import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
+import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
+import com.mbta.tid.mbta_app.model.Favorites
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
+import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import org.koin.core.component.get
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+
+class FavoritesViewModelTest : KoinTest {
+    val objects = ObjectCollectionBuilder()
+    val stop1 = objects.stop()
+    val stop2 = objects.stop()
+    val route1 = objects.route { directionNames = listOf("Outbound", "Inbound") }
+    val route2 = objects.route { directionNames = listOf("Outbound", "Inbound") }
+    val patterns =
+        listOf(Pair(route1, stop1), Pair(route2, stop2)).associate { (route, stop) ->
+            route to
+                listOf(0, 1).associateWith { directionId ->
+                    objects.routePattern(route) {
+                        this.directionId = directionId
+                        representativeTrip { stopIds = listOf(stop.id) }
+                    }
+                }
+        }
+
+    val favorites =
+        Favorites(
+            setOf(
+                RouteStopDirection(route1.id, stop1.id, 0),
+                RouteStopDirection(route2.id, stop2.id, 1),
+            )
+        )
+
+    private fun setUpKoin(
+        objects: ObjectCollectionBuilder = this.objects,
+        repositoriesBlock: MockRepositories.() -> Unit = {},
+    ) {
+        startKoin {
+            modules(
+                repositoriesModule(
+                    MockRepositories().apply {
+                        useObjects(objects)
+                        favorites = MockFavoritesRepository(this@FavoritesViewModelTest.favorites)
+                        predictions =
+                            MockPredictionsRepository(
+                                connectV2Response = PredictionsByStopJoinResponse(objects)
+                            )
+                        repositoriesBlock()
+                    }
+                ),
+                viewModelModule(),
+            )
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        stopKoin()
+    }
+
+    @Test
+    fun `loads empty favorites`() = runTest {
+        setUpKoin { favorites = MockFavoritesRepository(Favorites(emptySet())) }
+        val viewModel: FavoritesViewModel = get()
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+        viewModel.setNow(Clock.System.now())
+        viewModel.setLocation(stop1.position)
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = null,
+                    isReturningFromBackground = false,
+                    routeCardData = null,
+                    staticRouteCardData = null,
+                ),
+                awaitItem(),
+            )
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = emptySet(),
+                    isReturningFromBackground = false,
+                    routeCardData = null,
+                    staticRouteCardData = null,
+                ),
+                awaitItem(),
+            )
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = emptySet(),
+                    isReturningFromBackground = false,
+                    routeCardData = emptyList(),
+                    staticRouteCardData = emptyList(),
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `loads full favorites with filtered predictions`() = runTest {
+        val now = Clock.System.now()
+        val objects = objects.clone()
+        val predictions =
+            listOf(stop1, stop2).associateWith { stop ->
+                listOf(route1, route2).associateWith { route ->
+                    listOf(0, 1).associateWith { directionId ->
+                        val routePattern =
+                            objects.routePatterns.values.first {
+                                it.routeId == route.id && it.directionId == directionId
+                            }
+                        objects.prediction {
+                            trip = objects.trip(routePattern)
+                            stopId = stop.id
+                            departureTime = now + 5.minutes
+                        }
+                    }
+                }
+            }
+
+        val globalData = GlobalResponse(objects)
+        setUpKoin(objects)
+
+        val viewModel: FavoritesViewModel = get()
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+        viewModel.setNow(now)
+        viewModel.setLocation(stop1.position)
+
+        val staticDataTime = Instant.DISTANT_FUTURE
+        val expectedStaticData =
+            listOf(
+                RouteCardData(
+                    RouteCardData.LineOrRoute.Route(route1),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            route1,
+                            stop1,
+                            listOf(
+                                RouteCardData.Leaf(
+                                    RouteCardData.LineOrRoute.Route(route1),
+                                    stop1,
+                                    directionId = 0,
+                                    listOf(patterns.getValue(route1).getValue(0)),
+                                    setOf(stop1.id),
+                                    upcomingTrips = emptyList(),
+                                    alertsHere = emptyList(),
+                                    allDataLoaded = true,
+                                    hasSchedulesToday = false,
+                                    alertsDownstream = emptyList(),
+                                    context = RouteCardData.Context.Favorites,
+                                )
+                            ),
+                            globalData,
+                        )
+                    ),
+                    staticDataTime,
+                ),
+                RouteCardData(
+                    RouteCardData.LineOrRoute.Route(route2),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            route2,
+                            stop2,
+                            listOf(
+                                RouteCardData.Leaf(
+                                    RouteCardData.LineOrRoute.Route(route2),
+                                    stop2,
+                                    directionId = 1,
+                                    listOf(patterns.getValue(route2).getValue(1)),
+                                    setOf(stop2.id),
+                                    upcomingTrips = emptyList(),
+                                    alertsHere = emptyList(),
+                                    allDataLoaded = true,
+                                    hasSchedulesToday = false,
+                                    alertsDownstream = emptyList(),
+                                    context = RouteCardData.Context.Favorites,
+                                )
+                            ),
+                            globalData,
+                        )
+                    ),
+                    staticDataTime,
+                ),
+            )
+        val expectedRealtimeData =
+            listOf(
+                RouteCardData(
+                    RouteCardData.LineOrRoute.Route(route1),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            route1,
+                            stop1,
+                            listOf(
+                                RouteCardData.Leaf(
+                                    RouteCardData.LineOrRoute.Route(route1),
+                                    stop1,
+                                    directionId = 0,
+                                    listOf(patterns.getValue(route1).getValue(0)),
+                                    setOf(stop1.id),
+                                    upcomingTrips =
+                                        listOf(
+                                            objects.upcomingTrip(
+                                                predictions
+                                                    .getValue(stop1)
+                                                    .getValue(route1)
+                                                    .getValue(0)
+                                            )
+                                        ),
+                                    alertsHere = emptyList(),
+                                    allDataLoaded = true,
+                                    hasSchedulesToday = false,
+                                    alertsDownstream = emptyList(),
+                                    context = RouteCardData.Context.Favorites,
+                                )
+                            ),
+                            globalData,
+                        )
+                    ),
+                    now,
+                ),
+                RouteCardData(
+                    RouteCardData.LineOrRoute.Route(route2),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            route2,
+                            stop2,
+                            listOf(
+                                RouteCardData.Leaf(
+                                    RouteCardData.LineOrRoute.Route(route2),
+                                    stop2,
+                                    directionId = 1,
+                                    listOf(patterns.getValue(route2).getValue(1)),
+                                    setOf(stop2.id),
+                                    upcomingTrips =
+                                        listOf(
+                                            objects.upcomingTrip(
+                                                predictions
+                                                    .getValue(stop2)
+                                                    .getValue(route2)
+                                                    .getValue(1)
+                                            )
+                                        ),
+                                    alertsHere = emptyList(),
+                                    allDataLoaded = true,
+                                    hasSchedulesToday = false,
+                                    alertsDownstream = emptyList(),
+                                    context = RouteCardData.Context.Favorites,
+                                )
+                            ),
+                            globalData,
+                        )
+                    ),
+                    now,
+                ),
+            )
+        fun FavoritesViewModel.State.tweakStaticDataTime() =
+            this.copy(
+                staticRouteCardData =
+                    this.staticRouteCardData?.map { routeCardData ->
+                        routeCardData.copy(at = staticDataTime)
+                    }
+            )
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = null,
+                    isReturningFromBackground = false,
+                    routeCardData = null,
+                    staticRouteCardData = null,
+                ),
+                awaitItem(),
+            )
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = favorites.routeStopDirection,
+                    isReturningFromBackground = false,
+                    routeCardData = null,
+                    staticRouteCardData = null,
+                ),
+                awaitItem(),
+            )
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = favorites.routeStopDirection,
+                    isReturningFromBackground = false,
+                    routeCardData = null,
+                    staticRouteCardData = expectedStaticData,
+                ),
+                awaitItem().tweakStaticDataTime(),
+            )
+            assertEquals(
+                FavoritesViewModel.State(
+                    favorites = favorites.routeStopDirection,
+                    isReturningFromBackground = false,
+                    routeCardData = expectedRealtimeData,
+                    staticRouteCardData = expectedStaticData,
+                ),
+                awaitItem().tweakStaticDataTime(),
+            )
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -5,5 +5,6 @@ import org.koin.core.component.inject
 
 @Suppress("unused")
 class ViewModelDI : KoinComponent {
+    val favorites: FavoritesViewModel by inject()
     val search: SearchViewModel by inject()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -3,4 +3,7 @@ package com.mbta.tid.mbta_app.viewModel
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
-actual fun viewModelModule() = module { singleOf(::SearchViewModel) }
+actual fun viewModelModule() = module {
+    singleOf(::FavoritesViewModel)
+    singleOf(::SearchViewModel)
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Show favorites in tab](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210440278891499?focus=true)

I’m splitting out the shared changes from the iOS changes so that this PR isn’t absurdly large.

This creates shared versions of some of the state helpers from Android: some of them are structured differently, so I haven’t removed the Android versions yet, but they’ll hopefully be useful across several Molecule ViewModels as we move more of the logic to the shared code.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests for the new Molecule `FavoritesViewModel`. Checked manually that this will work with the iOS changes that still need their own tests and will be in a forthcoming PR.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
