### PR TITLE
fix(shared.MapViewModel): Don't clear stopFilter when vehicle is selected

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -161,7 +161,7 @@ class MapViewModel(
                 is State.Overview -> null to null
                 is State.VehicleSelected -> {
                     val currentState = (state as State.VehicleSelected)
-                    currentState.stop?.id to null
+                    currentState.stop?.id to currentState.stopFilter
                 }
             }
         LaunchedEffect(null) { globalRepository.getGlobalData() }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | v1.2.6 QA | Selected bus route shape doesn't stay visible](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210793281349693?focus=true)

What is this PR for?
* Ensures that when a vehicle is selected, the route shape no longer flickers in and out. 
The order of operations prior to this change was:
1. handleNavChange called with selected stop & stop filter
2. handleNavChange called with selected stop, stop filter, trip filter
3. selectedVehicle called with selected stop & stop filter, but the stop filter was dropped by the VM. 


This repairs step 3 by preserving the stopFilter when in the `SelectedVehicle` state.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally on android, confirmed that the shape of the vehicle persists as expected
* Haven't written an automated test for this - expect that doing so would be flaky as it was in https://github.com/mbta/mobile_app/pull/1126
<img width="612" height="1326" alt="image" src="https://github.com/user-attachments/assets/473e64b0-ae83-4c25-9ced-d4d3b7c5dd26" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
