### PR TITLE
build: error on missing iOS translations

### DIFF
--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -109,7 +109,7 @@
         <item quantity="other">%1$d asansè yo fèmen</item>
     </plurals>
     <plurals name="elevator_closure_count_accessibility_description">
-        <item quantity="zero">This stop has %1$d elevators closed</item>
+        <item quantity="zero">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="one">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="two">Estasyon sa a gen %1$d asansè fèmen</item>
         <item quantity="few">Estasyon sa a gen %1$d asansè fèmen</item>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -17621,8 +17621,8 @@
               },
               "zero" : {
                 "stringUnit" : {
-                  "state" : "new",
-                  "value" : "This stop has %ld elevators closed"
+                  "state" : "needs_review",
+                  "value" : "Estasyon sa a gen %ld asansè fèmen"
                 }
               }
             }


### PR DESCRIPTION
### Summary

_Ticket:_ none

[Suggested](https://github.com/mbta/mobile_app/pull/1082#discussion_r2153180830) in #1082. Unfortunately, since the place we’re checking this is from Android, this will cause the Android build to fail rather than causing the iOS build to fail, but c’est la vie.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that without the included Haitian Creole translation fix an error with useful diagnostic information is emitted, and that with it no error is emitted.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
