### PR TITLE
fix(Android): Hide fav hint toast on back nav

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -192,7 +192,10 @@ fun RouteStopListView(
             closeText =
                 if (context is RouteDetailsContext.Favorites) stringResource(R.string.done)
                 else null,
-            onBack = onBack,
+            onBack = {
+                showFirstTimeFavoritesToast = false
+                onBack()
+            },
             onClose = {
                 showFirstTimeFavoritesToast = false
                 onClose()


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Add stops flow - Tap stars toast](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210229158900372?focus=true)

Follow up to #1095 

This fixes an issue in the add favorites flow, where the first time toast will stick around after you go back, until you dismiss it. The back functionality wasn't implemented when the toast stuff was done, so I missed it after merging in main.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Split out the back and close functionality into separate tests, each with a check to ensure that the toast is closed.