### PR TITLE
feat(Android): Add first time favorite hint text

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
@@ -1,0 +1,71 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.viewModel.ToastViewModel
+import org.junit.Rule
+import org.junit.Test
+
+class BarAndToastScaffoldTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testToastDisplay() {
+        val toastVM = ToastViewModel()
+
+        composeTestRule.setContent {
+            BarAndToastScaffold(toastViewModel = toastVM) { Text("Content") }
+        }
+
+        toastVM.showToast(ToastViewModel.Toast(message = "Toast message"))
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Toast message").assertIsDisplayed()
+    }
+
+    @Test
+    fun testToastAction() {
+        val toastVM = ToastViewModel()
+
+        composeTestRule.setContent {
+            BarAndToastScaffold(toastViewModel = toastVM) { Text("Content") }
+        }
+
+        var actionTapped = false
+        toastVM.showToast(
+            ToastViewModel.Toast(
+                message = "Toast message",
+                actionLabel = "Action",
+                onAction = { actionTapped = true },
+            )
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Action").assertIsDisplayed().performClick()
+
+        assert(actionTapped)
+    }
+
+    @Test
+    fun testToastClose() {
+        val toastVM = ToastViewModel()
+
+        composeTestRule.setContent {
+            BarAndToastScaffold(toastViewModel = toastVM) { Text("Content") }
+        }
+
+        var closeTapped = false
+        toastVM.showToast(
+            ToastViewModel.Toast(message = "Toast message", onClose = { closeTapped = true })
+        )
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Close").assertIsDisplayed().performClick()
+
+        assert(closeTapped)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
@@ -33,6 +33,7 @@ enum class ActionButtonKind(
 @Composable
 fun ActionButton(
     kind: ActionButtonKind,
+    modifier: Modifier = Modifier,
     size: Dp = 32.dp,
     colors: ButtonColors =
         ButtonDefaults.buttonColors(
@@ -43,7 +44,7 @@ fun ActionButton(
 ) {
     Button(
         onClick = action,
-        modifier = Modifier.size(size).width(size),
+        modifier = modifier.size(size).width(size),
         shape = CircleShape,
         colors = colors,
         contentPadding = PaddingValues(5.dp),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffold.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffold.kt
@@ -1,0 +1,126 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarData
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.viewModel.ToastViewModel
+import org.koin.compose.koinInject
+
+@Composable
+fun BarAndToastScaffold(
+    bottomBar: @Composable () -> Unit = {},
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    toastViewModel: ToastViewModel = koinInject(),
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val toastState by toastViewModel.models.collectAsState()
+
+    LaunchedEffect(toastState) {
+        when (val state = toastState) {
+            is ToastViewModel.State.Hidden -> snackbarHostState.currentSnackbarData?.dismiss()
+            is ToastViewModel.State.Visible ->
+                snackbarHostState.showSnackbar(
+                    message = state.toast.message,
+                    actionLabel =
+                        if (state.toast.actionLabel != null && state.toast.onAction != null)
+                            state.toast.actionLabel
+                        else null,
+                    withDismissAction = state.toast.onClose != null,
+                    duration =
+                        when (state.toast.duration) {
+                            ToastViewModel.Duration.Short -> SnackbarDuration.Short
+                            ToastViewModel.Duration.Long -> SnackbarDuration.Long
+                            ToastViewModel.Duration.Indefinite -> SnackbarDuration.Indefinite
+                        },
+                )
+        }
+    }
+
+    Scaffold(
+        bottomBar = bottomBar,
+        snackbarHost = {
+            SnackbarHost(snackbarHostState) {
+                Snackbar(
+                    modifier = Modifier.padding(start = 8.dp, bottom = 16.dp, end = 8.dp),
+                    action = { ToastActionButton(it, toastState) },
+                    dismissAction = { ToastCloseButton(it, toastState) },
+                    shape = RoundedCornerShape(8.dp),
+                    containerColor = colorResource(R.color.contrast),
+                    contentColor = Color.Transparent,
+                    actionContentColor = Color.Transparent,
+                    dismissActionContentColor = Color.Transparent,
+                ) {
+                    Text(it.visuals.message, color = colorResource(R.color.fill3))
+                }
+            }
+        },
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}
+
+@Composable
+private fun ToastActionButton(snackbarData: SnackbarData, toastState: ToastViewModel.State) {
+    snackbarData.visuals.actionLabel?.let { label ->
+        NavTextButton(
+            label,
+            modifier =
+                Modifier.padding(
+                    start = 8.dp,
+                    end = if (snackbarData.visuals.withDismissAction) 0.dp else 16.dp,
+                ),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = colorResource(R.color.halo_inverse),
+                    contentColor = colorResource(R.color.fill3),
+                ),
+        ) {
+            when (toastState) {
+                is ToastViewModel.State.Hidden -> {}
+                is ToastViewModel.State.Visible ->
+                    toastState.toast.onAction?.let { action -> action() }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToastCloseButton(snackbarData: SnackbarData, toastState: ToastViewModel.State) {
+    if (snackbarData.visuals.withDismissAction)
+        ActionButton(
+            ActionButtonKind.Close,
+            modifier = Modifier.padding(start = 8.dp, end = 16.dp),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = colorResource(R.color.halo_inverse),
+                    contentColor = colorResource(R.color.fill3),
+                ),
+        ) {
+            when (toastState) {
+                is ToastViewModel.State.Hidden -> {}
+                is ToastViewModel.State.Visible ->
+                    toastState.toast.onClose?.let { close -> close() }
+            }
+        }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.android.util.Typography
 @Composable
 fun NavTextButton(
     string: String,
+    modifier: Modifier = Modifier,
     colors: ButtonColors =
         ButtonDefaults.buttonColors(
             containerColor = colorResource(R.color.text).copy(alpha = 0.6f),
@@ -27,7 +28,7 @@ fun NavTextButton(
         onTap,
         colors = colors,
         contentPadding = PaddingValues(horizontal = 12.dp),
-        modifier = Modifier.heightIn(min = 32.dp),
+        modifier = modifier.heightIn(min = 32.dp),
     ) {
         Text(string, style = Typography.callout)
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,6 +47,7 @@ import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.SheetRoutes
 import com.mbta.tid.mbta_app.android.alertDetails.AlertDetailsPage
+import com.mbta.tid.mbta_app.android.component.BarAndToastScaffold
 import com.mbta.tid.mbta_app.android.component.DragHandle
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
@@ -548,9 +548,10 @@ fun MapAndSheetPage(
             }
         }
     }
+
     // setting WindowInsets top to 0 to prevent the sheet from having extra padding on top even
     // when not fully expanded https://stackoverflow.com/a/77361483
-    Scaffold(bottomBar = bottomBar, contentWindowInsets = WindowInsets(top = 0.dp)) {
+    BarAndToastScaffold(bottomBar = bottomBar, contentWindowInsets = WindowInsets(top = 0.dp)) {
         outerSheetPadding ->
         val showSearchBar = remember(currentNavEntry) { currentNavEntry?.showSearchBar ?: true }
         if (nearbyTransit.hideMaps) {

--- a/androidApp/src/main/res/color-night/halo_inverse.xml
+++ b/androidApp/src/main/res/color-night/halo_inverse.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#1A192026" />
+</selector>

--- a/androidApp/src/main/res/color/halo_inverse.xml
+++ b/androidApp/src/main/res/color/halo_inverse.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#26FFFFFF" />
+</selector>

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -337,6 +337,7 @@
     <string name="switch_issue_lowercase">problema de cambio de carril</string>
     <string name="switch_problem">Problema de cambio de carril</string>
     <string name="switch_problem_lowercase">problema del interruptor</string>
+    <string name="tap_favorites_hint">Toca las estrellas para añadirlas a Favoritos</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="technical_problem_lowercase">problema técnico</string>
     <string name="tie_replacement">Reemplazo de traviesas</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -337,6 +337,7 @@
     <string name="switch_issue_lowercase">problème de commutation</string>
     <string name="switch_problem">Problème d’aiguillage</string>
     <string name="switch_problem_lowercase">problème de commutation</string>
+    <string name="tap_favorites_hint">Appuyez sur les étoiles pour ajouter aux favoris</string>
     <string name="technical_problem">Problème technique</string>
     <string name="technical_problem_lowercase">problème technique</string>
     <string name="tie_replacement">Remplacement de traverses</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -349,6 +349,7 @@
     <string name="switch_issue_lowercase">pwoblèm nan switch ray</string>
     <string name="switch_problem">Pann nan switch ray</string>
     <string name="switch_problem_lowercase">pann nan switch ray</string>
+    <string name="tap_favorites_hint">Tape zetwal yo pou ajoute nan Favori yo</string>
     <string name="technical_problem">Pwoblèm Teknik</string>
     <string name="technical_problem_lowercase">pwoblèm teknik</string>
     <string name="tie_replacement">Ranplasman kòd</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -337,6 +337,7 @@
     <string name="switch_issue_lowercase">problema na agulha</string>
     <string name="switch_problem">Problema de troca</string>
     <string name="switch_problem_lowercase">problema na agulha</string>
+    <string name="tap_favorites_hint">Toque nas estrelas para adicionar aos favoritos</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="technical_problem_lowercase">problema técnico</string>
     <string name="tie_replacement">Troca de pneu</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -329,6 +329,7 @@
     <string name="switch_issue_lowercase">vấn đề chuyển đổi</string>
     <string name="switch_problem">Vấn đề chuyển đổi</string>
     <string name="switch_problem_lowercase">vấn đề chuyển đổi</string>
+    <string name="tap_favorites_hint">Nhấn vào các ngôi sao để thêm vào mục Yêu thích</string>
     <string name="technical_problem">Vấn đề kỹ thuật</string>
     <string name="technical_problem_lowercase">vấn đề kỹ thuật</string>
     <string name="tie_replacement">Thay tà vẹt</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -329,6 +329,7 @@
     <string name="switch_issue_lowercase">道岔问题</string>
     <string name="switch_problem">道岔故障</string>
     <string name="switch_problem_lowercase">道岔故障</string>
+    <string name="tap_favorites_hint">点按星星即可添加到收藏夹</string>
     <string name="technical_problem">技术故障</string>
     <string name="technical_problem_lowercase">技术故障</string>
     <string name="tie_replacement">更换轨枕</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -329,6 +329,7 @@
     <string name="switch_issue_lowercase">道岔問題</string>
     <string name="switch_problem">道岔故障</string>
     <string name="switch_problem_lowercase">道岔故障</string>
+    <string name="tap_favorites_hint">點按星星即可加入收藏夾</string>
     <string name="technical_problem">技術故障</string>
     <string name="technical_problem_lowercase">技術故障</string>
     <string name="tie_replacement">更換軌枕</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -340,6 +340,7 @@
     <string name="switch_issue_lowercase">switch issue</string>
     <string name="switch_problem">Switch Problem</string>
     <string name="switch_problem_lowercase">switch problem</string>
+    <string name="tap_favorites_hint">Tap stars to add to Favorites</string>
     <string name="technical_problem">Technical Problem</string>
     <string name="technical_problem_lowercase">technical problem</string>
     <string name="tie_replacement">Tie Replacement</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -964,53 +964,6 @@
         }
       }
     },
-    "%1$@ arriving at %2$@" : {
-      "comment" : "Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.\nFor example, 'bus arriving at 10:30AM'",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ llegará a la(s) %2$@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ arrivant à %2$@"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ ap rive a %2$@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ chegando às %2$@"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ sẽ đến lúc %2$@"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@于%2$@到站"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@於%2$@到站"
-          }
-        }
-      }
-    },
     "%@ arriving at %@ cancelled" : {
       "comment" : "Describe the time at which a cancelled vehicle was scheduled to arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.\nFor example, 'bus arriving at 10:30AM cancelled'",
       "localizations" : {
@@ -1907,6 +1860,53 @@
           "stringUnit" : {
             "state" : "needs_review",
             "value" : "%1$@%2$@提前"
+          }
+        }
+      }
+    },
+    "%1$@ arriving at %2$@" : {
+      "comment" : "Describe the time at which a vehicle will arrive, as read aloud for VoiceOver users.\nFirst value is the type of vehicle (bus, train, ferry), second is the clock time it will arrive.\nFor example, 'bus arriving at 10:30AM'",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ llegará a la(s) %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ arrivant à %2$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ ap rive a %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ chegando às %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ sẽ đến lúc %2$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@于%2$@到站"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@於%2$@到站"
           }
         }
       }
@@ -3693,53 +3693,6 @@
         }
       }
     },
-    "and at %1$@" : {
-      "comment" : "The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM], and at 10:45 AM'",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "y a la(s) %1$@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "et à %1$@"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "epi a %1$@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "e às %1$@"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "và lúc %1$@"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一趟车将于%1$@到站"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下一趟車將於%1$@到站"
-          }
-        }
-      }
-    },
     "and at %@ cancelled" : {
       "comment" : "The second or more cancelled arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM], and at 10:45 AM cancelled'",
       "localizations" : {
@@ -3830,6 +3783,53 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下一趟車預定將於%@到站"
+          }
+        }
+      }
+    },
+    "and at %1$@" : {
+      "comment" : "The second or more arrival in a list of upcoming arrivals read aloud for VoiceOver users.\nFor example, '[bus arriving at 10:30AM], and at 10:45 AM'",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "y a la(s) %1$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "et à %1$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "epi a %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e às %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "và lúc %1$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一趟车将于%1$@到站"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一趟車將於%1$@到站"
           }
         }
       }
@@ -17419,6 +17419,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "切換方向"
+          }
+        }
+      }
+    },
+    "Tap stars to add to Favorites" : {
+      "comment" : "Hint text that shows up on a toast when the user enters a route on the add favorites flow for the first time",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toca las estrellas para añadirlas a Favoritos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Appuyez sur les étoiles pour ajouter aux favoris"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tape zetwal yo pou ajoute nan Favori yo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Toque nas estrelas para adicionar aos favoritos"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nhấn vào các ngôi sao để thêm vào mục Yêu thích"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "点按星星即可添加到收藏夹"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "點按星星即可加入收藏夾"
           }
         }
       }

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -9,4 +10,8 @@ actual fun viewModelModule() = module {
     viewModelOf(::FavoritesViewModel)
     viewModelOf(::SearchRoutesViewModel)
     viewModelOf(::SearchViewModel)
+    // Use singleOf to ensure a shared ToastViewModel across all views that need it, it should be
+    // injected using koinInject() rather than koinViewModel(), because if it gets destroyed by the
+    // VM lifecycle management, it will break the toast state across different composables.
+    singleOf(::ToastViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
@@ -1,0 +1,64 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.Serializable
+
+class ToastViewModel : MoleculeViewModel<ToastViewModel.Event, ToastViewModel.State>() {
+
+    /**
+     * These are parallel to [androidx.compose.material3.SnackbarDuration], because the Jetpack
+     * Compose Material 3 snackbar does not allow you to set a specific time, and no toast/snackbar
+     * implementation exists in SwiftUI, so we might as well make the behavior match.
+     */
+    enum class Duration {
+        Short,
+        Long,
+        Indefinite,
+    }
+
+    @Serializable
+    data class Toast(
+        val message: String,
+        val duration: Duration = Duration.Indefinite,
+        val onClose: (() -> Unit)? = null,
+        val actionLabel: String? = null,
+        val onAction: (() -> Unit)? = null,
+    )
+
+    sealed interface Event {
+        data object Hide : Event
+
+        data class ShowToast(val toast: Toast) : Event
+    }
+
+    sealed class State {
+        data object Hidden : State()
+
+        data class Visible(val toast: Toast) : State()
+    }
+
+    @Composable
+    override fun runLogic(events: Flow<Event>): State {
+        return produceState(State.Hidden as State, events) {
+                events.collect { event ->
+                    value =
+                        when (event) {
+                            is Event.Hide -> State.Hidden
+                            is Event.ShowToast -> State.Visible(event.toast)
+                        }
+                }
+            }
+            .value
+    }
+
+    val models
+        get() = internalModels
+
+    fun hideToast() = fireEvent(Event.Hide)
+
+    fun showToast(toast: Toast) = fireEvent(Event.ShowToast(toast))
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModelTest.kt
@@ -1,0 +1,20 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import app.cash.turbine.test
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+
+class ToastViewModelTest {
+    @Test
+    fun testShowAndHideToast() = runTest {
+        val vm = ToastViewModel()
+        testViewModelFlow(vm).test {
+            assertEquals(ToastViewModel.State.Hidden, awaitItem())
+            vm.showToast(ToastViewModel.Toast("Message"))
+            assertEquals(ToastViewModel.State.Visible(ToastViewModel.Toast("Message")), awaitItem())
+            vm.hideToast()
+            assertEquals(ToastViewModel.State.Hidden, awaitItem())
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -8,4 +8,5 @@ class ViewModelDI : KoinComponent {
     val favorites: FavoritesViewModel by inject()
     val search: SearchViewModel by inject()
     val searchRoutes: SearchRoutesViewModel by inject()
+    val toastViewModel: ToastViewModel by inject()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -8,5 +8,5 @@ class ViewModelDI : KoinComponent {
     val favorites: FavoritesViewModel by inject()
     val search: SearchViewModel by inject()
     val searchRoutes: SearchRoutesViewModel by inject()
-    val toastViewModel: ToastViewModel by inject()
+    val toast: ToastViewModel by inject()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -7,4 +7,5 @@ actual fun viewModelModule() = module {
     singleOf(::FavoritesViewModel)
     singleOf(::SearchRoutesViewModel)
     singleOf(::SearchViewModel)
+    singleOf(::ToastViewModel)
 }

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -7,4 +7,5 @@ actual fun viewModelModule() = module {
     singleOf(::FavoritesViewModel)
     singleOf(::SearchRoutesViewModel)
     singleOf(::SearchViewModel)
+    singleOf(::ToastViewModel)
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Add stops flow - Tap stars toast](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210229158900372?focus=true)

Add a toast to the route details favorites flow that is displayed when the user has no favorites yet, notifying them to tap on the star button to add stops to their favorites.

Also added currently unused functionality to the toast to accept an action label button, which we do want to add in the near future to allow for undoing added favorites.

![Screenshot_20250624_151552](https://github.com/user-attachments/assets/8f46e823-56a1-417c-a179-63b48fdb7915)


iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added tests for the new toast scaffold, the new toast VM, and for the functionality in the existing route stop list tests.