### PR TITLE
feat(iOS): route details UX

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -44,6 +44,7 @@ import com.mbta.tid.mbta_app.android.state.getRouteStops
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.fromHex
@@ -60,6 +61,7 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
+import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.viewModel.IToastViewModel
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel
 import kotlinx.coroutines.launch
@@ -277,6 +279,7 @@ private fun RouteStops(
                         connectingRoutes = stop.connectingRoutes,
                         onClickLabel = onClickLabel(stopRowContext),
                         stopPlacement = stopPlacement,
+                        showStationAccessibility = SettingsCache.get(Settings.StationAccessibility),
                         rightSideContent = { modifier ->
                             rightSideContent(stopRowContext, modifier)
                         },

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -199,6 +199,7 @@ platform :ios do
       device: 'iPhone 15 (17.5)',
       testplan: 'iosAppRetries',
       output_directory: options[:output_directory],
+      include_simulator_logs: true,
       xcodebuild_formatter: options[:xcodebuild_formatter],
       number_of_retries: 3
     )

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -211,6 +211,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                             }
                         }
                     )
+                    .simultaneousGesture(TapGesture())
                     .accessibilityElement(children: .combine)
                     .accessibilityInputLabels([stop.name])
                     .accessibilityAddTraits(.isHeader)

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -155,17 +155,14 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
             HStack(alignment: .center, spacing: 0) {
                 HStack(alignment: .center) {
                     if showStationAccessibility, activeElevatorAlerts > 0 {
-                        Image(.accessibilityIconAlert)
-                            .accessibilityHidden(true)
-                            .tag("elevator_alert")
+                        Image(.accessibilityIconAlert).tag("elevator_alert")
                     } else if showStationAccessibility, !stop.isWheelchairAccessible {
-                        Image(.accessibilityIconNotAccessible)
-                            .accessibilityHidden(true)
-                            .tag("wheelchair_not_accessible")
+                        Image(.accessibilityIconNotAccessible).tag("wheelchair_not_accessible")
                     } else {
-                        EmptyView().accessibilityHidden(true)
+                        EmptyView()
                     }
                 }
+                .accessibilityHidden(true)
                 .frame(minWidth: 28, maxWidth: 28)
                 .padding(.leading, 6)
                 if stopPlacement.includeLineDiagram {

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -1,0 +1,328 @@
+//
+//  StopListRow.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/8/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopPlacement {
+    let isFirst: Bool
+    let isLast: Bool
+    let includeLineDiagram: Bool
+
+    init(isFirst: Bool = false, isLast: Bool = false, includeLineDiagram: Bool = true) {
+        self.isFirst = isFirst
+        self.isLast = isLast
+        self.includeLineDiagram = includeLineDiagram
+    }
+}
+
+enum StopListContext {
+    case trip
+    case routeDetails
+}
+
+struct StopListRow<Descriptor: View, RightSideContent: View>: View {
+    var stop: Stop
+    var onClick: () -> Void
+    var routeAccents: TripRouteAccents
+    var stopListContext: StopListContext
+    var activeElevatorAlerts: Int
+    var alertSummaries: [String: AlertSummary?]
+    var background: Color?
+    var connectingRoutes: [Route]?
+    var disruption: UpcomingFormat.Disruption?
+    var isTruncating: Bool
+    var stopPlacement: StopPlacement
+    var onOpenAlertDetails: (Shared.Alert) -> Void
+    var showDownstreamAlert: Bool
+    var showStationAccessibility: Bool
+    var targeted: Bool
+    var trackNumber: String?
+    var descriptor: () -> Descriptor
+    var rightSideContent: () -> RightSideContent
+
+    init(
+        stop: Stop,
+        onClick: @escaping () -> Void,
+        routeAccents: TripRouteAccents,
+        stopListContext: StopListContext,
+        activeElevatorAlerts: Int = 0,
+        alertSummaries: [String: AlertSummary?] = [:],
+        background: Color? = nil,
+        connectingRoutes: [Route]? = nil,
+        disruption: UpcomingFormat.Disruption? = nil,
+        isTruncating: Bool = false,
+        stopPlacement: StopPlacement = .init(),
+        onOpenAlertDetails: @escaping (Shared.Alert) -> Void = { _ in },
+        showDownstreamAlert: Bool = false,
+        showStationAccessibility: Bool = false,
+        targeted: Bool = false,
+        trackNumber: String? = nil,
+        descriptor: @escaping () -> Descriptor,
+        rightSideContent: @escaping () -> RightSideContent
+    ) {
+        self.stop = stop
+        self.onClick = onClick
+        self.routeAccents = routeAccents
+        self.stopListContext = stopListContext
+        self.activeElevatorAlerts = activeElevatorAlerts
+        self.alertSummaries = alertSummaries
+        self.background = background
+        self.connectingRoutes = connectingRoutes
+        self.disruption = disruption
+        self.isTruncating = isTruncating
+        self.stopPlacement = stopPlacement
+        self.onOpenAlertDetails = onOpenAlertDetails
+        self.showDownstreamAlert = showDownstreamAlert
+        self.showStationAccessibility = showStationAccessibility
+        self.targeted = targeted
+        self.trackNumber = trackNumber
+        self.descriptor = descriptor
+        self.rightSideContent = rightSideContent
+    }
+
+    var stateBefore: ColoredRouteLine.State {
+        if !stopPlacement.includeLineDiagram {
+            .empty
+        } else if stopPlacement.isFirst {
+            .empty
+        } else {
+            .regular
+        }
+    }
+
+    var stateAfter: ColoredRouteLine.State {
+        if !stopPlacement.includeLineDiagram {
+            .empty
+        } else if stopPlacement.isLast {
+            .empty
+        } else if showDownstreamAlert, disruption?.alert.effect == .shuttle {
+            .shuttle
+        } else {
+            .regular
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            stopRow
+                .background(background?.padding(.horizontal, 2))
+                .overlay {
+                    if targeted {
+                        VStack {
+                            HaloSeparator(height: 2)
+                            Spacer()
+                            HaloSeparator(height: 2)
+                        }
+                    }
+                }
+            if let disruption {
+                ZStack(alignment: .leading) {
+                    VStack(spacing: 0) {
+                        ColoredRouteLine(routeAccents.color, state: stateAfter)
+                        if isTruncating {
+                            ColoredRouteLine(routeAccents.color, state: .empty)
+                        }
+                    }
+                    .padding(.leading, 42)
+                    AlertCard(
+                        alert: disruption.alert,
+                        alertSummary: alertSummaries[disruption.alert.id] ?? nil,
+                        spec: .downstream,
+                        color: routeAccents.color,
+                        textColor: routeAccents.textColor,
+                        onViewDetails: { onOpenAlertDetails(disruption.alert) },
+                        internalPadding: .init(top: 0, leading: 21, bottom: 0, trailing: 0)
+                    )
+                    .padding(.horizontal, -4)
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, 6)
+    }
+
+    @ViewBuilder
+    var stopRow: some View {
+        ZStack(alignment: .bottom) {
+            if !stopPlacement.isLast, !targeted, disruption == nil {
+                HaloSeparator()
+            }
+            HStack(alignment: .center, spacing: 0) {
+                HStack(alignment: .center) {
+                    if showStationAccessibility, activeElevatorAlerts > 0 {
+                        Image(.accessibilityIconAlert)
+                            .accessibilityHidden(true)
+                            .tag("elevator_alert")
+                    } else if showStationAccessibility, !stop.isWheelchairAccessible {
+                        Image(.accessibilityIconNotAccessible)
+                            .accessibilityHidden(true)
+                            .tag("wheelchair_not_accessible")
+                    } else {
+                        EmptyView().accessibilityHidden(true)
+                    }
+                }
+                .frame(minWidth: 28, maxWidth: 28)
+                .padding(.leading, 6)
+                if stopPlacement.includeLineDiagram {
+                    routeLine
+                } else {
+                    standaloneStopIcon
+                }
+                VStack(alignment: .leading, spacing: 8) {
+                    Button(
+                        action: { onClick() },
+                        label: {
+                            HStack(alignment: .center, spacing: 0) {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    descriptor()
+                                    Text(stop.name)
+                                        .font(targeted ? Typography.headlineBold : Typography.body)
+                                        .foregroundStyle(Color.text)
+                                        .multilineTextAlignment(.leading)
+                                        .accessibilityLabel(stopAccessibilityLabel)
+                                    if let trackNumber {
+                                        Text("Track \(trackNumber)")
+                                            .font(Typography.footnote)
+                                            .foregroundStyle(Color.text)
+                                            .multilineTextAlignment(.leading)
+                                            .accessibilityLabel(Text("Boarding on track \(trackNumber)"))
+                                    }
+                                }
+                                Spacer()
+                                rightSideContent()
+
+                                // Adding the accessibility description into the stop label rather than on the
+                                // accessibility icon so that it is clear which stop it is associated with
+                                if showStationAccessibility, activeElevatorAlerts > 0 {
+                                    HStack {}
+                                        .accessibilityLabel(Text(
+                                            "This stop has \(activeElevatorAlerts, specifier: "%ld") elevators closed",
+                                            comment: "Describe an elevator outage at the stop in the list of all stops on the trip"
+                                        ))
+                                } else if showStationAccessibility, !stop.isWheelchairAccessible {
+                                    HStack {}
+                                        .accessibilityLabel(Text("This stop is not accessible"))
+                                }
+                            }
+                        }
+                    )
+                    .accessibilityElement(children: .combine)
+                    .accessibilityInputLabels([stop.name])
+                    .accessibilityAddTraits(.isHeader)
+                    .accessibilityHeading(.h4)
+
+                    if let connectingRoutes, !connectingRoutes.isEmpty {
+                        scrollRoutes
+                            .accessibilityElement()
+                            .accessibilityLabel(scrollRoutesAccessibilityLabel)
+                    }
+                }
+                .accessibilitySortPriority(1)
+                .padding(.leading, 8)
+                .padding(.vertical, 12)
+                .padding(.trailing, 8)
+                .padding(.bottom, stopPlacement.isLast ? 0 : 1)
+                .frame(minHeight: 56)
+            }.accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder
+    var routeLine: some View {
+        ZStack(alignment: .center) {
+            VStack(spacing: 0) {
+                ColoredRouteLine(routeAccents.color, state: stateBefore)
+                ColoredRouteLine(routeAccents.color, state: stateAfter)
+            }
+            StopDot(routeAccents: routeAccents, targeted: targeted)
+        }
+        .padding(.leading, 3)
+        .padding(.trailing, 8)
+    }
+
+    @ViewBuilder
+    var standaloneStopIcon: some View {
+        if stop.locationType == .station {
+            Image(.mbtaLogo).accessibilityHidden(true)
+        } else if stop.vehicleType == .bus {
+            Image(.mapStopCloseBUS).accessibilityHidden(true)
+        } else {
+            StopDot(routeAccents: routeAccents, targeted: false)
+        }
+    }
+
+    func connectionLabel(route: Route) -> String {
+        String(format: NSLocalizedString(
+            "%@ %@",
+            comment: """
+            A route label and route type pair,
+            ex 'Red Line train' or '73 bus', used in connecting stop labels
+            """
+        ), route.label, route.type.typeText(isOnly: true))
+    }
+
+    var scrollRoutes: some View {
+        let routeView = ScrollView(.horizontal, showsIndicators: false) {
+            HStack {
+                if let connectingRoutes {
+                    ForEach(connectingRoutes, id: \.id) { route in
+                        RoutePill(route: route, line: nil, type: .flex)
+                    }
+                }
+            }.padding(.trailing, 20)
+        }.onTapGesture { onClick() }
+        return routeView.scrollBounceBehavior(.basedOnSize, axes: [.horizontal])
+    }
+
+    var scrollRoutesAccessibilityLabel: String {
+        guard let connectingRoutes, !connectingRoutes.isEmpty else { return "" }
+        if connectingRoutes.count == 1 {
+            return String(format: NSLocalizedString(
+                "Connection to %@",
+                comment: "VoiceOver label for a single connecting route at a stop, ex 'Connection to 1 bus'"
+            ), connectionLabel(route: connectingRoutes.first!))
+        } else {
+            let firstConnections = connectingRoutes.prefix(connectingRoutes.count - 1)
+            let lastConnection = connectingRoutes.last!
+            return String(
+                format: NSLocalizedString(
+                    "Connections to %@ and %@",
+                    comment: """
+                    VoiceOver label for multiple connecting routes at a stop,
+                    ex 'Connections to Red Line train, 71 bus, and 73 bus',
+                    the first replaced value can be any number of comma separated route labels
+                    """
+                ),
+                firstConnections.map(connectionLabel).joined(separator: ", "),
+                connectionLabel(route: lastConnection)
+            )
+        }
+    }
+
+    var stopAccessibilityLabel: String {
+        let name = stop.name
+        return if targeted, stopPlacement.isFirst {
+            String(format: NSLocalizedString(
+                "%@, selected stop, first stop",
+                comment: "Screen reader text for a stop name on the stop details page when that stop is both selected and first"
+            ), name)
+        } else if targeted {
+            String(format: NSLocalizedString(
+                "%@, selected stop",
+                comment: "Screen reader text for a stop name on the stop details page when that stop is the selected one"
+            ), name)
+        } else if stopPlacement.isFirst {
+            String(format: NSLocalizedString(
+                "%@, first stop",
+                comment: "Screen reader text for a stop name on the stop details page when that stop is the first stop on the line"
+            ), name)
+        } else {
+            name
+        }
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -202,6 +202,23 @@ struct ContentView: View {
                 case .favorites, .nearby:
                     tabbedSheetContents.transition(transition)
 
+                case let .routeDetails(navEntry):
+                    // Wrapping in a TabView helps the page to animate in as a single unit
+                    // Otherwise only the header animates
+                    TabView {
+                        RouteDetailsView(
+                            selectionId: navEntry.routeId, context: navEntry.context,
+                            onOpenStopDetails: { nearbyVM.pushNavEntry(.stopDetails(
+                                stopId: $0,
+                                stopFilter: nil,
+                                tripFilter: nil
+                            )) }, onBack: { nearbyVM.goBack() }, onClose: { nearbyVM.popToEntrypoint() },
+                            errorBannerVM: errorBannerVM
+                        )
+                        .toolbar(.hidden, for: .tabBar)
+                    }
+                    .transition(transition)
+
                 case let .stopDetails(stopId, stopFilter, tripFilter):
                     // Wrapping in a TabView helps the page to animate in as a single unit
                     // Otherwise only the header animates

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -1,0 +1,99 @@
+//
+//  RouteDetailsView.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/7/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct RouteDetailsView: View {
+    let selectionId: String
+    let context: RouteDetailsContext
+    let onOpenStopDetails: (String) -> Void
+    let onBack: () -> Void
+    let onClose: () -> Void
+    let errorBannerVM: ErrorBannerViewModel
+
+    @State var globalData: GlobalResponse?
+    let globalRepository: IGlobalRepository = RepositoryDI().global
+    var errorBannerRepository = RepositoryDI().errorBanner
+
+    var body: some View {
+        Group {
+            if let globalData, let lineOrRoute = RouteDetailsStopList.companion.getLineOrRoute(
+                selectionId: selectionId,
+                globalData: globalData
+            ) {
+                RouteStopListView(
+                    lineOrRoute: lineOrRoute,
+                    context: context,
+                    globalData: globalData,
+                    onClick: { row in
+                        switch row {
+                        case let .details(stop: stop): onOpenStopDetails(stop.id)
+                        case let .favorites(isFavorited: _, onTapStar: onTapStar): onTapStar()
+                        }
+                    },
+                    onBack: onBack,
+                    onClose: onClose,
+                    errorBannerVM: errorBannerVM,
+                    defaultSelectedRouteId: selectionId == lineOrRoute.id ? nil : selectionId,
+                    rightSideContent: rightSideContent
+                )
+            } else {
+                loadingBody()
+            }
+        }
+        .onAppear {
+            getGlobal()
+        }
+    }
+
+    @MainActor
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            self.globalData = globalData
+        }
+    }
+
+    func getGlobal() {
+        Task(priority: .high) {
+            await activateGlobalListener()
+        }
+        Task {
+            await fetchApi(
+                errorBannerRepository,
+                errorKey: "NearbyTransitView.getGlobal",
+                getData: { try await globalRepository.getGlobalData() },
+                onRefreshAfterError: { @MainActor in getGlobal() }
+            )
+        }
+    }
+
+    @ViewBuilder private func loadingBody() -> some View {
+        let mockRoute = RouteCardData.LineOrRouteRoute(route: ObjectCollectionBuilder.Single.shared.route { _ in })
+        RouteStopListView(
+            lineOrRoute: mockRoute,
+            context: context,
+            globalData: globalData ?? GlobalResponse(objects: .init()),
+            onClick: { _ in },
+            onBack: {},
+            onClose: {},
+            errorBannerVM: errorBannerVM,
+            rightSideContent: rightSideContent
+        )
+        .loadingPlaceholder()
+    }
+
+    @ViewBuilder private func rightSideContent(rowContext: RouteDetailsRowContext) -> some View {
+        switch rowContext {
+        case .details: Image(.faChevronRight).resizable().frame(width: 8, height: 14)
+            .foregroundStyle(Color.deemphasized)
+        case let .favorites(isFavorited: isFavorited, onTapStar: _): StarIcon(pinned: isFavorited, color: Color.text)
+            .accessibilityLabel(isFavorited ? Text("favorite stop") : Text(verbatim: ""))
+        }
+    }
+}

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -1,0 +1,279 @@
+//
+//  RouteStopListView.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/7/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+enum RouteDetailsRowContext: Equatable {
+    case details(stop: Stop)
+    case favorites(isFavorited: Bool, onTapStar: () -> Void)
+
+    static func == (lhs: RouteDetailsRowContext, rhs: RouteDetailsRowContext) -> Bool {
+        switch (lhs, rhs) {
+        case let (.details(stop: lhs), .details(stop: rhs)):
+            lhs == rhs
+        case let (.favorites(isFavorited: lhs, onTapStar: _), .favorites(isFavorited: rhs, onTapStar: _)):
+            lhs == rhs
+        case (.details, .favorites):
+            false
+        case (.favorites, .details):
+            false
+        }
+    }
+}
+
+struct RouteStopListView<RightSideContent: View>: View {
+    let lineOrRoute: RouteCardData.LineOrRoute
+    let context: RouteDetailsContext
+    let globalData: GlobalResponse
+    let onClick: (RouteDetailsRowContext) -> Void
+    let onBack: () -> Void
+    let onClose: () -> Void
+    let errorBannerVM: ErrorBannerViewModel
+    let defaultSelectedRouteId: String?
+    let rightSideContent: (RouteDetailsRowContext) -> RightSideContent
+
+    let favoritesUsecases: FavoritesUsecases
+    @State var favorites: Set<RouteStopDirection>?
+    let routeStopsRepository: IRouteStopsRepository
+    @State var routeStops: RouteStopsResult?
+    @State var stopList: RouteDetailsStopList?
+
+    @State var selectedRouteId: String
+    @State var selectedDirection: Int32
+
+    let inspection = Inspection<Self>()
+
+    init(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        context: RouteDetailsContext,
+        globalData: GlobalResponse,
+        onClick: @escaping (RouteDetailsRowContext) -> Void,
+        onBack: @escaping () -> Void,
+        onClose: @escaping () -> Void,
+        errorBannerVM: ErrorBannerViewModel,
+        defaultSelectedRouteId: String? = nil,
+        rightSideContent: @escaping (RouteDetailsRowContext) -> RightSideContent,
+        routeStopsRepository: IRouteStopsRepository = RepositoryDI().routeStops,
+        favoritesUsecases: FavoritesUsecases = UsecaseDI().favoritesUsecases,
+    ) {
+        self.lineOrRoute = lineOrRoute
+        self.context = context
+        self.globalData = globalData
+        self.onClick = onClick
+        self.onBack = onBack
+        self.onClose = onClose
+        self.errorBannerVM = errorBannerVM
+        self.defaultSelectedRouteId = defaultSelectedRouteId
+        self.rightSideContent = rightSideContent
+        self.routeStopsRepository = routeStopsRepository
+        self.favoritesUsecases = favoritesUsecases
+
+        selectedRouteId = defaultSelectedRouteId ?? lineOrRoute.sortRoute.id
+        let parameters = RouteDetailsStopList.RouteParameters(lineOrRoute: lineOrRoute, globalData: globalData)
+        selectedDirection = Int32(truncating: parameters.availableDirections.first ?? 0)
+    }
+
+    private struct RouteStopsParams: Equatable {
+        let routeId: String
+        let directionId: Int32
+    }
+
+    private struct RouteStopListParams: Equatable {
+        let routeId: String
+        let directionId: Int32
+        let routeStops: RouteStopsResult?
+        let globalData: GlobalResponse
+    }
+
+    var body: some View {
+        let routes = lineOrRoute.allRoutes.sorted(by: { $0.sortOrder <= $1.sortOrder })
+        let parameters = RouteDetailsStopList.RouteParameters(lineOrRoute: lineOrRoute, globalData: globalData)
+
+        VStack {
+            SheetHeader(title: lineOrRoute.name, onBack: onBack, onClose: onClose)
+            ErrorBanner(errorBannerVM)
+            DirectionPicker(
+                availableDirections: parameters.availableDirections.map { Int32(truncating: $0) },
+                directions: parameters.directions,
+                route: lineOrRoute.sortRoute,
+                selectedDirectionId: selectedDirection,
+                updateDirectionId: { selectedDirection = $0 }
+            )
+            .fixedSize(horizontal: false, vertical: true).padding(.horizontal, 14).padding(.vertical, 8)
+            if case let .line(lineOrRoute) = onEnum(of: lineOrRoute), routes.count > 1 {
+                lineRoutePicker(line: lineOrRoute.line, routes: routes)
+            }
+            routeStopList(stopList: stopList, onTapStop: onClick)
+        }
+        .onAppear {
+            loadEverything()
+            if !parameters.availableDirections.contains(where: { $0.intValue == selectedDirection }) {
+                selectedDirection = Int32(truncating: parameters.availableDirections.first ?? 0)
+            }
+        }
+        .onChange(of: RouteStopsParams(routeId: selectedRouteId, directionId: selectedDirection)) {
+            loadRouteStops(routeId: $0.routeId, directionId: $0.directionId)
+        }
+        .onChange(of: RouteStopListParams(
+            routeId: selectedRouteId,
+            directionId: selectedDirection,
+            routeStops: routeStops,
+            globalData: globalData
+        )) {
+            loadStopList(
+                routeId: $0.routeId,
+                directionId: $0.directionId,
+                routeStops: $0.routeStops,
+                globalData: $0.globalData
+            )
+        }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+    }
+
+    @ViewBuilder private func routeStopList(stopList: RouteDetailsStopList?,
+                                            onTapStop: @escaping (RouteDetailsRowContext) -> Void) -> some View {
+        if let stopList, stopList.directionId == Int32(selectedDirection) {
+            ScrollView {
+                VStack {
+                    ForEach(Array(stopList.segments.enumerated()), id: \.offset) { segmentIndex, segment in
+                        if segment.isTypical {
+                            ForEach(Array(segment.stops.enumerated()), id: \.offset) { stopIndex, stop in
+                                let stopPlacement = StopPlacement(
+                                    isFirst: segmentIndex == stopList.segments.startIndex && stopIndex == segment.stops
+                                        .startIndex,
+                                    isLast: segmentIndex == stopList.segments
+                                        .index(before: stopList.segments.endIndex) && stopIndex == segment.stops
+                                        .index(before: segment.stops.endIndex),
+                                    includeLineDiagram: segment.hasRouteLine
+                                )
+                                let stopRowContext = stopRowContext(stop.stop)
+                                StopListRow(
+                                    stop: stop.stop,
+                                    onClick: { onTapStop(stopRowContext) },
+                                    routeAccents: .init(route: lineOrRoute.sortRoute),
+                                    stopListContext: .routeDetails,
+                                    connectingRoutes: stop.connectingRoutes,
+                                    stopPlacement: stopPlacement,
+                                    descriptor: { EmptyView() },
+                                    rightSideContent: { rightSideContent(stopRowContext) }
+                                )
+                            }
+                        } else {
+                            // TODO: CollapsableStopList
+                        }
+                    }
+                }
+            }
+        } else {
+            AnyView(loadingRouteStops())
+        }
+    }
+
+    @ViewBuilder private func lineRoutePicker(line: Line, routes: [Route]) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(routes, id: \.id) { route in
+                let selected = route.id == selectedRouteId
+                let rowColor = selected ? Color.fill3 : Color.clear
+                let textColor = selected ? Color.text : Color(hex: line.textColor)
+                Button {
+                    selectedRouteId = route.id
+                } label: {
+                    HStack(alignment: .center, spacing: 8) {
+                        RoutePill(route: route, line: line, type: .fixed)
+                        Text(((route.directionDestinations[Int(selectedDirection)] as? String?) ?? "") ?? "")
+                            .foregroundStyle(textColor)
+                            .font(Typography.title3Semibold)
+                        Spacer()
+                    }
+                    .padding(8)
+                    .background(rowColor)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.deselectedToggle2.opacity(0.6))
+        .background(Color(hex: line.color))
+    }
+
+    @ViewBuilder private func loadingRouteStops() -> some View {
+        let loadingStops = LoadingPlaceholders.shared.routeDetailsStops(
+            lineOrRoute: lineOrRoute,
+            directionId: Int32(selectedDirection)
+        )
+        routeStopList(stopList: loadingStops, onTapStop: { _ in }).loadingPlaceholder()
+    }
+
+    private func loadEverything() {
+        loadFavorites()
+        loadRouteStops(routeId: selectedRouteId, directionId: selectedDirection)
+        if let routeStops {
+            loadStopList(
+                routeId: selectedRouteId,
+                directionId: selectedDirection,
+                routeStops: routeStops,
+                globalData: globalData
+            )
+        }
+    }
+
+    private func loadFavorites() {
+        Task {
+            favorites = try? await favoritesUsecases.getRouteStopDirectionFavorites()
+        }
+    }
+
+    private func loadRouteStops(routeId: String, directionId: Int32) {
+        Task {
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "RouteStopListView.loadRouteStops",
+                getData: { try await routeStopsRepository.getRouteStops(
+                    routeId: routeId,
+                    directionId: directionId
+                ) },
+                onSuccess: { routeStops = $0 },
+                onRefreshAfterError: loadEverything
+            )
+        }
+    }
+
+    private func loadStopList(
+        routeId: String,
+        directionId: Int32,
+        routeStops: RouteStopsResult?,
+        globalData: GlobalResponse
+    ) {
+        Task {
+            stopList = try? await RouteDetailsStopList.companion.fromPieces(
+                routeId: routeId,
+                directionId: directionId,
+                routeStops: routeStops,
+                globalData: globalData
+            )
+        }
+    }
+
+    private func isFavorite(_ routeStopDirection: RouteStopDirection) -> Bool {
+        favorites?.contains(routeStopDirection) ?? false
+    }
+
+    private func stopRowContext(_ stop: Stop) -> RouteDetailsRowContext {
+        switch onEnum(of: context) {
+        case .details: .details(stop: stop)
+        case .favorites: .favorites(
+                isFavorited: isFavorite(.init(
+                    route: selectedRouteId,
+                    stop: stop.id,
+                    direction: selectedDirection
+                )),
+                onTapStar: {}
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -44,6 +44,8 @@ struct RouteStopListView<RightSideContent: View>: View {
     @State var routeStops: RouteStopsResult?
     @State var stopList: RouteDetailsStopList?
 
+    @EnvironmentObject var settingsCache: SettingsCache
+
     @State var selectedRouteId: String
     @State var selectedDirection: Int32
 
@@ -160,6 +162,7 @@ struct RouteStopListView<RightSideContent: View>: View {
                                     stopListContext: .routeDetails,
                                     connectingRoutes: stop.connectingRoutes,
                                     stopPlacement: stopPlacement,
+                                    showStationAccessibility: settingsCache.get(.stationAccessibility),
                                     descriptor: { EmptyView() },
                                     rightSideContent: { rightSideContent(stopRowContext) }
                                 )

--- a/iosApp/iosApp/Pages/Search/Results/RouteResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/RouteResultsView.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct RouteResultsView: View {
     let routes: [SearchViewModel.RouteResult]
+    let handleRouteTap: (String) -> Void
 
     var body: some View {
         VStack {
@@ -20,15 +21,19 @@ struct RouteResultsView: View {
             ResultContainer {
                 VStack(spacing: .zero) {
                     ForEach(routes, id: \.id) { route in
-                        HStack {
-                            RoutePill(spec: route.routePill)
-                            Text(route.name)
-                                .font(Typography.bodySemibold)
-                                .foregroundStyle(Color.text)
-                                .multilineTextAlignment(.leading)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                        Button {
+                            handleRouteTap(route.id)
+                        } label: {
+                            HStack {
+                                RoutePill(spec: route.routePill)
+                                Text(route.name)
+                                    .font(Typography.bodySemibold)
+                                    .foregroundStyle(Color.text)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .padding(12)
                         }
-                        .padding(12)
                         if route != routes.last {
                             Divider().overlay(Color.halo)
                         }

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
@@ -39,10 +39,15 @@ struct SearchResultsContainer: View {
         nearbyVM.pushNavEntry(.stopDetails(stopId: stopId, stopFilter: nil, tripFilter: nil))
     }
 
+    func handleRouteTap(routeId: String) {
+        nearbyVM.pushNavEntry(.routeDetails(.init(routeId: routeId, context: .Details.shared)))
+    }
+
     var body: some View {
         SearchResultsView(
             state: searchVMState,
-            handleStopTap: handleStopTap
+            handleStopTap: handleStopTap,
+            handleRouteTap: handleRouteTap,
         )
         .task {
             for await state in searchVM.models {
@@ -97,7 +102,8 @@ struct SearchResultView_Previews: PreviewProvider {
                     ),
                 ]
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in },
+            handleRouteTap: { _ in },
         ).font(Typography.body).previewDisplayName("SearchResultView")
     }
 }

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct SearchResultsView: View {
     private var state: SearchViewModel.State
     private var handleStopTap: (String) -> Void
+    private var handleRouteTap: (String) -> Void
 
     @EnvironmentObject var settingsCache: SettingsCache
 
@@ -20,10 +21,12 @@ struct SearchResultsView: View {
 
     init(
         state: SearchViewModel.State,
-        handleStopTap: @escaping (String) -> Void
+        handleStopTap: @escaping (String) -> Void,
+        handleRouteTap: @escaping (String) -> Void,
     ) {
         self.state = state
         self.handleStopTap = handleStopTap
+        self.handleRouteTap = handleRouteTap
     }
 
     var body: some View {
@@ -56,7 +59,7 @@ struct SearchResultsView: View {
                         VStack(spacing: 8) {
                             StopResultsView(stops: state.stops, handleStopTap: handleStopTap)
                             if includeRoutes, !state.routes.isEmpty {
-                                RouteResultsView(routes: state.routes)
+                                RouteResultsView(routes: state.routes, handleRouteTap: handleRouteTap)
                                     .padding(.top, 8)
                             }
                         }

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -24,6 +24,10 @@ struct TripStopRow: View {
     var lastStop: Bool = false
     var background: Color? = nil
 
+    var activeElevatorAlerts: [Shared.Alert] {
+        stop.activeElevatorAlerts(now: now)
+    }
+
     var disruption: UpcomingFormat.Disruption? {
         if let disruption = stop.disruption, disruption.alert.hasNoThroughService, showDownstreamAlert {
             disruption
@@ -32,231 +36,37 @@ struct TripStopRow: View {
         }
     }
 
-    var stateBefore: ColoredRouteLine.State {
-        if firstStop {
-            .empty
-        } else {
-            .regular
-        }
-    }
-
-    var stateAfter: ColoredRouteLine.State {
-        if lastStop {
-            .empty
-        } else if disruption?.alert.effect == .shuttle {
-            .shuttle
-        } else {
-            .regular
-        }
-    }
-
     var body: some View {
-        VStack(spacing: 0) {
-            stopRow
-                .background(background?.padding(.horizontal, 2))
-                .overlay {
-                    if targeted {
-                        VStack {
-                            HaloSeparator(height: 2)
-                            Spacer()
-                            HaloSeparator(height: 2)
-                        }
-                    }
-                }
-            if let disruption {
-                ZStack(alignment: .leading) {
-                    VStack(spacing: 0) {
-                        ColoredRouteLine(routeAccents.color, state: stateAfter)
-                        if stop.isTruncating {
-                            ColoredRouteLine(routeAccents.color, state: .empty)
-                        }
-                    }
-                    .padding(.leading, 42)
-                    AlertCard(
-                        alert: disruption.alert,
-                        alertSummary: alertSummaries[disruption.alert.id] ?? nil,
-                        spec: .downstream,
-                        color: routeAccents.color,
-                        textColor: routeAccents.textColor,
-                        onViewDetails: { onOpenAlertDetails(disruption.alert) },
-                        internalPadding: .init(top: 0, leading: 21, bottom: 0, trailing: 0)
-                    )
-                    .padding(.horizontal, -4)
-                }
-            }
-        }
-        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, 6)
+        StopListRow(
+            stop: stop.stop,
+            onClick: { onTapLink(stop) },
+            routeAccents: routeAccents,
+            stopListContext: .trip,
+            activeElevatorAlerts: activeElevatorAlerts.count,
+            alertSummaries: alertSummaries,
+            background: background,
+            connectingRoutes: stop.routes,
+            disruption: disruption,
+            isTruncating: stop.isTruncating,
+            stopPlacement: .init(isFirst: firstStop, isLast: lastStop, includeLineDiagram: true),
+            onOpenAlertDetails: onOpenAlertDetails,
+            showDownstreamAlert: showDownstreamAlert,
+            showStationAccessibility: showStationAccessibility,
+            targeted: targeted,
+            trackNumber: stop.trackNumber,
+            descriptor: { EmptyView() },
+            rightSideContent: rightSideContent
+        )
     }
 
-    @ViewBuilder
-    var stopRow: some View {
-        let activeElevatorAlerts = stop.activeElevatorAlerts(now: now)
-
-        ZStack(alignment: .bottom) {
-            if !lastStop, !targeted, disruption == nil {
-                HaloSeparator()
-            }
-            HStack(alignment: .center, spacing: 0) {
-                HStack(alignment: .center) {
-                    if showStationAccessibility, !activeElevatorAlerts.isEmpty {
-                        Image(.accessibilityIconAlert)
-                            .accessibilityHidden(true)
-                            .tag("elevator_alert")
-                    } else if showStationAccessibility, !stop.stop.isWheelchairAccessible {
-                        Image(.accessibilityIconNotAccessible)
-                            .accessibilityHidden(true)
-                            .tag("wheelchair_not_accessible")
-                    } else {
-                        EmptyView().accessibilityHidden(true)
-                    }
-                }
-                .frame(minWidth: 28, maxWidth: 28)
-                .padding(.leading, 6)
-                routeLine
-                VStack(alignment: .leading, spacing: 8) {
-                    Button(
-                        action: { onTapLink(stop) },
-                        label: {
-                            HStack(alignment: .center, spacing: 0) {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(stop.stop.name)
-                                        .font(targeted ? Typography.headlineBold : Typography.body)
-                                        .foregroundStyle(Color.text)
-                                        .multilineTextAlignment(.leading)
-                                        .accessibilityLabel(stopAccessibilityLabel)
-                                    if let trackNumber = stop.trackNumber {
-                                        Text("Track \(trackNumber)")
-                                            .font(Typography.footnote)
-                                            .foregroundStyle(Color.text)
-                                            .multilineTextAlignment(.leading)
-                                            .accessibilityLabel(Text("Boarding on track \(trackNumber)"))
-                                    }
-                                }
-                                Spacer()
-                                if let upcomingTripViewState {
-                                    UpcomingTripView(
-                                        prediction: upcomingTripViewState,
-                                        routeType: routeAccents.type,
-                                        hideRealtimeIndicators: true,
-                                        maxTextAlpha: 0.6
-                                    ).foregroundStyle(Color.text)
-                                }
-
-                                // Adding the accessibility description into the stop label rather than on the
-                                // accessibility icon so that it is clear which stop it is associated with
-                                if showStationAccessibility, !activeElevatorAlerts.isEmpty {
-                                    HStack {}
-                                        .accessibilityLabel(Text(
-                                            "This stop has \(activeElevatorAlerts.count, specifier: "%ld") elevators closed",
-                                            comment: "Describe an elevator outage at the stop in the list of all stops on the trip"
-                                        ))
-                                } else if showStationAccessibility, !stop.stop.isWheelchairAccessible {
-                                    HStack {}
-                                        .accessibilityLabel(Text("This stop is not accessible"))
-                                }
-                            }
-                        }
-                    )
-                    .accessibilityElement(children: .combine)
-                    .accessibilityInputLabels([stop.stop.name])
-                    .accessibilityAddTraits(.isHeader)
-                    .accessibilityHeading(.h4)
-
-                    if !stop.routes.isEmpty {
-                        scrollRoutes
-                            .accessibilityElement()
-                            .accessibilityLabel(scrollRoutesAccessibilityLabel)
-                    }
-                }
-                .accessibilitySortPriority(1)
-                .padding(.leading, 8)
-                .padding(.vertical, 12)
-                .padding(.trailing, 8)
-                .padding(.bottom, lastStop ? 0 : 1)
-                .frame(minHeight: 56)
-            }.accessibilityElement(children: .contain)
-        }
-    }
-
-    @ViewBuilder
-    var routeLine: some View {
-        ZStack(alignment: .center) {
-            VStack(spacing: 0) {
-                ColoredRouteLine(routeAccents.color, state: stateBefore)
-                ColoredRouteLine(routeAccents.color, state: stateAfter)
-            }
-            StopDot(routeAccents: routeAccents, targeted: targeted)
-        }
-        .padding(.leading, 3)
-        .padding(.trailing, 8)
-    }
-
-    func connectionLabel(route: Route) -> String {
-        String(format: NSLocalizedString(
-            "%@ %@",
-            comment: """
-            A route label and route type pair,
-            ex 'Red Line train' or '73 bus', used in connecting stop labels
-            """
-        ), route.label, route.type.typeText(isOnly: true))
-    }
-
-    var scrollRoutes: some View {
-        let routeView = ScrollView(.horizontal, showsIndicators: false) {
-            HStack {
-                ForEach(stop.routes, id: \.id) { route in
-                    RoutePill(route: route, line: nil, type: .flex)
-                }
-            }.padding(.trailing, 20)
-        }.onTapGesture { onTapLink(stop) }
-        return routeView.scrollBounceBehavior(.basedOnSize, axes: [.horizontal])
-    }
-
-    var scrollRoutesAccessibilityLabel: String {
-        if stop.routes.isEmpty {
-            return ""
-        } else if stop.routes.count == 1 {
-            return String(format: NSLocalizedString(
-                "Connection to %@",
-                comment: "VoiceOver label for a single connecting route at a stop, ex 'Connection to 1 bus'"
-            ), connectionLabel(route: stop.routes.first!))
-        } else {
-            let firstConnections = stop.routes.prefix(stop.routes.count - 1)
-            let lastConnection = stop.routes.last!
-            return String(
-                format: NSLocalizedString(
-                    "Connections to %@ and %@",
-                    comment: """
-                    VoiceOver label for multiple connecting routes at a stop,
-                    ex 'Connections to Red Line train, 71 bus, and 73 bus',
-                    the first replaced value can be any number of comma separated route labels
-                    """
-                ),
-                firstConnections.map(connectionLabel).joined(separator: ", "),
-                connectionLabel(route: lastConnection)
-            )
-        }
-    }
-
-    var stopAccessibilityLabel: String {
-        let name = stop.stop.name
-        return if targeted, firstStop {
-            String(format: NSLocalizedString(
-                "%@, selected stop, first stop",
-                comment: "Screen reader text for a stop name on the stop details page when that stop is both selected and first"
-            ), name)
-        } else if targeted {
-            String(format: NSLocalizedString(
-                "%@, selected stop",
-                comment: "Screen reader text for a stop name on the stop details page when that stop is the selected one"
-            ), name)
-        } else if firstStop {
-            String(format: NSLocalizedString(
-                "%@, first stop",
-                comment: "Screen reader text for a stop name on the stop details page when that stop is the first stop on the line"
-            ), name)
-        } else {
-            name
+    @ViewBuilder func rightSideContent() -> some View {
+        if let upcomingTripViewState {
+            UpcomingTripView(
+                prediction: upcomingTripViewState,
+                routeType: routeAccents.type,
+                hideRealtimeIndicators: true,
+                maxTextAlpha: 0.6
+            ).foregroundStyle(Color.text)
         }
     }
 

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -19,6 +19,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
     case favorites
     case more
     case nearby
+    case routeDetails(SheetRoutes.RouteDetails)
     case stopDetails(stopId: String, stopFilter: StopDetailsFilter?, tripFilter: TripDetailsFilter?)
 
     var id: Int {
@@ -37,6 +38,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         case .favorites: .favorites
         case .more: .settings
         case .nearby: .nearbyTransit
+        case .routeDetails: .routeDetails
         case let .stopDetails(_, stopFilter, _): stopFilter == nil ? .stopDetailsUnfiltered : .stopDetailsFiltered
         default: nil
         }
@@ -48,6 +50,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         case .favorites: "favorites"
         case .more: "more"
         case .nearby: "nearby"
+        case .routeDetails: "routeDetails"
         case .stopDetails: "stopDetails"
         }
     }
@@ -86,6 +89,7 @@ struct NearbySheetItem: Identifiable {
         switch stackEntry {
         case .favorites: "favorites"
         case .nearby: "nearby"
+        case .routeDetails: "routeDetails"
         case let .stopDetails(stopId, _, _): stopId
         default: ""
         }

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -72,7 +72,11 @@ final class RouteStopListViewTests: XCTestCase {
             }}
         )
 
-        let exp = sut.inspection.inspect(onReceive: gotRouteStops, after: 0.2) { view in
+        let exp = sut.inspection.inspect(onReceive: gotRouteStops, after: 1) { view in
+            XCTAssertNil(
+                try? view.find(where: { (try? $0.modifier(LoadingPlaceholderModifier.self)) != nil }).pathToRoot,
+                "has not finished loading"
+            )
             XCTAssertNotNil(try view.find(text: mainRoute.longName))
             XCTAssertNotNil(try view.find(text: "Westbound to"))
             XCTAssertNotNil(try view.find(text: "Here"))
@@ -85,10 +89,6 @@ final class RouteStopListViewTests: XCTestCase {
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop2.name)"))
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop3.name)"))
             XCTAssertNotNil(try view.find(text: connectingRoute.shortName))
-            try NSLog(
-                "testDisplaysEverything - all text: %@",
-                view.findAll(ViewType.Text.self).map { try $0.string() }.debugDescription
-            )
 
             try view.find(text: stop2.name).find(ViewType.Button.self, relation: .parent).tap()
             XCTAssertEqual([RouteDetailsRowContext.details(stop: stop2)], clicks)

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -46,11 +46,13 @@ final class RouteStopListViewTests: XCTestCase {
         var backTapped = false
         var closeTapped = false
 
+        let gotRouteStops = PassthroughSubject<Void, Never>()
         let repositories = MockRepositories()
         repositories.useObjects(objects: objects)
         repositories.routeStops = MockRouteStopsRepository(
             stopIds: [stop1.id, stop2.id, stop3.id],
-            routeId: mainRoute.id
+            routeId: mainRoute.id,
+            onGet: { _, _ in gotRouteStops.send() }
         )
         HelpersKt.loadKoinMocks(repositories: repositories)
         let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
@@ -70,7 +72,7 @@ final class RouteStopListViewTests: XCTestCase {
             }}
         )
 
-        let exp = sut.inspection.inspect(after: 0.5) { view in
+        let exp = sut.inspection.inspect(onReceive: gotRouteStops, after: 0.2) { view in
             XCTAssertNotNil(try view.find(text: mainRoute.longName))
             XCTAssertNotNil(try view.find(text: "Westbound to"))
             XCTAssertNotNil(try view.find(text: "Here"))

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -93,7 +93,7 @@ final class RouteStopListViewTests: XCTestCase {
             try view.find(ViewType.Button.self, where: { try $0.accessibilityLabel().string() == "Close" }).tap()
             XCTAssertTrue(closeTapped)
         }
-        ViewHosting.host(view: sut)
+        ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 2)
     }
 
@@ -156,7 +156,7 @@ final class RouteStopListViewTests: XCTestCase {
             XCTAssertEqual(route1.id, lastSelectedRoute)
         }
 
-        ViewHosting.host(view: sut)
+        ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp1, exp2, exp3], timeout: 5)
     }
 }

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -85,9 +85,9 @@ final class RouteStopListViewTests: XCTestCase {
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop2.name)"))
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop3.name)"))
             XCTAssertNotNil(try view.find(text: connectingRoute.shortName))
-            try debugPrint(
-                "testDisplaysEverything - all text:",
-                view.findAll(ViewType.Text.self).map { try $0.string() }
+            try NSLog(
+                "testDisplaysEverything - all text: %@",
+                view.findAll(ViewType.Text.self).map { try $0.string() }.debugDescription
             )
 
             try view.find(text: stop2.name).find(ViewType.Button.self, relation: .parent).tap()

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -85,6 +85,10 @@ final class RouteStopListViewTests: XCTestCase {
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop2.name)"))
             XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop3.name)"))
             XCTAssertNotNil(try view.find(text: connectingRoute.shortName))
+            try debugPrint(
+                "testDisplaysEverything - all text:",
+                view.findAll(ViewType.Text.self).map { try $0.string() }
+            )
 
             try view.find(text: stop2.name).find(ViewType.Button.self, relation: .parent).tap()
             XCTAssertEqual([RouteDetailsRowContext.details(stop: stop2)], clicks)

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -1,0 +1,162 @@
+//
+//  RouteStopListViewTests.swift
+//  iosAppTests
+//
+//  Created by Melody Horn on 7/8/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Combine
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class RouteStopListViewTests: XCTestCase {
+    @MainActor func testDisplaysEverything() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop1 = objects.stop { $0.name = "Stop 1" }
+        let stop2 = objects.stop { $0.name = "Stop 2" }
+        let stop3 = objects.stop { $0.name = "Stop 3" }
+        let mainRoute = objects.route { route in
+            route.directionNames = ["West", "East"]
+            route.directionDestinations = ["Here", "There"]
+            route.longName = "Mauve Line"
+            route.type = .heavyRail
+        }
+        objects.routePattern(route: mainRoute) { pattern in
+            pattern.directionId = 0
+            pattern.typicality = .typical
+            pattern.representativeTrip { $0.stopIds = [stop1.id, stop2.id, stop3.id] }
+        }
+        objects.routePattern(route: mainRoute) { pattern in
+            pattern.directionId = 1
+            pattern.typicality = .typical
+        }
+        let connectingRoute = objects.route { route in
+            route.shortName = "32"
+            route.type = .bus
+        }
+        objects.routePattern(route: connectingRoute) { pattern in
+            pattern.typicality = .typical
+            pattern.representativeTrip { $0.stopIds = [stop2.id] }
+        }
+        var clicks: [RouteDetailsRowContext] = []
+        var backTapped = false
+        var closeTapped = false
+
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.routeStops = MockRouteStopsRepository(
+            stopIds: [stop1.id, stop2.id, stop3.id],
+            routeId: mainRoute.id
+        )
+        HelpersKt.loadKoinMocks(repositories: repositories)
+        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+
+        let sut = RouteStopListView(
+            lineOrRoute: .route(mainRoute),
+            context: .Details.shared,
+            globalData: .init(objects: objects),
+            onClick: { clicks.append($0) },
+            onBack: { backTapped = true },
+            onClose: { closeTapped = true },
+            errorBannerVM: errorBannerVM,
+            rightSideContent: { switch $0 {
+            case let .details(stop: stop): return Text(verbatim: "rightSideContent for \(stop.name)")
+            default: XCTFail("Wrong row context provided")
+                return Text(verbatim: "")
+            }}
+        )
+
+        let exp = sut.inspection.inspect(after: 0.5) { view in
+            XCTAssertNotNil(try view.find(text: mainRoute.longName))
+            XCTAssertNotNil(try view.find(text: "Westbound to"))
+            XCTAssertNotNil(try view.find(text: "Here"))
+            XCTAssertNotNil(try view.find(text: "Eastbound to"))
+            XCTAssertNotNil(try view.find(text: "There"))
+            XCTAssertNotNil(try view.find(text: stop1.name))
+            XCTAssertNotNil(try view.find(text: stop2.name))
+            XCTAssertNotNil(try view.find(text: stop3.name))
+            XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop1.name)"))
+            XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop2.name)"))
+            XCTAssertNotNil(try view.find(text: "rightSideContent for \(stop3.name)"))
+            XCTAssertNotNil(try view.find(text: connectingRoute.shortName))
+
+            try view.find(text: stop2.name).find(ViewType.Button.self, relation: .parent).tap()
+            XCTAssertEqual([RouteDetailsRowContext.details(stop: stop2)], clicks)
+
+            try view.find(ViewType.Button.self, where: { try $0.accessibilityLabel().string() == "Back" }).tap()
+            XCTAssertTrue(backTapped)
+
+            try view.find(ViewType.Button.self, where: { try $0.accessibilityLabel().string() == "Close" }).tap()
+            XCTAssertTrue(closeTapped)
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 2)
+    }
+
+    @MainActor func testSelectsWithinLine() throws {
+        let objects = ObjectCollectionBuilder()
+        let line = objects.line()
+        let route1 = objects.route { route in
+            route.lineId = line.id
+            route.type = .bus
+            route.shortName = "1"
+            route.directionDestinations = ["One", ""]
+        }
+        let route2 = objects.route { route in
+            route.lineId = line.id
+            route.type = .bus
+            route.shortName = "2"
+            route.directionDestinations = ["Two", ""]
+        }
+        let route3 = objects.route { route in
+            route.lineId = line.id
+            route.type = .bus
+            route.shortName = "3"
+            route.directionDestinations = ["Three", ""]
+        }
+        objects.routePattern(route: route1) { $0.directionId = 0 }
+
+        var lastSelectedRoute: String?
+
+        let getRouteStopsSubject = PassthroughSubject<Void, Never>()
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.routeStops = MockRouteStopsRepository(
+            stopIds: [],
+            onGet: { routeId, _ in lastSelectedRoute = routeId; getRouteStopsSubject.send() }
+        )
+        HelpersKt.loadKoinMocks(repositories: repositories)
+        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+
+        let sut = RouteStopListView(
+            lineOrRoute: .line(line, [route1, route2, route3]),
+            context: .Details.shared,
+            globalData: .init(objects: objects),
+            onClick: { _ in },
+            onBack: {},
+            onClose: {},
+            errorBannerVM: errorBannerVM,
+            defaultSelectedRouteId: route2.id,
+            rightSideContent: { _ in EmptyView() }
+        )
+
+        let exp1 = sut.inspection.inspect(onReceive: getRouteStopsSubject, after: 0.2) { view in
+            XCTAssertEqual(route2.id, lastSelectedRoute)
+            try view.find(button: route3.shortName).tap()
+        }
+        let exp2 = sut.inspection.inspect(onReceive: getRouteStopsSubject.dropFirst(), after: 0.2) { view in
+            XCTAssertEqual(route3.id, lastSelectedRoute)
+            try view.find(button: "One").tap()
+        }
+        let exp3 = sut.inspection.inspect(onReceive: getRouteStopsSubject.dropFirst(2), after: 0.2) { _ in
+            XCTAssertEqual(route1.id, lastSelectedRoute)
+        }
+
+        ViewHosting.host(view: sut)
+        wait(for: [exp1, exp2, exp3], timeout: 5)
+    }
+}

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -28,8 +28,12 @@ final class SearchResultViewTests: XCTestCase {
     }
 
     @MainActor func testPending() throws {
-        let sut = SearchResultsView(state: SearchViewModel.StateLoading.shared, handleStopTap: { _ in })
-            .withFixedSettings([:])
+        let sut = SearchResultsView(
+            state: SearchViewModel.StateLoading.shared,
+            handleStopTap: { _ in },
+            handleRouteTap: { _ in }
+        )
+        .withFixedSettings([:])
         XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(LoadingResultsView.self))
     }
 
@@ -138,15 +142,23 @@ final class SearchResultViewTests: XCTestCase {
     }
 
     @MainActor func testNoResults() throws {
-        let sut = SearchResultsView(state: SearchViewModel.StateResults(stops: [], routes: []), handleStopTap: { _ in })
-            .withFixedSettings([:])
+        let sut = SearchResultsView(
+            state: SearchViewModel.StateResults(stops: [], routes: []),
+            handleStopTap: { _ in },
+            handleRouteTap: { _ in }
+        )
+        .withFixedSettings([:])
         XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(text: "No results found 🤔"))
         XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(text: "Try a different spelling or name."))
     }
 
     @MainActor func testError() throws {
-        let sut = SearchResultsView(state: SearchViewModel.StateError.shared, handleStopTap: { _ in })
-            .withFixedSettings([:])
+        let sut = SearchResultsView(
+            state: SearchViewModel.StateError.shared,
+            handleStopTap: { _ in },
+            handleRouteTap: { _ in }
+        )
+        .withFixedSettings([:])
         XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(text: "Results failed to load ☹️"))
         XCTAssertNotNil(try sut.inspect().view(SearchResultsView.self).find(text: "Try your search again."))
     }
@@ -163,7 +175,7 @@ final class SearchResultViewTests: XCTestCase {
                     ),
                 ]
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in }, handleRouteTap: { _ in }
         ).withFixedSettings([:])
 
         XCTAssertNoThrow(try sut.inspect().find(text: "Haymarket"))
@@ -189,7 +201,7 @@ final class SearchResultViewTests: XCTestCase {
                     ),
                 ]
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in }, handleRouteTap: { _ in }
         )
 
         ViewHosting.host(view: sut.withFixedSettings([.searchRouteResults: true]))
@@ -212,7 +224,7 @@ final class SearchResultViewTests: XCTestCase {
                     ),
                 ]
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in }, handleRouteTap: { _ in }
         )
 
         ViewHosting.host(view: sut.withFixedSettings([.searchRouteResults: true]))
@@ -235,7 +247,7 @@ final class SearchResultViewTests: XCTestCase {
                     ),
                 ]
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in }, handleRouteTap: { _ in }
         )
 
         XCTAssertThrowsError(
@@ -256,7 +268,7 @@ final class SearchResultViewTests: XCTestCase {
                 ],
                 routes: []
             ),
-            handleStopTap: { _ in }
+            handleStopTap: { _ in }, handleRouteTap: { _ in }
         ).withFixedSettings([:])
 
         XCTAssertNoThrow(try sut.inspect().find(text: "Haymarket"))
@@ -281,7 +293,7 @@ final class SearchResultViewTests: XCTestCase {
             handleStopTap: { stopId in
                 XCTAssertEqual("place-haecl", stopId)
                 tapStopExpectation.fulfill()
-            }
+            }, handleRouteTap: { _ in }
         ).withFixedSettings([:])
 
         XCTAssertNoThrow(
@@ -290,5 +302,40 @@ final class SearchResultViewTests: XCTestCase {
                 .tap()
         )
         await fulfillment(of: [tapStopExpectation], timeout: 1)
+    }
+
+    @MainActor func testRouteTapping() async throws {
+        let tapRouteExpectation = expectation(description: "route was tapped")
+
+        let sut = SearchResultsView(
+            state: SearchViewModel.StateResults(
+                stops: [],
+                routes: [
+                    .init(
+                        id: "Orange",
+                        name: "Orange",
+                        routePill: .init(
+                            textColor: "000000",
+                            routeColor: "000000",
+                            content: RoutePillSpecContentEmpty.shared,
+                            size: .circle,
+                            shape: .capsule,
+                            contentDescription: nil
+                        )
+                    ),
+                ]
+            ),
+            handleStopTap: { _ in }, handleRouteTap: { routeId in
+                XCTAssertEqual("Orange", routeId)
+                tapRouteExpectation.fulfill()
+            }
+        ).withFixedSettings([.searchRouteResults: true])
+
+        XCTAssertNoThrow(
+            try sut.inspect()
+                .find(button: "Orange")
+                .tap()
+        )
+        await fulfillment(of: [tapRouteExpectation], timeout: 1)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Route details - basic UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210440278891515?focus=true)

Ported over the component structure from Android, and moved the iOS TripStopRow into StopListRow. Includes the non-GL branching because it’d’ve been more work to separate that out.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Ported over relevant tests from Android. Checked that page works.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210559767128765