### PR TITLE
chore: use Android NDK 27 builds of Mapbox

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,8 +91,8 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-websockets = { module = "io.ktor:ktor-client-websockets", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-mapbox-android = { module = "com.mapbox.maps:android", version.ref = "mapbox" }
-mapbox-compose = { module = "com.mapbox.extension:maps-compose", version.ref = "mapbox" }
+mapbox-android = { module = "com.mapbox.maps:android-ndk27", version.ref = "mapbox" }
+mapbox-compose = { module = "com.mapbox.extension:maps-compose-ndk27", version.ref = "mapbox" }
 mapbox-turf = { module = "com.mapbox.mapboxsdk:mapbox-sdk-turf", version.ref = "mapboxTurf" }
 molecule-runtime = { module = "app.cash.molecule:molecule-runtime", version.ref = "molecule" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
### Summary

_Ticket:_ none

I just got an Android Studio warning about [16 KB page size support](https://developer.android.com/guide/practices/page-sizes), which Google Play will start requiring in November and which Mapbox doesn’t provide by default. [Evidently](https://github.com/mapbox/mapbox-maps-android/issues/2448), Mapbox had been using the Android NDK 23, which doesn’t support 16 KB page sizes and would’ve been a breaking change to just upgrade from, so they’re publishing `-ndk27` versions of most of their packages, and if we move to those now then we should be ready for the requirement coming in November.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that the Android Studio APK analyzer says the Mapbox shared libraries are aligned to 16 KB and that the map still works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
