### PR TITLE
 feat(ios.NearbyTransitView): Don't sort by pinned when enhancedFavorites 

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -35,6 +35,9 @@ struct NearbyTransitView: View {
     let inspection = Inspection<Self>()
     let scrollSubject = PassthroughSubject<String, Never>()
 
+    @EnvironmentObject var settingsCache: SettingsCache
+    var enhancedFavorites: Bool { settingsCache.get(.enhancedFavorites) }
+
     struct RouteCardParams: Equatable {
         let state: NearbyViewModel.NearbyTransitState
         let global: GlobalResponse?
@@ -74,11 +77,6 @@ struct NearbyTransitView: View {
                 scrollToTop()
             }
         }
-        .onChange(of: predictionsByStop) { newPredictionsByStop in
-            if let newPredictionsByStop {
-                let condensedPredictions = newPredictionsByStop.toPredictionsStreamDataResponse()
-            }
-        }
         .onChange(of: RouteCardParams(
             state: nearbyVM.nearbyState,
             global: globalData,
@@ -96,7 +94,7 @@ struct NearbyTransitView: View {
                     predictions: newParams.predictions,
                     alerts: newParams.alerts,
                     now: newParams.now,
-                    pinnedRoutes: newParams.pinnedRoutes
+                    pinnedRoutes: enhancedFavorites ? [] : newParams.pinnedRoutes
                 )
             }
         }

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -170,7 +170,6 @@ final class NearbyTransitViewTests: XCTestCase {
     struct LoadedStops {
         let predictionStops: [String]
         let scheduleStops: [String]
-        let pinnedRoutes: [String]
     }
 
     func setUpSut(
@@ -187,14 +186,11 @@ final class NearbyTransitViewTests: XCTestCase {
         let schedulePub = PassthroughSubject<[String], Never>()
         let pinnedRoutesPub = PassthroughSubject<[String], Never>()
 
-        let pinnedRoutesRepository = MockPinnedRoutesRepository(
-            initialPinnedRoutes: pinnedRoutes,
-            onGet: { pinnedRoutesPub.send(pinnedRoutes.sorted()) }
-        )
+        let pinnedRoutesRepository = MockPinnedRoutesRepository(initialPinnedRoutes: pinnedRoutes)
 
-        Publishers.Zip3(predictionPub, schedulePub, pinnedRoutesPub).sink { predictionStops, scheduleStops, _ in
+        Publishers.Zip(predictionPub, schedulePub).sink { predictionStops, scheduleStops in
             loadPublisher.send(
-                LoadedStops(predictionStops: predictionStops, scheduleStops: scheduleStops, pinnedRoutes: [])
+                LoadedStops(predictionStops: predictionStops, scheduleStops: scheduleStops)
             )
         }.store(in: &cancellables)
 
@@ -488,7 +484,7 @@ final class NearbyTransitViewTests: XCTestCase {
         }.store(in: &cancellables)
 
         let sut = setUpSut(route52Objects(), loadPublisher)
-        ViewHosting.host(view: sut.withFixedSettings([:]))
+        ViewHosting.host(view: sut.withFixedSettings([.enhancedFavorites: false]))
 
         wait(for: [sawmillAtWalshExpectation], timeout: 1)
 

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -53,7 +53,7 @@ final class NearbyTransitViewTests: XCTestCase {
             isReturningFromBackground: .constant(false),
             nearbyVM: .init(),
             noNearbyStops: noNearbyStops
-        )
+        ).withFixedSettings([.enhancedFavorites: false])
         let cards = try sut.inspect().findAll(RouteCard.self)
         XCTAssertEqual(cards.count, 5)
         for card in cards {
@@ -170,12 +170,14 @@ final class NearbyTransitViewTests: XCTestCase {
     struct LoadedStops {
         let predictionStops: [String]
         let scheduleStops: [String]
+        let pinnedRoutes: [String]
     }
 
     func setUpSut(
         _ objects: ObjectCollectionBuilder,
         _ loadPublisher: PassthroughSubject<LoadedStops, Never>,
-        now: Date? = nil
+        now: Date? = nil,
+        _ pinnedRoutes: Set<String> = []
     ) -> NearbyTransitView {
         let nearbyVM = NearbyViewModel()
         nearbyVM.nearbyState = getNearbyState(objects: objects)
@@ -183,9 +185,16 @@ final class NearbyTransitViewTests: XCTestCase {
 
         let predictionPub = PassthroughSubject<[String], Never>()
         let schedulePub = PassthroughSubject<[String], Never>()
-        Publishers.Zip(predictionPub, schedulePub).sink { predictionStops, scheduleStops in
+        let pinnedRoutesPub = PassthroughSubject<[String], Never>()
+
+        let pinnedRoutesRepository = MockPinnedRoutesRepository(
+            initialPinnedRoutes: pinnedRoutes,
+            onGet: { pinnedRoutesPub.send(pinnedRoutes.sorted()) }
+        )
+
+        Publishers.Zip3(predictionPub, schedulePub, pinnedRoutesPub).sink { predictionStops, scheduleStops, _ in
             loadPublisher.send(
-                LoadedStops(predictionStops: predictionStops, scheduleStops: scheduleStops)
+                LoadedStops(predictionStops: predictionStops, scheduleStops: scheduleStops, pinnedRoutes: [])
             )
         }.store(in: &cancellables)
 
@@ -212,6 +221,54 @@ final class NearbyTransitViewTests: XCTestCase {
         sut.globalRepository = MockGlobalRepository(response: .init(objects: objects))
 
         return sut
+    }
+
+    @MainActor func testSortsPinnedRoutesToTopByDefault() throws {
+        let loadPublisher = PassthroughSubject<LoadedStops, Never>()
+        let objects = route52Objects()
+
+        let testData = Shared.TestData.clone()
+
+        objects.put(object: testData.getRoute(id: "15"))
+        objects.put(object: testData.getRoutePattern(id: "15-2-0"))
+        objects.put(object: testData.getTrip(id: "68166816"))
+        objects.put(object: testData.getStop(id: "17863"))
+
+        let sut = setUpSut(objects, loadPublisher, ["52"])
+
+        let exp = sut.inspection.inspect(onReceive: loadPublisher, after: 0.5) { view in
+            let routes = view.findAll(RouteCard.self)
+
+            XCTAssertEqual(routes.count, 2)
+            XCTAssertNotNil(try routes[0].find(text: "52"))
+            XCTAssertNotNil(try routes[1].find(text: "15"))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([.enhancedFavorites: false]))
+        wait(for: [exp], timeout: 1)
+    }
+
+    @MainActor func testDoesntSortsPinnedRoutesToTopEnhancedFavorites() throws {
+        let loadPublisher = PassthroughSubject<LoadedStops, Never>()
+        let objects = route52Objects()
+
+        let testData = Shared.TestData.clone()
+
+        objects.put(object: testData.getRoute(id: "15"))
+        objects.put(object: testData.getRoutePattern(id: "15-2-0"))
+        objects.put(object: testData.getTrip(id: "68166816"))
+        objects.put(object: testData.getStop(id: "17863"))
+
+        let sut = setUpSut(objects, loadPublisher, ["52"])
+
+        let exp = sut.inspection.inspect(onReceive: loadPublisher, after: 0.5) { view in
+            let routes = view.findAll(RouteCard.self)
+
+            XCTAssertEqual(routes.count, 2)
+            XCTAssertNotNil(try routes[0].find(text: "15"))
+            XCTAssertNotNil(try routes[1].find(text: "52"))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([.enhancedFavorites: true]))
+        wait(for: [exp], timeout: 1)
     }
 
     @MainActor func testRoutePatternsGroupedByRouteAndStop() throws {


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Don't consider favorites when sorting nearby transit](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210559766928410?focus=true)

What is this PR for?
iOS version of https://github.com/mbta/mobile_app/pull/1037

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally and confirmed that pinned routes aren't sorted to the top with enhanced favorites on
* Added unit tests

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
