### PR TITLE
feat(iOS): display favorites in favorites page

### DIFF
--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -203,6 +203,7 @@
     <string name="no_service">Sin servicio</string>
     <string name="no_service_sentence_case">Sin servicio</string>
     <string name="no_service_today">No hay servicio hoy</string>
+    <string name="no_stops_added">No se agregaron paradas</string>
     <string name="no_stops_nearby">Está fuera del área de servicio de MBTA.</string>
     <string name="no_stops_nearby_pan">Ver el tránsito cerca de Boston</string>
     <string name="no_stops_nearby_search">Buscar por parada</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -203,6 +203,7 @@
     <string name="no_service">Pas de service</string>
     <string name="no_service_sentence_case">Aucun service</string>
     <string name="no_service_today">Aucun service aujourd’hui</string>
+    <string name="no_stops_added">Aucun arrêt ajouté</string>
     <string name="no_stops_nearby">Vous vous situez en dehors de la zone de service de MBTA.</string>
     <string name="no_stops_nearby_pan">Voir les transports près de Boston</string>
     <string name="no_stops_nearby_search">Rechercher par arrêt</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -108,7 +108,7 @@
         <item quantity="other">%1$d asansè yo fèmen</item>
     </plurals>
     <plurals name="elevator_closure_count_accessibility_description">
-        <item quantity="zero">This stop has %1$d elevators closed</item>
+        <item quantity="zero">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="one">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="two">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="few">Estasyon sa a gen %1$d asansè fèmen</item>
@@ -212,6 +212,7 @@
     <string name="no_service">Pa gen Sèvis</string>
     <string name="no_service_sentence_case">Pa gen sèvis</string>
     <string name="no_service_today">Pa gen sèvis jodi a</string>
+    <string name="no_stops_added">Pa gen arè te ajoute</string>
     <string name="no_stops_nearby">Ou deyò zòn sèvis MBTA a.</string>
     <string name="no_stops_nearby_pan">Gade transpò piblik toupre Boston</string>
     <string name="no_stops_nearby_search">Chèche dapre arè a</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -203,6 +203,7 @@
     <string name="no_service">Sem serviço</string>
     <string name="no_service_sentence_case">Sem serviço</string>
     <string name="no_service_today">Sem serviço hoje</string>
+    <string name="no_stops_added">Nenhuma parada adicionada</string>
     <string name="no_stops_nearby">Você está fora da área de serviço da MBTA.</string>
     <string name="no_stops_nearby_pan">Ver trânsito perto de Boston</string>
     <string name="no_stops_nearby_search">Pesquisar por parada</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -197,6 +197,7 @@
     <string name="no_service">Không có dịch vụ</string>
     <string name="no_service_sentence_case">Không có dịch vụ</string>
     <string name="no_service_today">Hôm nay không có dịch vụ</string>
+    <string name="no_stops_added">Không có điểm dừng nào được thêm vào</string>
     <string name="no_stops_nearby">Bạn đang ở ngoài khu vực dịch vụ của MBTA.</string>
     <string name="no_stops_nearby_pan">Xem phương tiện công cộng gần Boston</string>
     <string name="no_stops_nearby_search">Tìm kiếm theo điểm dừng</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -197,6 +197,7 @@
     <string name="no_service">无服务</string>
     <string name="no_service_sentence_case">无服务</string>
     <string name="no_service_today">今日无服务</string>
+    <string name="no_stops_added">未添加停靠站</string>
     <string name="no_stops_nearby">您不在MBTA服务区内。</string>
     <string name="no_stops_nearby_pan">查看波士顿车站附近的交通运输服务</string>
     <string name="no_stops_nearby_search">按站点搜索</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -197,6 +197,7 @@
     <string name="no_service">無服務</string>
     <string name="no_service_sentence_case">無服務</string>
     <string name="no_service_today">今日無服務</string>
+    <string name="no_stops_added">未添加停靠站</string>
     <string name="no_stops_nearby">您位於MBTA服務區域之外。</string>
     <string name="no_stops_nearby_pan">查看波士頓附近的交通</string>
     <string name="no_stops_nearby_search">按站點搜尋</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="no_service">No Service</string>
     <string name="no_service_sentence_case">No service</string>
     <string name="no_service_today">No service today</string>
-    <string name="no_stops_added" tools:ignore="MissingTranslation">No stops added</string>
+    <string name="no_stops_added">No stops added</string>
     <string name="no_stops_nearby">You’re outside the MBTA service area.</string>
     <string name="no_stops_nearby_pan">View transit near Boston</string>
     <string name="no_stops_nearby_search">Search by stop</string>

--- a/iosApp/iosApp/ComponentViews/RouteCard/LoadingRouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/LoadingRouteCard.swift
@@ -1,0 +1,24 @@
+//
+//  LoadingRouteCard.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/12/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct LoadingRouteCard: View {
+    var body: some View {
+        RouteCard(
+            cardData: LoadingPlaceholders.shared.nearbyRoute(),
+            global: nil,
+            now: .now,
+            onPin: { _ in },
+            pinned: false,
+            pushNavEntry: { _ in },
+            showStopHeader: true
+        )
+    }
+}

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
@@ -1,0 +1,63 @@
+//
+//  RouteCardList.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/12/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct RouteCardList<EmptyView: View>: View {
+    let routeCardData: [RouteCardData]?
+    @ViewBuilder let emptyView: () -> EmptyView
+    let global: GlobalResponse?
+    let now: Date
+    let isPinned: (String) -> Bool
+    let onPin: (String) -> Void
+    let showStationAccessibility: Bool
+    let pushNavEntry: (SheetNavigationStackEntry) -> Void
+    let showStopHeader: Bool
+
+    var body: some View {
+        if let routeCardData, !routeCardData.isEmpty {
+            ScrollView {
+                LazyVStack(alignment: .center, spacing: 18) {
+                    ForEach(routeCardData, id: \.lineOrRoute.id) { routeCardData in
+                        RouteCard(
+                            cardData: routeCardData,
+                            global: global,
+                            now: now,
+                            onPin: onPin,
+                            pinned: isPinned(routeCardData.lineOrRoute.id),
+                            pushNavEntry: pushNavEntry,
+                            showStopHeader: showStopHeader
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+            }
+        } else if let routeCardData, routeCardData.isEmpty {
+            ScrollView {
+                VStack {
+                    emptyView()
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+            }
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .center, spacing: 14) {
+                    ForEach(0 ..< 5) { _ in
+                        LoadingRouteCard()
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+                .loadingPlaceholder()
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -22,6 +22,7 @@ struct ContentView: View {
     @State private var sheetHeight: CGFloat =
         (UIScreen.current?.bounds.height ?? 0) * PresentationDetent.mediumDetentFraction
     @StateObject var errorBannerVM = ErrorBannerViewModel()
+    @State var favoritesVM = ViewModelDI().favorites
     @StateObject var nearbyVM = NearbyViewModel()
     @StateObject var mapVM = MapViewModel()
     @StateObject var settingsVM = SettingsViewModel()
@@ -265,7 +266,12 @@ struct ContentView: View {
 
     @ViewBuilder
     var favoritesPage: some View {
-        FavoritesPage()
+        FavoritesPage(
+            errorBannerVM: errorBannerVM,
+            favoritesVM: favoritesVM,
+            nearbyVM: nearbyVM,
+            viewportProvider: viewportProvider
+        )
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -11604,6 +11604,53 @@
         }
       }
     },
+    "No stops added" : {
+      "comment" : "Indicates the absence of favorites",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se agregaron paradas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucun arrêt ajouté"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pa gen arè te ajoute"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhuma parada adicionada"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Không có điểm dừng nào được thêm vào"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未添加停靠站"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未添加停靠站"
+          }
+        }
+      }
+    },
     "Northbound" : {
       "comment" : "A route direction label",
       "localizations" : {
@@ -17513,8 +17560,8 @@
               },
               "zero" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "This stop has %ld elevators closed"
+                  "state" : "needs_review",
+                  "value" : "Estasyon sa a gen %ld asansè fèmen"
                 }
               }
             }

--- a/iosApp/iosApp/Pages/Favorites/FavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesPage.swift
@@ -6,10 +6,50 @@
 //  Copyright © 2025 MBTA. All rights reserved.
 //
 
+import CoreLocation
+import Shared
 import SwiftUI
 
 struct FavoritesPage: View {
+    @ObservedObject var errorBannerVM: ErrorBannerViewModel
+    var favoritesVM: FavoritesViewModel
+    var nearbyVM: NearbyViewModel
+    @ObservedObject var viewportProvider: ViewportProvider
+
+    @State var location: CLLocationCoordinate2D?
+
     var body: some View {
-        Text("Favorites")
+        ZStack {
+            Color.sheetBackground.ignoresSafeArea(.all)
+            FavoritesView(
+                errorBannerVM: errorBannerVM,
+                favoritesVM: favoritesVM,
+                nearbyVM: nearbyVM,
+                location: $location
+            )
+            .onReceive(
+                viewportProvider.cameraStatePublisher
+                    .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+
+            ) { newCameraState in
+                guard nearbyVM.isFavoritesVisible() else { return }
+                location = newCameraState.center
+            }
+            .onChange(of: viewportProvider.isManuallyCentering) { isManuallyCentering in
+                if isManuallyCentering {
+                    // The user is manually moving the map, clear the nearby state and
+                    // reload it once the've stopped manipulating the map
+                    nearbyVM.clearNearbyData()
+                    location = nil
+                }
+            }
+            .onChange(of: viewportProvider.isFollowingPuck) { isFollowingPuck in
+                if isFollowingPuck {
+                    // The user just recentered the map, clear the nearby state
+                    nearbyVM.clearNearbyData()
+                    location = nil
+                }
+            }
+        }
     }
 }

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -1,0 +1,99 @@
+//
+//  FavoritesView.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/12/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreLocation
+import Shared
+import SwiftUI
+
+struct FavoritesView: View {
+    var errorBannerVM: ErrorBannerViewModel
+    var favoritesVM: IFavoritesViewModel
+    @State var favoritesVMState: FavoritesViewModel.State = .init()
+    @ObservedObject var nearbyVM: NearbyViewModel
+    @Binding var location: CLLocationCoordinate2D?
+
+    @State var globalData: GlobalResponse?
+    var globalRepository = RepositoryDI().global
+    let inspection = Inspection<Self>()
+    @State var now = Date.now
+    @EnvironmentObject var settingsCache: SettingsCache
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            SheetHeader(title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"))
+            ErrorBanner(errorBannerVM)
+            RouteCardList(
+                routeCardData: favoritesVMState.routeCardData,
+                emptyView: { Text("No stops added", comment: "Indicates the absence of favorites") },
+                global: globalData,
+                now: now,
+                isPinned: { _ in false },
+                onPin: { _ in },
+                showStationAccessibility: settingsCache.get(.stationAccessibility),
+                pushNavEntry: { nearbyVM.pushNavEntry($0) },
+                showStopHeader: true
+            )
+        }
+        .onAppear {
+            favoritesVM.setActive(active: true, wasSentToBackground: false)
+            favoritesVM.setAlerts(alerts: nearbyVM.alerts)
+            favoritesVM.setLocation(location: location?.positionKt)
+            favoritesVM.setNow(now: now.toKotlinInstant())
+            favoritesVM.reloadFavorites()
+            loadEverything()
+        }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        .task {
+            while !Task.isCancelled {
+                now = Date.now
+                try? await Task.sleep(for: .seconds(5))
+            }
+        }
+        .task {
+            for await model in favoritesVM.models {
+                favoritesVMState = model
+            }
+        }
+        .onChange(of: favoritesVMState.awaitingPredictionsAfterBackground) {
+            errorBannerVM.loadingWhenPredictionsStale = $0
+        }
+        .onChange(of: nearbyVM.alerts) { favoritesVM.setAlerts(alerts: $0) }
+        .onChange(of: location?.positionKt) { favoritesVM.setLocation(location: $0) }
+        .onChange(of: now) { favoritesVM.setNow(now: $0.toKotlinInstant()) }
+        .withScenePhaseHandlers(
+            onActive: { favoritesVM.setActive(active: true, wasSentToBackground: false) },
+            onInactive: { favoritesVM.setActive(active: false, wasSentToBackground: false) },
+            onBackground: { favoritesVM.setActive(active: false, wasSentToBackground: true) },
+        )
+    }
+
+    private func loadEverything() {
+        getGlobal()
+    }
+
+    @MainActor
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            self.globalData = globalData
+        }
+    }
+
+    func getGlobal() {
+        Task(priority: .high) {
+            await activateGlobalListener()
+        }
+        Task {
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "FavoritesView.getGlobal",
+                getData: { try await globalRepository.getGlobalData() },
+                onRefreshAfterError: loadEverything
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -85,6 +85,10 @@ class NearbyViewModel: ObservableObject {
         navigationStack.lastSafe() == .nearby
     }
 
+    func isFavoritesVisible() -> Bool {
+        navigationStack.lastSafe() == .favorites
+    }
+
     /*
      Directly append the given entry to the stack without considering the previous entries.
      This should be done with caution as it can result in multiple entries of the same type within the stack,

--- a/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
@@ -1,0 +1,253 @@
+//
+//  FavoritesViewTests.swift
+//  iosAppTests
+//
+//  Created by Melody Horn on 6/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreLocation
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class FavoritesViewTests: XCTestCase {
+    @MainActor func testShowsFavorites() {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { route in
+            route.longName = "Some Route"
+        }
+        let stop = objects.stop { stop in
+            stop.name = "Some Stop"
+        }
+        let routePattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.upcomingTrip(prediction: objects.prediction { prediction in
+            prediction.trip = objects.trip(routePattern: routePattern)
+            prediction.stopId = stop.id
+            prediction.departureTime = (now + 5 * 60).toKotlinInstant()
+        })
+        let globalData = GlobalResponse(objects: objects)
+        let favoritesVM = MockFavoritesViewModel(initialState: .init(
+            awaitingPredictionsAfterBackground: false,
+            favorites: [.init(route: route.id, stop: stop.id, direction: 0)],
+            routeCardData: [.init(
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    route: route,
+                    stop: stop,
+                    data: [.init(
+                        lineOrRoute: .route(route),
+                        stop: stop,
+                        directionId: 0,
+                        routePatterns: [routePattern],
+                        stopIds: [stop.id],
+                        upcomingTrips: [trip],
+                        alertsHere: [],
+                        allDataLoaded: true,
+                        hasSchedulesToday: true,
+                        alertsDownstream: [],
+                        context: .favorites
+                    )],
+                    globalData: globalData
+                )],
+                at: now.toKotlinInstant()
+            )],
+            staticRouteCardData: [.init(
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    route: route,
+                    stop: stop,
+                    data: [.init(
+                        lineOrRoute: .route(route),
+                        stop: stop,
+                        directionId: 0,
+                        routePatterns: [routePattern],
+                        stopIds: [stop.id],
+                        upcomingTrips: [],
+                        alertsHere: [],
+                        allDataLoaded: true,
+                        hasSchedulesToday: false,
+                        alertsDownstream: [],
+                        context: .favorites
+                    )],
+                    globalData: globalData
+                )],
+                at: now.toKotlinInstant()
+            )]
+        ))
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        let exp = sut.inspection.inspect(after: 0.2) { view in
+            XCTAssertNotNil(try view.find(text: "Some Route"))
+            XCTAssertNotNil(try view.find(text: "Some Stop"))
+            XCTAssertNotNil(try view.find(text: "5 min"))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp], timeout: 2)
+    }
+
+    @MainActor func testShowsEmpty() {
+        let favoritesVM = MockFavoritesViewModel(initialState: .init(
+            awaitingPredictionsAfterBackground: false,
+            favorites: [],
+            routeCardData: [],
+            staticRouteCardData: []
+        ))
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        let exp = sut.inspection.inspect(after: 0.2) { view in
+            XCTAssertNotNil(try view.find(text: "No stops added"))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp], timeout: 2)
+    }
+
+    @MainActor func testShowsLoading() {
+        let favoritesVM = MockFavoritesViewModel()
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        let exp = sut.inspection.inspect(after: 0.2) { view in
+            XCTAssertEqual(5, view.findAll(LoadingRouteCard.self).count)
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp], timeout: 2)
+    }
+
+    func testFiresReloadFavorites() throws {
+        let exp = expectation(description: "calls reloadFavorites in onAppear")
+        let favoritesVM = MockFavoritesViewModel()
+        favoritesVM.onReloadFavorites = { exp.fulfill() }
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        ).withFixedSettings([:])
+        try sut.inspect().view(FavoritesView.self).vStack().callOnAppear()
+        wait(for: [exp], timeout: 1)
+    }
+
+    func testSetsActive() throws {
+        let expActive = expectation(description: "sets to active")
+        let expInactive = expectation(description: "sets to inactive")
+        let expBackground = expectation(description: "sets to background")
+        let favoritesVM = MockFavoritesViewModel()
+        favoritesVM.onSetActive = { active, wasSentToBackground in
+            if active.boolValue {
+                XCTAssertFalse(wasSentToBackground.boolValue)
+                expActive.fulfill()
+            } else if !wasSentToBackground.boolValue {
+                expInactive.fulfill()
+            } else {
+                expBackground.fulfill()
+            }
+        }
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        ).withFixedSettings([:])
+
+        try sut.inspect().findAndCallOnChange(newValue: ScenePhase.inactive)
+        wait(for: [expInactive], timeout: 1)
+        try sut.inspect().findAndCallOnChange(newValue: ScenePhase.background)
+        wait(for: [expBackground], timeout: 1)
+        try sut.inspect().findAndCallOnChange(newValue: ScenePhase.active)
+        wait(for: [expActive], timeout: 1)
+    }
+
+    @MainActor func testSetsAlerts() throws {
+        let objects = ObjectCollectionBuilder()
+        objects.alert { _ in }
+        let alertsResponse = AlertsStreamDataResponse(objects: objects)
+        let setAlertExp = expectation(description: "sets alerts")
+        let favoritesVM = MockFavoritesViewModel()
+        favoritesVM.onSetAlerts = { alerts in
+            if let alerts {
+                XCTAssertEqual(alertsResponse, alerts)
+                setAlertExp.fulfill()
+            }
+        }
+        let nearbyVM = NearbyViewModel()
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: nearbyVM,
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        let appearExp = sut.inspection.inspect(after: 0.2) { _ in
+            nearbyVM.alerts = alertsResponse
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [appearExp, setAlertExp], timeout: 1)
+    }
+
+    @MainActor func testSetsLocation() throws {
+        let firstLocation = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let secondLocation = CLLocationCoordinate2D(latitude: 1, longitude: 1)
+        let locationBinding = Binding<CLLocationCoordinate2D?>(wrappedValue: firstLocation)
+        let setFirstExp = expectation(description: "sets first location")
+        let setSecondExp = expectation(description: "sets second location")
+        let favoritesVM = MockFavoritesViewModel()
+        favoritesVM.onSetLocation = { newLocation in
+            if newLocation == firstLocation.positionKt {
+                setFirstExp.fulfill()
+            } else if newLocation == secondLocation.positionKt {
+                setSecondExp.fulfill()
+            } else {
+                XCTFail("set location to unexpected \(newLocation.debugDescription)")
+            }
+        }
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: locationBinding
+        )
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [setFirstExp], timeout: 1)
+        locationBinding.wrappedValue = secondLocation
+        wait(for: [setSecondExp], timeout: 1)
+    }
+
+    @MainActor func testSetsNow() throws {
+        let setFirstExp = expectation(description: "sets a time")
+        var firstTime: Instant?
+        let setSecondExp = expectation(description: "sets a different time later")
+        let favoritesVM = MockFavoritesViewModel()
+        favoritesVM.onSetNow = { newNow in
+            if firstTime == nil {
+                firstTime = newNow
+                setFirstExp.fulfill()
+            } else {
+                XCTAssertNotEqual(firstTime, newNow)
+                setSecondExp.fulfill()
+            }
+        }
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: .init(),
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [setFirstExp], timeout: 1)
+        wait(for: [setSecondExp], timeout: 10)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -17,6 +17,7 @@ import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.subscribeToPredictions
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
@@ -26,7 +27,6 @@ interface IFavoritesViewModel {
 
     fun reloadFavorites()
 
-    @DefaultArgumentInterop.Enabled
     fun setActive(active: Boolean, wasSentToBackground: Boolean = false)
 
     fun setAlerts(alerts: AlertsStreamDataResponse?)
@@ -208,5 +208,38 @@ class FavoritesViewModel(private val favoritesUsecases: FavoritesUsecases) :
                 }
                 ?.filter { it.stopData.any { it.data.isNotEmpty() } }
         }
+    }
+}
+
+class MockFavoritesViewModel
+@DefaultArgumentInterop.Enabled
+constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State()) :
+    IFavoritesViewModel {
+    var onReloadFavorites = {}
+    var onSetActive = { _: Boolean, _: Boolean -> }
+    var onSetAlerts = { _: AlertsStreamDataResponse? -> }
+    var onSetLocation = { _: Position? -> }
+    var onSetNow = { _: Instant -> }
+
+    override val models = MutableStateFlow(initialState)
+
+    override fun reloadFavorites() {
+        onReloadFavorites()
+    }
+
+    override fun setActive(active: Boolean, wasSentToBackground: Boolean) {
+        onSetActive(active, wasSentToBackground)
+    }
+
+    override fun setAlerts(alerts: AlertsStreamDataResponse?) {
+        onSetAlerts(alerts)
+    }
+
+    override fun setLocation(location: Position?) {
+        onSetLocation(location)
+    }
+
+    override fun setNow(now: Instant) {
+        onSetNow(now)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Show favorites in tab](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210440278891499?focus=true)

Super easy. Mocking the ViewModel makes the tests a total breeze to write.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests for displaying state and for every event. Manually verified that favorites display identically to nearby transit and reload correctly when changed.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
