### PR TITLE
fix(test): limit the parameter space of parametric tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -93,6 +93,7 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert { effect = Alert.Effect.ServiceChange }
 
+        val context: RouteCardData.Context = anyEnumValue()
         for ((route, icon) in cases) {
             assertEquals(
                 LeafFormat.Single(
@@ -114,7 +115,7 @@ class RouteCardDataLeafTest {
                         true,
                         true,
                         emptyList(),
-                        anyEnumValue(),
+                        context,
                     )
                     .format(now, GlobalResponse(objects)),
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -526,7 +526,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `seconds less than 60 in trip details`() = parametricTest {
+    fun `seconds less than 60 in trip details`() {
         val now = Clock.System.now()
         assertEquals(
             TripInstantDisplay.Time(now + 45.seconds),
@@ -613,7 +613,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `time with status`() = parametricTest {
+    fun `time with status`() {
         val now = Clock.System.now()
         val predictionTime = now + 2.minutes
         val prediction =
@@ -636,7 +636,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `time with schedule early`() = parametricTest {
+    fun `time with schedule early`() {
         val now = Clock.System.now()
         val predictionTime = now + 2.minutes
         val scheduleTime = now + 5.minutes
@@ -659,7 +659,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `time with schedule late`() = parametricTest {
+    fun `time with schedule late`() {
         val now = Clock.System.now()
         val predictionTime = now + 2.minutes
         val scheduleTime = now - 5.minutes
@@ -787,7 +787,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `minutes less than 20 in trip details`() = parametricTest {
+    fun `minutes less than 20 in trip details`() {
         val now = Clock.System.now()
         assertEquals(
             TripInstantDisplay.Time(now + 90.seconds),
@@ -834,7 +834,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `scheduled trip cancelled`() = parametricTest {
+    fun `scheduled trip cancelled`() {
         val now = Clock.System.now()
         assertEquals(
             TripInstantDisplay.Cancelled(now + 15.minutes),
@@ -856,7 +856,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `scheduled trip cancelled in past is hidden`() = parametricTest {
+    fun `scheduled trip cancelled in past is hidden`() {
         val now = Clock.System.now()
         assertEquals(
             TripInstantDisplay.Hidden,
@@ -878,7 +878,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `cancelled subway trip is hidden`() = parametricTest {
+    fun `cancelled subway trip is hidden`() {
         val now = Clock.System.now()
         assertEquals(
             TripInstantDisplay.Hidden,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.parametric
 
 import kotlin.enums.enumEntries
 import kotlin.test.assertEquals
+import kotlin.test.fail
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -52,6 +53,13 @@ class ParametricTest(val block: suspend ParametricTest.() -> Unit) {
     }
 
     internal suspend fun executeAll() {
+        val parameterSetCount = parameterSpace.map { it.size }.fold(1, Int::times)
+        if (parameterSetCount == 1) {
+            fail("parametricTest has no parameters, don’t use it")
+        }
+        if (parameterSetCount >= 10_000) {
+            fail("parametricTest has $parameterSetCount iterations, that’s too many")
+        }
         // constructing all these partial lists will be inefficient for more than a handful of
         // parameters
         val parameterSets =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTestTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/parametric/ParametricTestTest.kt
@@ -3,12 +3,15 @@ package com.mbta.tid.mbta_app.parametric
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 
 class ParametricTestTest {
     @Test
-    fun `handles zero booleans`() {
+    fun `does not handle zero booleans`() {
         var callCount = 0
-        parametricTest { callCount++ }
+        assertFails("parametricTest has no parameters, don’t use it") {
+            parametricTest { callCount++ }
+        }
         assertEquals(1, callCount)
     }
 
@@ -32,6 +35,14 @@ class ParametricTestTest {
             ),
             calls,
         )
+    }
+
+    @Test
+    fun `does not handle 14 booleans`() {
+        var callCount = 0
+        assertFails("parametricTest has 16384 iterations, that’s too many") {
+            parametricTest { callCount += (1..14).map { anyBoolean() }.filter { it }.size }
+        }
     }
 
     enum class TestEnum {


### PR DESCRIPTION
### Summary

_Ticket:_ none

Noticed that our shared tests are slower than I expect them to be, and I think I found the issue.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the tests all still pass locally.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
