### PR TITLE
build(deps): upgrade to kotlinx.datetime 0.7.1 with stdlib Clock/Instant

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -22,6 +22,8 @@ plugins {
     id("check-mapbox-bridge")
 }
 
+kotlin { compilerOptions { optIn.add("kotlin.time.ExperimentalTime") } }
+
 sentry {
     // Generates a JVM (Java, Kotlin, etc.) source bundle and uploads your source code to Sentry.
     // This enables source context, allowing you to see your source

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -18,7 +18,7 @@ import com.mbta.tid.mbta_app.network.MockPhoenixSocket
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.viewModel.viewModelModule
 import kotlin.math.abs
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.junit.Assert.fail
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
@@ -8,8 +8,8 @@ import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -15,13 +15,13 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import java.util.Calendar
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
+import kotlin.time.toKotlinInstant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant
-import kotlinx.datetime.toKotlinInstant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
@@ -6,8 +6,8 @@ import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -20,8 +20,8 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -17,8 +17,8 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.TestData
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
@@ -21,8 +21,8 @@ import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
@@ -12,7 +12,7 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -19,8 +19,8 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -29,11 +29,11 @@ import dev.mokkery.answering.autofill.AutofillProvider
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -55,15 +55,15 @@ import dev.mokkery.mock
 import dev.mokkery.spy
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetTabViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetTabViewModelTest.kt
@@ -9,7 +9,7 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.junit.Test
 
 class MapAndSheetTabViewModelTest {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -31,7 +31,7 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
@@ -12,7 +12,7 @@ import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import kotlin.test.assertNotNull
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -20,8 +20,8 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -19,7 +19,7 @@ import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -16,8 +16,8 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.utils.serviceDate
 import com.mbta.tid.mbta_app.utils.toBostonTime
 import kotlin.test.assertTrue
+import kotlin.time.Instant
 import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -30,11 +30,11 @@ import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
@@ -29,8 +29,8 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeaderTest.kt
@@ -12,7 +12,7 @@ import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import kotlin.test.assertTrue
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -19,8 +19,8 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModelTest.kt
@@ -37,11 +37,11 @@ import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
 import junit.framework.TestCase.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -25,7 +25,7 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -17,8 +17,8 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -13,9 +13,9 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -20,9 +20,9 @@ import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -15,8 +15,8 @@ import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 import org.junit.Rule
 import org.junit.Test
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
@@ -59,10 +59,10 @@ import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.Stop
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.koinInject
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
@@ -13,8 +13,8 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 
 @Composable
 fun DirectionRowView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -39,8 +39,8 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/LocationAuthButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/LocationAuthButton.kt
@@ -34,9 +34,9 @@ import com.mbta.tid.mbta_app.android.BuildConfig
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.util.Typography
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -50,9 +50,9 @@ import com.mbta.tid.mbta_app.utils.MinutesFormat
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import kotlin.math.min
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toLocalDateTime

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -36,9 +36,9 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.koinInject
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/LoadingRouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/LoadingRouteCard.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 @Composable
 fun LoadingRouteCard() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -20,7 +20,7 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.RouteCardPreviewData
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardList.kt
@@ -19,7 +19,7 @@ import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun ColumnScope.RouteCardList(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewModel.kt
@@ -15,8 +15,8 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.time.Instant
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 
 class FavoritesViewModel(
     private val favoritesUsecases: FavoritesUsecases = UsecaseDI().favoritesUsecases

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapboxConfigManager.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapboxConfigManager.kt
@@ -5,15 +5,15 @@ import com.mapbox.common.MapboxOptions
 import com.mbta.tid.mbta_app.dependencyInjection.UsecaseDI
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.usecases.ConfigUseCase
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 
 interface IMapboxConfigManager {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
@@ -11,11 +11,11 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 
 class NearbyTransitViewModel(private val nearbyRepository: INearbyRepository) :

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -56,7 +56,7 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 @Composable
 fun EditFavoritesPage(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -91,13 +91,13 @@ import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.reflect.KClass
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSchedule.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getSchedule.kt
@@ -10,12 +10,12 @@ import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 class ScheduleFetcher(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -43,7 +43,7 @@ import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 
 @Composable
 fun DepartureTile(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -46,8 +46,8 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
 import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.time.Instant
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
@@ -44,7 +44,7 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun StopDetailsFilteredPickerView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -21,7 +21,7 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun StopDetailsFilteredView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -42,9 +42,9 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -18,7 +18,7 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.koinInject
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -47,8 +47,10 @@ import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockTripRepository
 import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -60,8 +62,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -33,7 +33,7 @@ import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
 import com.mbta.tid.mbta_app.repositories.Settings
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.compose.koinInject
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCard.kt
@@ -67,9 +67,9 @@ import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun TripHeaderCard(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -32,9 +32,9 @@ import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun TripStopRow(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -56,9 +56,9 @@ import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun TripStops(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/InstantExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/InstantExtension.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.android.util
 import android.icu.text.DateFormat
 import com.mbta.tid.mbta_app.utils.coerceInServiceDay
 import java.util.Date
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /** Converts this [Instant] into a [Date]. For use with [android.icu.text.DateFormat]. */
 fun Instant.toJavaDate() = Date(toEpochMilliseconds())

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/Timer.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -16,7 +17,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
 class ClockTickHandler {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
@@ -7,7 +7,7 @@ import com.mbta.tid.mbta_app.android.component.formatTime
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.utils.MinutesFormat
 import io.sentry.Sentry
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 @Composable
 fun TripInstantDisplay.contentDescription(isFirst: Boolean, vehicleType: String): String =

--- a/androidApp/src/test/java/com/mbta/tid/mbta_app/android/FavoritesViewModelTest.kt
+++ b/androidApp/src/test/java/com/mbta/tid/mbta_app/android/FavoritesViewModelTest.kt
@@ -14,8 +14,8 @@ import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.junit.Test
 
 class FavoritesViewModelTest {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,8 @@ junit = "4.13.2"
 koin-bom = "4.0.4"
 kotlinpoet = "2.2.0"
 kotlinxCoroutinesCore = "1.10.2"
-kotlinxDatetime = "0.6.2"
+kotlinxDatetime = "0.7.1"
+kotlinxSerialization = "1.9.0"
 ktor = "3.1.3"
 # changelog: https://github.com/mapbox/mapbox-maps-android/blob/main/CHANGELOG.md
 mapbox = "11.12.2"
@@ -38,7 +39,7 @@ mapboxTurf = "7.4.0"
 mokkery = "2.9.0"
 molecule = "2.1.0"
 okhttp = "4.12.0"
-okio = "3.13.0"
+okio = "3.14.0"
 playServicesLocation = "21.3.0"
 sentry = "0.11.0"
 sentryGradle = "5.3.0"
@@ -82,6 +83,7 @@ kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }

--- a/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
@@ -20,7 +20,7 @@ import Shared
  - Returns: A localized and formatted string describing the active period.
   */
 extension Shared.Alert.ActivePeriod {
-    private func format(instant: Instant, isStart: Bool) -> AttributedString {
+    private func format(instant: KotlinInstant, isStart: Bool) -> AttributedString {
         let date = instant.toNSDate()
         let dateFormat = Date.FormatStyle().weekday(.wide).month().day()
         var formattedDate = date.formatted(dateFormat)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -36,7 +36,7 @@ struct StopDetailsFilteredView: View {
     var analytics: Analytics = AnalyticsProvider.shared
 
     var stop: Stop? { stopDetailsVM.global?.getStop(stopId: stopId) }
-    var nowInstant: Instant { now.toKotlinInstant() }
+    var nowInstant: KotlinInstant { now.toKotlinInstant() }
 
     let inspection = Inspection<Self>()
 

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct TripStopRow: View {
     var stop: TripDetailsStopList.Entry
     var trip: Trip
-    var now: Instant
+    var now: KotlinInstant
     var onTapLink: (TripDetailsStopList.Entry) -> Void
     var onOpenAlertDetails: (Shared.Alert) -> Void
     var routeAccents: TripRouteAccents

--- a/iosApp/iosApp/Utils/DateExtension.swift
+++ b/iosApp/iosApp/Utils/DateExtension.swift
@@ -10,7 +10,7 @@ import Foundation
 import Shared
 
 extension Date {
-    init(instant: Instant) {
+    init(instant: KotlinInstant) {
         self.init(timeIntervalSince1970: TimeInterval(instant.epochSeconds))
     }
 }

--- a/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
+++ b/iosApp/iosApp/Utils/TripInstantDisplayExtension.swift
@@ -54,7 +54,7 @@ extension TripInstantDisplay {
                    """)
     }
 
-    private func cancelledLabel(_ scheduledTime: Instant, _ isFirst: Bool, _ vehicleType: String) -> Text {
+    private func cancelledLabel(_ scheduledTime: KotlinInstant, _ isFirst: Bool, _ vehicleType: String) -> Text {
         let time = timeFormatter.string(from: Date(instant: scheduledTime))
         return isFirst
             ? Text(
@@ -74,7 +74,7 @@ extension TripInstantDisplay {
             )
     }
 
-    private func delayString(_ scheduledTime: Instant, _ isFirst: Bool, _ vehicleType: String) -> String {
+    private func delayString(_ scheduledTime: KotlinInstant, _ isFirst: Bool, _ vehicleType: String) -> String {
         let time = timeFormatter.string(from: Date(instant: scheduledTime))
         return isFirst
             ? String(format: NSLocalizedString(
@@ -169,7 +169,7 @@ extension TripInstantDisplay {
             return Text(delayString(trip.predictionTime, isFirst, vehicleType))
         }
 
-        guard let predictionInstant: Instant = switch onEnum(of: self) {
+        guard let predictionInstant: KotlinInstant = switch onEnum(of: self) {
         case let .time(trip): trip.predictionTime
         case let .timeWithStatus(trip): trip.predictionTime
         default: nil
@@ -303,7 +303,7 @@ extension TripInstantDisplay {
         }
     }
 
-    private func scheduleTimeLabel(_ scheduledTime: Instant, _ isFirst: Bool, _ vehicleType: String) -> Text {
+    private func scheduleTimeLabel(_ scheduledTime: KotlinInstant, _ isFirst: Bool, _ vehicleType: String) -> Text {
         let time = timeFormatter.string(from: Date(instant: scheduledTime))
         return isFirst
             ? Text("\(vehicleType) arriving at \(time) scheduled",

--- a/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
@@ -228,7 +228,7 @@ final class FavoritesViewTests: XCTestCase {
 
     @MainActor func testSetsNow() throws {
         let setFirstExp = expectation(description: "sets a time")
-        var firstTime: Instant?
+        var firstTime: KotlinInstant?
         let setSecondExp = expectation(description: "sets a different time later")
         setSecondExp.assertForOverFulfill = false
         let favoritesVM = MockFavoritesViewModel()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -32,7 +32,10 @@ plugins {
 kotlin {
     applyDefaultHierarchyTemplate()
 
-    compilerOptions { freeCompilerArgs.add("-Xexpect-actual-classes") }
+    compilerOptions {
+        optIn.add("kotlin.time.ExperimentalTime")
+        freeCompilerArgs.add("-Xexpect-actual-classes")
+    }
 
     androidTarget { compilerOptions { jvmTarget.set(JvmTarget.JVM_1_8) } }
 
@@ -76,6 +79,7 @@ kotlin {
                 implementation(libs.koin.compose)
                 implementation(libs.koin.core)
                 implementation(libs.kotlinx.coroutines.core)
+                implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.encoding)

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
@@ -4,7 +4,7 @@ import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.network.NetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.utils.AndroidSystemPaths
 import com.mbta.tid.mbta_app.utils.SystemPaths
-import kotlinx.datetime.Clock
+import kotlin.time.Clock
 import org.koin.dsl.module
 
 fun platformModule() = module {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/TimeMarkSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/TimeMarkSerializer.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.cache
 
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlin.time.TimeSource
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -59,8 +59,8 @@ import com.mbta.tid.mbta_app.usecases.ConfigUseCase
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
 import com.mbta.tid.mbta_app.usecases.TogglePinnedRouteUsecase
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.koin.core.module.Module
 import org.koin.dsl.module
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/Visit.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/Visit.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.history
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -4,7 +4,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.ServiceDateRounding
 import com.mbta.tid.mbta_app.utils.serviceDate
 import com.mbta.tid.mbta_app.utils.toBostonTime
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -3,10 +3,10 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.serviceDate
 import com.mbta.tid.mbta_app.utils.toBostonTime
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.minus

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 sealed class ErrorBannerState {
     /** What to do when the button in the error banner is pressed */

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class MapStop(
     val stop: Stop,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -2,10 +2,10 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.viewModel.SearchViewModel
 import kotlin.random.Random
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 object LoadingPlaceholders {
     fun nearbyRoute() =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -3,9 +3,9 @@ package com.mbta.tid.mbta_app.model
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.uuid
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Allows related objects to be built and tracked more conveniently. Provides default values where

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -9,12 +9,12 @@ import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.jvm.JvmName
 import kotlin.math.max
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 // These are used in LineOrRoute to disambiguate them from LineOrRoute.Route and LineOrRoute.Line
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 object StopDetailsUtils {
     /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -5,9 +5,9 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 
 data class TripDetailsStopList
 @DefaultArgumentInterop.Enabled

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.utils.toBostonTime
 import kotlin.math.roundToInt
 import kotlin.time.DurationUnit
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * The state in which a prediction/schedule should be shown.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 interface TripStopTime : Comparable<TripStopTime> {
     val arrivalTime: Instant?

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 sealed class UpcomingFormat {
     sealed class NoTripsFormat {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -4,7 +4,7 @@ import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.utils.resolveParentId
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Conceptually, an [UpcomingTrip] represents a trip's future arrival and departure at a stop.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import io.github.dellisd.spatialk.geojson.Position
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 data class TileData(
     val route: Route?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -3,11 +3,11 @@ package com.mbta.tid.mbta_app.repositories
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -11,9 +11,9 @@ import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixPushStatus
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.PredictionsForStopsChannel
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.core.component.KoinComponent
 
 interface IPredictionsRepository {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
@@ -6,9 +6,9 @@ import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.call.body
 import io.ktor.http.path
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
@@ -9,9 +9,9 @@ import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixPushStatus
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.PredictionsForStopsChannel
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.core.component.KoinComponent
 
 interface ITripPredictionsRepository {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/InstantExtension.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/InstantExtension.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.utils
 
 import kotlin.time.Duration.Companion.hours
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toInstant

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -10,9 +10,9 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/Timer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/Timer.kt
@@ -4,8 +4,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
@@ -15,8 +17,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.compose.koinInject
 
 class ClockTickHandler {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -16,11 +16,11 @@ import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.subscribeToPredictions
 import io.github.dellisd.spatialk.geojson.Position
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 interface IFavoritesViewModel {
     val models: StateFlow<FavoritesViewModel.State>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -31,12 +31,12 @@ import com.mbta.tid.mbta_app.utils.ViewportManager
 import com.mbta.tid.mbta_app.utils.timer
 import com.mbta.tid.mbta_app.viewModel.MapViewModel.Event
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Instant
 
 interface IMapViewModel {
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
 import org.koin.compose.koinInject
 
 private fun fetchSchedules(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -19,9 +19,9 @@ import io.github.dellisd.spatialk.turf.ExperimentalTurfApi
 import io.github.dellisd.spatialk.turf.lineSlice
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
 
 @OptIn(ExperimentalTurfApi::class)
 class RouteFeaturesBuilderTest {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class AlertAssociatedStopTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -6,11 +6,11 @@ import com.mbta.tid.mbta_app.utils.toBostonTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -3,9 +3,9 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 
 class AlertTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerStateTest.kt
@@ -2,8 +2,8 @@ package com.mbta.tid.mbta_app.model
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 
 class ErrorBannerStateTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/LeafFormatTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/LeafFormatTest.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.parametric.parametricTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class LeafFormatTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -5,8 +5,8 @@ import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 
 class PatternSortingTest {
     var objects = ObjectCollectionBuilder()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -9,8 +9,8 @@ import com.mbta.tid.mbta_app.utils.toBostonTime
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.atTime
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -7,12 +7,12 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 class RouteCardDataTest {
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtilsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtilsTest.kt
@@ -8,8 +8,8 @@ import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 
 class StopDetailsUtilsTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -6,10 +6,10 @@ import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 class TripDetailsStopListTest {
     // Every good test case deserves its own DSL, right?

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -5,9 +5,9 @@ import com.mbta.tid.mbta_app.parametric.parametricTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 
 class TripInstantDisplayTest {
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -11,9 +11,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 
 class UpcomingTripTest {
     class DisplayTest {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class GlobalResponseTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponseTest.kt
@@ -6,7 +6,7 @@ import kotlin.test.Test
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 class ScheduleResponseTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileDataTest.kt
@@ -10,9 +10,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 
 class TileDataTest {
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
@@ -6,7 +6,7 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.add

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/VehiclesOnRouteChannelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/VehiclesOnRouteChannelTest.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
@@ -12,13 +12,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Clock
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -23,9 +23,9 @@ import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import org.koin.test.KoinTest
 
 class PredictionsRepositoryTests : KoinTest {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepositoryTest.kt
@@ -14,8 +14,8 @@ import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
-import kotlinx.datetime.Instant
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -19,10 +19,10 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import org.koin.core.component.get
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -13,9 +13,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Clock
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.koin.core.component.get
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -10,11 +10,14 @@ import com.mbta.tid.mbta_app.dependencyInjection.appModule
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.endToEnd.endToEndModule
 import com.mbta.tid.mbta_app.viewModel.viewModelModule
+import kotlin.time.Instant
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.datetime.toKotlinInstant
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import platform.Foundation.NSDate
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
@@ -77,3 +80,11 @@ fun startKoinE2E() {
         )
     }
 }
+
+/**
+ * Converts an [NSDate] into a Kotlin stdlib [Instant].
+ *
+ * Necessary because the real [kotlinx.datetime.toKotlinInstant] has an internal-visibility-only
+ * default parameter and default parameters evaporate in Objective-C interop.
+ */
+fun NSDate.toKotlinInstant(): Instant = this.toKotlinInstant()


### PR DESCRIPTION
### Summary

_Ticket:_ none

Includes #1102 and #1106.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the Android and iOS tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
