### PR TITLE
feat(iOS): collapsing rare stops in route details

### DIFF
--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -1,0 +1,92 @@
+//
+//  CollapsableStopList.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/8/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct CollapsableStopList<RightSideContent: View>: View {
+    let lineOrRoute: RouteCardData.LineOrRoute
+    let segment: RouteDetailsStopList.Segment
+    let onClick: (RouteDetailsStopList.Entry) -> Void
+    let isFirstSegment: Bool
+    let isLastSegment: Bool
+    let rightSideContent: (RouteDetailsStopList.Entry) -> RightSideContent
+
+    @State var stopsExpanded = false
+
+    let inspection = Inspection<Self>()
+
+    init(
+        lineOrRoute: RouteCardData.LineOrRoute,
+        segment: RouteDetailsStopList.Segment,
+        onClick: @escaping (RouteDetailsStopList.Entry) -> Void,
+        isFirstSegment: Bool = false,
+        isLastSegment: Bool = false,
+        rightSideContent: @escaping (RouteDetailsStopList.Entry) -> RightSideContent
+    ) {
+        self.lineOrRoute = lineOrRoute
+        self.segment = segment
+        self.onClick = onClick
+        self.isFirstSegment = isFirstSegment
+        self.isLastSegment = isLastSegment
+        self.rightSideContent = rightSideContent
+    }
+
+    var body: some View {
+        if let stop = segment.stops.first, segment.stops.count == 1 {
+            StopListRow(
+                stop: stop.stop,
+                onClick: { onClick(stop) },
+                routeAccents: .init(route: lineOrRoute.sortRoute),
+                stopListContext: .routeDetails,
+                connectingRoutes: stop.connectingRoutes,
+                stopPlacement: .init(isFirst: isFirstSegment, isLast: isLastSegment, includeLineDiagram: false),
+                descriptor: { Text("Less common stop").font(Typography.footnote) },
+                rightSideContent: { rightSideContent(stop) }
+            ).background(Color.fill1)
+                .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        } else {
+            DisclosureGroup(isExpanded: $stopsExpanded, content: {
+                VStack {
+                    ForEach(Array(segment.stops.enumerated()), id: \.offset) { index, stop in
+                        StopListRow(
+                            stop: stop.stop,
+                            onClick: { onClick(stop) },
+                            routeAccents: .init(route: lineOrRoute.sortRoute),
+                            stopListContext: .routeDetails,
+                            connectingRoutes: stop.connectingRoutes,
+                            stopPlacement: .init(
+                                isFirst: isFirstSegment && index == segment.stops.startIndex,
+                                isLast: isLastSegment && index == segment.stops.index(before: segment.stops.endIndex),
+                                includeLineDiagram: false
+                            ),
+                            descriptor: { EmptyView() },
+                            rightSideContent: { rightSideContent(stop) }
+                        ).background(Color.fill1)
+                    }
+                }
+            }, label: {
+                VStack(spacing: 4) {
+                    Text(AttributedString.tryMarkdown(String(format: NSLocalizedString(
+                        "**%1$ld** less common stops",
+                        comment: "Header for a list of stops that vehicles don't always stop at for a given route"
+                    ), segment.stops.count)))
+                        .foregroundStyle(Color.text)
+                        .font(Typography.body)
+                    Text(
+                        "Only served at certain times of day",
+                        comment: "Explainer text for \"Less common stops\" that vehicles don't always stop at"
+                    )
+                    .foregroundStyle(Color.deemphasized)
+                    .font(Typography.footnote)
+                }
+            })
+            .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        }
+    }
+}

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -18,6 +18,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
     let rightSideContent: (RouteDetailsStopList.Entry) -> RightSideContent
 
     @State var stopsExpanded = false
+    @EnvironmentObject var settingsCache: SettingsCache
 
     let inspection = Inspection<Self>()
 
@@ -46,6 +47,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                 stopListContext: .routeDetails,
                 connectingRoutes: stop.connectingRoutes,
                 stopPlacement: .init(isFirst: isFirstSegment, isLast: isLastSegment, includeLineDiagram: false),
+                showStationAccessibility: settingsCache.get(.stationAccessibility),
                 descriptor: { Text("Less common stop").font(Typography.footnote) },
                 rightSideContent: { rightSideContent(stop) }
             ).background(Color.fill1)
@@ -65,6 +67,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                                 isLast: isLastSegment && index == segment.stops.index(before: segment.stops.endIndex),
                                 includeLineDiagram: false
                             ),
+                            showStationAccessibility: settingsCache.get(.stationAccessibility),
                             descriptor: { EmptyView() },
                             rightSideContent: { rightSideContent(stop) }
                         ).background(Color.fill1)

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -168,7 +168,14 @@ struct RouteStopListView<RightSideContent: View>: View {
                                 )
                             }
                         } else {
-                            // TODO: CollapsableStopList
+                            CollapsableStopList(
+                                lineOrRoute: lineOrRoute,
+                                segment: segment,
+                                onClick: { onTapStop(stopRowContext($0.stop)) },
+                                isFirstSegment: segmentIndex == stopList.segments.startIndex,
+                                isLastSegment: segmentIndex == stopList.segments.endIndex,
+                                rightSideContent: { stop in rightSideContent(stopRowContext(stop.stop)) }
+                            )
                         }
                     }
                 }

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NoNearbyStopsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NoNearbyStopsViewTests.swift
@@ -14,10 +14,7 @@ import XCTest
 final class NoNearbyStopsViewTests: XCTestCase {
     func testCopy() throws {
         let sut = NoNearbyStopsView(onOpenSearch: {}, onPanToDefaultCenter: {}).withFixedSettings([:])
-        XCTAssertNotNil(try sut.inspect().find(
-            ViewType.Image.self,
-            where: { try $0.actualImage().name() == "mbta-logo" }
-        ))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mbta-logo"))
         XCTAssertNotNil(try sut.inspect().find(text: "No nearby stops"))
         XCTAssertNotNil(try sut.inspect().find(text: "You’re outside the MBTA service area."))
     }

--- a/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
@@ -42,7 +42,7 @@ final class CollapsableStopListTests: XCTestCase {
             isFirstSegment: false,
             isLastSegment: false,
             rightSideContent: { _ in EmptyView() }
-        )
+        ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: stop1.name))
         XCTAssertNotNil(try sut.inspect().find(text: "Less common stop"))
@@ -96,7 +96,7 @@ final class CollapsableStopListTests: XCTestCase {
             XCTAssertNotNil(try view.find(imageName: "map-stop-close-BUS"))
             XCTAssertNotNil(try view.find(text: stop2.name))
         }
-        ViewHosting.host(view: sut)
+        ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 1)
     }
 }

--- a/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
@@ -1,0 +1,102 @@
+//
+//  CollapsableStopListTests.swift
+//  iosAppTests
+//
+//  Created by Melody Horn on 7/8/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class CollapsableStopListTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testWhenOneStopJustShowsThatStop() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop1 = objects.stop { stop in
+            stop.name = "Stop 1"
+            stop.locationType = .station
+        }
+        var clicked = false
+        let mainRoute = objects.route { route in
+            route.directionNames = ["West", "East"]
+            route.directionDestinations = ["Here", "There"]
+            route.longName = "Mauve Line"
+            route.type = .heavyRail
+        }
+
+        let sut = CollapsableStopList(
+            lineOrRoute: .route(mainRoute),
+            segment: .init(stops: [.init(stop: stop1, patterns: [], connectingRoutes: [])], hasRouteLine: false),
+            onClick: { _ in clicked = true },
+            isFirstSegment: false,
+            isLastSegment: false,
+            rightSideContent: { _ in EmptyView() }
+        )
+
+        XCTAssertNotNil(try sut.inspect().find(text: stop1.name))
+        XCTAssertNotNil(try sut.inspect().find(text: "Less common stop"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mbta-logo"))
+        try sut.inspect().find(button: stop1.name).tap()
+        XCTAssertTrue(clicked)
+    }
+
+    @MainActor func testWhenMultipleStopsCanExpandAndCollapse() {
+        let objects = ObjectCollectionBuilder()
+        let stop1 = objects.stop { stop in
+            stop.name = "Stop 1"
+            stop.locationType = .station
+        }
+        let stop2 = objects.stop { stop in
+            stop.name = "Stop 2"
+            stop.locationType = .stop
+            stop.vehicleType = .bus
+        }
+        let mainRoute = objects.route { route in
+            route.directionNames = ["West", "East"]
+            route.directionDestinations = ["Here", "There"]
+            route.longName = "Mauve Line"
+            route.type = .bus
+        }
+
+        let sut = CollapsableStopList(
+            lineOrRoute: .route(mainRoute),
+            segment: .init(
+                stops: [.init(stop: stop1, patterns: [], connectingRoutes: []), .init(
+                    stop: stop2,
+                    patterns: [],
+                    connectingRoutes: []
+                )],
+                hasRouteLine: false
+            ),
+            onClick: { _ in },
+            rightSideContent: { _ in EmptyView() }
+        )
+
+        let exp = sut.inspection.inspect(after: 0.5) { view in
+            XCTAssertFalse(try view.find(ViewType.DisclosureGroup.self).isExpanded())
+            XCTAssertNotNil(try view.find(ViewType.DisclosureGroup.self).find(text: stop1.name))
+            XCTAssertEqual(
+                "2 less common stops",
+                try view.find(ViewType.DisclosureGroup.self).labelView().find(ViewType.Text.self).string()
+            )
+            try view.find(ViewType.DisclosureGroup.self).expand()
+            XCTAssertTrue(try view.find(ViewType.DisclosureGroup.self).isExpanded())
+            XCTAssertNotNil(try view.find(imageName: "mbta-logo"))
+            XCTAssertNotNil(try view.find(imageName: "map-stop-close-BUS"))
+            XCTAssertNotNil(try view.find(text: stop2.name))
+        }
+        ViewHosting.host(view: sut)
+        wait(for: [exp], timeout: 1)
+    }
+}

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -165,4 +165,71 @@ final class RouteStopListViewTests: XCTestCase {
         ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp1, exp2, exp3], timeout: 5)
     }
+
+    @MainActor func testCollapsesNonTypicalStops() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop1 = objects.stop { $0.name = "Stop 1" }
+        let stop2 = objects.stop { $0.name = "Stop 2" }
+        let stop3NonTypical = objects.stop { $0.name = "Stop 3" }
+        let stop4NonTypical = objects.stop { $0.name = "Stop 4" }
+        let mainRoute = objects.route { route in
+            route.directionNames = ["West", "East"]
+            route.directionNames = ["Here", "There"]
+            route.longName = "Mauve Line"
+            route.type = .heavyRail
+        }
+        objects.routePattern(route: mainRoute) { pattern in
+            pattern.directionId = 0
+            pattern.typicality = .typical
+            pattern.representativeTrip { $0.stopIds = [stop1.id, stop2.id] }
+        }
+        objects.routePattern(route: mainRoute) { pattern in
+            pattern.directionId = 0
+            pattern.typicality = .deviation
+            pattern.representativeTrip { $0.stopIds = [stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id] }
+        }
+
+        let gotRouteStops = PassthroughSubject<Void, Never>()
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.routeStops = MockRouteStopsRepository(
+            stopIds: [stop1.id, stop2.id, stop3NonTypical.id, stop4NonTypical.id],
+            routeId: mainRoute.id,
+            onGet: { _, _ in gotRouteStops.send() }
+        )
+        HelpersKt.loadKoinMocks(repositories: repositories)
+        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+
+        let sut = RouteStopListView(
+            lineOrRoute: .route(mainRoute),
+            context: .Details.shared,
+            globalData: .init(objects: objects),
+            onClick: { _ in },
+            onBack: {},
+            onClose: {},
+            errorBannerVM: errorBannerVM,
+            rightSideContent: { _ in EmptyView() }
+        )
+
+        let exp = sut.inspection.inspect(onReceive: gotRouteStops, after: 1) { view in
+            XCTAssertNil(
+                try? view.find(where: { (try? $0.modifier(LoadingPlaceholderModifier.self)) != nil }).pathToRoot,
+                "has not finished loading"
+            )
+            XCTAssertNotNil(try view.find(text: stop1.name))
+            XCTAssertNotNil(try view.find(text: stop2.name))
+            XCTAssertNil(try? view.find(text: stop1.name).find(ViewType.DisclosureGroup.self, relation: .parent))
+            XCTAssertNotNil(try view.find(text: stop3NonTypical.name))
+            XCTAssertNotNil(try view.find(text: stop3NonTypical.name).find(
+                ViewType.DisclosureGroup.self,
+                relation: .parent
+            ))
+            XCTAssertEqual(
+                "2 less common stops",
+                try view.find(ViewType.DisclosureGroup.self).labelView().find(ViewType.Text.self).string()
+            )
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp], timeout: 2)
+    }
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/ExplainerPageTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/ExplainerPageTests.swift
@@ -23,12 +23,8 @@ final class ExplainerPageTests: XCTestCase {
             onClose: {}
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Finishing another trip"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "turnaround-icon-bus"
-        }))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "turnaround-shape"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "turnaround-icon-bus"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "turnaround-shape"))
     }
 
     func testNoPrediction() throws {
@@ -43,9 +39,7 @@ final class ExplainerPageTests: XCTestCase {
 
     func testRouteType() throws {
         let sut = ExplainerPage(explainer: .init(type: .noPrediction, routeAccents: .init(type: .bus)), onClose: {})
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "mode-bus"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mode-bus"))
     }
 
     func testClose() throws {

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -340,9 +340,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "Trip cancelled"))
         XCTAssertNotNil(try sut.inspect()
             .find(text: "This trip has been cancelled. We’re sorry for the inconvenience."))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "mode-bus-slash"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mode-bus-slash"))
     }
 
     func testShowsNoTripCard() throws {

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsNoTripCardTests.swift
@@ -23,9 +23,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
             accentColor: Color.text,
             routeType: .bus
         ).withFixedSettings([:])
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "live-data-slash"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "live-data-slash"))
         XCTAssertNotNil(try sut.inspect().find(text: "Predictions unavailable"))
         XCTAssertNotNil(try sut.inspect().find(ViewType.Divider.self))
         XCTAssertNotNil(try sut.inspect().find(
@@ -40,9 +38,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
             accentColor: Color.text,
             routeType: .ferry
         ).withFixedSettings([:])
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "mode-ferry-slash"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mode-ferry-slash"))
         XCTAssertNotNil(try sut.inspect().find(text: "Service ended"))
         XCTAssertThrowsError(try sut.inspect().find(ViewType.Divider.self))
     }
@@ -53,9 +49,7 @@ final class StopDetailsNoTripCardTests: XCTestCase {
             accentColor: Color.text,
             routeType: .commuterRail
         ).withFixedSettings([:])
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "mode-cr-slash"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "mode-cr-slash"))
         XCTAssertNotNil(try sut.inspect().find(text: "No service today"))
         XCTAssertThrowsError(try sut.inspect().find(ViewType.Divider.self))
     }

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -143,9 +143,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
 
-        XCTAssertNotNil(try targeted.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertNotNil(try targeted.inspect().find(imageName: "stop-pin-indicator"))
 
         let notTargeted = TripHeaderCard(
             spec: .vehicle(vehicle, stop, nil, false),
@@ -156,9 +154,7 @@ final class TripHeaderCardTests: XCTestCase {
             now: now
         )
 
-        XCTAssertThrowsError(try notTargeted.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertThrowsError(try notTargeted.inspect().find(imageName: "stop-pin-indicator"))
     }
 
     func testAtTerminal() throws {
@@ -196,9 +192,7 @@ final class TripHeaderCardTests: XCTestCase {
         )
 
         try XCTAssertNotNil(sut.inspect().find(text: "Waiting to depart"))
-        try XCTAssertNotNil(sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        try XCTAssertNotNil(sut.inspect().find(imageName: "stop-pin-indicator"))
         try XCTAssertNotNil(sut.inspect().find(UpcomingTripView.self))
     }
 
@@ -278,9 +272,7 @@ final class TripHeaderCardTests: XCTestCase {
         try XCTAssertNotNil(sut.inspect().find(text: "Scheduled to depart"))
         try XCTAssertNotNil(sut.inspect().find(text: stop.name))
         try XCTAssertNotNil(sut.inspect().find(UpcomingTripView.self))
-        try XCTAssertThrowsError(sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        try XCTAssertThrowsError(sut.inspect().find(imageName: "fa-circle-info"))
     }
 
     func testScheduledTap() throws {
@@ -315,9 +307,7 @@ final class TripHeaderCardTests: XCTestCase {
 
         try sut.inspect().find(ViewType.ZStack.self).callOnTapGesture()
         wait(for: [tapExpectation], timeout: 1)
-        try XCTAssertNotNil(sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        try XCTAssertNotNil(sut.inspect().find(imageName: "fa-circle-info"))
     }
 
     func testAccessibility() throws {

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -142,9 +142,7 @@ final class TripStopRowTests: XCTestCase {
             targeted: true
         )
 
-        XCTAssertNotNil(try targeted.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertNotNil(try targeted.inspect().find(imageName: "stop-pin-indicator"))
 
         let notTargeted = TripStopRow(
             stop: .init(
@@ -160,9 +158,7 @@ final class TripStopRowTests: XCTestCase {
             alertSummaries: [:]
         )
 
-        XCTAssertThrowsError(try notTargeted.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertThrowsError(try notTargeted.inspect().find(imageName: "stop-pin-indicator"))
     }
 
     func testAccessibility() throws {

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -107,9 +107,7 @@ final class TripStopsTests: XCTestCase {
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: "2 stops away"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "stop-pin-indicator"))
         XCTAssertNotNil(try sut.inspect().find(text: stop3Target.name))
         XCTAssertNotNil(try sut.inspect().find(text: stop5.name))
     }
@@ -188,9 +186,7 @@ final class TripStopsTests: XCTestCase {
             global: .init(objects: objects)
         ).withFixedSettings([:])
 
-        XCTAssertThrowsError(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertThrowsError(try sut.inspect().find(imageName: "stop-pin-indicator"))
         XCTAssertNotNil(try sut.inspect().find(text: stop1.name))
         XCTAssertNotNil(try sut.inspect().find(text: stop2.name))
         XCTAssertNotNil(try sut.inspect().find(text: stop3.name))
@@ -267,9 +263,7 @@ final class TripStopsTests: XCTestCase {
         ).withFixedSettings([:])
 
         XCTAssertThrowsError(try sut.inspect().find(text: stop1.name))
-        XCTAssertThrowsError(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "stop-pin-indicator"
-        }))
+        XCTAssertThrowsError(try sut.inspect().find(imageName: "stop-pin-indicator"))
     }
 
     func testFirstStopSeparated() throws {

--- a/iosApp/iosAppTests/ViewInspectorExtensions.swift
+++ b/iosApp/iosAppTests/ViewInspectorExtensions.swift
@@ -17,6 +17,10 @@ extension InspectableView {
         try find { try accessibilityLabelRegex.wholeMatch(in: $0.accessibilityLabel().string()) != nil }
     }
 
+    func find(imageName: String) throws -> InspectableView<ViewType.Image> {
+        try find(ViewType.Image.self, where: { try $0.actualImage().name() == imageName })
+    }
+
     func findAndCallOnChange(
         relation: ViewSearch.Relation = .child,
         newValue value: some Equatable,

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -36,12 +36,8 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Station Closure"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "alert-borderless-suspension"
-        }))
-        XCTAssertThrowsError(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-suspension"))
+        XCTAssertThrowsError(try sut.inspect().find(imageName: "fa-circle-info"))
         try sut.inspect().find(button: "View details").tap()
         wait(for: [exp], timeout: 1)
     }
@@ -191,12 +187,8 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Detour"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "alert-borderless-issue"
-        }))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-issue"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
     }
@@ -240,12 +232,8 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Service change ahead"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "alert-borderless-issue"
-        }))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-issue"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
     }
@@ -269,12 +257,8 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: alert.header!))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "accessibility-icon-alert"
-        }))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "accessibility-icon-alert"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
     }
@@ -304,12 +288,8 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Elevator closure (Elevator name)"))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "accessibility-icon-alert"
-        }))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "accessibility-icon-alert"))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
     }
@@ -332,9 +312,7 @@ final class AlertCardTests: XCTestCase {
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Delays due to heavy ridership"))
 
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
     }
 
     func testDelayAlertCardUnknownCause() throws {
@@ -355,9 +333,7 @@ final class AlertCardTests: XCTestCase {
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Delays"))
 
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
     }
 
     func testSingleTrackingInfoDelay() throws {
@@ -379,8 +355,6 @@ final class AlertCardTests: XCTestCase {
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Single Tracking"))
 
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "fa-circle-info"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "fa-circle-info"))
     }
 }

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -38,9 +38,7 @@ final class RouteCardTests: XCTestCase {
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: "66"))
-        XCTAssertNotNil(try? sut.inspect().find(ViewType.Image.self) { image in
-            try image.actualImage().name() == "mode-bus"
-        })
+        XCTAssertNotNil(try? sut.inspect().find(imageName: "mode-bus"))
     }
 
     func testLineHeader() throws {
@@ -70,9 +68,7 @@ final class RouteCardTests: XCTestCase {
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: "Green Line"))
-        XCTAssertNotNil(try? sut.inspect().find(ViewType.Image.self) { image in
-            try image.actualImage().name() == "mode-subway"
-        })
+        XCTAssertNotNil(try? sut.inspect().find(imageName: "mode-subway"))
     }
 
     func testPinRoute() throws {

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -241,8 +241,6 @@ final class UpcomingTripViewTests: XCTestCase {
         let alert = ObjectCollectionBuilder.Single.shared.alert { $0.effect = .snowRoute }
         let disruption = UpcomingFormat.Disruption(alert: alert, mapStopRoute: .bus)
         let sut = UpcomingTripView(prediction: .disruption(.init(alert: alert), iconName: disruption.iconName))
-        XCTAssertNotNil(try sut.inspect().find(ViewType.Image.self, where: { image in
-            try image.actualImage().name() == "alert-large-bus-issue"
-        }))
+        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-large-bus-issue"))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Collapse non-typical bus stops](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210559767128761?focus=true)

Did this as part of #1123; splitting it out for very slightly easier review, since it’s the only piece I could think of that really separates out cleanly.

Also includes a bonus refactor for finding images by name in ViewInspector.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Ported over the Android unit tests. Checked that the stops collapse.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
