### PR TITLE
fix(ios.StopDetailsFilteredDepartureDetails):  Recalculate leaf format when now changes

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -189,6 +189,9 @@ struct StopDetailsFilteredDepartureDetails: View {
         .onChange(of: leaf) { leaf in
             leafFormat = leaf.format(now: now.toKotlinInstant(), globalData: stopDetailsVM.global)
         }
+        .onChange(of: now) { now in
+            leafFormat = leaf.format(now: now.toKotlinInstant(), globalData: stopDetailsVM.global)
+        }
         .onChange(of: AlertSummaryParams(
             global: stopDetailsVM.global,
             alerts: alerts,

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -125,6 +125,47 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "7 min"))
     }
 
+    @MainActor
+    func testUpdatesTilesWhenNowChanges() throws {
+        let objects = ObjectCollectionBuilder()
+        let now = Date.now
+        let stop = objects.stop { _ in }
+        let route = objects.route()
+        let trip1 = objects.upcomingTrip(prediction: objects.prediction { prediction in
+            prediction.trip = objects.trip { $0.headsign = "A" }
+            prediction.departureTime = (now + 15).toKotlinInstant()
+        })
+
+        let leaf = makeLeaf(route: route, stop: stop, upcomingTrips: [trip1], objects: objects)
+
+        let sut = StopDetailsFilteredDepartureDetails(
+            stopId: stop.id,
+            stopFilter: .init(routeId: route.id, directionId: 0),
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            leaf: leaf,
+            selectedDirection: .init(name: nil, destination: nil, id: 0),
+            favorite: false,
+            now: now,
+            errorBannerVM: .init(),
+            nearbyVM: .init(),
+            mapVM: .init(),
+            stopDetailsVM: .init(),
+            viewportProvider: .init()
+        )
+
+        let updateNowExp = sut.inspection.inspect(after: 0.5) { view in
+            XCTAssertNotNil(try view.find(text: "A"))
+            XCTAssertNotNil(try view.find(text: "ARR"))
+            try view.find(ViewType.VStack.self).callOnChange(newValue: now + 120)
+            XCTAssertThrowsError(try view.find(text: "ARR"))
+        }
+
+        ViewHosting.host(view: sut.environmentObject(ViewportProvider()).withFixedSettings([:]))
+        wait(for: [updateNowExp], timeout: 2)
+    }
+
     func testShowsHeadsignAndPillsWhenBranchingLine() throws {
         let objects = ObjectCollectionBuilder()
         let now = Date.now


### PR DESCRIPTION
### Summary

_Ticket:_ [Bug: Stop Details | Next trip selected before current trip disappears](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210616350159111?focus=true)

What is this PR for?
This PR resolves the bug with selecting the next trip before the current trip disappears by updating the leaf format when now changes. This is consistent [with the implementation in android](https://github.com/mbta/mobile_app/blob/a28cb0921ade1eb87b024125900b5edb4df8f3a3/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt#L71).

The reason the trip filter is correctly accounting for now is that autoTripFilter calculates the leaf format too, [using the latest value of now](https://github.com/mbta/mobile_app/blob/a28cb0921ade1eb87b024125900b5edb4df8f3a3/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt#L35).

Perhaps a bigger fix here would be to store the leaf format as part of the RouteCardData since we already recalculate RouteCardData on every change of now. That might be overkill though. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added a unit test
* Ran simultaneously with this change applied & in prod. Confirmed that with this change, the Now tile disappeared before the next tile was selected. 
Before: 
https://github.com/user-attachments/assets/d0442b95-62fb-4619-aa1b-4c7ddef159e3
After:
https://github.com/user-attachments/assets/fbabf628-fbcb-465b-870e-89e4fb453e31



<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
