### PR TITLE
feat: show selected stop at any zoom

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopLayerGeneratorTest.kt
@@ -13,6 +13,8 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 
 class StopLayerGeneratorTest {
@@ -154,7 +156,11 @@ class StopLayerGeneratorTest {
                 StopLayerGenerator.State(selectedStopId = alewifeFeature.id),
             )
 
+        val stopLayer = stopLayers[3]
         val selectedPinLayer = stopLayers[10]
+
+        assertTrue(stopLayer.filter!!.evaluate(alewifeFeature.properties, zoom = 2.0))
+        assertFalse(stopLayer.filter!!.evaluate(assemblyFeature.properties, zoom = 2.0))
 
         assertEquals(
             StopIcons.stopPinIcon,


### PR DESCRIPTION
### Summary

_Ticket:_ [Show selected stop and pin at all zoom levels](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210456691287467?focus=true)

Nice and easy.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the selected stop shows up on the map at all zoom levels on both iOS and Android.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
