### PR TITLE
feat(ios.FavoritesPage): Edit favorites entrypoint

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -44,6 +44,7 @@ fun SheetHeader(
     closeText: String? = null,
     onBack: (() -> Unit)? = null,
     onClose: (() -> Unit)? = null,
+    rightActionContents: @Composable () -> Unit = {},
     buttonColors: ButtonColors = ButtonDefaults.contrast(),
 ) {
     val context = LocalContext.current
@@ -98,6 +99,8 @@ fun SheetHeader(
         } else {
             Spacer(Modifier.weight(1f))
         }
+
+        Row(modifier = Modifier.padding(top = buttonPadding)) { rightActionContents() }
 
         if (onClose != null) {
             if (closeText != null)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -3,11 +3,7 @@ package com.mbta.tid.mbta_app.android.favorites
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -15,8 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ActionButton
@@ -24,11 +18,11 @@ import com.mbta.tid.mbta_app.android.component.ActionButtonKind
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.component.NavTextButton
+import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
 import com.mbta.tid.mbta_app.android.state.getSchedule
 import com.mbta.tid.mbta_app.android.state.subscribeToPredictions
 import com.mbta.tid.mbta_app.android.util.SettingsCache
-import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.FavoriteBridge
@@ -85,31 +79,23 @@ fun FavoritesView(
     val routeCardData = favoritesViewModel.routeCardData
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Row(
-            Modifier.fillMaxWidth().heightIn(min = 48.dp).padding(horizontal = 16.dp).semantics {
-                heading()
-            },
-            Arrangement.SpaceBetween,
-            Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(R.string.favorites_link),
-                modifier = Modifier.padding(start = 8.dp).weight(1f),
-                style = Typography.title2Bold,
-            )
-            Row(Modifier, Arrangement.spacedBy(16.dp), Alignment.CenterVertically) {
-                if (!routeCardData.isNullOrEmpty()) {
-                    ActionButton(
-                        ActionButtonKind.Plus,
-                        colors = ButtonDefaults.contrastTranslucent(),
-                        action = ::onAddFavorites,
-                    )
-                    NavTextButton(stringResource(R.string.edit)) {
-                        openSheetRoute(SheetRoutes.EditFavorites)
+        SheetHeader(
+            title = stringResource(R.string.favorites_link),
+            rightActionContents = {
+                Row(Modifier, Arrangement.spacedBy(16.dp), Alignment.CenterVertically) {
+                    if (!routeCardData.isNullOrEmpty()) {
+                        ActionButton(
+                            ActionButtonKind.Plus,
+                            colors = ButtonDefaults.contrastTranslucent(),
+                            action = ::onAddFavorites,
+                        )
+                        NavTextButton(stringResource(R.string.edit)) {
+                            openSheetRoute(SheetRoutes.EditFavorites)
+                        }
                     }
                 }
-            }
-        }
+            },
+        )
 
         ErrorBanner(errorBannerViewModel)
         RouteCardList(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.items
@@ -30,18 +29,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.heading
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DirectionLabel
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
-import com.mbta.tid.mbta_app.android.component.NavTextButton
 import com.mbta.tid.mbta_app.android.component.PillDecoration
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorColumn
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorLazyColumn
+import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.LoadingRouteCard
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardContainer
 import com.mbta.tid.mbta_app.android.favorites.FavoritesViewModel
@@ -73,7 +70,14 @@ fun EditFavoritesPage(
     LaunchedEffect(Unit) { routeCardData = favoritesViewModel.loadStaticRouteCardData(global) }
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Header(favoritesViewModel, favoritesState, onClose)
+        SheetHeader(
+            title = stringResource(R.string.edit_favorites),
+            closeText = stringResource(R.string.done),
+            buttonColors = ButtonDefaults.key(),
+            onClose = {
+                favoritesViewModel.updateFavorites(favoritesState.toMap(), onFinish = onClose)
+            },
+        )
         EditFavoritesList(routeCardData, showStationAccessibility, global) {
             favoritesState[it] = false
             if (global == null) return@EditFavoritesList
@@ -83,24 +87,6 @@ fun EditFavoritesPage(
                     global,
                     favoritesState.filter { it.value }.keys,
                 )
-        }
-    }
-}
-
-@Composable
-private fun Header(
-    viewModel: FavoritesViewModel,
-    currentState: MutableMap<RouteStopDirection, Boolean>?,
-    onClose: () -> Unit,
-) {
-    Row(
-        Modifier.semantics { heading() }.padding(horizontal = 16.dp).fillMaxWidth(),
-        Arrangement.SpaceBetween,
-        Alignment.CenterVertically,
-    ) {
-        Text(text = stringResource(R.string.edit_favorites), style = Typography.title2Bold)
-        NavTextButton(stringResource(R.string.done), colors = ButtonDefaults.key()) {
-            viewModel.updateFavorites(currentState?.toMap(), onFinish = onClose)
         }
     }
 }

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -91,10 +91,13 @@
     <string name="dock_closure">Cierre del muelle</string>
     <string name="dock_issue">Problema con dársena</string>
     <string name="dock_issue_sentence_case">Problema con dársena</string>
+    <string name="done">Hecho</string>
     <string name="drag_handle">Palanca de arrastre</string>
     <string name="drawbridge_being_raised">Puente levadizo en elevación</string>
     <string name="drawbridge_being_raised_lowercase">puente levadizo levantado</string>
     <string name="eastbound">En dirección este</string>
+    <string name="edit">Editar</string>
+    <string name="edit_favorites">Editar favoritos</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b> adelantado</string>
     <string name="electrical_work">Trabajo eléctrico</string>
     <string name="electrical_work_lowercase">trabajo eléctrico</string>

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -74,6 +74,7 @@
     <string name="delay">Demora</string>
     <string name="delays_due_to_cause">Retrasos debido a &lt;b>%1$s&lt;/b></string>
     <string name="delays_unknown_reason">&lt;b>Retrasos&lt;/b></string>
+    <string name="delete">Borrar</string>
     <string name="demonstration">Demostración</string>
     <string name="demonstration_lowercase">demostración</string>
     <string name="departure_tile_on_click_label">mostrar más información sobre este viaje</string>

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">accidente</string>
     <string name="add_confirmation_button">Agregar</string>
     <string name="add_favorite">añadir favorito</string>
+    <string name="add_stops">Añadir paradas</string>
     <string name="add_to_favorites_title">Añadir &lt;b>%1$s&lt;/b> en &lt;b>%2$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">Añadir &lt;b>%1$s&lt;/b> en &lt;b>%2$s&lt;/b> a Favoritos</string>
     <string name="additional_service">Servicio adicional</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -74,6 +74,7 @@
     <string name="delay">Retard</string>
     <string name="delays_due_to_cause">Retards dus à &lt;b>%1$s&lt;/b></string>
     <string name="delays_unknown_reason">&lt;b>Retards&lt;/b></string>
+    <string name="delete">Supprimer</string>
     <string name="demonstration">Manifestation</string>
     <string name="demonstration_lowercase">manifestation</string>
     <string name="departure_tile_on_click_label">afficher plus d’informations sur ce trajet</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">accident</string>
     <string name="add_confirmation_button">Ajouter</string>
     <string name="add_favorite">ajouter aux favoris</string>
+    <string name="add_stops">Ajouter des arrêts</string>
     <string name="add_to_favorites_title">Ajoutez &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">Ajouter &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b> aux favoris</string>
     <string name="additional_service">Service supplémentaire</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -91,10 +91,13 @@
     <string name="dock_closure">Fermeture du quai</string>
     <string name="dock_issue">Problème de quai</string>
     <string name="dock_issue_sentence_case">Problème de quai</string>
+    <string name="done">Fait</string>
     <string name="drag_handle">Poignée de déplacement</string>
     <string name="drawbridge_being_raised">Élévation du pont</string>
     <string name="drawbridge_being_raised_lowercase">le pont est relevé</string>
     <string name="eastbound">En direction de l’est</string>
+    <string name="edit">Modifier</string>
+    <string name="edit_favorites">Modifier les favoris</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b> à venir</string>
     <string name="electrical_work">Travaux électriques</string>
     <string name="electrical_work_lowercase">travaux électriques</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -77,6 +77,7 @@
     <string name="delay">Reta</string>
     <string name="delays_due_to_cause">Reta akòz &lt;b>%1$s&lt;/b></string>
     <string name="delays_unknown_reason">&lt;b>Reta&lt;/b></string>
+    <string name="delete">Efase</string>
     <string name="demonstration">Demonstrasyon</string>
     <string name="demonstration_lowercase">manifestasyon</string>
     <string name="departure_tile_on_click_label">montre plis enfòmasyon sou vwayaj sa a</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">aksidan</string>
     <string name="add_confirmation_button">Ajoute</string>
     <string name="add_favorite">ajoute nan favori</string>
+    <string name="add_stops">Ajoute arè</string>
     <string name="add_to_favorites_title">Ajoute &lt;b>%1$s&lt;/b> nan &lt;b>%2$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">Ajoute &lt;b>%1$s&lt;/b> nan &lt;b>%2$s&lt;/b> nan Favorites</string>
     <string name="additional_service">Plis Sèvis</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -94,10 +94,13 @@
     <string name="dock_closure">Waf la Fèmen</string>
     <string name="dock_issue">Pwoblèm Waf</string>
     <string name="dock_issue_sentence_case">Pwoblèm waf</string>
+    <string name="done">Fè</string>
     <string name="drag_handle">Kontwolè deplasman</string>
     <string name="drawbridge_being_raised">Y ap Leve Pon ki ka Bouje a</string>
     <string name="drawbridge_being_raised_lowercase">pon levasyon ap monte</string>
     <string name="eastbound">Pran direksyon lès</string>
+    <string name="edit">Edit</string>
+    <string name="edit_favorites">Edit Favorites</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b> devan</string>
     <string name="electrical_work">Travay Elektrik</string>
     <string name="electrical_work_lowercase">travay elektrik</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -91,10 +91,13 @@
     <string name="dock_closure">Fechamento de doca</string>
     <string name="dock_issue">Problema na doca</string>
     <string name="dock_issue_sentence_case">Problema na doca</string>
+    <string name="done">Feito</string>
     <string name="drag_handle">Alça para arrastar</string>
     <string name="drawbridge_being_raised">Ponte móvel em elevação</string>
     <string name="drawbridge_being_raised_lowercase">ponte levadiça sendo levantada</string>
     <string name="eastbound">Sentido leste</string>
+    <string name="edit">Editar</string>
+    <string name="edit_favorites">Editar Favoritos</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b> à frente</string>
     <string name="electrical_work">Obra elétrica</string>
     <string name="electrical_work_lowercase">serviço elétrico</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -74,6 +74,7 @@
     <string name="delay">Atraso</string>
     <string name="delays_due_to_cause">Atrasos devido a &lt;b>%1$s&lt;/b></string>
     <string name="delays_unknown_reason">&lt;b>Atrasos&lt;/b></string>
+    <string name="delete">Excluir</string>
     <string name="demonstration">Manifestação</string>
     <string name="demonstration_lowercase">manifestação</string>
     <string name="departure_tile_on_click_label">exibir mais informações sobre esta viagem</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">acidente</string>
     <string name="add_confirmation_button">Adicionar</string>
     <string name="add_favorite">adicionar favorito</string>
+    <string name="add_stops">Adicionar paradas</string>
     <string name="add_to_favorites_title">Adicione &lt;b>%1$s&lt;/b> em &lt;b>%2$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">Adicione &lt;b>%1$s&lt;/b> em &lt;b>%2$s&lt;/b> aos favoritos</string>
     <string name="additional_service">Serviço adicional</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">tai nạn</string>
     <string name="add_confirmation_button">Thêm vào</string>
     <string name="add_favorite">thêm mục yêu thích</string>
+    <string name="add_stops">Thêm điểm dừng</string>
     <string name="add_to_favorites_title">Thêm &lt;b>%1$s&lt;/b> vào &lt;b>%2$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">Thêm &lt;b>%1$s&lt;/b> tại &lt;b>%2$s&lt;/b> vào mục Yêu thích</string>
     <string name="additional_service">Dịch vụ bổ sung</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -72,6 +72,7 @@
     <string name="delay">Trễ</string>
     <string name="delays_due_to_cause">Trì hoãn do &lt;b>%1$s&lt;/b></string>
     <string name="delays_unknown_reason">&lt;b>Sự chậm trễ&lt;/b></string>
+    <string name="delete">Xóa bỏ</string>
     <string name="demonstration">Biểu tình</string>
     <string name="demonstration_lowercase">cuộc biểu tình</string>
     <string name="departure_tile_on_click_label">hiển thị thêm thông tin về chuyến đi này</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -89,10 +89,13 @@
     <string name="dock_closure">Đóng bến tàu</string>
     <string name="dock_issue">Vấn đề về bến tàu</string>
     <string name="dock_issue_sentence_case">Vấn đề về bến tàu</string>
+    <string name="done">Xong</string>
     <string name="drag_handle">Tay kéo</string>
     <string name="drawbridge_being_raised">Cầu rút đang nâng</string>
     <string name="drawbridge_being_raised_lowercase">cầu kéo đang được nâng lên</string>
     <string name="eastbound">Về hướng đông</string>
+    <string name="edit">Biên tập</string>
+    <string name="edit_favorites">Chỉnh sửa mục ưa thích</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b> phía trước</string>
     <string name="electrical_work">Thi công điện</string>
     <string name="electrical_work_lowercase">công việc về điện</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -89,10 +89,13 @@
     <string name="dock_closure">码头关闭</string>
     <string name="dock_issue">停靠区域问题</string>
     <string name="dock_issue_sentence_case">停靠区域问题</string>
+    <string name="done">完毕</string>
     <string name="drag_handle">拖动手柄</string>
     <string name="drawbridge_being_raised">吊桥升起</string>
     <string name="drawbridge_being_raised_lowercase">吊桥升起</string>
     <string name="eastbound">东行</string>
+    <string name="edit">编辑</string>
+    <string name="edit_favorites">编辑收藏夹</string>
     <string name="effect_ahead">&lt;b>%1$s&lt;/b>提前到站</string>
     <string name="electrical_work">电力作业</string>
     <string name="electrical_work_lowercase">电力作业</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -72,6 +72,7 @@
     <string name="delay">延误</string>
     <string name="delays_due_to_cause">由于 &lt;b>%1$s&lt;/b> 造成延误</string>
     <string name="delays_unknown_reason">&lt;b>延误&lt;/b></string>
+    <string name="delete">删除</string>
     <string name="demonstration">示威</string>
     <string name="demonstration_lowercase">示威</string>
     <string name="departure_tile_on_click_label">显示有关此行程的更多信息</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">事故</string>
     <string name="add_confirmation_button">添加</string>
     <string name="add_favorite">添加收藏</string>
+    <string name="add_stops">添加停靠点</string>
     <string name="add_to_favorites_title">在 &lt;b>%2$s&lt;/b> 添加 &lt;b>%1$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">将 &lt;b>%2$s&lt;/b> 的 &lt;b>%1$s&lt;/b> 添加到收藏夹</string>
     <string name="additional_service">附加服务</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -89,10 +89,13 @@
     <string name="dock_closure">碼頭關閉</string>
     <string name="dock_issue">停靠區域問題</string>
     <string name="dock_issue_sentence_case">停靠區域問題</string>
+    <string name="done">完畢</string>
     <string name="drag_handle">拖曳控制柄</string>
     <string name="drawbridge_being_raised">吊橋升起</string>
     <string name="drawbridge_being_raised_lowercase">吊橋升起</string>
     <string name="eastbound">東行</string>
+    <string name="edit">編輯</string>
+    <string name="edit_favorites">編輯收藏夾</string>
     <string name="effect_ahead">提前&lt;b>%1$s&lt;/b></string>
     <string name="electrical_work">電力作業</string>
     <string name="electrical_work_lowercase">電力作業</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -6,6 +6,7 @@
     <string name="accident_lowercase">事故</string>
     <string name="add_confirmation_button">添加</string>
     <string name="add_favorite">新增收藏</string>
+    <string name="add_stops">新增停靠點</string>
     <string name="add_to_favorites_title">在 &lt;b>%2$s&lt;/b> 加 &lt;b>%1$s&lt;/b></string>
     <string name="add_to_favorites_title_stop_details">將 &lt;b>%2$s&lt;/b> 的 &lt;b>%1$s&lt;/b> 加入到收藏夾</string>
     <string name="additional_service">附加服務</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -72,6 +72,7 @@
     <string name="delay">延誤</string>
     <string name="delays_due_to_cause">因 &lt;b>%1$s&lt;/b> 造成延誤</string>
     <string name="delays_unknown_reason">&lt;b>延誤&lt;/b></string>
+    <string name="delete">刪除</string>
     <string name="demonstration">示威</string>
     <string name="demonstration_lowercase">示威</string>
     <string name="departure_tile_on_click_label">顯示有關此行程的更多信息</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="accident_lowercase">accident</string>
     <string name="add_confirmation_button">Add</string>
     <string name="add_favorite">add favorite</string>
-    <string name="add_stops" tools:ignore="MissingTranslation">Add stops</string>
+    <string name="add_stops">Add stops</string>
     <string name="add_to_favorites_title">Add &lt;b&gt;%1$s&lt;/b&gt; at &lt;b&gt;%2$s&lt;/b&gt;</string>
     <string name="add_to_favorites_title_stop_details">Add &lt;b&gt;%1$s&lt;/b&gt; at &lt;b&gt;%2$s&lt;/b&gt; to Favorites</string>
     <string name="additional_service">Additional Service</string>
@@ -73,7 +73,7 @@
     <string name="delay">Delay</string>
     <string name="delays_due_to_cause">&lt;b&gt;Delays&lt;/b&gt; due to %1$s</string>
     <string name="delays_unknown_reason">&lt;b&gt;Delays&lt;/b&gt;</string>
-    <string name="delete" tools:ignore="MissingTranslation">Delete</string>
+    <string name="delete">Delete</string>
     <string name="demonstration">Demonstration</string>
     <string name="demonstration_lowercase">demonstration</string>
     <string name="departure_tile_on_click_label">display more information about this trip</string>
@@ -92,13 +92,13 @@
     <string name="dock_closure">Dock Closure</string>
     <string name="dock_issue">Dock Issue</string>
     <string name="dock_issue_sentence_case">Dock issue</string>
-    <string name="done" tools:ignore="MissingTranslation">Done</string>
+    <string name="done">Done</string>
     <string name="drag_handle">Drag handle</string>
     <string name="drawbridge_being_raised">Drawbridge Being Raised</string>
     <string name="drawbridge_being_raised_lowercase">drawbridge being raised</string>
     <string name="eastbound">Eastbound</string>
-    <string name="edit" tools:ignore="MissingTranslation">Edit</string>
-    <string name="edit_favorites" tools:ignore="MissingTranslation">Edit Favorites</string>
+    <string name="edit">Edit</string>
+    <string name="edit_favorites">Edit Favorites</string>
     <string name="effect" translatable="false">&lt;b&gt;%1$s&lt;/b&gt;</string>
     <string name="effect_ahead">&lt;b&gt;%1$s&lt;/b&gt; ahead</string>
     <string name="electrical_work">Electrical Work</string>
@@ -327,10 +327,10 @@
     <string name="stop_closure">Stop Closure</string>
     <string name="stop_filter_pills_filter_hint">Apply a filter so that only arrivals from this route are displayed</string>
     <string name="stop_filter_pills_remove_hint">Remove the filter and display all routes</string>
-    <string name="stop_moved" tools:ignore="MissingTranslation">Stop Moved</string>
-    <string name="stop_moved_sentence_case" tools:ignore="MissingTranslation">Stop moved</string>
-    <string name="stop_shoveling" tools:ignore="MissingTranslation">Stop Shoveling</string>
-    <string name="stop_shoveling_sentence_case" tools:ignore="MissingTranslation">Stop shoveling</string>
+    <string name="stop_moved">Stop Moved</string>
+    <string name="stop_moved_sentence_case">Stop moved</string>
+    <string name="stop_shoveling">Stop Shoveling</string>
+    <string name="stop_shoveling_sentence_case">Stop shoveling</string>
     <string name="stops">Stops</string>
     <plurals name="stops_away">
         <item quantity="one">%1$d stop away</item>
@@ -341,7 +341,7 @@
     <string name="strike">Strike</string>
     <string name="strike_lowercase">strike</string>
     <string name="subway">Subway</string>
-    <string name="summary" tools:ignore="MissingTranslation">Summary</string>
+    <string name="summary">Summary</string>
     <string name="suspension">Suspension</string>
     <string name="switch_issue">Switch Issue</string>
     <string name="switch_issue_lowercase">switch issue</string>
@@ -352,9 +352,9 @@
     <string name="technical_problem_lowercase">technical problem</string>
     <string name="tie_replacement">Tie Replacement</string>
     <string name="tie_replacement_lowercase">tie replacement</string>
-    <string name="track_change" tools:ignore="MissingTranslation">Track Change</string>
-    <string name="track_change_sentence_case" tools:ignore="MissingTranslation">Track change</string>
-    <string name="track_number" tools:ignore="MissingTranslation">Track %1$s</string>
+    <string name="track_change">Track Change</string>
+    <string name="track_change_sentence_case">Track change</string>
+    <string name="track_number">Track %1$s</string>
     <string name="track_problem">Track Problem</string>
     <string name="track_problem_lowercase">track problem</string>
     <string name="track_work">Track Work</string>

--- a/iosApp/iosApp/ComponentViews/NavTextButton.swift
+++ b/iosApp/iosApp/ComponentViews/NavTextButton.swift
@@ -1,0 +1,29 @@
+//
+//  NavTextButton.swift
+//  iosApp
+//
+//  Created by Kayla Brady on 7/10/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct NavTextButton: View {
+    let string: String
+    let backgroundColor: Color
+    let textColor: Color
+    let action: () -> Void
+
+    var body: some View {
+        Button(
+            action: action,
+            label: { Text(string).font(Typography.callout).padding(.horizontal, 12).padding(.vertical, 4)
+                .foregroundColor(textColor)
+                .background(backgroundColor)
+                .buttonBorderShape(.capsule)
+                .clipShape(Capsule())
+            }
+        )
+    }
+}

--- a/iosApp/iosApp/ComponentViews/SheetHeader.swift
+++ b/iosApp/iosApp/ComponentViews/SheetHeader.swift
@@ -9,10 +9,26 @@
 import Foundation
 import SwiftUI
 
-struct SheetHeader: View {
-    var title: String?
-    var onBack: (() -> Void)?
-    var onClose: (() -> Void)?
+struct SheetHeader<Content: View>: View {
+    let title: String?
+    let onBack: (() -> Void)?
+    let onClose: (() -> Void)?
+    let closeText: String?
+    let rightActionContents: () -> Content
+
+    init(
+        title: String?,
+        onBack: (() -> Void)? = nil,
+        onClose: (() -> Void)? = nil,
+        closeText: String? = nil,
+        @ViewBuilder rightActionContents: @escaping () -> Content = { EmptyView() }
+    ) {
+        self.title = title
+        self.onBack = onBack
+        self.onClose = onClose
+        self.closeText = closeText
+        self.rightActionContents = rightActionContents
+    }
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
@@ -25,9 +41,16 @@ struct SheetHeader: View {
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h1)
             }
+            Spacer()
+            rightActionContents()
             if let onClose {
-                Spacer()
-                ActionButton(kind: .close, action: { onClose() })
+                if let closeText {
+                    NavTextButton(string: closeText, backgroundColor: Color.key, textColor: Color.fill3) {
+                        onClose()
+                    }
+                } else {
+                    ActionButton(kind: .close, action: { onClose() })
+                }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -199,7 +199,7 @@ struct ContentView: View {
         NavigationStack {
             VStack {
                 switch navEntry {
-                case .favorites, .nearby:
+                case .editFavorites, .favorites, .nearby:
                     tabbedSheetContents.transition(transition)
 
                 case let .routeDetails(navEntry):
@@ -283,12 +283,25 @@ struct ContentView: View {
 
     @ViewBuilder
     var favoritesPage: some View {
-        FavoritesPage(
-            errorBannerVM: errorBannerVM,
-            favoritesVM: favoritesVM,
-            nearbyVM: nearbyVM,
-            viewportProvider: viewportProvider
-        )
+        let navEntry = nearbyVM.navigationStack.lastSafe()
+        VStack {
+            if case .editFavorites = navEntry {
+                EditFavoritesPage(
+                    viewModel: favoritesVM,
+                    onClose: { nearbyVM.popToEntrypoint() },
+                    errorBannerVM: errorBannerVM
+                )
+                .transition(transition)
+            } else {
+                FavoritesPage(
+                    errorBannerVM: errorBannerVM,
+                    favoritesVM: favoritesVM,
+                    nearbyVM: nearbyVM,
+                    viewportProvider: viewportProvider
+                )
+                .transition(transition)
+            }
+        }.animation(.easeOut, value: navEntry.sheetItemIdentifiable()?.id)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7312,6 +7312,9 @@
         }
       }
     },
+    "Done" : {
+      "comment" : "Button text for closing flow"
+    },
     "Drag handle" : {
       "comment" : "Screen reader text for the sheet drag handle to move the textual content over the map",
       "extractionState" : "manual",
@@ -7500,6 +7503,12 @@
           }
         }
       }
+    },
+    "Edit" : {
+      "comment" : "Button text to enter edit favorites flow"
+    },
+    "Edit Favorites" : {
+      "comment" : "Title for flow to edit favorites"
     },
     "electrical work" : {
       "comment" : "Alert cause, used in 'Delays due to [cause]'",
@@ -18443,6 +18452,9 @@
           }
         }
       }
+    },
+    "TODO" : {
+
     },
     "Track %@" : {
       "comment" : "The platform that a commuter rail train is boarding at, ex. \"Track 1\", \"Track 8\" etc",

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -7313,7 +7313,51 @@
       }
     },
     "Done" : {
-      "comment" : "Button text for closing flow"
+      "comment" : "Button text for closing flow",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Hecho"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fait"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Feito"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Xong"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "完毕"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "完畢"
+          }
+        }
+      }
     },
     "Drag handle" : {
       "comment" : "Screen reader text for the sheet drag handle to move the textual content over the map",
@@ -7505,10 +7549,98 @@
       }
     },
     "Edit" : {
-      "comment" : "Button text to enter edit favorites flow"
+      "comment" : "Button text to enter edit favorites flow",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Editar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modifier"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Edit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Editar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Biên tập"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "编辑"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "編輯"
+          }
+        }
+      }
     },
     "Edit Favorites" : {
-      "comment" : "Title for flow to edit favorites"
+      "comment" : "Title for flow to edit favorites",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Editar favoritos"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Modifier les favoris"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Edit Favorites"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Editar Favoritos"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chỉnh sửa mục ưa thích"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "编辑收藏夹"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "編輯收藏夾"
+          }
+        }
+      }
     },
     "electrical work" : {
       "comment" : "Alert cause, used in 'Delays due to [cause]'",
@@ -18452,9 +18584,6 @@
           }
         }
       }
-    },
-    "TODO" : {
-
     },
     "Track %@" : {
       "comment" : "The platform that a commuter rail train is boarding at, ex. \"Track 1\", \"Track 8\" etc",

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2862,6 +2862,53 @@
         }
       }
     },
+    "Add stops" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Añadir paradas"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajouter des arrêts"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ajoute arè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Adicionar paradas"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Thêm điểm dừng"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "添加停靠点"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新增停靠點"
+          }
+        }
+      }
+    },
     "Additional service" : {
       "comment" : "Possible alert effect",
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -6510,6 +6510,54 @@
         }
       }
     },
+    "Delete" : {
+      "comment" : "Content description for a button that removes a favorited route/stop/direction",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Borrar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Supprimer"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Efase"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Excluir"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Xóa bỏ"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "删除"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "刪除"
+          }
+        }
+      }
+    },
     "demonstration" : {
       "comment" : "Alert cause, used in 'Delays due to [cause]'",
       "localizations" : {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -25,7 +25,7 @@ struct EditFavoritesPage: View {
                 onClose: onClose,
                 closeText: NSLocalizedString("Done", comment: "Button text for closing flow")
             )
-            Text("TODO")
+            Text(verbatim: "TODO")
             Spacer()
         }
         .background(Color.fill2)

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -1,0 +1,57 @@
+//
+//  EditFavoritesPage.swift
+//  iosApp
+//
+//  Created by Kayla Brady on 7/10/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct EditFavoritesPage: View {
+    let viewModel: FavoritesViewModel
+    let onClose: () -> Void
+
+    @State var globalResponse: GlobalResponse?
+
+    let errorBannerVM: ErrorBannerViewModel
+    let globalRepository: IGlobalRepository = RepositoryDI().global
+
+    var body: some View {
+        VStack {
+            SheetHeader(
+                title: NSLocalizedString("Edit Favorites", comment: "Title for flow to edit favorites"),
+                onClose: onClose,
+                closeText: NSLocalizedString("Done", comment: "Button text for closing flow")
+            )
+            Text("TODO")
+            Spacer()
+        }
+        .background(Color.fill2)
+        .onAppear {
+            loadGlobal()
+        }
+    }
+
+    @MainActor
+    func activateGlobalListener() async {
+        for await globalData in globalRepository.state {
+            globalResponse = globalData
+        }
+    }
+
+    private func loadGlobal() {
+        Task(priority: .high) {
+            await activateGlobalListener()
+        }
+        Task {
+            await fetchApi(
+                errorBannerVM.errorRepository,
+                errorKey: "EditDetailsPage.loadGlobal",
+                getData: { try await globalRepository.getGlobalData() },
+                onRefreshAfterError: loadGlobal
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -10,7 +10,7 @@ import Shared
 import SwiftUI
 
 struct EditFavoritesPage: View {
-    let viewModel: FavoritesViewModel
+    let viewModel: IFavoritesViewModel
     let onClose: () -> Void
 
     @State var globalResponse: GlobalResponse?

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -25,7 +25,18 @@ struct FavoritesView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            SheetHeader(title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"))
+            SheetHeader(
+                title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"),
+                rightActionContents: {
+                    NavTextButton(string: NSLocalizedString("Edit",
+                                                            comment: "Button text to enter edit favorites flow"),
+                                  backgroundColor: Color.text.opacity(0.6),
+                                  textColor: Color.fill2) {
+                        nearbyVM.pushNavEntry(.editFavorites)
+                    }
+                }
+            )
+
             ErrorBanner(errorBannerVM)
             RouteCardList(
                 routeCardData: favoritesVMState.routeCardData,

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -28,11 +28,13 @@ struct FavoritesView: View {
             SheetHeader(
                 title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"),
                 rightActionContents: {
-                    NavTextButton(string: NSLocalizedString("Edit",
-                                                            comment: "Button text to enter edit favorites flow"),
-                                  backgroundColor: Color.text.opacity(0.6),
-                                  textColor: Color.fill2) {
-                        nearbyVM.pushNavEntry(.editFavorites)
+                    if let routeCardData = favoritesVMState.routeCardData, !routeCardData.isEmpty {
+                        NavTextButton(string: NSLocalizedString("Edit",
+                                                                comment: "Button text to enter edit favorites flow"),
+                                      backgroundColor: Color.text.opacity(0.6),
+                                      textColor: Color.fill2) {
+                            nearbyVM.pushNavEntry(.editFavorites)
+                        }
                     }
                 }
             )

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -16,6 +16,7 @@ struct TripDetailsTarget: Hashable {
 
 enum SheetNavigationStackEntry: Hashable, Identifiable {
     case alertDetails(alertId: String, line: Line?, routes: [Route]?, stop: Stop?)
+    case editFavorites
     case favorites
     case more
     case nearby
@@ -47,6 +48,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
     private var caseId: String {
         switch self {
         case .alertDetails: "alertDetails"
+        case .editFavorites: "editFavorites"
         case .favorites: "favorites"
         case .more: "more"
         case .nearby: "nearby"
@@ -66,8 +68,8 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         }
     }
 
-    func sheetItemIdentifiable() -> NearbySheetItem? {
-        let item = NearbySheetItem(stackEntry: self)
+    func sheetItemIdentifiable() -> SheetItem? {
+        let item = SheetItem(stackEntry: self)
         return item.id == "" ? nil : item
     }
 
@@ -78,16 +80,17 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
 }
 
 /// Struct that holds a SheetNavigationStackEntry. To be used with `sheet(item:onDismiss:content:)`
-/// the ids of two `NearbySheetItem`s will differ only if a new sheet should be opened when switching from one to
+/// the ids of two `SheetItem`s will differ only if a new sheet should be opened when switching from one to
 /// the other.
 /// For example, if switching between two `.stopDetails` entries, a new sheet should only be opened if the stop ID
 /// changes.
-struct NearbySheetItem: Identifiable {
+struct SheetItem: Identifiable {
     let stackEntry: SheetNavigationStackEntry
 
     var id: String {
         switch stackEntry {
         case .favorites: "favorites"
+        case .editFavorites: "editFavorites"
         case .nearby: "nearby"
         case .routeDetails: "routeDetails"
         case let .stopDetails(stopId, _, _): stopId

--- a/iosApp/iosAppTests/Pages/Favorites/EditFavoritesPageTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/EditFavoritesPageTests.swift
@@ -1,0 +1,33 @@
+//
+//  EditFavoritesPageTests.swift
+//  iosApp
+//
+//  Created by Kayla Brady on 7/11/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class EditFavoritesPageTests: XCTestCase {
+    @MainActor func testHeader() throws {
+        let objects = ObjectCollectionBuilder()
+        let globalData = GlobalResponse(objects: objects)
+        let favoritesVM = MockFavoritesViewModel(initialState: .init(
+            awaitingPredictionsAfterBackground: false,
+            favorites: [],
+            routeCardData: [],
+            staticRouteCardData: []
+        ))
+
+        var onCloseCalled = false
+        let sut = EditFavoritesPage(viewModel: favoritesVM, onClose: { onCloseCalled = true }, errorBannerVM: .init())
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Edit Favorites"))
+        try sut.inspect().find(button: "Done").tap()
+        XCTAssertTrue(onCloseCalled)
+    }
+}

--- a/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
@@ -78,6 +78,7 @@ final class FavoritesViewTests: XCTestCase {
                 at: now.toKotlinInstant()
             )]
         ))
+
         let sut = FavoritesView(
             errorBannerVM: .init(),
             favoritesVM: favoritesVM,
@@ -91,6 +92,87 @@ final class FavoritesViewTests: XCTestCase {
         }
         ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 2)
+    }
+
+    @MainActor func testEditButtonWhenHasFavorites() {
+        let now = Date.now
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { route in
+            route.longName = "Some Route"
+        }
+        let stop = objects.stop { stop in
+            stop.name = "Some Stop"
+        }
+        let routePattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.upcomingTrip(prediction: objects.prediction { prediction in
+            prediction.trip = objects.trip(routePattern: routePattern)
+            prediction.stopId = stop.id
+            prediction.departureTime = (now + 5 * 60).toKotlinInstant()
+        })
+        let globalData = GlobalResponse(objects: objects)
+        let favoritesVM = MockFavoritesViewModel(initialState: .init(
+            awaitingPredictionsAfterBackground: false,
+            favorites: [.init(route: route.id, stop: stop.id, direction: 0)],
+            routeCardData: [.init(
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    route: route,
+                    stop: stop,
+                    data: [.init(
+                        lineOrRoute: .route(route),
+                        stop: stop,
+                        directionId: 0,
+                        routePatterns: [routePattern],
+                        stopIds: [stop.id],
+                        upcomingTrips: [trip],
+                        alertsHere: [],
+                        allDataLoaded: true,
+                        hasSchedulesToday: true,
+                        alertsDownstream: [],
+                        context: .favorites
+                    )],
+                    globalData: globalData
+                )],
+                at: now.toKotlinInstant()
+            )],
+            staticRouteCardData: [.init(
+                lineOrRoute: .route(route),
+                stopData: [.init(
+                    route: route,
+                    stop: stop,
+                    data: [.init(
+                        lineOrRoute: .route(route),
+                        stop: stop,
+                        directionId: 0,
+                        routePatterns: [routePattern],
+                        stopIds: [stop.id],
+                        upcomingTrips: [],
+                        alertsHere: [],
+                        allDataLoaded: true,
+                        hasSchedulesToday: false,
+                        alertsDownstream: [],
+                        context: .favorites
+                    )],
+                    globalData: globalData
+                )],
+                at: now.toKotlinInstant()
+            )]
+        ))
+
+        let nearbyVM: NearbyViewModel = .init()
+        let sut = FavoritesView(
+            errorBannerVM: .init(),
+            favoritesVM: favoritesVM,
+            nearbyVM: nearbyVM,
+            location: .constant(.init(latitude: 0, longitude: 0))
+        )
+        let exp = sut.inspection.inspect(after: 0.2) { view in
+            try view.find(button: "Edit").tap()
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp], timeout: 2)
+
+        XCTAssertEqual(nearbyVM.navigationStack, [.editFavorites])
     }
 
     @MainActor func testShowsEmpty() {
@@ -108,6 +190,7 @@ final class FavoritesViewTests: XCTestCase {
         )
         let exp = sut.inspection.inspect(after: 0.2) { view in
             XCTAssertNotNil(try view.find(text: "No stops added"))
+            XCTAssertThrowsError(try view.find(button: "Edit"))
         }
         ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 2)

--- a/iosApp/iosAppTests/Views/SheetHeaderTests.swift
+++ b/iosApp/iosAppTests/Views/SheetHeaderTests.swift
@@ -34,4 +34,9 @@ final class SheetHeaderTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "Header Text"))
         XCTAssertThrowsError(try sut.inspect().find(ActionButton.self))
     }
+
+    func testIncludesRightActionContents() throws {
+        let sut = SheetHeader(title: "Header Text", rightActionContents: { Text("Hello") })
+        XCTAssertNotNil(try sut.inspect().find(text: "Hello"))
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | UX | Delete favorites](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210440278891503?focus=true)

What is this PR for?

This PR is the first chunk of adding navigation into the edit favorites flow. I opted to do a little refactoring to add the action buttons into the existing SheetHeader component and adopt that on android as well, so breaking this off here for review.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally on iOS & android
* Added some simple unit tests to build on in next PR
<img width="1170" height="2532" alt="IMG_0331" src="https://github.com/user-attachments/assets/e452b223-0fed-4b23-973d-689b8678ae46" />
<img width="1170" height="2532" alt="IMG_0332" src="https://github.com/user-attachments/assets/e8bfc250-bee5-4e6d-b98c-2f35b04818ee" />

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
