### PR TITLE
fix(shared.FavoritesViewModelTest): Address flakiness

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -32,6 +32,8 @@ import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import okio.FileSystem
 import okio.SYSTEM
 import org.koin.core.module.Module
@@ -42,6 +44,7 @@ fun appModule(appVariant: AppVariant) = module {
     includes(
         module { single { MobileBackendClient(appVariant) } },
         module { single { FileSystem.SYSTEM } },
+        module { single<CoroutineDispatcher> { Dispatchers.Default } },
         repositoriesModule(RealRepositories()),
     )
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -13,8 +13,8 @@ import kotlin.math.max
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.time.Instant
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.map.style.Color
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -643,6 +644,7 @@ data class RouteCardData(
          * [filterAtTime] and [filterAtTime] + [hideNonTypicalPatternsBeyondNext] are omitted.
          * Cancelled trips are also omitted when [context] = NearbyTransit.
          */
+        @DefaultArgumentInterop.Enabled
         suspend fun routeCardsForStopList(
             stopIds: List<String>,
             globalData: GlobalResponse?,
@@ -653,31 +655,7 @@ data class RouteCardData(
             now: Instant,
             pinnedRoutes: Set<String>,
             context: Context,
-        ): List<RouteCardData>? =
-            routeCardsForStopList(
-                stopIds,
-                globalData,
-                sortByDistanceFrom,
-                schedules,
-                predictions,
-                alerts,
-                now,
-                pinnedRoutes,
-                context,
-                Dispatchers.Default,
-            )
-
-        suspend fun routeCardsForStopList(
-            stopIds: List<String>,
-            globalData: GlobalResponse?,
-            sortByDistanceFrom: Position?,
-            schedules: ScheduleResponse?,
-            predictions: PredictionsStreamDataResponse?,
-            alerts: AlertsStreamDataResponse?,
-            now: Instant,
-            pinnedRoutes: Set<String>,
-            context: Context,
-            coroutineDispatcher: CoroutineDispatcher,
+            coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
         ): List<RouteCardData>? =
             withContext(coroutineDispatcher) {
 
@@ -720,20 +698,13 @@ data class RouteCardData(
          * 1. subway routes
          * 2. route pattern sort order
          */
+        @DefaultArgumentInterop.Enabled
         suspend fun routeCardsForStaticStopList(
             stopIds: List<String>,
             globalData: GlobalResponse?,
             context: Context,
             now: Instant = Clock.System.now(),
-        ): List<RouteCardData>? =
-            routeCardsForStaticStopList(stopIds, globalData, context, now, Dispatchers.Default)
-
-        suspend fun routeCardsForStaticStopList(
-            stopIds: List<String>,
-            globalData: GlobalResponse?,
-            context: Context,
-            now: Instant = Clock.System.now(),
-            coroutineDispatcher: CoroutineDispatcher,
+            coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
         ): List<RouteCardData>? =
             withContext(coroutineDispatcher) {
                 // if global data was still loading, there'd be no nearby data, and null handling is

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -11,6 +11,7 @@ import kotlin.jvm.JvmName
 import kotlin.math.max
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
@@ -653,7 +654,32 @@ data class RouteCardData(
             pinnedRoutes: Set<String>,
             context: Context,
         ): List<RouteCardData>? =
-            withContext(Dispatchers.Default) {
+            routeCardsForStopList(
+                stopIds,
+                globalData,
+                sortByDistanceFrom,
+                schedules,
+                predictions,
+                alerts,
+                now,
+                pinnedRoutes,
+                context,
+                Dispatchers.Default,
+            )
+
+        suspend fun routeCardsForStopList(
+            stopIds: List<String>,
+            globalData: GlobalResponse?,
+            sortByDistanceFrom: Position?,
+            schedules: ScheduleResponse?,
+            predictions: PredictionsStreamDataResponse?,
+            alerts: AlertsStreamDataResponse?,
+            now: Instant,
+            pinnedRoutes: Set<String>,
+            context: Context,
+            coroutineDispatcher: CoroutineDispatcher,
+        ): List<RouteCardData>? =
+            withContext(coroutineDispatcher) {
 
                 // if predictions or alerts are still loading, this is the loading state
                 if (predictions == null || alerts == null) return@withContext null
@@ -700,7 +726,16 @@ data class RouteCardData(
             context: Context,
             now: Instant = Clock.System.now(),
         ): List<RouteCardData>? =
-            withContext(Dispatchers.Default) {
+            routeCardsForStaticStopList(stopIds, globalData, context, now, Dispatchers.Default)
+
+        suspend fun routeCardsForStaticStopList(
+            stopIds: List<String>,
+            globalData: GlobalResponse?,
+            context: Context,
+            now: Instant = Clock.System.now(),
+            coroutineDispatcher: CoroutineDispatcher,
+        ): List<RouteCardData>? =
+            withContext(coroutineDispatcher) {
                 // if global data was still loading, there'd be no nearby data, and null handling is
                 // annoying
                 if (globalData == null) return@withContext null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.subscribeToPredictions
 import io.github.dellisd.spatialk.geojson.Position
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,8 +37,11 @@ interface IFavoritesViewModel {
     fun setNow(now: Instant)
 }
 
-class FavoritesViewModel(private val favoritesUsecases: FavoritesUsecases) :
-    MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
+class FavoritesViewModel(
+    private val favoritesUsecases: FavoritesUsecases,
+    private val coroutineDispatcher: CoroutineDispatcher,
+) : MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
+
     sealed interface Event {
         data object ReloadFavorites : Event
 
@@ -134,6 +138,7 @@ class FavoritesViewModel(private val favoritesUsecases: FavoritesUsecases) :
                         now,
                         emptySet(),
                         RouteCardData.Context.Favorites,
+                        coroutineDispatcher,
                     )
                 routeCardData = filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }
@@ -152,6 +157,7 @@ class FavoritesViewModel(private val favoritesUsecases: FavoritesUsecases) :
                         RouteCardData.Context.Favorites,
                         // not depending on now because it only matters for testing
                         now,
+                        coroutineDispatcher,
                     )
                 staticRouteCardData =
                     filterRouteAndDirection(loadedRouteCardData, globalData, favorites)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -16,9 +16,9 @@ import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.subscribeToPredictions
 import io.github.dellisd.spatialk.geojson.Position
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlin.time.Clock
 import kotlin.time.Instant
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -92,10 +92,14 @@ class FavoritesViewModel(
                 onAnyMessageReceived = { awaitingPredictionsAfterBackground = false },
             )
 
-        LaunchedEffect(Unit) { favorites = favoritesUsecases.getRouteStopDirectionFavorites() }
+        LaunchedEffect(Unit) {
+            println("LaunchedEffect 0: set favorites")
+            favorites = favoritesUsecases.getRouteStopDirectionFavorites()
+        }
 
         LaunchedEffect(Unit) {
             events.collect { event ->
+                println("LaunchedEffect 1: event received ${event}")
                 when (event) {
                     Event.ReloadFavorites ->
                         favorites = favoritesUsecases.getRouteStopDirectionFavorites()
@@ -122,9 +126,15 @@ class FavoritesViewModel(
             now,
             favorites,
         ) {
+            println(
+                "LaunchedEffect 2: ${stopIds} ${globalData.hashCode()} ${location} ${schedules.hashCode()} ${predictions.hashCode()} ${alerts.hashCode()} ${now} ${favorites.hashCode()}"
+            )
+
             if (stopIds == null || globalData == null || location == null) {
+                println("LaunchedEffect 2: set routeCardData null")
                 routeCardData = null
             } else if (stopIds.isEmpty()) {
+                println("LaunchedEffect 2: set routeCardData empty")
                 routeCardData = emptyList()
             } else {
                 val loadedRouteCardData =
@@ -140,14 +150,18 @@ class FavoritesViewModel(
                         RouteCardData.Context.Favorites,
                         coroutineDispatcher,
                     )
+                println("LaunchedEffect 2: set routeCardData actual")
                 routeCardData = filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }
         }
 
         LaunchedEffect(stopIds, globalData, favorites) {
+            println("LaunchedEffect 3: ${stopIds} ${globalData.hashCode()} ${favorites.hashCode()}")
             if (stopIds == null || globalData == null) {
+                println("LaunchedEffect 3: set staticRouteCardData null")
                 staticRouteCardData = null
             } else if (stopIds.isEmpty()) {
+                println("LaunchedEffect 3: set staticRouteCardData empty")
                 staticRouteCardData = emptyList()
             } else {
                 val loadedRouteCardData =
@@ -159,6 +173,7 @@ class FavoritesViewModel(
                         now,
                         coroutineDispatcher,
                     )
+                println("LaunchedEffect 3: set staticRouteCardData actual")
                 staticRouteCardData =
                     filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -92,14 +92,10 @@ class FavoritesViewModel(
                 onAnyMessageReceived = { awaitingPredictionsAfterBackground = false },
             )
 
-        LaunchedEffect(Unit) {
-            println("LaunchedEffect 0: set favorites")
-            favorites = favoritesUsecases.getRouteStopDirectionFavorites()
-        }
+        LaunchedEffect(Unit) { favorites = favoritesUsecases.getRouteStopDirectionFavorites() }
 
         LaunchedEffect(Unit) {
             events.collect { event ->
-                println("LaunchedEffect 1: event received ${event}")
                 when (event) {
                     Event.ReloadFavorites ->
                         favorites = favoritesUsecases.getRouteStopDirectionFavorites()
@@ -126,15 +122,9 @@ class FavoritesViewModel(
             now,
             favorites,
         ) {
-            println(
-                "LaunchedEffect 2: ${stopIds} ${globalData.hashCode()} ${location} ${schedules.hashCode()} ${predictions.hashCode()} ${alerts.hashCode()} ${now} ${favorites.hashCode()}"
-            )
-
             if (stopIds == null || globalData == null || location == null) {
-                println("LaunchedEffect 2: set routeCardData null")
                 routeCardData = null
             } else if (stopIds.isEmpty()) {
-                println("LaunchedEffect 2: set routeCardData empty")
                 routeCardData = emptyList()
             } else {
                 val loadedRouteCardData =
@@ -150,18 +140,14 @@ class FavoritesViewModel(
                         RouteCardData.Context.Favorites,
                         coroutineDispatcher,
                     )
-                println("LaunchedEffect 2: set routeCardData actual")
                 routeCardData = filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }
         }
 
         LaunchedEffect(stopIds, globalData, favorites) {
-            println("LaunchedEffect 3: ${stopIds} ${globalData.hashCode()} ${favorites.hashCode()}")
             if (stopIds == null || globalData == null) {
-                println("LaunchedEffect 3: set staticRouteCardData null")
                 staticRouteCardData = null
             } else if (stopIds.isEmpty()) {
-                println("LaunchedEffect 3: set staticRouteCardData empty")
                 staticRouteCardData = emptyList()
             } else {
                 val loadedRouteCardData =
@@ -173,7 +159,6 @@ class FavoritesViewModel(
                         now,
                         coroutineDispatcher,
                     )
-                println("LaunchedEffect 3: set staticRouteCardData actual")
                 staticRouteCardData =
                     filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -20,8 +20,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -403,7 +403,9 @@ class FavoritesViewModelTest : KoinTest {
             )
 
         testViewModelFlow(viewModel).test {
+            println("before advance")
             advanceUntilIdle()
+            println("after advance")
             assertEquals(
                 FavoritesViewModel.State(
                     awaitingPredictionsAfterBackground = false,
@@ -456,7 +458,9 @@ class FavoritesViewModelTest : KoinTest {
         viewModel.setLocation(Position(0.0, 0.0))
 
         testViewModelFlow(viewModel).test {
+            println("before advance")
             advanceUntilIdle()
+            println("after advance")
             val item = expectMostRecentItem()
             assertNotNull(item.routeCardData)
             assertFalse(item.awaitingPredictionsAfterBackground)
@@ -509,7 +513,9 @@ class FavoritesViewModelTest : KoinTest {
         viewModel.setLocation(stop1.position)
 
         testViewModelFlow(viewModel).test {
+            println("before advance")
             advanceUntilIdle()
+            println("after advance")
             assertEquals(
                 emptyList(),
                 expectMostRecentItem()
@@ -545,7 +551,9 @@ class FavoritesViewModelTest : KoinTest {
         viewModel.setLocation(stop1.position)
 
         testViewModelFlow(viewModel).test {
+            println("before advance")
             advanceUntilIdle()
+            println("after advance")
             assertEquals(
                 listOf(stop1, stop2),
                 expectMostRecentItem().routeCardData!!.flatMap { it.stopData }.map { it.stop },
@@ -575,7 +583,9 @@ class FavoritesViewModelTest : KoinTest {
         viewModel.setLocation(stop1.position)
 
         testViewModelFlow(viewModel).test {
+            println("before advance")
             advanceUntilIdle()
+            println("after advance")
             assertEquals(
                 listOf(now),
                 expectMostRecentItem().routeCardData!!.map { it.at }.distinct(),

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -11,6 +11,8 @@ import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.endToEnd.endToEndModule
 import com.mbta.tid.mbta_app.viewModel.viewModelModule
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -64,7 +66,12 @@ subsequently load in specific modules to override these base definitions.
 fun startKoinIOSTestApp() {
     startKoin {
         modules(
-            platformModule() + viewModelModule() + module { single<Analytics> { MockAnalytics() } }
+            platformModule() +
+                viewModelModule() +
+                module {
+                    single<Analytics> { MockAnalytics() }
+                    single<CoroutineDispatcher> { Dispatchers.Default }
+                }
         )
     }
     loadDefaultRepoModules()


### PR DESCRIPTION
### Summary

_Ticket:_ [favorites flaky molecule tests](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210621071746794?focus=true)

What is this PR for?

<details><summary>Pre-Review</summary>
This PR takes an approach for addressing flakiness in Molecule VM tests. There may be other approaches we want to consider instead, but this is is a first step towards solving the problem. 

This PR combines approach #2 and #4 as outlined [in slack here](https://mbta.slack.com/archives/C062QNAJZ2M/p1750874718166159)

> 2. Use [runCurrent() + expectMostRecent()](https://github.com/cashapp/turbine/issues/246#issuecomment-1674281572) instead of awaitItemSatisfying to get the last item that should match the desired state rather than the first (except I used advanceUntilIdle() instead of runCurrent())

> 4. Pass the dispatcher context from the test to routeCardsForStopList

@boringcactus had raised some concerns about how using `awaitItemSatisfying` could ignore inconsistent states that we wouldn't necessarily want to ignore. I think that remains true in this switch to `expectMostRecent`, but I like the explicitness that what is being tested is expected to be the last available item.

**Note:** this does go a bit against the philosophy of Turbine as outlined [in the readme](https://github.com/cashapp/turbine/?tab=readme-ov-file#asynchronicity-and-turbine)

> instead of using tools like runCurrent() to "push" an asynchronous flow along, Turbine's awaitItem(), awaitComplete(), and awaitError() "pull" them along by parking until a new event is ready.

Potentially we could continue to use `awaitItemSatisfying` here in combination with only the change to inject the test dispatcher. Still, I prefer the explicitness of `expectMostRecent`, but am open to other opinions on that! 
</details> 

Based on review, removing the use of `expectMostRecent` in favor of continuing to use `awaitItemSatisfying`, though in some cases with some more specific matchers. 

This keeps the change to use the test's coroutine context in `routeCardsForStopList` as recommended in the [Testing Coroutines doc ](https://developer.android.com/kotlin/coroutines/test#injecting-test-dispatchers).


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [X] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Updated unit tests. Ran a few times locally without flakiness, but the real test will be seeing how this plays out over time in CI.
While testing, I periodically changed the injected dispatcher to Dispatchers.Default and confirmed that the tests would fail, which confirmed for me that doing the dispatcher injection was a worthwhile change to make. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
