### PR TITLE
fix(Android): Fix stop details vehicle overview

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -69,6 +69,7 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
+import com.mbta.tid.mbta_app.viewModel.MapViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel.State
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.flow.map
@@ -359,7 +360,9 @@ fun HomeMapView(
                         if (routeType != null) {
                             RecenterButton(
                                 routeIcon(routeType).first,
-                                onClick = { viewModel.recenter() },
+                                onClick = {
+                                    viewModel.recenter(MapViewModel.Event.RecenterType.Trip)
+                                },
                                 modifier =
                                     Modifier.padding(horizontal = 16.dp)
                                         .testTag("tripRecenterButton"),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/RecenterButton.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
@@ -28,9 +29,10 @@ fun RecenterButton(painter: Painter, modifier: Modifier = Modifier, onClick: () 
         modifier =
             modifier
                 .semantics(mergeDescendants = true) {}
-                .clickable(onClick = onClick, role = Role.Button)
                 .size(44.dp)
-                .background(colorResource(R.color.halo), CircleShape),
+                .background(colorResource(R.color.halo), CircleShape)
+                .clip(CircleShape)
+                .clickable(onClick = onClick, role = Role.Button),
         contentAlignment = Alignment.Center,
     ) {
         Box(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -173,25 +173,27 @@ fun MapAndSheetPage(
         )
     }
 
+    val filters =
+        (when (currentNavEntry) {
+            is SheetRoutes.StopDetails ->
+                StopDetailsPageFilters(
+                    currentNavEntry.stopId,
+                    currentNavEntry.stopFilter,
+                    currentNavEntry.tripFilter,
+                )
+            else -> null
+        })
     val stopDetailsVM =
         stopDetailsManagedVM(
-            filters =
-                (when (currentNavEntry) {
-                    is SheetRoutes.StopDetails ->
-                        StopDetailsPageFilters(
-                            currentNavEntry.stopId,
-                            currentNavEntry.stopFilter,
-                            currentNavEntry.tripFilter,
-                        )
-                    else -> null
-                }),
+            filters = filters,
             globalResponse = nearbyTransit.globalResponse,
             alertData = nearbyTransit.alertData,
             pinnedRoutes = pinnedRoutes ?: emptySet(),
             updateStopFilter = ::updateStopFilter,
             updateTripFilter = ::updateTripFilter,
             setMapSelectedVehicle = { vehicle ->
-                vehicle?.let { mapViewModel.selectedVehicle(it, null, null) }
+                val stop = nearbyTransit.globalResponse?.getStop(filters?.stopId)
+                vehicle?.let { mapViewModel.selectedVehicle(it, stop, filters?.stopFilter) }
             },
             now = now,
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -149,6 +149,12 @@ class MapViewModelTests : KoinTest {
             assertEquals(MapViewModel.State.VehicleSelected(vehicle, null, null), awaitItem())
             delay(10)
             assertEquals(1, timesVehicleOverViewCalled)
+            viewModel.recenter(MapViewModel.Event.RecenterType.Trip)
+            delay(10)
+            assertEquals(2, timesVehicleOverViewCalled)
+            viewModel.recenter(MapViewModel.Event.RecenterType.CurrentLocation)
+            delay(10)
+            assertEquals(3, timesFollowCalled)
         }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 Fix vehicle centering on stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210733324373948?focus=true)

Fixes vehicle overview on stop details, recentering on current location in vehicle overview mode, and the click ripple going beyond the recenter button boundaries.

### Testing

Existing tests pass and tweaked recenter test a bit.
