### PR TITLE
feat(iOS): Remove pin stars on route cards when enhanced favorites is selected

### DIFF
--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -19,6 +19,8 @@ struct RouteCard: View {
     let showStopHeader: Bool
 
     @EnvironmentObject var settingsCache: SettingsCache
+    var enhancedFavorites: Bool { settingsCache.get(.enhancedFavorites) }
+    var showStationAccessibility: Bool { settingsCache.get(.stationAccessibility) }
 
     @ScaledMetric private var modeIconHeight: CGFloat = 24
 
@@ -29,16 +31,24 @@ struct RouteCard: View {
                 routeType: cardData.lineOrRoute.type,
                 backgroundColor: Color(hex: cardData.lineOrRoute.backgroundColor),
                 textColor: Color(hex: cardData.lineOrRoute.textColor),
-                rightContent: { PinButton(pinned: pinned,
-                                          color: Color(hex: cardData.lineOrRoute.textColor),
-                                          action: { onPin(cardData.lineOrRoute.id) }) }
+                rightContent: {
+                    HStack {
+                        if !enhancedFavorites {
+                            PinButton(
+                                pinned: pinned,
+                                color: Color(hex: cardData.lineOrRoute.textColor),
+                                action: { onPin(cardData.lineOrRoute.id) }
+                            )
+                        }
+                    }
+                }
             )
             .accessibilityElement(children: .contain)
             ForEach(Array(cardData.stopData.enumerated()), id: \.element) { index, stopData in
                 if showStopHeader {
                     RouteCardStopHeader(
                         data: stopData,
-                        showStationAccessibility: settingsCache.get(.stationAccessibility)
+                        showStationAccessibility: showStationAccessibility
                     )
                 }
                 RouteCardDepartures(

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
@@ -49,7 +49,7 @@ struct SearchResultsView: View {
                             subheadline: NSLocalizedString(
                                 "Try a different spelling or name.",
                                 comment: "Displayed when search has no results"
-                            ),
+                            )
                         )
                         .padding(.top, 16)
                     } else {
@@ -70,7 +70,7 @@ struct SearchResultsView: View {
                         subheadline: NSLocalizedString(
                             "Try your search again.",
                             comment: "Displayed when search encounters an error"
-                        ),
+                        )
                     )
                     .padding(.top, 16)
                 }

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -101,13 +101,40 @@ final class RouteCardTests: XCTestCase {
             pinned: false,
             pushNavEntry: { _ in },
             showStopHeader: true
-        ).withFixedSettings([:])
+        ).withFixedSettings([.enhancedFavorites: false])
 
         let button =
             try sut.inspect().find(viewWithAccessibilityIdentifier: "pinButton").button()
 
         try button.tap()
         wait(for: [pinRouteExp], timeout: 1)
+    }
+
+    func testPinHiddenWhenEnhanced() throws {
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { route in
+            route.longName = "Red"
+        }
+
+        let routeCardData = RouteCardData(
+            lineOrRoute: .route(route),
+            stopData: [],
+            at: Date.now.toKotlinInstant()
+        )
+
+        let sut = RouteCard(
+            cardData: routeCardData,
+            global: .init(objects: objects),
+            now: Date.now,
+            onPin: { _ in },
+            pinned: false,
+            pushNavEntry: { _ in },
+            showStopHeader: true
+        ).withFixedSettings([.enhancedFavorites: true])
+
+        XCTAssertThrowsError(
+            try sut.inspect().find(viewWithAccessibilityIdentifier: "pinButton")
+        )
     }
 
     func testStopHeader() throws {


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Remove star from route card behind flag](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210559767128756?focus=true)

Remove the legacy pin buttons when you have the feature flag for new favorites enabled.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Updated and added tests for the pin button