### PR TITLE
fix(android.RouteStopListView): correct direction labels in confirmation per stop

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -1,17 +1,21 @@
 package com.mbta.tid.mbta_app.android.routeDetails
 
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilNodeCountDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
@@ -21,6 +25,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
+import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
@@ -254,5 +259,57 @@ class RouteStopListViewTest {
         composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop3NonTypical.name))
         composeTestRule.onNodeWithText(stop4NonTypical.name).assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testFavoritesWithConfirmationDialog() {
+        val objects = TestData.clone()
+
+        val koin =
+            testKoinApplication(objects) {
+                routeStops =
+                    MockRouteStopsRepository(listOf("place-alfcl", "place-davis", "place-portr"))
+            }
+        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                RouteStopListView(
+                    RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                    RouteDetailsContext.Favorites,
+                    GlobalResponse(objects),
+                    onClick = {},
+                    onClose = {},
+                    errorBannerViewModel = errorBannerVM,
+                    rightSideContent = { rowContext, _ ->
+                        Text(
+                            "Tap me",
+                            modifier =
+                                Modifier.clickable {
+                                    when (rowContext) {
+                                        is RouteDetailsRowContext.Details -> {}
+                                        is RouteDetailsRowContext.Favorites ->
+                                            rowContext.onTapStar()
+                                    }
+                                },
+                        )
+                    },
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Davis"))
+        // Direction toggle on route page
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Southbound to"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Ashmont/Braintree"))
+
+        composeTestRule.onAllNodesWithText("Tap me")[1].performClick()
+
+        // 2 sets of direction labels - one on toggle, and one in favorites confirmation modal
+        composeTestRule.waitUntilNodeCountDefaultTimeout(hasText("Southbound to"), 2)
+        composeTestRule.waitUntilNodeCountDefaultTimeout(hasText("Ashmont/Braintree"), 2)
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add"))
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -116,11 +116,17 @@ fun RouteStopListView(
         }
 
     showFavoritesStopConfirmation?.let { stop ->
+        val stopDirections =
+            lineOrRoute.directions(
+                globalData,
+                stop,
+                globalData.getPatternsFor(stop.id, lineOrRoute).filter { it.isTypical() },
+            )
         Column(verticalArrangement = Arrangement.spacedBy(0.dp)) {
             FavoriteConfirmationDialog(
                 lineOrRoute,
                 stop,
-                parameters.directions.filter { it.id in parameters.availableDirections },
+                stopDirections.filter { it.id in parameters.availableDirections },
                 proposedFavorites =
                     parameters.availableDirections.associateWith {
                         it == selectedDirection ||

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -132,6 +132,15 @@ data class GlobalResponse(
         return patternIds.mapNotNull { routePatterns[it] }
     }
 
+    fun getPatternsFor(stopId: String, lineOrRoute: RouteCardData.LineOrRoute): List<RoutePattern> {
+        val stop = stops[stopId] ?: return emptyList()
+        val stopIds = stop.childStopIds + listOf(stopId)
+        val patternIds = stopIds.flatMap { patternIdsByStop[it] ?: emptyList() }
+        return patternIds
+            .mapNotNull { routePatterns[it] }
+            .filter { lineOrRoute.containsRoute(it.routeId) }
+    }
+
     fun getPatternsFor(stopId: String, routeId: String): List<RoutePattern> {
         return getPatternsFor(stopId).filter { it.routeId == routeId }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model.response
 
+import com.mbta.tid.mbta_app.map.MapTestDataHelper.global
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.MapStopRoute
@@ -14,6 +15,7 @@ import com.mbta.tid.mbta_app.model.silverRoutes
 import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -520,5 +522,41 @@ class GlobalResponseTest {
         val ferryRoutes = global.getRoutesForPicker(RoutePickerPath.Ferry)
         assertTrue(ferryRoutes.isNotEmpty())
         assertTrue(ferryRoutes.all { it.type == RouteType.FERRY })
+    }
+
+    @Test
+    fun `getPatternsFor stop + route includes only patterns for that route`() {
+        val objects = TestData.clone()
+
+        val allPatternsForStop = global.getPatternsFor("place-haecl")
+        assertTrue(allPatternsForStop.map { it.routeId }.any { it != "Orange" })
+        val orangePatterns =
+            global.getPatternsFor(
+                "place-haecl",
+                RouteCardData.LineOrRoute.Route(objects.getRoute("Orange")),
+            )
+        assertFalse(orangePatterns.map { it.routeId }.any { it != "Orange" })
+    }
+
+    @Test
+    fun `getPatternsFor stop + line includes only patterns for that route`() {
+        val objects = TestData.clone()
+
+        val allPatternsForStop = global.getPatternsFor("place-haecl")
+        assertTrue(allPatternsForStop.map { it.routeId }.any { it == "Orange" })
+        val greenPatterns =
+            global.getPatternsFor(
+                "place-haecl",
+                RouteCardData.LineOrRoute.Line(
+                    objects.getLine("line-Green"),
+                    setOf(
+                        objects.getRoute("Green-B"),
+                        objects.getRoute("Green-C"),
+                        objects.getRoute("Green-D"),
+                        objects.getRoute("Green-E"),
+                    ),
+                ),
+            )
+        assertTrue(greenPatterns.map { it.routeId }.all { it.startsWith("Green-") })
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 Favorites | Destinations in route details confirmation modals ](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210560254436168?focus=true)

What is this PR for?
Rather than using the route-level directions in the favorites confirmation modal from the route details page, use the stop-level directions with customized direction labels.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests
* Ran locally and confirmed for a handful of stops
![image](https://github.com/user-attachments/assets/c6e99500-185c-4dcd-98f6-867de239bfe6)
![image](https://github.com/user-attachments/assets/649d660e-3568-4b41-850f-b7ecd8589183)


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
