### PR TITLE
refactor: create settings view model with Molecule

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.viewModel.SettingsViewModel
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -29,7 +30,9 @@ class MoreSectionViewTests {
                     ),
                 settingsCache =
                     SettingsCache(
-                        MockSettingsRepository(onSaveSettings = { toggleCallbackCalled = true })
+                        SettingsViewModel(
+                            MockSettingsRepository(onSaveSettings = { toggleCallbackCalled = true })
+                        )
                     ),
             )
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
@@ -15,6 +15,7 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.viewModel.SettingsViewModel
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
@@ -63,13 +64,14 @@ class OnboardingScreenViewTest {
                     savedSetting = true
                 },
             )
+        val settingsCache = SettingsCache(SettingsViewModel(settingsRepo))
         var advanced = false
         composeTestRule.setContent {
             OnboardingScreenView(
                 screen = OnboardingScreen.StationAccessibility,
                 advance = { advanced = true },
                 locationDataManager = MockLocationDataManager(),
-                settingsCache = SettingsCache(settingsRepo),
+                settingsCache = settingsCache,
             )
         }
 
@@ -106,13 +108,14 @@ class OnboardingScreenViewTest {
                     savedSetting = true
                 },
             )
+        val settingsCache = SettingsCache(SettingsViewModel(settingsRepo))
         var advanced = false
         composeTestRule.setContent {
             OnboardingScreenView(
                 screen = OnboardingScreen.HideMaps,
                 advance = { advanced = true },
                 locationDataManager = MockLocationDataManager(),
-                settingsCache = SettingsCache(settingsRepo),
+                settingsCache = settingsCache,
             )
         }
         composeTestRule

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -39,6 +39,7 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.viewModel.SettingsViewModel
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Clock
 import org.koin.compose.KoinContext
@@ -203,7 +204,7 @@ private fun ErrorBannerPreviews() {
     // but it won't actually use the debug value set here when displayed
     val settingsRepo = MockSettingsRepository(mapOf(Settings.DevDebugMode to false))
     val koinApplication = koinApplication {
-        modules(module { single<SettingsCache> { SettingsCache(settingsRepo) } })
+        modules(module { single<SettingsCache> { SettingsCache(SettingsViewModel(settingsRepo)) } })
     }
     KoinContext(koinApplication.koin) {
         MyApplicationTheme {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
@@ -1,16 +1,10 @@
 package com.mbta.tid.mbta_app.android.util
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import com.mbta.tid.mbta_app.viewModel.SettingsViewModel
 import org.koin.compose.koinInject
 import org.koin.core.component.KoinComponent
 
@@ -18,34 +12,25 @@ import org.koin.core.component.KoinComponent
  * Stores the state of the [Settings] so that they can be read instantly from anywhere with a hot
  * cache and loaded transparently with a cold cache. Intended to be used as a Koin singleton.
  */
-class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinComponent {
-    private val cache = MutableStateFlow<Map<Settings, Boolean>?>(null)
+class SettingsCache(private val viewModel: SettingsViewModel) : KoinComponent {
 
-    /** Changes the value of a [Settings] both in the cache and in the [settingsRepository]. */
+    /** Changes the value of a [Settings]. */
     fun set(setting: Settings, value: Boolean) {
-        val newSettings = mapOf(setting to value)
-        cache.update { it.orEmpty() + newSettings }
-        CoroutineScope(Dispatchers.IO).launch { settingsRepository.setSettings(newSettings) }
+        viewModel.set(setting, value)
     }
 
     /**
      * Retrieves the value of a [Settings], updating automatically when this cache is updated, and
      * loading in the background if the cache is empty.
      *
-     * Will not automatically see changes made directly to the [settingsRepository]; make sure all
+     * Will not automatically see changes made directly to the settings repository; make sure all
      * changes are made via [set].
      */
     @Composable
     fun get(setting: Settings): Boolean {
-        val cachedData by cache.collectAsState()
+        val state by viewModel.models.collectAsState()
 
-        LaunchedEffect(cachedData == null) {
-            if (cachedData == null) {
-                cache.value = settingsRepository.getSettings()
-            }
-        }
-
-        return cachedData?.get(setting) ?: false
+        return state[setting] ?: false
     }
 
     companion object {

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
     @State var favoritesVM = ViewModelDI().favorites
     @StateObject var nearbyVM = NearbyViewModel()
     @StateObject var mapVM = MapViewModel()
-    @StateObject var settingsVM = SettingsViewModel()
+    @StateObject var settingsVM = MoreViewModel()
     @StateObject var stopDetailsVM = StopDetailsViewModel()
 
     @EnvironmentObject var settingsCache: SettingsCache

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct MorePage: View {
     let inspection = Inspection<Self>()
 
-    var viewModel = SettingsViewModel()
+    var viewModel = MoreViewModel()
 
     var body: some View {
         NavigationStack {

--- a/iosApp/iosApp/ViewModels/MoreViewModel.swift
+++ b/iosApp/iosApp/ViewModels/MoreViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SettingsViewModel.swift
+//  MoreViewModel.swift
 //  iosApp
 //
 //  Created by Brandon Rodriguez on 7/11/24.
@@ -11,7 +11,7 @@ import Foundation
 import Shared
 import SwiftUI
 
-class SettingsViewModel: ObservableObject {
+class MoreViewModel: ObservableObject {
     @Published var sections = [MoreSection]()
 
     // swiftlint:disable:next function_body_length

--- a/iosApp/iosAppTests/Pages/Onboarding/OnboardingScreenViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Onboarding/OnboardingScreenViewTests.swift
@@ -48,7 +48,9 @@ final class OnboardingScreenViewTests: XCTestCase {
             advance: { advanceExp.fulfill() }
         )
 
-        ViewHosting.host(view: sut.environmentObject(SettingsCache(settingsRepo: settingsRepo)))
+        ViewHosting
+            .host(view: sut
+                .environmentObject(SettingsCache(settingsViewModel: .init(settingsRepository: settingsRepo))))
 
         XCTAssertNotNil(try sut.inspect().find(where: { view in
             try view.text().string()
@@ -75,7 +77,9 @@ final class OnboardingScreenViewTests: XCTestCase {
             advance: { advanceExp.fulfill() }
         )
 
-        ViewHosting.host(view: sut.environmentObject(SettingsCache(settingsRepo: settingsRepo)))
+        ViewHosting
+            .host(view: sut
+                .environmentObject(SettingsCache(settingsViewModel: .init(settingsRepository: settingsRepo))))
 
         XCTAssertNotNil(try sut.inspect().find(
             text: "When using VoiceOver, we can hide maps to make the app easier to navigate."

--- a/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
+++ b/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class MorePageTests: XCTestCase {
     @MainActor func testLoadsState() async throws {
-        let viewModel = SettingsViewModel()
+        let viewModel = MoreViewModel()
 
         let sut = MorePage(viewModel: viewModel)
         let exp = sut.inspection.inspect(after: 1) { view in
@@ -39,20 +39,22 @@ final class MorePageTests: XCTestCase {
                 savedExp.fulfill()
             }
         )
-        let viewModel = SettingsViewModel()
+        let viewModel = MoreViewModel()
 
         let sut = MorePage(viewModel: viewModel)
         let tapExp = sut.inspection.inspect(after: 1) { view in
             try view.find(text: "Debug Mode").parent().parent().find(ViewType.Toggle.self).tap()
         }
 
-        ViewHosting.host(view: sut.environmentObject(SettingsCache(settingsRepo: settingsRepository)))
+        ViewHosting
+            .host(view: sut
+                .environmentObject(SettingsCache(settingsViewModel: .init(settingsRepository: settingsRepository))))
 
         await fulfillment(of: [tapExp, savedExp], timeout: 5)
     }
 
     @MainActor func testLinksExist() async throws {
-        let viewModel = SettingsViewModel()
+        let viewModel = MoreViewModel()
 
         let sut = MorePage(viewModel: viewModel)
         let exp = sut.inspection.inspect(after: 2) { view in

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 
@@ -9,4 +10,6 @@ actual fun viewModelModule() = module {
     viewModelOf(::FavoritesViewModel)
     viewModelOf(::SearchRoutesViewModel)
     viewModelOf(::SearchViewModel)
+    // declared as a singleton to avoid having different instances in different navigation contexts
+    singleOf(::SettingsViewModel)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SettingsViewModel.kt
@@ -1,0 +1,49 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(private val settingsRepository: ISettingsRepository) :
+    MoleculeViewModel<SettingsViewModel.Event, Map<Settings, Boolean>>() {
+    @Composable
+    override fun runLogic(events: Flow<Event>): Map<Settings, Boolean> {
+        var cache by remember { mutableStateOf<Map<Settings, Boolean>>(emptyMap()) }
+
+        LaunchedEffect(Unit) {
+            cache = settingsRepository.getSettings()
+
+            events.collect { event ->
+                when (event) {
+                    is Event.Set -> {
+                        val newSettings = mapOf(event.setting to event.value)
+                        cache = cache + newSettings
+                        CoroutineScope(Dispatchers.IO).launch {
+                            settingsRepository.setSettings(newSettings)
+                        }
+                    }
+                }
+            }
+        }
+
+        return cache
+    }
+
+    sealed class Event {
+        data class Set(val setting: Settings, val value: Boolean) : Event()
+    }
+
+    val models = internalModels
+
+    fun set(setting: Settings, value: Boolean) = fireEvent(Event.Set(setting, value))
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -8,4 +8,5 @@ class ViewModelDI : KoinComponent {
     val favorites: FavoritesViewModel by inject()
     val search: SearchViewModel by inject()
     val searchRoutes: SearchRoutesViewModel by inject()
+    val settings: SettingsViewModel by inject()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -7,4 +7,5 @@ actual fun viewModelModule() = module {
     singleOf(::FavoritesViewModel)
     singleOf(::SearchRoutesViewModel)
     singleOf(::SearchViewModel)
+    singleOf(::SettingsViewModel)
 }

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -7,4 +7,5 @@ actual fun viewModelModule() = module {
     singleOf(::FavoritesViewModel)
     singleOf(::SearchRoutesViewModel)
     singleOf(::SearchViewModel)
+    singleOf(::SettingsViewModel)
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none

This is the code I threw out when I was working on my initial Molecule experimentation.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
