### PR TITLE
feat(Android): Route details polish and GL picker

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -56,6 +56,7 @@ import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.UpcomingFormat
+import kotlinx.serialization.Serializable
 
 class StopPlacement(
     val isFirst: Boolean = false,
@@ -63,11 +64,19 @@ class StopPlacement(
     val includeLineDiagram: Boolean = true,
 )
 
+@Serializable
+sealed class StopListContext {
+    data object Trip : StopListContext()
+
+    data object RouteDetails : StopListContext()
+}
+
 @Composable
 fun StopListRow(
     stop: Stop,
     onClick: () -> Unit,
     routeAccents: TripRouteAccents,
+    stopListContext: StopListContext,
     modifier: Modifier = Modifier,
     activeElevatorAlerts: Int = 0,
     alertSummaries: Map<String, AlertSummary?> = emptyMap(),
@@ -103,7 +112,9 @@ fun StopListRow(
 
     Column {
         Box(
-            Modifier.padding(horizontal = 6.dp)
+            Modifier.padding(
+                    horizontal = if (stopListContext is StopListContext.Trip) 6.dp else 0.dp
+                )
                 .then(modifier)
                 .height(IntrinsicSize.Min)
                 .defaultMinSize(minHeight = 48.dp)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -75,77 +75,72 @@ fun CollapsableStopList(
         )
     } else {
         Column {
-            Column(Modifier.padding(horizontal = 6.dp)) {
-                Row(
-                    Modifier.height(IntrinsicSize.Min)
-                        .clickable(
-                            onClickLabel =
-                                stringResource(
-                                    if (stopsExpanded) R.string.collapse_stops
-                                    else R.string.expand_stops
-                                ),
-                            role = Role.Button,
-                        ) {
-                            stopsExpanded = !stopsExpanded
-                        }
-                        .padding(horizontal = 10.dp)
-                        .defaultMinSize(minHeight = 48.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    AnimatedContent(
-                        stopsExpanded,
-                        transitionSpec = {
-                            fadeIn(animationSpec = tween(500)) togetherWith
-                                fadeOut(animationSpec = tween(500))
-                        },
-                    ) { stopsExpanded ->
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Center,
-                            modifier = Modifier.padding(start = 22.dp).width(20.dp),
-                        ) {
-                            if (stopsExpanded) {
-                                Icon(
-                                    painterResource(R.drawable.fa_caret_right),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(12.dp).rotate(90f),
-                                    tint = colorResource(R.color.deemphasized),
-                                )
-                            } else {
-                                Icon(
-                                    painterResource(R.drawable.fa_caret_right),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(12.dp),
-                                    tint = colorResource(R.color.deemphasized),
-                                )
-                            }
-                        }
-                    }
-                    Column(
-                        modifier =
-                            Modifier.weight(1f)
-                                .padding(vertical = 12.dp)
-                                .padding(horizontal = 16.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Text(
-                            AnnotatedString.fromHtml(
-                                stringResource(R.string.less_common_stops, segment.stops.size)
+            Row(
+                Modifier.height(IntrinsicSize.Min)
+                    .clickable(
+                        onClickLabel =
+                            stringResource(
+                                if (stopsExpanded) R.string.collapse_stops
+                                else R.string.expand_stops
                             ),
-                            color = colorResource(R.color.text),
-                            style = Typography.body,
-                        )
-                        Text(
-                            stringResource(R.string.only_served_at_certain_times),
-                            color = colorResource(R.color.deemphasized),
-                            style = Typography.footnote,
-                        )
+                        role = Role.Button,
+                    ) {
+                        stopsExpanded = !stopsExpanded
+                    }
+                    .padding(horizontal = 16.dp)
+                    .defaultMinSize(minHeight = 48.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                AnimatedContent(
+                    stopsExpanded,
+                    transitionSpec = {
+                        fadeIn(animationSpec = tween(500)) togetherWith
+                            fadeOut(animationSpec = tween(500))
+                    },
+                ) { stopsExpanded ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                        modifier = Modifier.padding(start = 22.dp).width(20.dp),
+                    ) {
+                        if (stopsExpanded) {
+                            Icon(
+                                painterResource(R.drawable.fa_caret_right),
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp).rotate(90f),
+                                tint = colorResource(R.color.deemphasized),
+                            )
+                        } else {
+                            Icon(
+                                painterResource(R.drawable.fa_caret_right),
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                                tint = colorResource(R.color.deemphasized),
+                            )
+                        }
                     }
                 }
-
-                if (!isLastSegment) {
-                    HaloSeparator()
+                Column(
+                    modifier = Modifier.weight(1f).padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Text(
+                        AnnotatedString.fromHtml(
+                            stringResource(R.string.less_common_stops, segment.stops.size)
+                        ),
+                        color = colorResource(R.color.text),
+                        style = Typography.body,
+                    )
+                    Text(
+                        stringResource(R.string.only_served_at_certain_times),
+                        color = colorResource(R.color.deemphasized),
+                        style = Typography.footnote,
+                    )
                 }
+            }
+
+            if (!isLastSegment) {
+                HaloSeparator()
             }
 
             if (stopsExpanded) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
+import com.mbta.tid.mbta_app.android.component.StopListContext
 import com.mbta.tid.mbta_app.android.component.StopListRow
 import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
@@ -62,6 +63,7 @@ fun CollapsableStopList(
             stop.stop,
             onClick = { onClick(stop) },
             routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+            stopListContext = StopListContext.RouteDetails,
             modifier =
                 Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
             connectingRoutes = stop.connectingRoutes,
@@ -152,6 +154,7 @@ fun CollapsableStopList(
                         stop.stop,
                         onClick = { onClick(stop) },
                         routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+                        stopListContext = StopListContext.RouteDetails,
                         modifier =
                             Modifier.minimumInteractiveComponentSize()
                                 .background(colorResource(R.color.fill1)),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -35,6 +35,7 @@ import com.mbta.tid.mbta_app.android.component.SaveFavoritesContext
 import com.mbta.tid.mbta_app.android.component.SaveFavoritesFlow
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorColumn
 import com.mbta.tid.mbta_app.android.component.SheetHeader
+import com.mbta.tid.mbta_app.android.component.StopListContext
 import com.mbta.tid.mbta_app.android.component.StopListRow
 import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.state.getRouteStops
@@ -242,6 +243,7 @@ private fun RouteStops(
                         stop.stop,
                         onClick = { onTapStop(stop) },
                         routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
+                        stopListContext = StopListContext.RouteDetails,
                         modifier = Modifier.minimumInteractiveComponentSize().fillMaxWidth(),
                         connectingRoutes = stop.connectingRoutes,
                         stopPlacement = stopPlacement,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -1,12 +1,12 @@
 package com.mbta.tid.mbta_app.android.routeDetails
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
@@ -23,6 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -42,12 +43,16 @@ import com.mbta.tid.mbta_app.android.state.getRouteStops
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
+import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.manageFavorites
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
+import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -166,27 +171,12 @@ fun RouteStopListView(
             lineOrRoute.sortRoute,
             selectedDirection,
             updateDirectionId = { selectedDirection = it },
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
         )
 
         if (lineOrRoute is RouteCardData.LineOrRoute.Line && routes.size > 1) {
-            Column {
-                for (route in routes) {
-                    val selected = route.id == selectedRouteId
-                    Row(
-                        Modifier.fillMaxWidth()
-                            .background(
-                                if (selected) colorResource(R.color.fill3) else Color.Transparent
-                            )
-                            .clickable { selectedRouteId = route.id }
-                            .padding(8.dp),
-                        Arrangement.spacedBy(8.dp),
-                        Alignment.CenterVertically,
-                    ) {
-                        RoutePill(route, lineOrRoute.line, RoutePillType.Fixed)
-                        Text(route.directionDestinations[selectedDirection] ?: "")
-                    }
-                }
+            LineRoutePicker(lineOrRoute.line, routes, selectedRouteId, selectedDirection) {
+                selectedRouteId = it
             }
         }
 
@@ -262,6 +252,50 @@ private fun RouteStops(
                 ) { stop, modifier ->
                     rightSideContent(stopRowContext(stop.stop), modifier)
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LineRoutePicker(
+    line: Line,
+    routes: List<Route>,
+    selectedRouteId: String,
+    selectedDirection: Int,
+    onSelect: (String) -> Unit,
+) {
+    val backgroundColor =
+        colorResource(R.color.deselected_toggle_2)
+            .copy(alpha = 0.6f)
+            .compositeOver(Color.fromHex(line.color))
+
+    Column(
+        Modifier.padding(horizontal = 14.dp)
+            .padding(top = 6.dp, bottom = 4.dp)
+            .haloContainer(1.dp, backgroundColor, backgroundColor)
+    ) {
+        for (route in routes) {
+            val selected = route.id == selectedRouteId
+            val haloColor = if (selected) colorResource(R.color.halo) else Color.Transparent
+            val rowColor = if (selected) colorResource(R.color.fill3) else Color.Transparent
+            val textColor =
+                if (selected) colorResource(R.color.text) else Color.fromHex(line.textColor)
+            Row(
+                Modifier.fillMaxWidth()
+                    .heightIn(min = 44.dp)
+                    .haloContainer(1.dp, haloColor, rowColor, 7.dp)
+                    .clickable { onSelect(route.id) }
+                    .padding(8.dp),
+                Arrangement.spacedBy(8.dp),
+                Alignment.CenterVertically,
+            ) {
+                RoutePill(route, line, RoutePillType.Fixed)
+                Text(
+                    route.directionDestinations[selectedDirection] ?: "",
+                    color = textColor,
+                    style = Typography.title3Semibold,
+                )
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
@@ -1,19 +1,20 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.annotation.ColorRes
-import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
@@ -23,6 +24,7 @@ import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionLabel
 import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
@@ -40,24 +42,23 @@ fun DirectionPicker(
 ) {
     if (availableDirections.size > 1) {
         val deselectedBackgroundColor =
-            colorResource(deselectedBackgroundColor(route)).copy(alpha = 0.6f)
+            colorResource(deselectedBackgroundColor(route))
+                .copy(alpha = 0.6f)
+                .compositeOver(Color.fromHex(route.color))
+
         TabRow(
             modifier =
                 modifier
-                    .padding(horizontal = 2.dp)
-                    .background(
-                        deselectedBackgroundColor.copy(alpha = 0.6f),
-                        RoundedCornerShape(8.dp),
-                    )
-                    .padding(2.dp)
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(6.dp)),
+                    .haloContainer(2.dp, deselectedBackgroundColor, Color.Transparent, 6.dp)
+                    .fillMaxWidth(),
+            containerColor = deselectedBackgroundColor,
             selectedTabIndex = selectedDirectionId ?: 0,
             indicator = {},
             divider = {},
         ) {
             for (direction in availableDirections) {
                 val isSelected = selectedDirectionId == direction
+                val selectedDirection = directions[(direction)]
                 val action = { updateDirectionId(direction) }
 
                 Tab(
@@ -65,18 +66,22 @@ fun DirectionPicker(
                     onClick = action,
                     modifier =
                         Modifier.fillMaxHeight()
-                            .background(Color.fromHex(route.color))
-                            .background(deselectedBackgroundColor)
-                            .background(
+                            .haloContainer(
+                                0.dp,
+                                Color.Transparent,
                                 if (isSelected) Color.fromHex(route.color) else Color.Transparent,
-                                shape = if (isSelected) RoundedCornerShape(6.dp) else RectangleShape,
-                            )
-                            .clip(RoundedCornerShape(6.dp)),
+                                6.dp,
+                            ),
                     selectedContentColor = Color.fromHex(route.textColor),
                     unselectedContentColor = colorResource(R.color.deselected_toggle_text),
                 ) {
-                    Column(modifier = Modifier.padding(8.dp)) {
-                        DirectionLabel(direction = directions[(direction)])
+                    Row(
+                        Modifier.fillMaxWidth().heightIn(min = 44.dp).padding(8.dp),
+                        if (selectedDirection.destination == null) Arrangement.Center
+                        else Arrangement.Start,
+                        Alignment.CenterVertically,
+                    ) {
+                        DirectionLabel(direction = selectedDirection)
                     }
                 }
             }
@@ -85,7 +90,7 @@ fun DirectionPicker(
         availableDirections.firstOrNull()?.let {
             DirectionLabel(
                 direction = directions[it],
-                modifier.padding(horizontal = 8.dp).fillMaxWidth().semantics(
+                modifier.padding(horizontal = 12.dp).fillMaxWidth().semantics(
                     mergeDescendants = true
                 ) {
                     heading()
@@ -100,22 +105,60 @@ fun DirectionPicker(
 @Composable
 private fun DirectionPickerPreview() {
     val objects = ObjectCollectionBuilder()
-    val route =
+    val red =
+        objects.route {
+            color = "DA291C"
+            textColor = "FFFFFF"
+        }
+    val bus =
         objects.route {
             color = "FFC72C"
             textColor = "000000"
         }
+    val green =
+        objects.route {
+            color = "00843D"
+            textColor = "FFFFFF"
+        }
     MyApplicationTheme {
-        DirectionPicker(
-            availableDirections = listOf(0, 1),
-            directions =
-                listOf(
-                    Direction(name = "Outbound", destination = "Out", id = 0),
-                    Direction(name = "Inbound", destination = "In", id = 1),
-                ),
-            route = route,
-            selectedDirectionId = 0,
-            updateDirectionId = {},
-        )
+        Column {
+            DirectionPicker(
+                availableDirections = listOf(0, 1),
+                directions =
+                    listOf(
+                        Direction(name = "South", destination = "Ashmont/Braintree", id = 0),
+                        Direction(name = "North", destination = "Alewife", id = 1),
+                    ),
+                route = red,
+                selectedDirectionId = 0,
+                updateDirectionId = {},
+            )
+            DirectionPicker(
+                availableDirections = listOf(0, 1),
+                directions =
+                    listOf(
+                        Direction(
+                            name = "Outbound",
+                            destination = "Fields Corner or St Peter’s Square",
+                            id = 0,
+                        ),
+                        Direction(name = "Inbound", destination = "Ruggles Station", id = 1),
+                    ),
+                route = bus,
+                selectedDirectionId = 1,
+                updateDirectionId = {},
+            )
+            DirectionPicker(
+                availableDirections = listOf(0, 1),
+                directions =
+                    listOf(
+                        Direction(name = "West", destination = null, id = 0),
+                        Direction(name = "East", destination = null, id = 1),
+                    ),
+                route = green,
+                selectedDirectionId = 0,
+                updateDirectionId = {},
+            )
+        }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DirectionPicker.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
-import androidx.annotation.ColorRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,8 +28,6 @@ import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 
-@ColorRes private fun deselectedBackgroundColor(route: Route): Int = R.color.deselected_toggle_2
-
 @Composable
 fun DirectionPicker(
     availableDirections: List<Int>,
@@ -42,7 +39,7 @@ fun DirectionPicker(
 ) {
     if (availableDirections.size > 1) {
         val deselectedBackgroundColor =
-            colorResource(deselectedBackgroundColor(route))
+            colorResource(R.color.deselected_toggle_2)
                 .copy(alpha = 0.6f)
                 .compositeOver(Color.fromHex(route.color))
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.StopListContext
 import com.mbta.tid.mbta_app.android.component.StopListRow
 import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.component.UpcomingTripView
@@ -59,6 +60,7 @@ fun TripStopRow(
         stop = stop.stop,
         onClick = { onTapLink(stop) },
         routeAccents = routeAccents,
+        stopListContext = StopListContext.Trip,
         modifier = modifier,
         activeElevatorAlerts = activeElevatorAlerts.size,
         alertSummaries = alertSummaries,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -42,6 +42,7 @@ import com.mbta.tid.mbta_app.android.MyApplicationTheme
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.Alert
@@ -350,18 +351,20 @@ private fun TripStopsPreview() {
             },
         )
     MyApplicationTheme {
-        TripStops(
-            targetId = stops[4].id,
-            stopList,
-            4,
-            TripHeaderSpec.NoVehicle,
-            Clock.System.now(),
-            emptyMap(),
-            GlobalResponse(objects),
-            onTapLink = {},
-            onOpenAlertDetails = {},
-            TripRouteAccents(route),
-            showStationAccessibility = true,
-        )
+        Column(Modifier.background(Color.fromHex(route.color))) {
+            TripStops(
+                targetId = stops[4].id,
+                stopList,
+                4,
+                TripHeaderSpec.NoVehicle,
+                Clock.System.now(),
+                emptyMap(),
+                GlobalResponse(objects),
+                onTapLink = {},
+                onOpenAlertDetails = {},
+                TripRouteAccents(route),
+                showStationAccessibility = true,
+            )
+        }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites Route Details layout UI](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210485399858975?focus=true)

Follow up to https://github.com/mbta/mobile_app/pull/1098 and https://github.com/mbta/mobile_app/pull/1110

This includes a few discrete changes:
* Update direction toggle to match spec, this involved left aligning destinations unless there is no destination label, in which case center on both axes
* The route details stop rows had excess padding on the sides, which included padding around the halo separators between rows, which was awkward to fix because the trip stop list really heavily relies on that padding
* Implement the GL route picker UI

I didn't do the background flood route color, but confirmed that it's blocked on [🤖 | Refactor sheet handle](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1210561875928843?focus=true), I'll put an AC on there for updating the bg color here.

| Before | After |
| --- | --- |
| ![Screenshot_20250702_161827](https://github.com/user-attachments/assets/e772301e-fea1-469a-94db-9a587fe14163) | ![Screenshot_20250702_164147](https://github.com/user-attachments/assets/8a324780-657d-40ce-88de-205c98126919) |
| ![Screenshot_20250702_161853](https://github.com/user-attachments/assets/554724b1-1702-405a-802d-8fbcd91f8c35) | ![Screenshot_20250702_160807](https://github.com/user-attachments/assets/b0b789af-b449-463d-bfb3-7e46312ee4a0) |

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Changes preserve existing functionality, current tests pass
