### PR TITLE
feat(Android): First pass for route UI

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -75,7 +75,11 @@ class RouteStopListViewTest {
 
         val koin =
             testKoinApplication(objects) {
-                routeStops = MockRouteStopsRepository(listOf(stop1.id, stop2.id, stop3.id))
+                routeStops =
+                    MockRouteStopsRepository(
+                        listOf(stop1.id, stop2.id, stop3.id),
+                        routeId = mainRoute.id,
+                    )
             }
         val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
@@ -86,6 +90,7 @@ class RouteStopListViewTest {
                     RouteDetailsContext.Details,
                     GlobalResponse(objects),
                     onClick = clicks::add,
+                    onBack = {},
                     onClose = { closed = true },
                     errorBannerViewModel = errorBannerVM,
                     rightSideContent = { context, _ ->
@@ -176,6 +181,7 @@ class RouteStopListViewTest {
                     RouteDetailsContext.Details,
                     GlobalResponse(objects),
                     onClick = {},
+                    onBack = {},
                     onClose = {},
                     errorBannerViewModel = errorBannerVM,
                     defaultSelectedRouteId = route2.id,
@@ -232,7 +238,8 @@ class RouteStopListViewTest {
             testKoinApplication(objects) {
                 routeStops =
                     MockRouteStopsRepository(
-                        listOf(stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id)
+                        listOf(stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id),
+                        routeId = mainRoute.id,
                     )
             }
         val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
@@ -244,6 +251,7 @@ class RouteStopListViewTest {
                     RouteDetailsContext.Details,
                     GlobalResponse(objects),
                     onClick = {},
+                    onBack = {},
                     onClose = {},
                     errorBannerViewModel = errorBannerVM,
                     rightSideContent = { _, _ -> },
@@ -265,21 +273,26 @@ class RouteStopListViewTest {
     @Test
     fun testFavoritesWithConfirmationDialog() {
         val objects = TestData.clone()
+        val route = RouteCardData.LineOrRoute.Route(objects.getRoute("Red"))
 
         val koin =
             testKoinApplication(objects) {
                 routeStops =
-                    MockRouteStopsRepository(listOf("place-alfcl", "place-davis", "place-portr"))
+                    MockRouteStopsRepository(
+                        listOf("place-alfcl", "place-davis", "place-portr"),
+                        routeId = route.id,
+                    )
             }
         val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
                 RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                    route,
                     RouteDetailsContext.Favorites,
                     GlobalResponse(objects),
                     onClick = {},
+                    onBack = {},
                     onClose = {},
                     errorBannerViewModel = errorBannerVM,
                     rightSideContent = { rowContext, _ ->

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumn.kt
@@ -26,11 +26,12 @@ fun ScrollSeparatorColumn(
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     haloColor: Color = colorResource(R.color.halo),
     scrollState: ScrollState = rememberScrollState(),
+    scrollEnabled: Boolean = true,
     content: @Composable (ColumnScope.() -> Unit),
 ) {
     Box(Modifier, Alignment.TopCenter) {
         Column(
-            Modifier.verticalScroll(scrollState).then(modifier),
+            Modifier.verticalScroll(scrollState, scrollEnabled).then(modifier),
             verticalArrangement,
             horizontalAlignment,
             content,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -69,6 +69,7 @@ import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
 import com.mbta.tid.mbta_app.android.stopDetails.stopDetailsManagedVM
 import com.mbta.tid.mbta_app.android.util.currentRoute
 import com.mbta.tid.mbta_app.android.util.currentRouteAs
+import com.mbta.tid.mbta_app.android.util.currentRouteMatches
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.android.util.navigateFrom
 import com.mbta.tid.mbta_app.android.util.plus
@@ -522,7 +523,15 @@ fun MapAndSheetPage(
                     selectionId = navRoute.routeId,
                     context = navRoute.context,
                     onOpenStopDetails = ::handleStopNavigation,
-                    onClose = { navController.popBackStackFrom<SheetRoutes.RouteDetails>() },
+                    onBack = { navController.popBackStackFrom<SheetRoutes.RouteDetails>() },
+                    onClose = {
+                        while (
+                            navController.currentRouteMatches<SheetRoutes.RoutePicker>() ||
+                                navController.currentRouteMatches<SheetRoutes.RouteDetails>()
+                        ) {
+                            navController.popBackStack()
+                        }
+                    },
                     errorBannerViewModel = errorBannerViewModel,
                 )
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
@@ -2,8 +2,8 @@ package com.mbta.tid.mbta_app.android.routeDetails
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.ColorFilter
@@ -14,7 +14,11 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.PinButton
 import com.mbta.tid.mbta_app.android.state.getGlobalData
+import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 
 @Composable
@@ -22,13 +26,14 @@ fun RouteDetailsView(
     selectionId: String,
     context: RouteDetailsContext,
     onOpenStopDetails: (String) -> Unit,
+    onBack: () -> Unit,
     onClose: () -> Unit,
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
     val globalData = getGlobalData("RouteDetailsView.globalData")
     val lineOrRoute = globalData?.let { RouteDetailsStopList.getLineOrRoute(selectionId, it) }
     if (lineOrRoute == null) {
-        CircularProgressIndicator()
+        LoadingRouteStopListView(context, errorBannerViewModel)
         return
     }
 
@@ -37,6 +42,7 @@ fun RouteDetailsView(
         context,
         globalData,
         onClick = { onOpenStopDetails(it.stop.id) },
+        onBack = onBack,
         onClose = onClose,
         errorBannerViewModel,
         defaultSelectedRouteId = selectionId.takeUnless { it == lineOrRoute.id },
@@ -58,4 +64,41 @@ fun RouteDetailsView(
             }
         },
     )
+}
+
+@Composable
+private fun LoadingRouteStopListView(
+    context: RouteDetailsContext,
+    errorBannerViewModel: ErrorBannerViewModel,
+) {
+    CompositionLocalProvider(IsLoadingSheetContents provides true) {
+        val mockRoute = RouteCardData.LineOrRoute.Route(ObjectCollectionBuilder.Single.route {})
+        RouteStopListView(
+            mockRoute,
+            context,
+            GlobalResponse(ObjectCollectionBuilder()),
+            onClick = {},
+            onBack = {},
+            onClose = {},
+            errorBannerViewModel,
+            rightSideContent = { rowContext, modifier ->
+                when (rowContext) {
+                    is RouteDetailsRowContext.Details ->
+                        Image(
+                            painterResource(id = R.drawable.baseline_chevron_right_24),
+                            contentDescription = null,
+                            modifier = modifier.width(8.dp),
+                            colorFilter = ColorFilter.tint(colorResource(R.color.deemphasized)),
+                        )
+
+                    is RouteDetailsRowContext.Favorites ->
+                        PinButton(
+                            rowContext.isFavorited,
+                            colorResource(R.color.text),
+                            rowContext.onTapStar,
+                        )
+                }
+            },
+        )
+    }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
-import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
+import com.mbta.tid.mbta_app.repositories.RouteStopsResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +26,7 @@ class RouteStopsFetcher(
         routeId: String,
         directionId: Int,
         errorKey: String,
-        onSuccess: (RouteStopsResponse) -> Unit,
+        onSuccess: (RouteStopsResult) -> Unit,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             fetchApi(
@@ -46,8 +46,8 @@ class RouteStopsViewModel(
 ) : ViewModel() {
 
     private val routeStopsFetcher = RouteStopsFetcher(routeStopsRepository, errorBannerRepository)
-    private val _routeStops = MutableStateFlow<RouteStopsResponse?>(null)
-    val routeStops: StateFlow<RouteStopsResponse?> = _routeStops
+    private val _routeStops = MutableStateFlow<RouteStopsResult?>(null)
+    val routeStops: StateFlow<RouteStopsResult?> = _routeStops
 
     fun getRouteStops(routeId: String, directionId: Int, errorKey: String) {
         _routeStops.value = null
@@ -71,7 +71,7 @@ fun getRouteStops(
     errorKey: String,
     routeStopsRepository: IRouteStopsRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
-): RouteStopsResponse? {
+): RouteStopsResult? {
     val viewModel: RouteStopsViewModel =
         viewModel(
             factory = RouteStopsViewModel.Factory(routeStopsRepository, errorBannerRepository)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
@@ -91,6 +92,42 @@ object LoadingPlaceholders {
         val routeData = RouteCardData(lineOrRoute, stopData = listOf(stopData), now)
 
         return routeData
+    }
+
+    fun routeDetailsStops(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        directionId: Int,
+    ): RouteDetailsStopList {
+        val objects = ObjectCollectionBuilder()
+        val fixedRand = Random("${lineOrRoute.id}-$directionId".hashCode())
+        fun randString(from: Int, until: Int) =
+            (1..fixedRand.nextInt(from, until)).joinToString("") { " " }
+
+        return RouteDetailsStopList(
+            directionId = directionId,
+            segments =
+                listOf(
+                    RouteDetailsStopList.Segment(
+                        (1..20).map {
+                            val stopName = randString(15, 30)
+                            val transferRoutes =
+                                (0..fixedRand.nextInt(0, 7)).map {
+                                    objects.route { shortName = randString(2, 5) }
+                                }
+                            RouteDetailsStopList.Entry(
+                                objects.stop { name = stopName },
+                                listOf(
+                                    objects.routePattern(lineOrRoute.sortRoute) {
+                                        typicality = RoutePattern.Typicality.Typical
+                                    }
+                                ),
+                                transferRoutes,
+                            )
+                        },
+                        hasRouteLine = true,
+                    )
+                ),
+        )
     }
 
     fun stopDetailsRouteCards() =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
@@ -6,11 +6,17 @@ import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.call.body
 import io.ktor.http.path
+import kotlinx.serialization.Serializable
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+// The response doesn't include the route ID and direction ID, which we need in the UI to ensure
+// that we're using the correct stop list for the selected route and direction.
+@Serializable
+data class RouteStopsResult(val routeId: String, val directionId: Int, val stopIds: List<String>)
+
 interface IRouteStopsRepository {
-    suspend fun getRouteStops(routeId: String, directionId: Int): ApiResult<RouteStopsResponse>
+    suspend fun getRouteStops(routeId: String, directionId: Int): ApiResult<RouteStopsResult>
 }
 
 class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
@@ -19,34 +25,38 @@ class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
     override suspend fun getRouteStops(
         routeId: String,
         directionId: Int,
-    ): ApiResult<RouteStopsResponse> =
+    ): ApiResult<RouteStopsResult> =
         ApiResult.runCatching {
-            mobileBackendClient
-                .get {
-                    url {
-                        path("api/route/stops")
-                        parameters.append("route_id", routeId)
-                        parameters.append("direction_id", directionId.toString())
+            val response: RouteStopsResponse =
+                mobileBackendClient
+                    .get {
+                        url {
+                            path("api/route/stops")
+                            parameters.append("route_id", routeId)
+                            parameters.append("direction_id", directionId.toString())
+                        }
                     }
-                }
-                .body()
+                    .body()
+            RouteStopsResult(routeId, directionId, response.stopIds)
         }
 }
 
 class MockRouteStopsRepository(
-    private val result: ApiResult<RouteStopsResponse>,
+    private val result: ApiResult<RouteStopsResult>,
     private val onGet: (String, Int) -> Unit = { _, _ -> },
 ) : IRouteStopsRepository {
     @DefaultArgumentInterop.Enabled
     constructor(
         stopIds: List<String>,
+        routeId: String = "",
+        directionId: Int = 0,
         onGet: (String, Int) -> Unit = { _, _ -> },
-    ) : this(ApiResult.Ok(RouteStopsResponse(stopIds)), onGet)
+    ) : this(ApiResult.Ok(RouteStopsResult(routeId, directionId, stopIds)), onGet)
 
     override suspend fun getRouteStops(
         routeId: String,
         directionId: Int,
-    ): ApiResult<RouteStopsResponse> {
+    ): ApiResult<RouteStopsResult> {
         onGet(routeId, directionId)
         return result
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -1,9 +1,10 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
+import com.mbta.tid.mbta_app.repositories.RouteStopsResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 
@@ -201,6 +202,7 @@ class RouteDetailsStopListTest {
 
         assertEquals(
             RouteDetailsStopList(
+                0,
                 listOf(
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -212,14 +214,32 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = true,
                     )
-                )
+                ),
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResponse(listOf(mainStop.id)),
+                RouteStopsResult(mainRoute.id, 0, listOf(mainStop.id)),
                 globalData,
             ),
+        )
+    }
+
+    @Test
+    fun `fromPieces returns null if direction doesn't match`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val mainStop = objects.stop {}
+        val mainRoute = objects.route()
+
+        val globalData = GlobalResponse(objects)
+
+        assertNull(
+            RouteDetailsStopList.fromPieces(
+                mainRoute.id,
+                0,
+                RouteStopsResult(mainRoute.id, 1, listOf(mainStop.id)),
+                globalData,
+            )
         )
     }
 
@@ -272,6 +292,7 @@ class RouteDetailsStopListTest {
 
         assertEquals(
             RouteDetailsStopList(
+                0,
                 listOf(
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -345,12 +366,14 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = false,
                     ),
-                )
+                ),
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResponse(
+                RouteStopsResult(
+                    mainRoute.id,
+                    0,
                     listOf(
                         stop0.id,
                         stop1.id,
@@ -359,7 +382,7 @@ class RouteDetailsStopListTest {
                         stop4.id,
                         stop5NonTypical.id,
                         stop6.id,
-                    )
+                    ),
                 ),
                 globalData,
             ),
@@ -397,6 +420,7 @@ class RouteDetailsStopListTest {
 
         assertEquals(
             RouteDetailsStopList(
+                0,
                 listOf(
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -418,12 +442,12 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = true,
                     )
-                )
+                ),
             ),
             RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResponse(listOf(stop0.id, stop1.id, stop2.id)),
+                RouteStopsResult(mainRoute.id, 0, listOf(stop0.id, stop1.id, stop2.id)),
                 globalData,
             ),
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -70,7 +69,9 @@ class RouteStopsRepositoryTest : KoinTest {
             assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
             assertEquals(
                 ApiResult.Ok(
-                    RouteStopsResponse(
+                    RouteStopsResult(
+                        "Orange",
+                        0,
                         listOf(
                             "place-ogmnl",
                             "place-mlmnl",
@@ -92,7 +93,7 @@ class RouteStopsRepositoryTest : KoinTest {
                             "place-sbmnl",
                             "place-grnst",
                             "place-forhl",
-                        )
+                        ),
                     )
                 ),
                 response,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites Route Details layout UI](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210485399858975?focus=true)

We really should stop assuming every UI ticket will be trivial. This only includes direction picker, route list, and loading state styling, it does _not_ include the GL route picker styling, header styling, or background route color fill, those will happen in a follow up PR.

I did some minor refactoring to better handle the stop list data in the UI, since the stop list response from the backend had no context on what route and direction it was loaded for, `RouteDetailsStopList.fromPieces` was happily consuming stale data and returning stop lists based on the data from the previously loaded opposite direction. This was especially noticeable on bus routes, where it would collapse every non-station stop on the route as "uncommon", since they weren't actually served by any pattern in that direction. Now the response keeps the context of the route and direction it was loaded for, so `RouteDetailsStopList.fromPieces` can check that it's using the correct stop list, and return null if not.

I also did some probably too cute randomization of the stop name and route pill lengths of the loading placeholder data. It makes it so that there's not jarring uniformity in the placeholder data, but also keeps that data consistent across loads by seeding the RNG with the route ID and direction ID combo.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

A lot of the UI changes aren't testable, but added a new unit test for the mismatched route/direction stop list loading, and existing tests pass.
