### PR TITLE
fix(Android): Add > 1 hr departure TalkBack text

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -210,7 +210,11 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(65)))
         }
-        composeTestRule.onNodeWithText("1 hr 5 min").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("1 hr 5 min")
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("arriving in 1 hr 5 min", substring = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -218,7 +222,11 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(60)))
         }
-        composeTestRule.onNodeWithText("1 hr").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("1 hr")
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("arriving in 1 hr", substring = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -248,6 +256,40 @@ class UpcomingTripViewTest {
             .onNodeWithText("5 min")
             .assertIsDisplayed()
             .assertContentDescriptionContains("and in 5 min", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeHoursAndMinutesOtherBus() {
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(TripInstantDisplay.Minutes(65)),
+                routeType = RouteType.BUS,
+                isFirst = false,
+            )
+        }
+        composeTestRule
+            .onNodeWithText("1 hr 5 min")
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("and in 1 hr 5 min", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeHoursOtherBus() {
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(TripInstantDisplay.Minutes(60)),
+                routeType = RouteType.BUS,
+                isFirst = false,
+            )
+        }
+        composeTestRule
+            .onNodeWithText("1 hr")
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("and in 1 hr", substring = true)
             .assertIsDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -45,6 +45,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
+import com.mbta.tid.mbta_app.utils.MinutesFormat
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import kotlin.math.min
@@ -237,10 +238,7 @@ fun UpcomingTripView(
 
                 is TripInstantDisplay.ScheduleMinutes ->
                     Text(
-                        text =
-                            AnnotatedString.fromHtml(
-                                stringResource(R.string.minutes_abbr, state.trip.minutes)
-                            ),
+                        text = AnnotatedString.fromHtml(predictionTextMinutes(state.trip.minutes)),
                         modifier =
                             modifier
                                 .alpha(min(maxTextAlpha, 0.6F))
@@ -320,20 +318,13 @@ fun UpcomingTripView(
 }
 
 @Composable
-fun predictionTextMinutes(minutes: Int): String {
-    val hours = Math.floorDiv(minutes, 60)
-    val remainingMinutes = minutes - (hours * 60)
-
-    return if (hours >= 1) {
-        if (remainingMinutes == 0) {
-            stringResource(R.string.exact_hours_format_abbr, hours)
-        } else {
-            stringResource(R.string.hr_min_abbr, hours, remainingMinutes)
-        }
-    } else {
-        stringResource(R.string.minutes_abbr, minutes)
+fun predictionTextMinutes(minutes: Int): String =
+    when (val format = MinutesFormat.from(minutes)) {
+        is MinutesFormat.Hour -> stringResource(R.string.exact_hours_format_abbr, format.hours)
+        is MinutesFormat.HourMinute ->
+            stringResource(R.string.hr_min_abbr, format.hours, format.minutes)
+        is MinutesFormat.Minute -> stringResource(R.string.minutes_abbr, format.minutes)
     }
-}
 
 @Composable
 fun DisruptionView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.res.stringResource
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.formatTime
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
+import com.mbta.tid.mbta_app.utils.MinutesFormat
+import io.sentry.Sentry
 
 @Composable
 fun TripInstantDisplay.contentDescription(isFirst: Boolean, vehicleType: String): String =
@@ -24,9 +26,16 @@ fun TripInstantDisplay.contentDescription(isFirst: Boolean, vehicleType: String)
             else stringResource(R.string.vehicle_cancelled_other, time)
         }
         is TripInstantDisplay.ScheduleMinutes -> {
-            val min = this.minutes
-            if (isFirst) stringResource(R.string.vehicle_schedule_minutes_first, vehicleType, min)
-            else stringResource(R.string.vehicle_schedule_minutes_other, min)
+            val format = MinutesFormat.from(this.minutes)
+            if (format !is MinutesFormat.Minute) {
+                Sentry.captureMessage(
+                    "Schedules displayed as minutes should never be over 1 hour, " +
+                        "content description text is not supported for this case"
+                )
+                ""
+            } else if (isFirst)
+                stringResource(R.string.vehicle_schedule_minutes_first, vehicleType, format.minutes)
+            else stringResource(R.string.vehicle_schedule_minutes_other, format.minutes)
         }
         is TripInstantDisplay.ScheduleTime -> {
             val time = formatTime(this.scheduledTime)
@@ -67,15 +76,43 @@ private fun predictedMinutesDescription(
     isFirst: Boolean,
     vehicleType: String,
 ): String {
-    val minutes =
-        when (trip) {
-            is TripInstantDisplay.Approaching -> 1
-            is TripInstantDisplay.Minutes -> trip.minutes
-            else -> return ""
+    val format =
+        MinutesFormat.from(
+            when (trip) {
+                is TripInstantDisplay.Approaching -> 1
+                is TripInstantDisplay.Minutes -> trip.minutes
+                else -> return ""
+            }
+        )
+    return if (isFirst)
+        when (format) {
+            is MinutesFormat.Hour ->
+                stringResource(R.string.vehicle_prediction_hours_first, vehicleType, format.hours)
+            is MinutesFormat.HourMinute ->
+                stringResource(
+                    R.string.vehicle_prediction_hours_minutes_first,
+                    vehicleType,
+                    format.hours,
+                    format.minutes,
+                )
+            is MinutesFormat.Minute ->
+                stringResource(
+                    R.string.vehicle_prediction_minutes_first,
+                    vehicleType,
+                    format.minutes,
+                )
         }
-    return if (isFirst) {
-        stringResource(R.string.vehicle_prediction_minutes_first, vehicleType, minutes)
-    } else {
-        stringResource(R.string.vehicle_prediction_minutes_other, minutes)
-    }
+    else
+        when (format) {
+            is MinutesFormat.Hour ->
+                stringResource(R.string.vehicle_prediction_hours_other, format.hours)
+            is MinutesFormat.HourMinute ->
+                stringResource(
+                    R.string.vehicle_prediction_hours_minutes_other,
+                    format.hours,
+                    format.minutes,
+                )
+            is MinutesFormat.Minute ->
+                stringResource(R.string.vehicle_prediction_minutes_other, format.minutes)
+        }
 }

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -372,6 +372,10 @@
     <string name="vehicle_cancelled_other">y a las %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s seleccionado</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s seleccionada, parada seleccionada</string>
+    <string name="vehicle_prediction_hours_first">%1$s llegando en %2$d h</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s llegando en %2$d h %3$d min</string>
+    <string name="vehicle_prediction_hours_minutes_other">y en %1$d h %2$d min</string>
+    <string name="vehicle_prediction_hours_other">y en %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s llegará en %2$d min.</string>
     <string name="vehicle_prediction_minutes_other">y en %1$d min.</string>
     <string name="vehicle_prediction_time_first">%1$s llegará a la(s) %2$s</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -372,6 +372,10 @@
     <string name="vehicle_cancelled_other">et à %1$s est annulé</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s sélectionné</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s sélectionné, arrêt sélectionné</string>
+    <string name="vehicle_prediction_hours_first">%1$s arrive dans %2$d h</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s arrive dans %2$d h et %3$d min</string>
+    <string name="vehicle_prediction_hours_minutes_other">et dans %1$d h et %2$d min</string>
+    <string name="vehicle_prediction_hours_other">et dans %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s arrive dans %2$d min</string>
     <string name="vehicle_prediction_minutes_other">et dans %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s arrivant à %2$s</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -387,6 +387,10 @@
     <string name="vehicle_cancelled_other">epi a %1$s anile</string>
     <string name="vehicle_desc_accessibility_desc">Chwazi %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Chwazi %1$s %2$s %3$s, arè ou chwazi a</string>
+    <string name="vehicle_prediction_hours_first">%1$s ap rive nan %2$d èdtan</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s rive nan %2$d è %3$d min</string>
+    <string name="vehicle_prediction_hours_minutes_other">epi nan %1$d è %2$d min</string>
+    <string name="vehicle_prediction_hours_other">epi nan %1$d èdtan</string>
     <string name="vehicle_prediction_minutes_first">%1$s ap rive nan %2$d minit</string>
     <string name="vehicle_prediction_minutes_other">epi nan %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s ap rive a %2$s</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -372,6 +372,10 @@
     <string name="vehicle_cancelled_other">e às %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s selecionados</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s selecionados, parada selecionada</string>
+    <string name="vehicle_prediction_hours_first">%1$s chegando em %2$d h</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s chegando em %2$d hr %3$d min</string>
+    <string name="vehicle_prediction_hours_minutes_other">e em %1$d h %2$d min</string>
+    <string name="vehicle_prediction_hours_other">e em %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s chegando em %2$d min</string>
     <string name="vehicle_prediction_minutes_other">e em %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s chegando às %2$s</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -362,6 +362,10 @@
     <string name="vehicle_cancelled_other">và tại %1$s đã hủy</string>
     <string name="vehicle_desc_accessibility_desc">Đã chọn %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Đã chọn %1$s %2$s %3$s, điểm dừng đã chọn</string>
+    <string name="vehicle_prediction_hours_first">%1$s sẽ đến trong %2$d giờ</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s sẽ đến trong %2$d giờ %3$d phút</string>
+    <string name="vehicle_prediction_hours_minutes_other">và trong %1$d giờ %2$d phút</string>
+    <string name="vehicle_prediction_hours_other">và trong %1$d giờ</string>
     <string name="vehicle_prediction_minutes_first">%1$s sẽ đến sau %2$d phút nữa</string>
     <string name="vehicle_prediction_minutes_other">và sau %1$d phút nữa</string>
     <string name="vehicle_prediction_time_first">%1$s sẽ đến lúc %2$s</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -362,6 +362,10 @@
     <string name="vehicle_cancelled_other">于%1$s到站的下一趟车已取消</string>
     <string name="vehicle_desc_accessibility_desc">选定%1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">选定%1$s %2$s %3$s，选定站点</string>
+    <string name="vehicle_prediction_hours_first">%1$s将于%2$d小时内到站</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s将于%2$d小时%3$d分钟内到站</string>
+    <string name="vehicle_prediction_hours_minutes_other">下一趟车将在%1$d小时%2$d分钟内抵达</string>
+    <string name="vehicle_prediction_hours_other">下一趟车将在%1$d小时内抵达</string>
     <string name="vehicle_prediction_minutes_first">%1$s将在%2$d分钟内到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟车将在%1$d分钟内抵达</string>
     <string name="vehicle_prediction_time_first">%1$s于%2$s到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -362,6 +362,10 @@
     <string name="vehicle_cancelled_other">於%1$s到站的下一趟車已取消</string>
     <string name="vehicle_desc_accessibility_desc">選定%1$s%2$s%3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">選定%1$s%2$s%3$s，選定站點</string>
+    <string name="vehicle_prediction_hours_first">%1$s將在%2$d小時內到站</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s將在%2$d小時%3$d分鐘內到站</string>
+    <string name="vehicle_prediction_hours_minutes_other">下一趟車將在%1$d小時%2$d分鐘內抵達</string>
+    <string name="vehicle_prediction_hours_other">下一趟車將在%1$d小時內抵達</string>
     <string name="vehicle_prediction_minutes_first">%1$s將在%2$d分鐘內到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟車將在%1$d分鐘內抵達</string>
     <string name="vehicle_prediction_time_first">%1$s於%2$s到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -375,6 +375,10 @@
     <string name="vehicle_cancelled_other">and at %1$s cancelled</string>
     <string name="vehicle_desc_accessibility_desc">Selected %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Selected %1$s %2$s %3$s, selected stop</string>
+    <string name="vehicle_prediction_hours_first">%1$s arriving in %2$d hr</string>
+    <string name="vehicle_prediction_hours_other">and in %1$d hr</string>
+    <string name="vehicle_prediction_hours_minutes_first">%1$s arriving in %2$d hr %3$d min</string>
+    <string name="vehicle_prediction_hours_minutes_other">and in %1$d hr %2$d min</string>
     <string name="vehicle_prediction_minutes_first">%1$s arriving in %2$d min</string>
     <string name="vehicle_prediction_minutes_other">and in %1$d min</string>
     <string name="vehicle_prediction_time_first">%1$s arriving at %2$s</string>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MinutesFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MinutesFormat.kt
@@ -1,0 +1,19 @@
+package com.mbta.tid.mbta_app.utils
+
+sealed class MinutesFormat {
+    companion object {
+        fun from(minutes: Int): MinutesFormat {
+            val hours = minutes.floorDiv(60)
+            val remainingMinutes = minutes - (hours * 60)
+            return if (hours >= 1)
+                if (remainingMinutes == 0) Hour(hours) else HourMinute(hours, remainingMinutes)
+            else Minute(minutes)
+        }
+    }
+
+    data class Hour(val hours: Int) : MinutesFormat()
+
+    data class HourMinute(val hours: Int, val minutes: Int) : MinutesFormat()
+
+    data class Minute(val minutes: Int) : MinutesFormat()
+}


### PR DESCRIPTION
### Summary

_Ticket:_ Can of worms found during [[screen reader text for crossed out CR schedule times]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210503750238562?focus=true)

Implement a `MinutesFormat` class in shared code, so that we can use it to get rid of duplicate logic when the changes are implemented in iOS. All the added screen reader text strings already existed in iOS, they just weren't being used in Android.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
~- [ ] Add temporary machine translations, marked "Needs Review"~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Added a couple new tests and a couple new content description checks to existing tests