### PR TITLE
feat(Android): Route details header consistency

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -71,7 +71,8 @@ class RouteStopListViewTest {
         }
 
         val clicks = mutableListOf<RouteDetailsStopList.Entry>()
-        var closed = false
+        var backTapped = false
+        var closeTapped = false
 
         val koin =
             testKoinApplication(objects) {
@@ -90,8 +91,8 @@ class RouteStopListViewTest {
                     RouteDetailsContext.Details,
                     GlobalResponse(objects),
                     onClick = clicks::add,
-                    onBack = {},
-                    onClose = { closed = true },
+                    onBack = { backTapped = true },
+                    onClose = { closeTapped = true },
                     errorBannerViewModel = errorBannerVM,
                     rightSideContent = { context, _ ->
                         when (context) {
@@ -131,8 +132,11 @@ class RouteStopListViewTest {
             clicks,
         )
 
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+        assertTrue(backTapped)
+
         composeTestRule.onNodeWithContentDescription("Close").performClick()
-        assertTrue(closed)
+        assertTrue(closeTapped)
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ActionButton.kt
@@ -4,7 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
@@ -33,13 +33,14 @@ enum class ActionButtonKind(
 @Composable
 fun ActionButton(
     kind: ActionButtonKind,
+    modifier: Modifier = Modifier,
     size: Dp = 32.dp,
     colors: ButtonColors = ButtonDefaults.contrast(),
     action: () -> Unit,
 ) {
     Button(
         onClick = action,
-        modifier = Modifier.size(size).width(size),
+        modifier = modifier.sizeIn(minWidth = size, minHeight = size),
         shape = CircleShape,
         colors = colors,
         contentPadding = PaddingValues(5.dp),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/NavTextButton.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
@@ -15,6 +16,8 @@ import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 @Composable
 fun NavTextButton(
     string: String,
+    modifier: Modifier = Modifier,
+    height: Dp = 32.dp,
     colors: ButtonColors = ButtonDefaults.contrastTranslucent(),
     action: () -> Unit,
 ) {
@@ -22,8 +25,8 @@ fun NavTextButton(
         action,
         colors = colors,
         contentPadding = PaddingValues(horizontal = 12.dp),
-        modifier = Modifier.heightIn(min = 32.dp),
+        modifier = modifier.heightIn(min = height),
     ) {
-        Text(string, style = Typography.callout)
+        Text(string, style = Typography.callout, maxLines = 1)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -1,42 +1,121 @@
 package com.mbta.tid.mbta_app.android.component
 
+import android.content.Context
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
+import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.contrast
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import kotlin.math.abs
+
+fun Float.toDp(context: Context): Dp = (this / context.resources.displayMetrics.density).dp
 
 @Composable
-fun SheetHeader(title: String? = null, onClose: (() -> Unit)? = null) {
+fun SheetHeader(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    titleColor: Color = colorResource(R.color.text),
+    closeText: String? = null,
+    onBack: (() -> Unit)? = null,
+    onClose: (() -> Unit)? = null,
+    buttonColors: ButtonColors = ButtonDefaults.contrast(),
+) {
+    val context = LocalContext.current
+    val buttonSize = 32.dp
+    val touchTarget = 48.dp
+    var buttonPadding by remember { mutableStateOf(0.dp) }
+    var textPadding by remember { mutableStateOf(0.dp) }
+
+    /**
+     * This sets padding for either the buttons or the text, so that the back and close buttons are
+     * always aligned with the first line of text, even if the text breaks to multiple lines.
+     */
+    fun alignButtons(layout: TextLayoutResult) {
+        val lineHeight = (layout.getLineBottom(0) - layout.getLineTop(0)).toDp(context)
+        val padding = (lineHeight / 2) - (touchTarget / 2)
+        if (padding < 0.dp) {
+            buttonPadding = 0.dp
+            textPadding = abs(padding.value).dp
+        } else {
+            buttonPadding = padding + layout.getLineTop(0).toDp(context)
+            textPadding = 0.dp
+        }
+    }
+
     Row(
-        Modifier.padding(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier.padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.Top,
     ) {
+        if (onBack != null) {
+            ActionButton(
+                ActionButtonKind.Back,
+                modifier = Modifier.padding(top = buttonPadding),
+                size = buttonSize,
+                colors = buttonColors,
+                action = onBack,
+            )
+        }
         if (title != null) {
             Text(
                 title,
-                modifier = Modifier.semantics { heading() }.weight(1f).placeholderIfLoading(),
-                style = Typography.title3Semibold,
+                color = titleColor,
+                modifier =
+                    Modifier.semantics { heading() }
+                        .padding(top = textPadding)
+                        .padding(start = if (onBack == null) 8.dp else 0.dp)
+                        .weight(1f)
+                        .placeholderIfLoading(),
+                style = Typography.title2Bold,
+                onTextLayout = ::alignButtons,
             )
         } else {
             Spacer(Modifier.weight(1f))
         }
 
         if (onClose != null) {
-            ActionButton(ActionButtonKind.Close, action = onClose)
+            if (closeText != null)
+                NavTextButton(
+                    closeText,
+                    modifier = Modifier.padding(top = buttonPadding),
+                    colors = buttonColors,
+                    height = buttonSize,
+                    action = onClose,
+                )
+            else
+                ActionButton(
+                    ActionButtonKind.Close,
+                    modifier = Modifier.padding(top = buttonPadding),
+                    size = buttonSize,
+                    colors = buttonColors,
+                    action = onClose,
+                )
         }
     }
 }
@@ -45,12 +124,20 @@ fun SheetHeader(title: String? = null, onClose: (() -> Unit)? = null) {
 @Composable
 private fun SheetHeaderPreview() {
     MyApplicationTheme {
-        Column {
-            SheetHeader(onClose = {}, title = "This is a very long sheet title it should wrap")
+        Column(Modifier.background(colorResource(R.color.fill2))) {
+            SheetHeader(title = "This is a very long sheet title it should wrap", onClose = {})
             HorizontalDivider()
-            SheetHeader(onClose = {}, title = "short")
+            SheetHeader(title = "Short", onClose = {})
             HorizontalDivider()
-            SheetHeader(title = "no back button")
+            SheetHeader(title = "No back button")
+            HorizontalDivider()
+            SheetHeader(title = "Back and close", onBack = {}, onClose = {})
+            SheetHeader(
+                title = "Back and text close",
+                closeText = "Done",
+                onBack = {},
+                onClose = {},
+            )
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -94,7 +94,7 @@ fun FavoritesView(
         ) {
             Text(
                 text = stringResource(R.string.favorites_link),
-                modifier = Modifier.weight(1f),
+                modifier = Modifier.padding(start = 8.dp).weight(1f),
                 style = Typography.title2Bold,
             )
             Row(Modifier, Arrangement.spacedBy(16.dp), Alignment.CenterVertically) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -3,8 +3,6 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -12,18 +10,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
+import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
 import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.SettingsCache
-import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.manageFavorites
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.android.util.timer
@@ -89,11 +85,7 @@ fun NearbyTransitView(
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Text(
-            text = stringResource(R.string.nearby_transit),
-            modifier = Modifier.semantics { heading() }.padding(horizontal = 16.dp),
-            style = Typography.title3Semibold,
-        )
+        SheetHeader(title = stringResource(R.string.nearby_transit))
         ErrorBanner(errorBannerViewModel)
         LaunchedEffect(
             stopIds,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
@@ -39,6 +41,7 @@ import com.mbta.tid.mbta_app.android.state.getRouteStops
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.manageFavorites
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
@@ -145,7 +148,15 @@ fun RouteStopListView(
     }
 
     Column {
-        SheetHeader(onClose = onClose, title = lineOrRoute.name)
+        SheetHeader(
+            title = lineOrRoute.name,
+            closeText =
+                if (context is RouteDetailsContext.Favorites) stringResource(R.string.done)
+                else null,
+            onBack = onBack,
+            onClose = onClose,
+            buttonColors = ButtonDefaults.contrastTranslucent(),
+        )
         ErrorBanner(errorBannerViewModel)
 
         DirectionPicker(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -3,9 +3,7 @@ package com.mbta.tid.mbta_app.android.routePicker
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -30,15 +28,13 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.android.component.ActionButton
-import com.mbta.tid.mbta_app.android.component.ActionButtonKind
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.ErrorCard
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
-import com.mbta.tid.mbta_app.android.component.NavTextButton
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorColumn
 import com.mbta.tid.mbta_app.android.component.SearchInput
+import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
@@ -87,42 +83,31 @@ fun RoutePickerView(
         )
     val routes = remember(globalData, path) { globalData.getRoutesForPicker(path) }
 
-    Column(Modifier.fillMaxWidth(), Arrangement.Top, Alignment.CenterHorizontally) {
-        Row(
-            Modifier.heightIn(min = 48.dp)
-                .padding(start = 24.dp, top = 0.dp, end = 16.dp, bottom = 8.dp)
-                .fillMaxWidth(),
-            Arrangement.SpaceBetween,
-            Alignment.CenterVertically,
-        ) {
-            Row(Modifier, Arrangement.spacedBy(16.dp), Alignment.CenterVertically) {
-                if (path !is RoutePickerPath.Root)
-                    ActionButton(
-                        ActionButtonKind.Back,
-                        colors = ButtonDefaults.contrastTranslucent(),
-                        action = onBack,
-                    )
-                Text(
-                    when (path) {
-                        is RoutePickerPath.Root ->
-                            when (context) {
-                                is RouteDetailsContext.Favorites ->
-                                    stringResource(R.string.route_picker_header_favorites)
+    val headerTitle =
+        when (path) {
+            is RoutePickerPath.Root ->
+                when (context) {
+                    is RouteDetailsContext.Favorites ->
+                        stringResource(R.string.route_picker_header_favorites)
 
-                                is RouteDetailsContext.Details -> TODO("Implement details header")
-                            }
+                    is RouteDetailsContext.Details -> TODO("Implement details header")
+                }
 
-                        is RoutePickerPath.Bus -> stringResource(R.string.bus)
-                        is RoutePickerPath.Silver -> "Silver Line"
-                        is RoutePickerPath.CommuterRail -> "Commuter Rail"
-                        is RoutePickerPath.Ferry -> stringResource(R.string.ferry)
-                    },
-                    style = Typography.title2Bold,
-                    color = path.textColor,
-                )
-            }
-            NavTextButton(stringResource(R.string.done), action = onClose)
+            is RoutePickerPath.Bus -> stringResource(R.string.bus)
+            is RoutePickerPath.Silver -> "Silver Line"
+            is RoutePickerPath.CommuterRail -> "Commuter Rail"
+            is RoutePickerPath.Ferry -> stringResource(R.string.ferry)
         }
+
+    Column(Modifier.fillMaxWidth(), Arrangement.Top, Alignment.CenterHorizontally) {
+        SheetHeader(
+            title = headerTitle,
+            titleColor = path.textColor,
+            closeText = stringResource(R.string.done),
+            onBack = if (path !is RoutePickerPath.Root) onBack else null,
+            onClose = onClose,
+            buttonColors = ButtonDefaults.contrastTranslucent(),
+        )
         ErrorBanner(errorBannerViewModel, Modifier.padding(start = 14.dp, top = 6.dp, end = 14.dp))
         AnimatedVisibility(searchVMState is SearchRoutesViewModel.State.Error) {
             ErrorCard(
@@ -153,7 +138,7 @@ fun RoutePickerView(
                     searchInputFocused = it
                 },
                 searchFocusRequester,
-                modifier = Modifier.padding(bottom = 14.dp),
+                modifier = Modifier.padding(top = 8.dp, bottom = 14.dp),
             ) {
                 Text(stringResource(R.string.filter_routes), style = Typography.callout)
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -68,13 +68,19 @@ fun StopDetailsUnfilteredRoutesView(
     val elevatorAlerts =
         routeCardData.flatMap { it.stopData.flatMap { it.elevatorAlerts } }.distinct()
     val hasAccessibilityWarning = elevatorAlerts.isNotEmpty() || !stop.isWheelchairAccessible
+    val multiRoute = servedRoutes.size > 1
+
     Column(
         Modifier.background(colorResource(R.color.fill2)),
         verticalArrangement = Arrangement.spacedBy(0.dp),
     ) {
         Column(Modifier.heightIn(min = 48.dp)) {
-            SheetHeader(onClose = onClose, title = stop.name)
-            if (servedRoutes.size > 1) {
+            SheetHeader(
+                if (!multiRoute) Modifier.padding(bottom = 16.dp) else Modifier,
+                title = stop.name,
+                onClose = onClose,
+            )
+            if (multiRoute) {
                 Box(Modifier.height(56.dp).fillMaxWidth()) {
                     StopDetailsFilterPills(
                         servedRoutes = servedRoutes,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites Route Details layout UI](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210485399858975?focus=true)

Next step in the route details UI implementation, this only covers the header behavior and does not touch GL route picker designs or the background route color flood.

I ended up doing a bit of an overhaul of the headers on all pages that use a more standard header, to make them consistent with each other. Also added some layout handling which measures the rendered header text and aligns the back and close buttons to the first line of text at any text size and number of overflow lines.

![Screenshot_20250701_161840](https://github.com/user-attachments/assets/8315e53b-c9ee-45fa-86f7-a60ecdbd2644) ![Screenshot_20250701_173931](https://github.com/user-attachments/assets/bede5374-3ed2-41eb-a812-823789f7b050)


android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a new test for the route details back functionality, all other functionality is the same as before and should already be tested