### PR TITLE
refactor(Android): Consolidate button colors

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
@@ -12,13 +12,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.util.contrast
 
 enum class ActionButtonKind(
     val iconSize: Dp,
@@ -34,11 +34,7 @@ enum class ActionButtonKind(
 fun ActionButton(
     kind: ActionButtonKind,
     size: Dp = 32.dp,
-    colors: ButtonColors =
-        ButtonDefaults.buttonColors(
-            containerColor = colorResource(R.color.contrast),
-            contentColor = colorResource(R.color.fill2),
-        ),
+    colors: ButtonColors = ButtonDefaults.contrast(),
     action: () -> Unit,
 ) {
     Button(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
@@ -8,23 +8,18 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
-import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 
 @Composable
 fun NavTextButton(
     string: String,
-    colors: ButtonColors =
-        ButtonDefaults.buttonColors(
-            containerColor = colorResource(R.color.text).copy(alpha = 0.6f),
-            contentColor = colorResource(R.color.fill2),
-        ),
-    onTap: () -> Unit,
+    colors: ButtonColors = ButtonDefaults.contrastTranslucent(),
+    action: () -> Unit,
 ) {
     Button(
-        onTap,
+        action,
         colors = colors,
         contentPadding = PaddingValues(horizontal = 12.dp),
         modifier = Modifier.heightIn(min = 32.dp),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -31,6 +30,7 @@ import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -101,11 +101,7 @@ fun FavoritesView(
                 if (!routeCardData.isNullOrEmpty()) {
                     ActionButton(
                         ActionButtonKind.Plus,
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = colorResource(R.color.text).copy(alpha = 0.6f),
-                                contentColor = colorResource(R.color.fill2),
-                            ),
+                        colors = ButtonDefaults.contrastTranslucent(),
                         action = ::onAddFavorites,
                     )
                     NavTextButton(stringResource(R.string.edit)) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -49,6 +49,7 @@ import com.mbta.tid.mbta_app.android.favorites.NoFavoritesView
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.key
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.LeafFormat
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -98,14 +99,7 @@ private fun Header(
         Alignment.CenterVertically,
     ) {
         Text(text = stringResource(R.string.edit_favorites), style = Typography.title2Bold)
-        NavTextButton(
-            stringResource(R.string.done),
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = colorResource(R.color.key),
-                    contentColor = colorResource(R.color.fill2),
-                ),
-        ) {
+        NavTextButton(stringResource(R.string.done), colors = ButtonDefaults.key()) {
             viewModel.updateFavorites(currentState?.toMap(), onFinish = onClose)
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -39,6 +39,7 @@ import com.mbta.tid.mbta_app.android.more.MoreButton
 import com.mbta.tid.mbta_app.android.more.MoreSectionView
 import com.mbta.tid.mbta_app.android.more.MoreViewModel
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.key
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
@@ -115,11 +116,7 @@ fun MorePage(bottomBar: @Composable () -> Unit) {
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Button(
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        contentColor = colorResource(R.color.key),
-                                        containerColor = colorResource(R.color.fill3),
-                                    ),
+                                colors = ButtonDefaults.key(),
                                 onClick = { navController.popBackStack() },
                             ) {
                                 Icon(
@@ -179,11 +176,7 @@ fun MorePage(bottomBar: @Composable () -> Unit) {
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Button(
-                                colors =
-                                    ButtonDefaults.buttonColors(
-                                        contentColor = colorResource(R.color.key),
-                                        containerColor = colorResource(R.color.fill3),
-                                    ),
+                                colors = ButtonDefaults.key(),
                                 onClick = { navController.popBackStack() },
                             ) {
                                 Icon(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -42,6 +41,7 @@ import com.mbta.tid.mbta_app.android.component.ScrollSeparatorColumn
 import com.mbta.tid.mbta_app.android.component.SearchInput
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
@@ -99,11 +99,7 @@ fun RoutePickerView(
                 if (path !is RoutePickerPath.Root)
                     ActionButton(
                         ActionButtonKind.Back,
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = colorResource(R.color.text).copy(alpha = 0.6f),
-                                contentColor = colorResource(R.color.fill2),
-                            ),
+                        colors = ButtonDefaults.contrastTranslucent(),
                         action = onBack,
                     )
                 Text(
@@ -125,7 +121,7 @@ fun RoutePickerView(
                     color = path.textColor,
                 )
             }
-            NavTextButton(stringResource(R.string.done), onTap = onClose)
+            NavTextButton(stringResource(R.string.done), action = onClose)
         }
         ErrorBanner(errorBannerViewModel, Modifier.padding(start = 14.dp, top = 6.dp, end = 14.dp))
         AnimatedVisibility(searchVMState is SearchRoutesViewModel.State.Error) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilterPills.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilterPills.kt
@@ -32,6 +32,7 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.contrast
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -127,11 +128,7 @@ fun StopDetailsFilterPills(
                 modifier = Modifier.align(Alignment.CenterEnd),
                 onClick = onClearFilter,
                 shape = RoundedCornerShape(8.dp),
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = colorResource(R.color.contrast),
-                        contentColor = colorResource(R.color.fill1),
-                    ),
+                colors = ButtonDefaults.contrast(),
                 border = BorderStroke(2.dp, colorResource(R.color.halo)),
             ) {
                 Text(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ButtonDefaultsExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/ButtonDefaultsExtension.kt
@@ -1,0 +1,27 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.colorResource
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun ButtonDefaults.contrastTranslucent() =
+    buttonColors(
+        containerColor = colorResource(R.color.text).copy(alpha = 0.6f),
+        contentColor = colorResource(R.color.fill2),
+    )
+
+@Composable
+fun ButtonDefaults.contrast() =
+    buttonColors(
+        containerColor = colorResource(R.color.contrast),
+        contentColor = colorResource(R.color.fill2),
+    )
+
+@Composable
+fun ButtonDefaults.key() =
+    buttonColors(
+        containerColor = colorResource(R.color.key),
+        contentColor = colorResource(R.color.fill3),
+    )


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, detour on [🤖 | Favorites Route Details layout UI](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210485399858975?focus=true)

We had a bunch of duplicated button color objects, this consolidates all the reused ones into extensions on `ButtonDefaults`.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Not testable