### PR TITLE
dev: add helper script for placeholder translations via Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,16 @@ gradle task on Android build.
 If there are distinct strings that have the same English translation, give them an iOS key of
 `key/<Android ID>` and then the Android resources will be written with that key automatically.
 
+### Temporary machine translations
+
 Any time we add new user facing strings to the app, we add temporary machine translations of that
 text, while we're waiting to get translations back from our vendor. Any machine translations that
 are added must be marked as "Needs review" in XCode so that the translators know to audit them.
+
+To mostly-automatically fill in temporary machine translations, use [`placeholder-translations.py`](bin/placeholder-translations.py),
+which will require you to paste in and copy out of Google Sheets, but will automatically determine
+which new strings need translations, set up Google Sheets `=GOOGLETRANSLATE()` formulas, and then
+save the results directly in `Localizable.xcstrings` marked as “Needs review”.
 
 ### Importing from `.xliff`
 

--- a/bin/placeholder-translations.py
+++ b/bin/placeholder-translations.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""
+Google Sheets has a `GOOGLETRANSLATE` function that simplifies small-batch translations.
+This script automates a little bit of the glue involved in using Google Sheets for creating placeholder translations.
+It will automatically find strings (but not plurals) that need placeholder translations, create the Google Sheets formula calls, and copy them.
+Afterwards, it will read the clipboard, decode the structure, and write the placeholder translations as needs review directly into Localizable.xcstrings.
+All you need to do is paste, wait, and copy.
+"""
+
+import json
+import subprocess
+import time
+
+with open("iosApp/iosApp/Localizable.xcstrings", mode="r", encoding="utf-8") as f:
+    xcstrings = json.load(f)
+
+target_locales = ["es", "fr", "ht", "pt-BR", "vi", "zh-Hans-CN", "zh-Hant-TW"]
+missing_keys = dict()
+for key, string_info in xcstrings["strings"].items():
+    if "localizations" not in string_info:
+        missing_keys[key] = key
+    else:
+        localizations = string_info["localizations"]
+        if len(localizations) == 1 and "variations" in localizations["en"].keys():
+            print(f"Cannot create placeholders for plural translation with key {repr(key)}; plurals are complicated.")
+
+if len(missing_keys) == 0:
+    print("Couldn’t find any strings that need placeholder translations.")
+    exit()
+
+print("Found", len(missing_keys), "strings that need placeholder translations.")
+
+sheet_header = ["key", "en"] + target_locales
+sheet_rows = [[key, missing_keys[key]] + [f'=GOOGLETRANSLATE("{missing_keys[key]}", "en", "{target}")' for target in target_locales] for key in sorted(missing_keys.keys())]
+sheet_out = [sheet_header] + sheet_rows
+
+subprocess.run("pbcopy", input="\n".join("\t".join(row) for row in sheet_out), text=True)
+
+print("Open your Google Sheets spreadsheet, paste, wait for all the translations to load, and then copy.")
+print("DO NOT PASTE HERE!")
+garbage = input("Just press Enter and this script will read your clipboard.")
+
+if garbage != "":
+    while True:
+        garbage_time = time.monotonic()
+        print()
+        input("You pasted. Press Enter once your terminal has finished pasting.")
+        if time.monotonic() - garbage_time > 0.1:
+            break
+
+paste = subprocess.run("pbpaste", capture_output=True, text=True)
+sheet_in = [line.strip().split("\t") for line in paste.stdout.split("\n") if line.strip() != ""]
+
+sheet_in_header = sheet_in[0]
+
+for body_row in sheet_in[1:]:
+    key = body_row[0]
+    localizations = dict()
+    for col in range(2, len(body_row)):
+        localization = {"stringUnit": {"state": "needs_review", "value": body_row[col]}}
+        localizations[sheet_in_header[col]] = localization
+    xcstrings["strings"][key]["localizations"] = localizations
+    print("Adding placeholder translations for key", repr(key))
+
+with open("iosApp/iosApp/Localizable.xcstrings", mode="w", encoding="utf-8") as f:
+    json.dump(xcstrings, f, ensure_ascii=False, indent=2, separators=(",", " : "))


### PR DESCRIPTION
### Summary

_Ticket:_ none

Realized during #1118 that there has to be a better way.

The ceiling on how good this can be is higher than I’ve reached right now — automatically polling `pbpaste` until it’s changed would simplify the tail end, writing and reading to a Google Sheet directly via the Google Sheets API would be simpler to work with, and plurals are probably achievable — but this seems like it’s still pretty simple.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that with a new English string the logic all works and the temporary translations are written correctly to Localizable.xcstrings. Checked that a new English plural string is correctly warned about and ignored.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
