### PR TITLE
dev: write script to generate component call graphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ xcuserdata
 fastlane/report.xml
 fastlane/test_output
 
+/component-graphs
 /iosApp/secrets/*
 /iosApp/Pods/*
 /androidApp/src/main/res/values/secrets*.xml

--- a/bin/component-graph.py
+++ b/bin/component-graph.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Generates an approximately accurate call graph for our Android and iOS UI components.
+
+Writes into `./component-graphs/`. Will render PNGs if GraphViz is installed, or write .dot source if not.
+
+Usage:
+$ bin/component-graph.py RouteCard AlertDetailsPage
+$ bin/component-graph.py # for everything
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+@dataclass(order=True, frozen=True)
+class Component:
+    name: str
+    path: Path
+
+
+@dataclass(order=True, frozen=True)
+class Edge:
+    caller: str
+    callee: str
+
+
+COMPONENT_CALL = re.compile(r"[^\.](\w+)\s*(?:\(|\{)")
+
+
+def get_android_components() -> set[Component]:
+    components = set()
+
+    for file in Path("androidApp/src/main/java").glob("**/*.kt"):
+        if (
+            re.search(
+                rf"@Composable\s+fun (\w+\.)?{file.stem}\(",
+                file.read_text(encoding="utf-8"),
+            )
+            and file.stem[0].isupper()
+            and file.stem != "MyApplicationTheme"
+        ):
+            components.add(Component(file.stem, file))
+
+    return components
+
+
+def get_ios_components() -> set[Component]:
+    components = set()
+
+    for file in Path("iosApp/iosApp").glob("**/*.swift"):
+        if re.search(
+            rf"struct {file.stem}(<.+>)?: View\b", file.read_text(encoding="utf-8")
+        ):
+            components.add(Component(file.stem, file))
+
+    return components
+
+
+def get_edges(components: set[Component]) -> set[Edge]:
+    component_names = {component.name for component in components}
+    edges = set()
+    for component in components:
+        for call in COMPONENT_CALL.finditer(component.path.read_text(encoding="utf-8")):
+            callee = call.group(1)
+            if callee in component_names and callee != component.name:
+                edges.add(Edge(component.name, callee))
+    return edges
+
+
+def filter_graph(
+    starting_from: str, components: set[str], edges: set[Edge]
+) -> tuple[set[str], set[Edge]]:
+    reachable = {starting_from}
+    frontier = [starting_from]
+    while len(frontier) > 0:
+        current_node = frontier.pop(0)
+        for edge in edges:
+            if edge.caller == current_node and edge.callee not in reachable:
+                frontier.append(edge.callee)
+                reachable.add(edge.callee)
+
+    filtered_components = {c for c in components if c in reachable}
+    filtered_edges = {
+        e for e in edges if e.caller in reachable and e.callee in reachable
+    }
+    return (filtered_components, filtered_edges)
+
+
+def main(roots: list[str]):
+    android_components = get_android_components()
+    android_edges = get_edges(android_components)
+
+    ios_components = get_ios_components()
+    ios_edges = get_edges(ios_components)
+
+    android_components = {c.name for c in android_components}
+    ios_components = {c.name for c in ios_components}
+
+    both_components = android_components.intersection(ios_components)
+    android_only_components = android_components.difference(both_components)
+    ios_only_components = ios_components.difference(both_components)
+
+    both_edges = android_edges.intersection(ios_edges)
+    android_only_edges = android_edges.difference(both_edges)
+    ios_only_edges = ios_edges.difference(both_edges)
+
+    if len(roots) == 0:
+        roots = list(android_components.union(ios_components))
+
+    Path("component-graphs").mkdir(exist_ok=True)
+    legend_content = """
+digraph {
+  BP1 [label="Component on Both Platforms"];
+  BP2 [label="Component on Both Platforms"];
+  AO [style=dashed, color=green, label="Component on Android Only"];
+  IO [style=dashed, color=red, label="Component on iOS Only"];
+  BP1 -> BP2 [label="Call on Both Platforms"];
+  BP1 -> AO [style=dashed, color=green, label="Call on Android Only"];
+  BP1 -> IO [style=dashed, color=red, label="Call on iOS Only"];
+  AO -> BP2 [style=dashed, color=green];
+}
+"""
+
+    try:
+        subprocess.run(
+            ["dot", "-Tpng", "-ocomponent-graphs/_Legend.png"],
+            input=legend_content,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        graphviz_installed = True
+    except FileNotFoundError:
+        graphviz_installed = False
+    except subprocess.CalledProcessError:
+        graphviz_installed = False
+
+    if not graphviz_installed:
+        print("Could not find Graphviz, writing .dot source instead of rendered .png")
+        Path("component-graphs/_Legend.dot").write_text(legend_content)
+
+    for root in sorted(roots):
+        print(root)
+        filtered_components, filtered_edges = filter_graph(
+            root,
+            android_components.union(ios_components),
+            android_edges.union(ios_edges),
+        )
+
+        dot_lines = []
+        dot_lines.append("digraph {")
+        for component in sorted(both_components):
+            if component in filtered_components:
+                dot_lines.append(f"  {component};")
+        for component in sorted(android_only_components):
+            if component in filtered_components:
+                dot_lines.append(f"  {component} [style=dashed, color=green];")
+        for component in sorted(ios_only_components):
+            if component in filtered_components:
+                dot_lines.append(f"  {component} [style=dashed, color=red];")
+        dot_lines.append("  subgraph pages {")
+        dot_lines.append("    rank = same;")
+        for component in sorted(android_components.union(ios_components)):
+            if (
+                component in filtered_components
+                and component.endswith("Page")
+                and component != "MapAndSheetPage"
+            ):
+                dot_lines.append(f"    {component};")
+        dot_lines.append("  }")
+        for edge in sorted(both_edges):
+            if edge in filtered_edges:
+                dot_lines.append(f"  {edge.caller} -> {edge.callee};")
+        for edge in sorted(android_only_edges):
+            if edge in filtered_edges:
+                dot_lines.append(
+                    f"  {edge.caller} -> {edge.callee} [style=dashed, color=green];",
+                )
+        for edge in sorted(ios_only_edges):
+            if edge in filtered_edges:
+                dot_lines.append(
+                    f"  {edge.caller} -> {edge.callee} [style=dashed, color=red];"
+                )
+        dot_lines.append("}")
+
+        dot_content = "\n".join(dot_lines)
+
+        if graphviz_installed:
+            subprocess.run(
+                ["dot", "-Tpng", f"-ocomponent-graphs/{root}.png"],
+                input=dot_content,
+                text=True,
+                check=True,
+            )
+        else:
+            Path(f"component-graphs/{root}.dot").write_text(dot_content)
+
+
+if __name__ == "__main__":
+    roots = []
+    if len(sys.argv) > 1:
+        roots = sys.argv[1:]
+    if roots == ["-h"] or roots == ["--help"]:
+        print(__doc__)
+        exit(1)
+    main(roots)


### PR DESCRIPTION
### Summary

_Ticket:_ none

This makes it easy to see where our component hierarchies diverge between iOS and Android.
Was thinking about this in #1082 where I added helper components on iOS that already existed on Android, and then the code just started flowing.

![_Legend](https://github.com/user-attachments/assets/d35afcb2-3b62-4636-bbe5-671b46bb5787)
![AlertDetailsPage](https://github.com/user-attachments/assets/3f7e5c18-d2f1-4710-8534-e56c7bc259dc)
![RouteCard](https://github.com/user-attachments/assets/1b05813b-e840-48fc-a0f1-d20a06cd2d37)


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
