### PR TITLE
chore: deep linking prod alias

### DIFF
--- a/androidApp/src/prod/AndroidManifest.xml
+++ b/androidApp/src/prod/AndroidManifest.xml
@@ -9,6 +9,15 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
+                <data android:host="go.mbta.com" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
                 <data android:host="mobile-app-backend.mbtace.com" />
             </intent-filter>
         </activity>

--- a/iosApp/iosApp/iosApp-prod.entitlements
+++ b/iosApp/iosApp/iosApp-prod.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>applinks:go.mbta.com</string>
 		<string>applinks:mobile-app-backend.mbtace.com</string>
 	</array>
 </dict>


### PR DESCRIPTION
### Summary

_Ticket:_ [alias go.mbta.com to mobile app backend](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210424949194033?focus=true)

What is this PR for?

Adds support for deep linking from go.mbta.com to the iOS & android app. Will test once https://github.com/mbta/devops/pull/2957 goes through

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Confirmed that as-is (without this change) links to go.mbta.com open the app listing in iOS & android stores. Tried testing the existing `mobile-app-backend.mbtace.com` config which opened the app directly on android but opened the store on iOS, whereas `mobile-app-backend-staging.mbtace.com` directly opens the app. ~Looking at the config I'm not entirely sure what would account for that difference on iOS, but looking into it further.~ Running on a device without TestFlight this worked as expected for prod.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
