### PR TITLE
fix(android.RouteStopListView): Don't pick a pattern in opposite direction as authoritative

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -85,8 +85,13 @@ fun RouteStopListView(
         getRouteStops(selectedRouteId, selectedDirection, "RouteDetailsView.routeStopIds")
 
     val stopList =
-        rememberSuspend(selectedRouteId, routeStops, globalData) {
-            RouteDetailsStopList.fromPieces(selectedRouteId, routeStops, globalData)
+        rememberSuspend(selectedRouteId, selectedDirection, routeStops, globalData) {
+            RouteDetailsStopList.fromPieces(
+                selectedRouteId,
+                selectedDirection,
+                routeStops,
+                globalData,
+            )
         }
     RouteDetailsContext.Details
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
@@ -73,6 +73,7 @@ data class RouteDetailsStopList(val segments: List<Segment>) {
 
         suspend fun fromPieces(
             routeId: String,
+            directionId: Int,
             routeStops: RouteStopsResponse?,
             globalData: GlobalResponse,
         ): RouteDetailsStopList? =
@@ -84,7 +85,10 @@ data class RouteDetailsStopList(val segments: List<Segment>) {
                         val stop =
                             globalData.getStop(stopId)?.resolveParent(globalData)
                                 ?: return@mapNotNull null
-                        val patterns = globalData.getPatternsFor(stopId, routeId)
+                        val patterns =
+                            globalData.getPatternsFor(stopId, routeId).filter {
+                                it.directionId == directionId
+                            }
                         val transferRoutes =
                             TripDetailsStopList.getTransferRoutes(stopId, routeId, globalData)
                         Entry(stop, patterns, transferRoutes)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -216,6 +216,7 @@ class RouteDetailsStopListTest {
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
+                0,
                 RouteStopsResponse(listOf(mainStop.id)),
                 globalData,
             ),
@@ -348,6 +349,7 @@ class RouteDetailsStopListTest {
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
+                0,
                 RouteStopsResponse(
                     listOf(
                         stop0.id,
@@ -359,6 +361,69 @@ class RouteDetailsStopListTest {
                         stop6.id,
                     )
                 ),
+                globalData,
+            ),
+        )
+    }
+
+    @Test
+    fun `fromPieces breaks segments by typicality in the selected direction`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val stop0 = objects.stop { id = "stop0" }
+        val stop1 = objects.stop { id = "stop1" }
+        val stop2 = objects.stop { id = "stop2" }
+
+        val mainRoute = objects.route()
+
+        val patternTypical0 =
+            objects.routePattern(mainRoute) {
+                id = "typical_0"
+                directionId = 0
+                sortOrder = 1
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop2.id) }
+            }
+
+        val patternTypicalOppositeDirection =
+            objects.routePattern(mainRoute) {
+                id = "typical_opposite_direction"
+                directionId = 1
+                sortOrder = 0
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip { stopIds = listOf(stop2.id, stop1.id, stop0.id) }
+            }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteDetailsStopList(
+                listOf(
+                    RouteDetailsStopList.Segment(
+                        listOf(
+                            RouteDetailsStopList.Entry(
+                                stop0,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternTypical0),
+                            ),
+                            RouteDetailsStopList.Entry(
+                                stop1,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternTypical0),
+                            ),
+                            RouteDetailsStopList.Entry(
+                                stop2,
+                                connectingRoutes = listOf(),
+                                patterns = listOf(patternTypical0),
+                            ),
+                        ),
+                        hasRouteLine = true,
+                    )
+                )
+            ),
+            RouteDetailsStopList.fromPieces(
+                mainRoute.id,
+                0,
+                RouteStopsResponse(listOf(stop0.id, stop1.id, stop2.id)),
                 globalData,
             ),
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Route details line broken on inbound bus routes ](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210504151095128?focus=true)

What is this PR for?
* Inbound bus route lines were broken. This is because an outbound pattern was being chosen as the authoritative pattern to determine what the primary line to draw should be. Now, we filter the list of patterns considered to match the chosen direction.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally and confirmed inbound direction shows line as appropriate
* Added a unit test
![image](https://github.com/user-attachments/assets/48be3802-4e4d-4a20-a456-628d426a131e)
![image](https://github.com/user-attachments/assets/adb3e681-d2c7-41ee-b619-9d5fbc8b4c05)



<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
