### PR TITLE
feat: Add screen reader text for the CR delayed/early prediction states

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -155,7 +155,66 @@ class UpcomingTripViewTest {
     }
 
     @Test
-    fun testUpcomingTripViewWithSomeAsTimeWithSchedule() {
+    fun testUpcomingTripViewWithSomeAsTimeWithStatusDelay() {
+        val instant = Instant.fromEpochSeconds(1722535384)
+        val shortTime = formatTime(instant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(TripInstantDisplay.TimeWithStatus(instant, "Delay")),
+                routeType = RouteType.COMMUTER_RAIL,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(instant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("$shortTime train delayed")
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithStatusLate() {
+        val instant = Instant.fromEpochSeconds(1722535384)
+        val shortTime = formatTime(instant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(TripInstantDisplay.TimeWithStatus(instant, "Late")),
+                routeType = RouteType.COMMUTER_RAIL,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(instant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("$shortTime train delayed")
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithScheduleDelay() {
+        val predictionInstant = Instant.fromEpochSeconds(1722535784)
+        val predictionShortTime = formatTime(predictionInstant)
+
+        val scheduleInstant = Instant.fromEpochSeconds(1722535384)
+        val scheduleShortTime = formatTime(scheduleInstant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.TimeWithSchedule(predictionInstant, scheduleInstant)
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(predictionInstant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains(
+                "$scheduleShortTime train delayed, arriving at $predictionShortTime"
+            )
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithScheduleEarly() {
         val predictionInstant = Instant.fromEpochSeconds(1722535384)
         val predictionShortTime = formatTime(predictionInstant)
 
@@ -165,13 +224,68 @@ class UpcomingTripViewTest {
             UpcomingTripView(
                 UpcomingTripViewState.Some(
                     TripInstantDisplay.TimeWithSchedule(predictionInstant, scheduleInstant)
-                )
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
             )
         }
         composeTestRule
             .onNodeWithText(formatTime(predictionInstant))
             .assertIsDisplayed()
-            .assertContentDescriptionContains("arriving at $predictionShortTime", substring = true)
+            .assertContentDescriptionContains(
+                "$scheduleShortTime train early, arriving at $predictionShortTime"
+            )
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithScheduleDelayOther() {
+        val predictionInstant = Instant.fromEpochSeconds(1722535784)
+        val predictionShortTime = formatTime(predictionInstant)
+
+        val scheduleInstant = Instant.fromEpochSeconds(1722535384)
+        val scheduleShortTime = formatTime(scheduleInstant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.TimeWithSchedule(predictionInstant, scheduleInstant)
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
+                isFirst = false,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(predictionInstant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains(
+                "and $scheduleShortTime train delayed, arriving at $predictionShortTime"
+            )
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeAsTimeWithScheduleEarlyOther() {
+        val predictionInstant = Instant.fromEpochSeconds(1722535384)
+        val predictionShortTime = formatTime(predictionInstant)
+
+        val scheduleInstant = Instant.fromEpochSeconds(1722535784)
+        val scheduleShortTime = formatTime(scheduleInstant)
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.TimeWithSchedule(predictionInstant, scheduleInstant)
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
+                isFirst = false,
+            )
+        }
+        composeTestRule
+            .onNodeWithText(formatTime(predictionInstant))
+            .assertIsDisplayed()
+            .assertContentDescriptionContains(
+                "and $scheduleShortTime train early, arriving at $predictionShortTime"
+            )
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
         composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -164,10 +164,8 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule
-            .onNodeWithText(formatTime(instant))
-            .assertIsDisplayed()
-            .assertContentDescriptionContains("$shortTime train delayed")
+        composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("$shortTime train delayed").assertIsDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
     }
 
@@ -181,10 +179,8 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule
-            .onNodeWithText(formatTime(instant))
-            .assertIsDisplayed()
-            .assertContentDescriptionContains("$shortTime train delayed")
+        composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("$shortTime train delayed").assertIsDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
     }
 
@@ -204,13 +200,19 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNodeWithText(formatTime(predictionInstant))
+            .onNodeWithText(formatTime(predictionInstant), useUnmergedTree = true)
             .assertIsDisplayed()
-            .assertContentDescriptionContains(
+        composeTestRule
+            .onNodeWithContentDescription(
                 "$scheduleShortTime train delayed, arriving at $predictionShortTime"
             )
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
-        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(formatTime(scheduleInstant), useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -229,13 +231,19 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNodeWithText(formatTime(predictionInstant))
+            .onNodeWithText(formatTime(predictionInstant), useUnmergedTree = true)
             .assertIsDisplayed()
-            .assertContentDescriptionContains(
+        composeTestRule
+            .onNodeWithContentDescription(
                 "$scheduleShortTime train early, arriving at $predictionShortTime"
             )
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
-        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(formatTime(scheduleInstant), useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -254,14 +262,21 @@ class UpcomingTripViewTest {
                 isFirst = false,
             )
         }
+
         composeTestRule
-            .onNodeWithText(formatTime(predictionInstant))
-            .assertIsDisplayed()
-            .assertContentDescriptionContains(
+            .onNodeWithContentDescription(
                 "and $scheduleShortTime train delayed, arriving at $predictionShortTime"
             )
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
-        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(predictionShortTime, useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(scheduleShortTime, useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -281,13 +296,19 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNodeWithText(formatTime(predictionInstant))
+            .onNodeWithText(formatTime(predictionInstant), useUnmergedTree = true)
             .assertIsDisplayed()
-            .assertContentDescriptionContains(
+        composeTestRule
+            .onNodeWithContentDescription(
                 "and $scheduleShortTime train early, arriving at $predictionShortTime"
             )
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
-        composeTestRule.onNodeWithText(formatTime(scheduleInstant)).assertIsDisplayed()
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(formatTime(scheduleInstant), useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -143,15 +143,23 @@ class UpcomingTripViewTest {
         val shortTime = formatTime(instant)
         composeTestRule.setContent {
             UpcomingTripView(
-                UpcomingTripViewState.Some(TripInstantDisplay.TimeWithStatus(instant, "All aboard"))
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.TimeWithStatus(instant, "All aboard")
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
             )
         }
+
         composeTestRule
-            .onNodeWithText(formatTime(instant))
+            .onNodeWithText(formatTime(instant), useUnmergedTree = true)
             .assertIsDisplayed()
-            .assertContentDescriptionContains("arriving at $shortTime", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
-        composeTestRule.onNodeWithText("All aboard").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("train arriving at $shortTime, All aboard")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("All aboard", useUnmergedTree = true).assertIsDisplayed()
     }
 
     @Test
@@ -164,9 +172,13 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(formatTime(instant), useUnmergedTree = true)
+            .assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("$shortTime train delayed").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test
@@ -179,9 +191,13 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule.onNodeWithText(formatTime(instant)).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(formatTime(instant), useUnmergedTree = true)
+            .assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("$shortTime train delayed").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -94,6 +94,7 @@ fun PredictionRowView(
                                     UpcomingTripView(
                                         UpcomingTripViewState.Some(prediction.format),
                                         modifier = Modifier.weight(1f, fill = false),
+                                        routeType = prediction.routeType,
                                         isFirst = index == 0,
                                         isOnly = index == 0 && predictions.trips.count() == 1,
                                     )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
@@ -181,6 +182,13 @@ fun UpcomingTripView(
                         }
                         Text(
                             state.trip.status,
+                            modifier =
+                                Modifier.semantics {
+                                    contentDescription =
+                                        if (state.trip.status in TripInstantDisplay.delayStatuses)
+                                            ""
+                                        else state.trip.status
+                                },
                             color = LocalContentColor.current.copy(alpha = min(maxTextAlpha, 0.6f)),
                             textAlign = TextAlign.End,
                             style = Typography.footnoteSemibold,
@@ -188,15 +196,17 @@ fun UpcomingTripView(
                     }
 
                 is TripInstantDisplay.TimeWithSchedule ->
-                    Column(modifier, horizontalAlignment = Alignment.End) {
+                    Column(
+                        modifier.clearAndSetSemantics { contentDescription = tripDescription },
+                        horizontalAlignment = Alignment.End,
+                    ) {
                         WithRealtimeIndicator(
                             modifier.then(maxAlphaModifier),
                             hideRealtimeIndicators,
                         ) {
                             Text(
                                 formatTime(state.trip.predictionTime),
-                                Modifier.semantics { contentDescription = tripDescription }
-                                    .placeholderIfLoading(),
+                                Modifier.placeholderIfLoading(),
                                 textAlign = TextAlign.End,
                                 style =
                                     if (state.trip.headline) Typography.headlineSemibold

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -165,15 +165,17 @@ fun UpcomingTripView(
                     }
 
                 is TripInstantDisplay.TimeWithStatus ->
-                    Column(modifier, horizontalAlignment = Alignment.End) {
+                    Column(
+                        modifier.clearAndSetSemantics { contentDescription = tripDescription },
+                        horizontalAlignment = Alignment.End,
+                    ) {
                         WithRealtimeIndicator(
                             modifier.then(maxAlphaModifier),
                             hideRealtimeIndicators,
                         ) {
                             Text(
                                 formatTime(state.trip.predictionTime),
-                                Modifier.semantics { contentDescription = tripDescription }
-                                    .placeholderIfLoading(),
+                                Modifier.placeholderIfLoading(),
                                 textAlign = TextAlign.End,
                                 style =
                                     if (state.trip.headline) Typography.headlineSemibold
@@ -182,13 +184,6 @@ fun UpcomingTripView(
                         }
                         Text(
                             state.trip.status,
-                            modifier =
-                                Modifier.semantics {
-                                    contentDescription =
-                                        if (state.trip.status in TripInstantDisplay.delayStatuses)
-                                            ""
-                                        else state.trip.status
-                                },
                             color = LocalContentColor.current.copy(alpha = min(maxTextAlpha, 0.6f)),
                             textAlign = TextAlign.End,
                             style = Typography.footnoteSemibold,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStatus.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStatus.kt
@@ -12,7 +12,11 @@ fun TripStatus(predictions: UpcomingFormat) {
         is UpcomingFormat.Some ->
             when (val trip = predictions.trips.firstOrNull()) {
                 null -> {}
-                else -> UpcomingTripView(UpcomingTripViewState.Some(trip.format))
+                else ->
+                    UpcomingTripView(
+                        UpcomingTripViewState.Some(trip.format),
+                        routeType = trip.routeType,
+                    )
             }
         is UpcomingFormat.Disruption ->
             UpcomingTripView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
@@ -124,7 +124,9 @@ private fun predictedTimeDescription(
     isFirst: Boolean,
     vehicleType: String,
 ): String {
-    if (trip is TripInstantDisplay.TimeWithStatus && trip.status in setOf("Delay", "Late")) {
+    if (
+        trip is TripInstantDisplay.TimeWithStatus && trip.status in TripInstantDisplay.delayStatuses
+    ) {
         return delayDescription(trip.predictionTime, isFirst, vehicleType)
     }
     val predictionTime =
@@ -148,7 +150,7 @@ private fun predictedWithScheduleDescription(
     vehicleType: String,
 ): String {
     val scheduleStatus =
-        if (trip.predictionTime > trip.scheduledTime)
+        if (trip.predictionTime >= trip.scheduledTime)
             delayDescription(trip.scheduledTime, isFirst, vehicleType)
         else {
             val scheduledTime = formatTime(trip.scheduledTime)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
@@ -126,21 +126,23 @@ private fun predictedTimeDescription(
 ): String {
     if (
         trip is TripInstantDisplay.TimeWithStatus && trip.status in TripInstantDisplay.delayStatuses
-    ) {
+    )
         return delayDescription(trip.predictionTime, isFirst, vehicleType)
-    }
+
     val predictionTime =
         formatTime(
             when (trip) {
                 is TripInstantDisplay.Time -> trip.predictionTime
-                is TripInstantDisplay.TimeWithSchedule -> trip.predictionTime
                 is TripInstantDisplay.TimeWithStatus -> trip.predictionTime
                 else -> return ""
             }
         )
-    return if (isFirst)
-        stringResource(R.string.vehicle_prediction_time_first, vehicleType, predictionTime)
-    else stringResource(R.string.vehicle_prediction_time_other, predictionTime)
+    val timeString =
+        if (isFirst)
+            stringResource(R.string.vehicle_prediction_time_first, vehicleType, predictionTime)
+        else stringResource(R.string.vehicle_prediction_time_other, predictionTime)
+    return if (trip is TripInstantDisplay.TimeWithStatus) "$timeString, ${trip.status}"
+    else timeString
 }
 
 @Composable

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -375,12 +375,17 @@
     <string name="vehicle_cancelled_other">y a las %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s seleccionado</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s seleccionada, parada seleccionada</string>
+    <string name="vehicle_prediction_actual_arrival">llegará a la(s) %2$s</string>
     <string name="vehicle_prediction_hours_first">%1$s llegando en %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s llegando en %2$d h %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">y en %1$d h %2$d min</string>
     <string name="vehicle_prediction_hours_other">y en %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s llegará en %2$d min.</string>
     <string name="vehicle_prediction_minutes_other">y en %1$d min.</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s retrasado</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">y %1$s %2$s retrasado</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s temprano</string>
+    <string name="vehicle_prediction_schedule_status_early_other">y %1$s %2$s temprano</string>
     <string name="vehicle_prediction_time_first">%1$s llegará a la(s) %2$s</string>
     <string name="vehicle_prediction_time_other">y a la(s) %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s llegará en %2$d min programado</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -375,12 +375,17 @@
     <string name="vehicle_cancelled_other">et à %1$s est annulé</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s sélectionné</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s sélectionné, arrêt sélectionné</string>
+    <string name="vehicle_prediction_actual_arrival">arrivant à %2$s</string>
     <string name="vehicle_prediction_hours_first">%1$s arrive dans %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s arrive dans %2$d h et %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">et dans %1$d h et %2$d min</string>
     <string name="vehicle_prediction_hours_other">et dans %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s arrive dans %2$d min</string>
     <string name="vehicle_prediction_minutes_other">et dans %1$d min</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s retardé</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">et %1$s %2$s retardé</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s tôt</string>
+    <string name="vehicle_prediction_schedule_status_early_other">et %1$s %2$s tôt</string>
     <string name="vehicle_prediction_time_first">%1$s arrivant à %2$s</string>
     <string name="vehicle_prediction_time_other">et à %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s arrivant dans %2$d min est prévu</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -390,12 +390,17 @@
     <string name="vehicle_cancelled_other">epi a %1$s anile</string>
     <string name="vehicle_desc_accessibility_desc">Chwazi %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Chwazi %1$s %2$s %3$s, arè ou chwazi a</string>
+    <string name="vehicle_prediction_actual_arrival">ap rive a %2$s</string>
     <string name="vehicle_prediction_hours_first">%1$s ap rive nan %2$d èdtan</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s rive nan %2$d è %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">epi nan %1$d è %2$d min</string>
     <string name="vehicle_prediction_hours_other">epi nan %1$d èdtan</string>
     <string name="vehicle_prediction_minutes_first">%1$s ap rive nan %2$d minit</string>
     <string name="vehicle_prediction_minutes_other">epi nan %1$d min</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s reta</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">epi %1$s %2$s an reta</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s byen bonè</string>
+    <string name="vehicle_prediction_schedule_status_early_other">ak %1$s %2$s byen bonè</string>
     <string name="vehicle_prediction_time_first">%1$s ap rive a %2$s</string>
     <string name="vehicle_prediction_time_other">epi a %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s ap rive nan %2$d min pwograme</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -375,12 +375,17 @@
     <string name="vehicle_cancelled_other">e às %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s selecionados</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s selecionados, parada selecionada</string>
+    <string name="vehicle_prediction_actual_arrival">chegando às %2$s</string>
     <string name="vehicle_prediction_hours_first">%1$s chegando em %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s chegando em %2$d hr %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">e em %1$d h %2$d min</string>
     <string name="vehicle_prediction_hours_other">e em %1$d h</string>
     <string name="vehicle_prediction_minutes_first">%1$s chegando em %2$d min</string>
     <string name="vehicle_prediction_minutes_other">e em %1$d min</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s atrasado</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">e %1$s %2$s atrasado</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s cedo</string>
+    <string name="vehicle_prediction_schedule_status_early_other">e %1$s %2$s cedo</string>
     <string name="vehicle_prediction_time_first">%1$s chegando às %2$s</string>
     <string name="vehicle_prediction_time_other">e às %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s chegando em %2$d min programado</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -365,12 +365,17 @@
     <string name="vehicle_cancelled_other">và tại %1$s đã hủy</string>
     <string name="vehicle_desc_accessibility_desc">Đã chọn %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Đã chọn %1$s %2$s %3$s, điểm dừng đã chọn</string>
+    <string name="vehicle_prediction_actual_arrival">sẽ đến lúc %2$s</string>
     <string name="vehicle_prediction_hours_first">%1$s sẽ đến trong %2$d giờ</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s sẽ đến trong %2$d giờ %3$d phút</string>
     <string name="vehicle_prediction_hours_minutes_other">và trong %1$d giờ %2$d phút</string>
     <string name="vehicle_prediction_hours_other">và trong %1$d giờ</string>
     <string name="vehicle_prediction_minutes_first">%1$s sẽ đến sau %2$d phút nữa</string>
     <string name="vehicle_prediction_minutes_other">và sau %1$d phút nữa</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s bị trì hoãn</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">và %1$s %2$s bị trì hoãn</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s sớm</string>
+    <string name="vehicle_prediction_schedule_status_early_other">và %1$s %2$s sớm</string>
     <string name="vehicle_prediction_time_first">%1$s sẽ đến lúc %2$s</string>
     <string name="vehicle_prediction_time_other">và lúc %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s sẽ đến sau %2$d phút nữa theo lịch trình</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -365,12 +365,17 @@
     <string name="vehicle_cancelled_other">于%1$s到站的下一趟车已取消</string>
     <string name="vehicle_desc_accessibility_desc">选定%1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">选定%1$s %2$s %3$s，选定站点</string>
+    <string name="vehicle_prediction_actual_arrival">于%2$s到站</string>
     <string name="vehicle_prediction_hours_first">%1$s将于%2$d小时内到站</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s将于%2$d小时%3$d分钟内到站</string>
     <string name="vehicle_prediction_hours_minutes_other">下一趟车将在%1$d小时%2$d分钟内抵达</string>
     <string name="vehicle_prediction_hours_other">下一趟车将在%1$d小时内抵达</string>
     <string name="vehicle_prediction_minutes_first">%1$s将在%2$d分钟内到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟车将在%1$d分钟内抵达</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s 延迟</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">下一趟%1$s%2$s延迟</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s%2$s提前</string>
+    <string name="vehicle_prediction_schedule_status_early_other">下一趟%1$s%2$s提前</string>
     <string name="vehicle_prediction_time_first">%1$s于%2$s到站</string>
     <string name="vehicle_prediction_time_other">下一趟车将于%1$s到站</string>
     <string name="vehicle_schedule_minutes_first">%1$s预定将于%2$d分钟内到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -365,12 +365,17 @@
     <string name="vehicle_cancelled_other">於%1$s到站的下一趟車已取消</string>
     <string name="vehicle_desc_accessibility_desc">選定%1$s%2$s%3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">選定%1$s%2$s%3$s，選定站點</string>
+    <string name="vehicle_prediction_actual_arrival">於%2$s到站</string>
     <string name="vehicle_prediction_hours_first">%1$s將在%2$d小時內到站</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s將在%2$d小時%3$d分鐘內到站</string>
     <string name="vehicle_prediction_hours_minutes_other">下一趟車將在%1$d小時%2$d分鐘內抵達</string>
     <string name="vehicle_prediction_hours_other">下一趟車將在%1$d小時內抵達</string>
     <string name="vehicle_prediction_minutes_first">%1$s將在%2$d分鐘內到站</string>
     <string name="vehicle_prediction_minutes_other">下一趟車將在%1$d分鐘內抵達</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s%2$s延遲</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">下一趟%1$s%2$s延遲</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s%2$s提前</string>
+    <string name="vehicle_prediction_schedule_status_early_other">下一趟%1$s%2$s提前</string>
     <string name="vehicle_prediction_time_first">%1$s於%2$s到站</string>
     <string name="vehicle_prediction_time_other">下一趟車將於%1$s到站</string>
     <string name="vehicle_schedule_minutes_first">%1$s預定將於%2$d分鐘內到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -377,12 +377,17 @@
     <string name="vehicle_cancelled_other">and at %1$s cancelled</string>
     <string name="vehicle_desc_accessibility_desc">Selected %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Selected %1$s %2$s %3$s, selected stop</string>
+    <string name="vehicle_prediction_actual_arrival">arriving at %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s arriving in %2$d hr</string>
     <string name="vehicle_prediction_hours_other">and in %1$d hr</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s arriving in %2$d hr %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">and in %1$d hr %2$d min</string>
     <string name="vehicle_prediction_minutes_first">%1$s arriving in %2$d min</string>
     <string name="vehicle_prediction_minutes_other">and in %1$d min</string>
+    <string name="vehicle_prediction_schedule_status_delay_first">%1$s %2$s delayed</string>
+    <string name="vehicle_prediction_schedule_status_delay_other">and %1$s %2$s delayed</string>
+    <string name="vehicle_prediction_schedule_status_early_first">%1$s %2$s early</string>
+    <string name="vehicle_prediction_schedule_status_early_other">and %1$s %2$s early</string>
     <string name="vehicle_prediction_time_first">%1$s arriving at %2$s</string>
     <string name="vehicle_prediction_time_other">and at %1$s</string>
     <string name="vehicle_schedule_minutes_first">%1$s arriving in %2$d min scheduled</string>

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -94,20 +94,24 @@ struct UpcomingTripView: View {
                     .font(Typography.footnoteSemibold)
                     .opacity(min(0.6, maxTextAlpha))
                     .multilineTextAlignment(.trailing)
-            }
+                    .accessibilityLabel(
+                        TripInstantDisplay.companion.delayStatuses.contains(format.status) ? "" : format.status
+                    )
+            }.accessibilityElement(children: .combine)
         case let .timeWithSchedule(format):
             VStack(alignment: .trailing, spacing: 0) {
                 Text(Date(instant: format.predictionTime), style: .time)
                     .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
                     .realtime(hideIndicator: hideRealtimeIndicators)
                     .opacity(min(1.0, maxTextAlpha))
-                    .accessibilityLabel(label)
                 Text(Date(instant: format.scheduledTime), style: .time)
                     .font(Typography.footnoteSemibold)
                     .opacity(min(0.6, maxTextAlpha))
                     .strikethrough()
                     .multilineTextAlignment(.trailing)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
         case let .minutes(format):
             PredictionText(minutes: format.minutes)
                 .realtime(hideIndicator: hideRealtimeIndicators)

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -89,15 +89,13 @@ struct UpcomingTripView: View {
                     .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
                     .realtime(hideIndicator: hideRealtimeIndicators)
                     .opacity(min(1.0, maxTextAlpha))
-                    .accessibilityLabel(label)
                 Text(format.status)
                     .font(Typography.footnoteSemibold)
                     .opacity(min(0.6, maxTextAlpha))
                     .multilineTextAlignment(.trailing)
-                    .accessibilityLabel(
-                        TripInstantDisplay.companion.delayStatuses.contains(format.status) ? "" : format.status
-                    )
-            }.accessibilityElement(children: .combine)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
         case let .timeWithSchedule(format):
             VStack(alignment: .trailing, spacing: 0) {
                 Text(Date(instant: format.predictionTime), style: .time)

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1823,6 +1823,102 @@
         }
       }
     },
+    "%1$@ %2$@ delayed" : {
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, '10:00 PM train delayed[, arriving at 10:05 PM]'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ retrasado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ retardé"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ reta"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ atrasado"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ bị trì hoãn"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ 延迟"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@%2$@延遲"
+          }
+        }
+      }
+    },
+    "%1$@ %2$@ early" : {
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, '10:00 PM train early[, arriving at 9:55 PM]'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ temprano"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ tôt"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ byen bonè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ cedo"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ %2$@ sớm"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@%2$@提前"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@%2$@提前"
+          }
+        }
+      }
+    },
     "%1$@ has departed %2$@" : {
       "comment" : "Screen reader text that is announced when a trip disappears from the screen.,\nin the format \"[train/bus/ferry] to [destination] has departed [stop name]\",\nex. \"[train] has departed [Central]\", \"[bus] has departed [Harvard]\"",
       "localizations" : {
@@ -3464,6 +3560,102 @@
         }
       }
     },
+    "and %1$@ %2$@ delayed" : {
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time, as the second or later arrival in a list of upcoming arrivals. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, 'and 10:00 PM train delayed[, arriving at 10:05 PM]'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "y %1$@ %2$@ retrasado"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "et %1$@ %2$@ retardé"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "epi %1$@ %2$@ an reta"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "e %1$@ %2$@ atrasado"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "và %1$@ %2$@ bị trì hoãn"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下一趟%1$@%2$@延迟"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下一趟%1$@%2$@延遲"
+          }
+        }
+      }
+    },
+    "and %1$@ %2$@ early" : {
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time, as the second or later arrival in a list of upcoming arrivals. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, 'and 10:00 PM train early[, arriving at 9:55 PM]'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "y %1$@ %2$@ temprano"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "et %1$@ %2$@ tôt"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ak %1$@ %2$@ byen bonè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "e %1$@ %2$@ cedo"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "và %1$@ %2$@ sớm"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下一趟%1$@%2$@提前"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "下一趟%1$@%2$@提前"
+          }
+        }
+      }
+    },
     "and arriving now" : {
       "comment" : "The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.\n For example, '[bus arriving in 1 minute], and arriving now'",
       "localizations" : {
@@ -4178,6 +4370,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "即將到達"
+          }
+        }
+      }
+    },
+    "arriving at %1$@" : {
+      "comment" : "Screen reader text appended to another string containing an originally scheduled time which is running early or delayed compared to the actual predicted time (contained in this string). ex, '[10:00 PM train delayed, ]arriving at 10:05 PM'",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "llegará a la(s) %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "arrivant à %2$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ap rive a %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "chegando às %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sẽ đến lúc %2$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "于%2$@到站"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "於%2$@到站"
           }
         }
       }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1824,8 +1824,7 @@
       }
     },
     "%1$@ %2$@ delayed" : {
-      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, '10:00 PM train delayed[, arriving at 10:05 PM]'",
-      "extractionState" : "manual",
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time.\nThe first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').\nex, '10:00 PM train delayed[, arriving at 10:05 PM]'",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -1872,8 +1871,7 @@
       }
     },
     "%1$@ %2$@ early" : {
-      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, '10:00 PM train early[, arriving at 9:55 PM]'",
-      "extractionState" : "manual",
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time.\nThe first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').\nex, '10:00 PM train early[, arriving at 9:55 PM]'",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3561,8 +3559,7 @@
       }
     },
     "and %1$@ %2$@ delayed" : {
-      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time, as the second or later arrival in a list of upcoming arrivals. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, 'and 10:00 PM train delayed[, arriving at 10:05 PM]'",
-      "extractionState" : "manual",
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing\nthe delayed predicted time, as the second or later arrival in a list of upcoming arrivals.\nThe first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').\nex, 'and 10:00 PM train delayed[, arriving at 10:05 PM]'",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3609,8 +3606,7 @@
       }
     },
     "and %1$@ %2$@ early" : {
-      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time, as the second or later arrival in a list of upcoming arrivals. The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry'). ex, 'and 10:00 PM train early[, arriving at 9:55 PM]'",
-      "extractionState" : "manual",
+      "comment" : "Screen reader text containing an originally scheduled time, which precedes another string containing\nthe early predicted time, as the second or later arrival in a list of upcoming arrivals.\nThe first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').\nex, 'and 10:00 PM train early[, arriving at 9:55 PM]'",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -4375,8 +4371,7 @@
       }
     },
     "arriving at %1$@" : {
-      "comment" : "Screen reader text appended to another string containing an originally scheduled time which is running early or delayed compared to the actual predicted time (contained in this string). ex, '[10:00 PM train delayed, ]arriving at 10:05 PM'",
-      "extractionState" : "manual",
+      "comment" : "Screen reader text appended to another string containing an originally scheduled time which is running early or delayed\ncompared to the actual predicted time (contained in this string).\nex, '[10:00 PM train delayed, ]arriving at 10:05 PM'",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -964,15 +964,9 @@
         }
       }
     },
-    "%@ arriving at %@" : {
+    "%1$@ arriving at %2$@" : {
       "comment" : "Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.\nFor example, 'bus arriving at 10:30AM'",
       "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ arriving at %2$@"
-          }
-        },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3699,49 +3693,49 @@
         }
       }
     },
-    "and at %@" : {
+    "and at %1$@" : {
       "comment" : "The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM], and at 10:45 AM'",
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "y a la(s) %@"
+            "value" : "y a la(s) %1$@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "et à %@"
+            "value" : "et à %1$@"
           }
         },
         "ht" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "epi a %@"
+            "value" : "epi a %1$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "e às %@"
+            "value" : "e às %1$@"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "và lúc %@"
+            "value" : "và lúc %1$@"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下一趟车将于%@到站"
+            "value" : "下一趟车将于%1$@到站"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "下一趟車將於%@到站"
+            "value" : "下一趟車將於%1$@到站"
           }
         }
       }

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -68,7 +68,7 @@ struct FavoritesView: View {
         .withScenePhaseHandlers(
             onActive: { favoritesVM.setActive(active: true, wasSentToBackground: false) },
             onInactive: { favoritesVM.setActive(active: false, wasSentToBackground: false) },
-            onBackground: { favoritesVM.setActive(active: false, wasSentToBackground: true) },
+            onBackground: { favoritesVM.setActive(active: false, wasSentToBackground: true) }
         )
     }
 

--- a/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
+++ b/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
@@ -20,7 +20,8 @@ extension TripInstantDisplay {
         case let .cancelled(trip): cancelledLabel(trip.scheduledTime, isFirst, vehicleType)
         case let .scheduleMinutes(trip): scheduledMinutesLabel(trip.minutes, isFirst, vehicleType)
         case let .scheduleTime(trip): scheduleTimeLabel(trip.scheduledTime, isFirst, vehicleType)
-        case .time, .timeWithSchedule, .timeWithStatus: predictedTimeLabel(isFirst, vehicleType)
+        case .time, .timeWithStatus: predictedTimeLabel(isFirst, vehicleType)
+        case let .timeWithSchedule(trip): predictedTimeWithScheduleLabel(trip, isFirst, vehicleType)
         default: Text(verbatim: "")
         }
     }
@@ -71,6 +72,29 @@ extension TripInstantDisplay {
                 For example, '[bus arriving at 10:30AM], and at 10:45 AM cancelled'
                 """
             )
+    }
+
+    private func delayString(_ scheduledTime: Instant, _ isFirst: Bool, _ vehicleType: String) -> String {
+        let time = timeFormatter.string(from: Date(instant: scheduledTime))
+        return isFirst
+            ? String(format: NSLocalizedString(
+                "%1$@ %2$@ delayed",
+                comment: """
+                Screen reader text containing an originally scheduled time, which precedes another string containing the delayed predicted time.
+                The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').
+                ex, '10:00 PM train delayed[, arriving at 10:05 PM]'
+                """
+            ), time, vehicleType)
+
+            : String(format: NSLocalizedString(
+                "and %1$@ %2$@ delayed",
+                comment: """
+                Screen reader text containing an originally scheduled time, which precedes another string containing
+                the delayed predicted time, as the second or later arrival in a list of upcoming arrivals.
+                The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').
+                ex, 'and 10:00 PM train delayed[, arriving at 10:05 PM]'
+                """
+            ), time, vehicleType)
     }
 
     private func predictedMinutesLabel(_ isFirst: Bool, _ vehicleType: String) -> Text {
@@ -140,6 +164,11 @@ extension TripInstantDisplay {
     }
 
     private func predictedTimeLabel(_ isFirst: Bool, _ vehicleType: String) -> Text {
+        if case let .timeWithStatus(trip) = onEnum(of: self),
+           TripInstantDisplay.companion.delayStatuses.contains(trip.status) {
+            return Text(delayString(trip.predictionTime, isFirst, vehicleType))
+        }
+
         guard let predictionInstant: Instant = switch onEnum(of: self) {
         case let .time(trip): trip.predictionTime
         case let .timeWithSchedule(trip): trip.predictionTime
@@ -160,6 +189,46 @@ extension TripInstantDisplay {
                    The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
                    For example, '[bus arriving at 10:30AM], and at 10:45 AM'
                    """)
+    }
+
+    private func predictedTimeWithScheduleLabel(
+        _ trip: TripInstantDisplay.TimeWithSchedule,
+        _ isFirst: Bool,
+        _ vehicleType: String
+    ) -> Text {
+        let scheduledTime = timeFormatter.string(from: Date(instant: trip.scheduledTime))
+        let scheduleStatus = if trip.predictionTime.epochSeconds >= trip.scheduledTime.epochSeconds {
+            delayString(trip.scheduledTime, isFirst, vehicleType)
+        } else {
+            isFirst
+                ? String(format: NSLocalizedString(
+                    "%1$@ %2$@ early",
+                    comment: """
+                    Screen reader text containing an originally scheduled time, which precedes another string containing the early predicted time.
+                    The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').
+                    ex, '10:00 PM train early[, arriving at 9:55 PM]'
+                    """
+                ), scheduledTime, vehicleType)
+                : String(format: NSLocalizedString(
+                    "and %1$@ %2$@ early",
+                    comment: """
+                    Screen reader text containing an originally scheduled time, which precedes another string containing
+                    the early predicted time, as the second or later arrival in a list of upcoming arrivals.
+                    The first interpolated value is the scheduled time, and the second one is the vehicle type ('train', 'bus', or 'ferry').
+                    ex, 'and 10:00 PM train early[, arriving at 9:55 PM]'
+                    """
+                ), scheduledTime, vehicleType)
+        }
+        let predictionTime = timeFormatter.string(from: Date(instant: trip.predictionTime))
+        let actualArrival = String(format: NSLocalizedString(
+            "arriving at %1$@",
+            comment: """
+            Screen reader text appended to another string containing an originally scheduled time which is running early or delayed
+            compared to the actual predicted time (contained in this string).
+            ex, '[10:00 PM train delayed, ]arriving at 10:05 PM'
+            """
+        ), predictionTime)
+        return Text(verbatim: "\(scheduleStatus), \(actualArrival)")
     }
 
     private func scheduledMinutesLabel(_ minutes: Int32, _ isFirst: Bool, _ vehicleType: String) -> Text {

--- a/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
+++ b/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
@@ -171,24 +171,18 @@ extension TripInstantDisplay {
 
         guard let predictionInstant: Instant = switch onEnum(of: self) {
         case let .time(trip): trip.predictionTime
-        case let .timeWithSchedule(trip): trip.predictionTime
         case let .timeWithStatus(trip): trip.predictionTime
         default: nil
         } else { return Text(verbatim: "") }
 
         let predictionTime = timeFormatter.string(from: Date(instant: predictionInstant))
-        return isFirst
-            ? Text("\(vehicleType) arriving at \(predictionTime)",
-                   comment: """
-                   Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.
-                   First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
-                   For example, 'bus arriving at 10:30AM'
-                   """)
-            : Text("and at \(predictionTime)",
-                   comment: """
-                   The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
-                   For example, '[bus arriving at 10:30AM], and at 10:45 AM'
-                   """)
+        let timeString = predictedTimeString(predictionTime, isFirst, vehicleType)
+        let finalLabel = if case let .timeWithStatus(trip) = onEnum(of: self) {
+            "\(timeString), \(trip.status)"
+        } else {
+            timeString
+        }
+        return Text(verbatim: finalLabel)
     }
 
     private func predictedTimeWithScheduleLabel(
@@ -229,6 +223,25 @@ extension TripInstantDisplay {
             """
         ), predictionTime)
         return Text(verbatim: "\(scheduleStatus), \(actualArrival)")
+    }
+
+    private func predictedTimeString(_ predictionTime: String, _ isFirst: Bool, _ vehicleType: String) -> String {
+        isFirst
+            ? String(format: NSLocalizedString(
+                "%1$@ arriving at %2$@",
+                comment: """
+                Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.
+                First value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.
+                For example, 'bus arriving at 10:30AM'
+                """
+            ), vehicleType, predictionTime)
+            : String(format: NSLocalizedString(
+                "and at %1$@",
+                comment: """
+                The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.
+                For example, '[bus arriving at 10:30AM], and at 10:45 AM'
+                """
+            ), predictionTime)
     }
 
     private func scheduledMinutesLabel(_ minutes: Int32, _ isFirst: Bool, _ vehicleType: String) -> Text {

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -84,7 +84,9 @@ final class UpcomingTripViewTests: XCTestCase {
             )),
             routeType: .commuterRail
         )
-        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "train arriving at 4:00\u{202F}PM"))
+        XCTAssertNotNil(try sut.inspect().find(
+            viewWithAccessibilityLabel: "train arriving at 4:00\u{202F}PM, All aboard"
+        ))
         XCTAssertNotNil(try sut.inspect().find(text: "All aboard"))
     }
 

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -88,6 +88,64 @@ final class UpcomingTripViewTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "All aboard"))
     }
 
+    func testTimeWithStatusLate() throws {
+        let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
+        let sut = UpcomingTripView(
+            prediction: .some(.TimeWithStatus(
+                predictionTime: date.toKotlinInstant(),
+                status: "Late",
+                headline: true
+            )),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "4:00\u{202F}PM train delayed"))
+    }
+
+    func testTimeWithStatusDelayed() throws {
+        let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
+        let sut = UpcomingTripView(
+            prediction: .some(.TimeWithStatus(
+                predictionTime: date.toKotlinInstant(),
+                status: "Delay",
+                headline: true
+            )),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "4:00\u{202F}PM train delayed"))
+    }
+
+    func testTimeWithScheduleEarly() throws {
+        let scheduleDate = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
+        let predictionDate = ISO8601DateFormatter().date(from: "2024-05-01T19:55:00Z")!
+        let sut = UpcomingTripView(
+            prediction: .some(.TimeWithSchedule(
+                predictionTime: predictionDate.toKotlinInstant(),
+                scheduledTime: scheduleDate.toKotlinInstant(),
+                headline: true
+            )),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(
+            viewWithAccessibilityLabel: "4:00\u{202F}PM train early, arriving at 3:55\u{202F}PM"
+        ))
+    }
+
+    func testTimeWithScheduleDelayed() throws {
+        let scheduleDate = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
+        let predictionDate = ISO8601DateFormatter().date(from: "2024-05-01T20:05:00Z")!
+        let sut = UpcomingTripView(
+            prediction: .some(.TimeWithSchedule(
+                predictionTime: predictionDate.toKotlinInstant(),
+                scheduledTime: scheduleDate.toKotlinInstant(),
+                headline: true
+            )),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(
+            viewWithAccessibilityLabel: "4:00\u{202F}PM train delayed, arriving at 4:05\u{202F}PM"
+        ))
+    }
+
     func testFirstScheduledAccessibilityLabel() throws {
         let date = ISO8601DateFormatter().date(from: "2024-05-01T20:00:00Z")!
         let sut = UpcomingTripView(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -57,6 +57,8 @@ sealed class TripInstantDisplay {
     }
 
     companion object {
+        val delayStatuses = setOf("Delay", "Late")
+
         fun from(
             prediction: Prediction?,
             schedule: Schedule?,


### PR DESCRIPTION
### Summary

_Ticket:_ [[screen reader text for crossed out CR schedule times]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210503750238562?focus=true), finally

See #1077, #1081, #1085

Add screen reader text on Android and iOS for the CR delay states. Doing this made me catch a few different issues with the existing screen reader text, including missing vehicle types in most places, and duplicate information being read out due to components not being merged.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Existing tests pass, added new unit tests for added functionality