### PR TITLE
fix: align search loading/error/empty between iOS and Android

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoundedCornerColumn.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoundedCornerColumn.kt
@@ -1,0 +1,36 @@
+package com.mbta.tid.mbta_app.android.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+
+@Composable
+fun <T> RoundedCornerColumn(
+    data: List<T>,
+    modifier: Modifier = Modifier,
+    element: @Composable (shape: RoundedCornerShape, item: T) -> Unit,
+) {
+    Column(modifier) {
+        data.forEachIndexed { index, item ->
+            val shape =
+                if (data.size == 1) {
+                    RoundedCornerShape(10.dp)
+                } else if (index == 0) {
+                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
+                } else if (index == data.lastIndex) {
+                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
+                } else {
+                    RoundedCornerShape(0.dp)
+                }
+            if (index != 0) {
+                HorizontalDivider(color = colorResource(R.color.fill1))
+            }
+            element(shape, item)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/EmptyStateView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/EmptyStateView.kt
@@ -1,0 +1,22 @@
+package com.mbta.tid.mbta_app.android.search.results
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.util.Typography
+
+@Composable
+fun EmptyStateView(headline: String, subheadline: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(headline, style = Typography.subheadlineSemibold)
+        Text(subheadline, style = Typography.subheadline)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/LoadingResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/LoadingResultsView.kt
@@ -1,0 +1,15 @@
+package com.mbta.tid.mbta_app.android.search.results
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.valentinilk.shimmer.shimmer
+
+@Composable
+fun LoadingResultsView() {
+    CompositionLocalProvider(IsLoadingSheetContents provides true) {
+        StopResultsView(LoadingPlaceholders.stopResults(), handleSearch = {}, Modifier.shimmer())
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -20,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.RoundedCornerColumn
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.RoutePillSpec
@@ -33,21 +33,8 @@ fun RouteResultsView(routes: List<SearchViewModel.RouteResult>, handleSearch: (S
         Modifier.padding(vertical = 8.dp),
         style = Typography.subheadlineSemibold,
     )
-    Column {
-        routes.forEachIndexed { index, routeResult ->
-            val shape =
-                if (routes.size == 1) {
-                    RoundedCornerShape(10.dp)
-                } else if (index == 0) {
-                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
-                } else if (index == routes.lastIndex) {
-                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
-                } else {
-                    RoundedCornerShape(0.dp)
-                }
-            HorizontalDivider(color = colorResource(R.color.fill1))
-            RouteResultsView(shape, routeResult, handleSearch)
-        }
+    RoundedCornerColumn(routes) { shape, routeResult ->
+        RouteResultsView(shape, routeResult, handleSearch)
     }
 }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
@@ -15,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
@@ -23,6 +25,31 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.RoutePillSpec
 import com.mbta.tid.mbta_app.utils.TestData
 import com.mbta.tid.mbta_app.viewModel.SearchViewModel
+
+@Composable
+fun RouteResultsView(routes: List<SearchViewModel.RouteResult>, handleSearch: (String) -> Unit) {
+    Text(
+        stringResource(R.string.routes),
+        Modifier.padding(vertical = 8.dp),
+        style = Typography.subheadlineSemibold,
+    )
+    Column {
+        routes.forEachIndexed { index, routeResult ->
+            val shape =
+                if (routes.size == 1) {
+                    RoundedCornerShape(10.dp)
+                } else if (index == 0) {
+                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
+                } else if (index == routes.lastIndex) {
+                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
+                } else {
+                    RoundedCornerShape(0.dp)
+                }
+            HorizontalDivider(color = colorResource(R.color.fill1))
+            RouteResultsView(shape, routeResult, handleSearch)
+        }
+    }
+}
 
 @Composable
 fun RouteResultsView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/SearchResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/SearchResultsView.kt
@@ -1,0 +1,72 @@
+package com.mbta.tid.mbta_app.android.search.results
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.util.SettingsCache
+import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.viewModel.SearchViewModel
+
+@Composable
+fun SearchResultsView(
+    state: SearchViewModel.State,
+    handleStopTap: (String) -> Unit,
+    handleRouteTap: (String) -> Unit,
+) {
+    val includeRoutes = SettingsCache.get(Settings.SearchRouteResults)
+    Column(
+        modifier =
+            Modifier.verticalScroll(rememberScrollState())
+                .fillMaxWidth()
+                .background(colorResource(R.color.fill1))
+                .padding(16.dp)
+    ) {
+        when (state) {
+            SearchViewModel.State.Loading -> LoadingResultsView()
+            is SearchViewModel.State.RecentStops -> {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        modifier = Modifier.padding(bottom = 10.dp),
+                        text = stringResource(R.string.recently_viewed),
+                        style = Typography.subheadlineSemibold,
+                    )
+                    StopResultsView(state.stops, handleStopTap)
+                }
+            }
+            is SearchViewModel.State.Results -> {
+                if (state.isEmpty(includeRoutes)) {
+                    EmptyStateView(
+                        headline = stringResource(R.string.no_results_found),
+                        subheadline = stringResource(R.string.try_a_different_spelling_or_name),
+                        modifier = Modifier.padding(top = 16.dp).fillMaxWidth(),
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        StopResultsView(state.stops, handleStopTap)
+                        if (includeRoutes && !state.routes.isEmpty()) {
+                            RouteResultsView(state.routes, handleRouteTap)
+                        }
+                    }
+                }
+            }
+            SearchViewModel.State.Error ->
+                EmptyStateView(
+                    headline = stringResource(R.string.results_failed_to_load),
+                    subheadline = stringResource(R.string.try_your_search_again),
+                    modifier = Modifier.padding(top = 16.dp).fillMaxWidth(),
+                )
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,7 +30,34 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.text
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.viewModel.SearchViewModel
+
+@Composable
+fun StopResultsView(
+    stops: List<SearchViewModel.StopResult>,
+    handleSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        stops.forEachIndexed { index, stopResult ->
+            val shape =
+                if (stops.size == 1) {
+                    RoundedCornerShape(10.dp)
+                } else if (index == 0) {
+                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
+                } else if (index == stops.lastIndex) {
+                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
+                } else {
+                    RoundedCornerShape(0.dp)
+                }
+            if (index != 0) {
+                HorizontalDivider(color = colorResource(R.color.fill1))
+            }
+            StopResultsView(shape, stopResult, handleSearch)
+        }
+    }
+}
 
 @Composable
 fun StopResultsView(
@@ -48,7 +76,7 @@ fun StopResultsView(
                     .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            val iconModifier = Modifier.height(32.dp).width(32.dp)
+            val iconModifier = Modifier.height(32.dp).width(32.dp).placeholderIfLoading()
 
             val routePillsData = stop.routePills
 
@@ -81,7 +109,9 @@ fun StopResultsView(
             ) {
                 Text(
                     text = stop.name,
-                    modifier = Modifier.padding(top = 12.dp, bottom = 8.dp, start = 16.dp),
+                    modifier =
+                        Modifier.padding(top = 12.dp, bottom = 8.dp, start = 16.dp)
+                            .placeholderIfLoading(),
                     style = Typography.bodySemibold,
                 )
                 Row(
@@ -89,6 +119,7 @@ fun StopResultsView(
                         Modifier.horizontalScroll(scrollState)
                             .padding(start = 16.dp, bottom = 12.dp)
                             .clearAndSetSemantics { contentDescription = routesContentDescription }
+                            .placeholderIfLoading()
                 ) {
                     routePillsData.map { spec ->
                         RoutePill(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/search/results/StopResultsView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -27,6 +26,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.RoundedCornerColumn
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.text
 import com.mbta.tid.mbta_app.android.util.Typography
@@ -39,23 +39,8 @@ fun StopResultsView(
     handleSearch: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier) {
-        stops.forEachIndexed { index, stopResult ->
-            val shape =
-                if (stops.size == 1) {
-                    RoundedCornerShape(10.dp)
-                } else if (index == 0) {
-                    RoundedCornerShape(topStart = 10.dp, topEnd = 10.dp)
-                } else if (index == stops.lastIndex) {
-                    RoundedCornerShape(bottomStart = 10.dp, bottomEnd = 10.dp)
-                } else {
-                    RoundedCornerShape(0.dp)
-                }
-            if (index != 0) {
-                HorizontalDivider(color = colorResource(R.color.fill1))
-            }
-            StopResultsView(shape, stopResult, handleSearch)
-        }
+    RoundedCornerColumn(stops, modifier) { shape, stopResult ->
+        StopResultsView(shape, stopResult, handleSearch)
     }
 }
 

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -204,6 +204,7 @@
     <string name="next_stop">Próxima parada</string>
     <string name="no_matching_routes">No hay rutas de %1$s que coincidan</string>
     <string name="no_predictions">Las predicciones no están disponibles</string>
+    <string name="no_results_found">No se encontraron resultados 🤔</string>
     <string name="no_service">Sin servicio</string>
     <string name="no_service_sentence_case">Sin servicio</string>
     <string name="no_service_today">No hay servicio hoy</string>
@@ -262,6 +263,7 @@
     <string name="resources_link_mticket">Billetes de tren de cercanías y ferri</string>
     <string name="resources_link_mticket_note">mTicket App</string>
     <string name="resources_link_trip_planner">Planificador de viaje</string>
+    <string name="results_failed_to_load">Los resultados no se pudieron cargar ☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">Añadir paradas favoritas</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -358,6 +360,8 @@
     <string name="trains">trenes</string>
     <string name="trip_cancelled">Viaje cancelado</string>
     <string name="trip_cancelled_details">Este viaje ha sido cancelado. Lamentamos las molestias.</string>
+    <string name="try_a_different_spelling_or_name">Pruebe con una ortografía o un nombre diferente.</string>
+    <string name="try_your_search_again">Intente su búsqueda nuevamente.</string>
     <string name="unable_to_connect">No se puede conectar</string>
     <string name="unruly_passenger">Pasajero indisciplinado</string>
     <string name="unruly_passenger_lowercase">pasajero rebelde</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -204,6 +204,7 @@
     <string name="next_stop">Prochain arrêt</string>
     <string name="no_matching_routes">Aucun itinéraire de %1$s correspondant</string>
     <string name="no_predictions">Les prévisions ne sont pas encore disponibles</string>
+    <string name="no_results_found">Aucun résultat trouvé 🤔</string>
     <string name="no_service">Pas de service</string>
     <string name="no_service_sentence_case">Aucun service</string>
     <string name="no_service_today">Aucun service aujourd’hui</string>
@@ -262,6 +263,7 @@
     <string name="resources_link_mticket">Titres pour train de banlieue et ferry</string>
     <string name="resources_link_mticket_note">Application mTicket</string>
     <string name="resources_link_trip_planner">Planificateur de trajet</string>
+    <string name="results_failed_to_load">Les résultats n’ont pas pu être chargés ☹️</string>
     <string name="route_effect">%2$s %1$s</string>
     <string name="route_picker_header_favorites">Ajouter des arrêts favoris</string>
     <string name="route_with_type">%2$s %1$s</string>
@@ -358,6 +360,8 @@
     <string name="trains">trains</string>
     <string name="trip_cancelled">Trajet annulé</string>
     <string name="trip_cancelled_details">Ce voyage a été annulé. Nous sommes désolés pour la gêne occasionnée.</string>
+    <string name="try_a_different_spelling_or_name">Essayez une orthographe ou un nom différent.</string>
+    <string name="try_your_search_again">Réessayez votre recherche.</string>
     <string name="unable_to_connect">Impossible de se connecter</string>
     <string name="unruly_passenger">Passager indiscipliné</string>
     <string name="unruly_passenger_lowercase">passager indiscipliné</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -213,6 +213,7 @@
     <string name="next_stop">Pwochen arè</string>
     <string name="no_matching_routes">Pa gen wout %1$s ki matche</string>
     <string name="no_predictions">Pa gen prediksyon disponib</string>
+    <string name="no_results_found">Pa jwenn rezilta 🤔</string>
     <string name="no_service">Pa gen Sèvis</string>
     <string name="no_service_sentence_case">Pa gen sèvis</string>
     <string name="no_service_today">Pa gen sèvis jodi a</string>
@@ -271,6 +272,7 @@
     <string name="resources_link_mticket">Tikè Tren Vil la ak Bato</string>
     <string name="resources_link_mticket_note">Aplikasyon mTicket</string>
     <string name="resources_link_trip_planner">Zouti pou planifye vwayaj</string>
+    <string name="results_failed_to_load">Rezilta yo pa t chaje ☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">Ajoute arè ou pi renmen yo</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -370,6 +372,8 @@
     <string name="trains">tren yo</string>
     <string name="trip_cancelled">Vwayaj la anile</string>
     <string name="trip_cancelled_details">Vwayaj sa a anile. Nou regrèt deranjman an.</string>
+    <string name="try_a_different_spelling_or_name">Eseye yon lòt òtograf oswa non.</string>
+    <string name="try_your_search_again">Eseye rechèch ou an ankò.</string>
     <string name="unable_to_connect">Pa ka konekte</string>
     <string name="unruly_passenger">Pasaje Ki Pa Respekte Règ</string>
     <string name="unruly_passenger_lowercase">pasaje ap fè dezòd</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -204,6 +204,7 @@
     <string name="next_stop">Próxima parada</string>
     <string name="no_matching_routes">Nenhuma rota de %1$s correspondente</string>
     <string name="no_predictions">Previsões indisponíveis</string>
+    <string name="no_results_found">Nenhum resultado encontrado 🤔</string>
     <string name="no_service">Sem serviço</string>
     <string name="no_service_sentence_case">Sem serviço</string>
     <string name="no_service_today">Sem serviço hoje</string>
@@ -262,6 +263,7 @@
     <string name="resources_link_mticket">Bilhetes de transporte diário por trem e balsa</string>
     <string name="resources_link_mticket_note">Aplicativo mTicket</string>
     <string name="resources_link_trip_planner">Planejador de trajetos</string>
+    <string name="results_failed_to_load">Falha ao carregar os resultados ☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">Adicionar paradas favoritas</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -358,6 +360,8 @@
     <string name="trains">trens</string>
     <string name="trip_cancelled">Viagem cancelada</string>
     <string name="trip_cancelled_details">Esta viagem foi cancelada. Lamentamos o inconveniente.</string>
+    <string name="try_a_different_spelling_or_name">Tente uma grafia ou nome diferente.</string>
+    <string name="try_your_search_again">Tente sua pesquisa novamente.</string>
     <string name="unable_to_connect">Impossível conectar</string>
     <string name="unruly_passenger">Passageiro indisciplinado</string>
     <string name="unruly_passenger_lowercase">passageiro problemático</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -198,6 +198,7 @@
     <string name="next_stop">Điểm dừng tiếp theo</string>
     <string name="no_matching_routes">Không có tuyến xe %1$s nào phù hợp</string>
     <string name="no_predictions">Dự đoán không có sẵn</string>
+    <string name="no_results_found">Không tìm thấy kết quả nào 🤔</string>
     <string name="no_service">Không có dịch vụ</string>
     <string name="no_service_sentence_case">Không có dịch vụ</string>
     <string name="no_service_today">Hôm nay không có dịch vụ</string>
@@ -256,6 +257,7 @@
     <string name="resources_link_mticket">Vé phà vé đường sắt ngoại ô (Commuter Rail)</string>
     <string name="resources_link_mticket_note">Ứng dụng mTicket</string>
     <string name="resources_link_trip_planner">Lập kế hoạch chuyến đi</string>
+    <string name="results_failed_to_load">Kết quả không tải được ☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">Thêm điểm dừng yêu thích</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -350,6 +352,8 @@
     <string name="trains">tàu</string>
     <string name="trip_cancelled">Chuyến đi đã bị hủy</string>
     <string name="trip_cancelled_details">Chuyến đi này đã bị hủy. Chúng tôi xin lỗi vì sự bất tiện này.</string>
+    <string name="try_a_different_spelling_or_name">Hãy thử cách viết hoặc tên khác.</string>
+    <string name="try_your_search_again">Hãy thử tìm kiếm lại.</string>
     <string name="unable_to_connect">Không thể kết nối</string>
     <string name="unruly_passenger">Hành khách ngỗ ngược</string>
     <string name="unruly_passenger_lowercase">hành khách ngỗ ngược</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -198,6 +198,7 @@
     <string name="next_stop">下一站</string>
     <string name="no_matching_routes">没有匹配的%1$s路线</string>
     <string name="no_predictions">预测不可用</string>
+    <string name="no_results_found">未找到结果🤔</string>
     <string name="no_service">无服务</string>
     <string name="no_service_sentence_case">无服务</string>
     <string name="no_service_today">今日无服务</string>
@@ -256,6 +257,7 @@
     <string name="resources_link_mticket">通勤铁路和渡轮票</string>
     <string name="resources_link_mticket_note">mTicket应用程序</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="results_failed_to_load">结果加载失败☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">添加最喜欢的站点</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -350,6 +352,8 @@
     <string name="trains">列车</string>
     <string name="trip_cancelled">行程已取消</string>
     <string name="trip_cancelled_details">此行程已取消。我们对此造成的不便深表歉意。</string>
+    <string name="try_a_different_spelling_or_name">尝试不同的拼写或名称。</string>
+    <string name="try_your_search_again">再次尝试搜索。</string>
     <string name="unable_to_connect">无法连接</string>
     <string name="unruly_passenger">乘客干扰</string>
     <string name="unruly_passenger_lowercase">乘客干扰</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -198,6 +198,7 @@
     <string name="next_stop">下一站</string>
     <string name="no_matching_routes">沒有符合的%1$s路線</string>
     <string name="no_predictions">預測不可用</string>
+    <string name="no_results_found">未找到結果🤔</string>
     <string name="no_service">無服務</string>
     <string name="no_service_sentence_case">無服務</string>
     <string name="no_service_today">今日無服務</string>
@@ -256,6 +257,7 @@
     <string name="resources_link_mticket">通勤鐵路和渡輪票</string>
     <string name="resources_link_mticket_note">mTicket應用程式</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="results_failed_to_load">結果載入失敗☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">新增最喜歡的站點</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -350,6 +352,8 @@
     <string name="trains">列車</string>
     <string name="trip_cancelled">行程已取消</string>
     <string name="trip_cancelled_details">本行程已取消。對於造成您的不便，我們深表歉意。</string>
+    <string name="try_a_different_spelling_or_name">嘗試不同的拼字或名稱。</string>
+    <string name="try_your_search_again">再次嘗試搜尋。</string>
     <string name="unable_to_connect">無法連接</string>
     <string name="unruly_passenger">乘客干擾</string>
     <string name="unruly_passenger_lowercase">乘客干擾</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -208,6 +208,7 @@
     <string name="next_stop">Next stop</string>
     <string name="no_matching_routes">No matching %1$s routes</string>
     <string name="no_predictions">Predictions unavailable</string>
+    <string name="no_results_found">No results found 🤔</string>
     <string name="no_service">No Service</string>
     <string name="no_service_sentence_case">No service</string>
     <string name="no_service_today">No service today</string>
@@ -266,6 +267,7 @@
     <string name="resources_link_mticket">Commuter Rail and Ferry Tickets</string>
     <string name="resources_link_mticket_note">mTicket App</string>
     <string name="resources_link_trip_planner">Trip Planner</string>
+    <string name="results_failed_to_load">Results failed to load ☹️</string>
     <string name="route_effect">%1$s %2$s</string>
     <string name="route_picker_header_favorites">Add favorite stops</string>
     <string name="route_with_type">%1$s %2$s</string>
@@ -361,6 +363,8 @@
     <string name="trains">trains</string>
     <string name="trip_cancelled">Trip cancelled</string>
     <string name="trip_cancelled_details">This trip has been cancelled. We’re sorry for the inconvenience.</string>
+    <string name="try_a_different_spelling_or_name">Try a different spelling or name.</string>
+    <string name="try_your_search_again">Try your search again.</string>
     <string name="unable_to_connect">Unable to connect</string>
     <string name="unruly_passenger">Unruly Passenger</string>
     <string name="unruly_passenger_lowercase">unruly passenger</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -11761,6 +11761,53 @@
         }
       }
     },
+    "No results found 🤔" : {
+      "comment" : "Displayed when search has no results",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "No se encontraron resultados 🤔"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Aucun résultat trouvé 🤔"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pa jwenn rezilta 🤔"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nenhum resultado encontrado 🤔"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Không tìm thấy kết quả nào 🤔"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未找到结果🤔"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "未找到結果🤔"
+          }
+        }
+      }
+    },
     "No service" : {
       "comment" : "Possible alert effect",
       "localizations" : {
@@ -13836,6 +13883,53 @@
         }
       }
     },
+    "Results failed to load ☹️" : {
+      "comment" : "Displayed when search encounters an error",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Los resultados no se pudieron cargar ☹️"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Les résultats n’ont pas pu être chargés ☹️"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Rezilta yo pa t chaje ☹️"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Falha ao carregar os resultados ☹️"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Kết quả không tải được ☹️"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "结果加载失败☹️"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "結果載入失敗☹️"
+          }
+        }
+      }
+    },
     "Route Search" : {
       "comment" : "A setting on the More page to display routes in search (only visible for developers)",
       "localizations" : {
@@ -14478,7 +14572,7 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Envoyer des commentaires sur l’application"
           }
         },
@@ -18859,6 +18953,100 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trip Planner"
+          }
+        }
+      }
+    },
+    "Try a different spelling or name." : {
+      "comment" : "Displayed when search has no results",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Pruebe con una ortografía o un nombre diferente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Essayez une orthographe ou un nom différent."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eseye yon lòt òtograf oswa non."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tente uma grafia ou nome diferente."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hãy thử cách viết hoặc tên khác."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "尝试不同的拼写或名称。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "嘗試不同的拼字或名稱。"
+          }
+        }
+      }
+    },
+    "Try your search again." : {
+      "comment" : "Displayed when search encounters an error",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Intente su búsqueda nuevamente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Réessayez votre recherche."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Eseye rechèch ou an ankò."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tente sua pesquisa novamente."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hãy thử tìm kiếm lại."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "再次尝试搜索。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "再次嘗試搜尋。"
           }
         }
       }

--- a/iosApp/iosApp/Pages/Search/Results/LoadingResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/LoadingResultsView.swift
@@ -6,30 +6,12 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
+import Shared
 import SwiftUI
 
-struct LoadingResults: View {
+struct LoadingResultsView: View {
     var body: some View {
-        VStack(spacing: 8) {
-            ForEach(0 ... 10, id: \.self) { _ in
-                ResultContainer { skeletonResult.padding(12) }
-            }
-        }
-    }
-
-    var skeletonResult: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 4) {
-                Rectangle()
-                    .fill(Color.fill1)
-                    .frame(height: 24)
-                    .frame(maxWidth: 240)
-                Rectangle()
-                    .fill(Color.fill1)
-                    .frame(height: 16)
-                    .frame(maxWidth: 48)
-            }
-            Spacer()
-        }
+        StopResultsView(stops: LoadingPlaceholders.shared.stopResults(), handleStopTap: { _ in })
+            .loadingPlaceholder()
     }
 }

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
@@ -31,7 +31,7 @@ struct SearchResultsView: View {
             Group {
                 switch onEnum(of: state) {
                 case .loading:
-                    LoadingResults()
+                    LoadingResultsView()
                 case let .recentStops(state):
                     VStack {
                         Text("Recently Viewed")
@@ -40,10 +40,16 @@ struct SearchResultsView: View {
                         StopResultsView(stops: state.stops, handleStopTap: handleStopTap)
                     }
                 case let .results(state):
-                    if state.isEmpty(includeRoutes: includeRoutes) == true {
+                    if state.isEmpty(includeRoutes: includeRoutes) {
                         EmptyStateView(
-                            headline: "No results found 🤔",
-                            subheadline: "Try a different spelling or name."
+                            headline: NSLocalizedString(
+                                "No results found 🤔",
+                                comment: "Displayed when search has no results"
+                            ),
+                            subheadline: NSLocalizedString(
+                                "Try a different spelling or name.",
+                                comment: "Displayed when search has no results"
+                            ),
                         )
                         .padding(.top, 16)
                     } else {
@@ -57,8 +63,14 @@ struct SearchResultsView: View {
                     }
                 case .error:
                     EmptyStateView(
-                        headline: "Results failed to load ☹️",
-                        subheadline: "Try your search again."
+                        headline: NSLocalizedString(
+                            "Results failed to load ☹️",
+                            comment: "Displayed when search encounters an error"
+                        ),
+                        subheadline: NSLocalizedString(
+                            "Try your search again.",
+                            comment: "Displayed when search encounters an error"
+                        ),
                     )
                     .padding(.top, 16)
                 }

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -30,7 +30,7 @@ final class SearchResultViewTests: XCTestCase {
     @MainActor func testPending() throws {
         let sut = SearchResultsView(state: SearchViewModel.StateLoading.shared, handleStopTap: { _ in })
             .withFixedSettings([:])
-        XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(LoadingResults.self))
+        XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(LoadingResultsView.self))
     }
 
     @MainActor func testResultLoad() throws {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.viewModel.SearchViewModel
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
@@ -137,6 +138,26 @@ object LoadingPlaceholders {
                 now = Clock.System.now(),
             )
         }
+
+    fun stopResults(): List<SearchViewModel.StopResult> {
+        val otherRoutePill =
+            RoutePillSpec(
+                textColor = "8A9199",
+                routeColor = "8A9199",
+                content = RoutePillSpec.Content.Text("Loading"),
+                size = RoutePillSpec.Size.FlexPillSmall,
+                shape = RoutePillSpec.Shape.Capsule,
+                contentDescription = null,
+            )
+        return (1..10).map { index ->
+            SearchViewModel.StopResult(
+                "$index",
+                isStation = index % 3 == 0,
+                name = index.toString().repeat(index) + " Stop",
+                routePills = listOf(otherRoutePill),
+            )
+        }
+    }
 
     data class TripDetailsInfo(
         val stops: TripDetailsStopList,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 Search | Implement empty/error search result states](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210561875928847?focus=true)

I went ahead and rearranged the Android component structure to be slightly more structurally similar to the iOS component structure while I was in there.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that empty state and error text displays correctly and is translated on both iOS and Android.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
