### PR TITLE
feat(Android): Sheet handle & background refactor

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SearchInput.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SearchInput.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.colorResource
@@ -30,6 +31,7 @@ fun SearchInput(
     onExpandedChange: (Boolean) -> Unit,
     inputFieldFocusRequester: FocusRequester,
     modifier: Modifier = Modifier,
+    haloColor: Color = colorResource(R.color.halo),
     onBarGloballyPositioned: (LayoutCoordinates) -> Unit = {},
     placeholder: @Composable () -> Unit,
 ) {
@@ -65,7 +67,7 @@ fun SearchInput(
                     borderRadius = 10.dp,
                     outlineColor =
                         if (expanded) colorResource(R.color.key_inverse).copy(alpha = 0.4f)
-                        else colorResource(R.color.halo),
+                        else haloColor,
                     backgroundColor = colorResource(R.color.fill3),
                 )
                 .fillMaxWidth()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
@@ -70,7 +71,7 @@ fun SheetHeader(
     }
 
     Row(
-        modifier.padding(horizontal = 16.dp),
+        modifier.padding(horizontal = 16.dp).heightIn(min = touchTarget),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.Top,
     ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/sheet/BottomSheetScaffold.kt
@@ -18,13 +18,14 @@
 package com.mbta.tid.mbta_app.android.component.sheet
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.requiredHeightIn
@@ -38,13 +39,15 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -72,7 +75,7 @@ import kotlinx.coroutines.launch
 @Composable
 @ExperimentalMaterial3Api
 fun BottomSheetScaffold(
-    sheetContent: @Composable ColumnScope.() -> Unit,
+    sheetContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     scaffoldState: BottomSheetScaffoldState = rememberBottomSheetScaffoldState(),
     sheetSmallHeight: Dp = 200.dp,
@@ -189,7 +192,7 @@ private fun StandardBottomSheet(
     tonalElevation: Dp,
     shadowElevation: Dp,
     dragHandle: @Composable (() -> Unit)?,
-    content: @Composable ColumnScope.() -> Unit,
+    content: @Composable () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
     val orientation = Orientation.Vertical
@@ -244,14 +247,19 @@ private fun StandardBottomSheet(
         tonalElevation = tonalElevation,
         shadowElevation = shadowElevation,
     ) {
-        Column(Modifier.fillMaxWidth()) {
+        Box(Modifier.fillMaxWidth()) {
+            content()
             if (dragHandle != null) {
+                var handleVisible by remember { mutableStateOf(true) }
+                LaunchedEffect(state.currentValue) {
+                    handleVisible = state.currentValue != SheetValue.Large
+                }
                 val collapseActionLabel =
                     stringResource(MaterialR.string.m3c_bottom_sheet_collapse_description)
                 val expandActionLabel =
                     stringResource(MaterialR.string.m3c_bottom_sheet_expand_description)
                 Box(
-                    Modifier.align(CenterHorizontally).semantics(mergeDescendants = true) {
+                    Modifier.align(TopCenter).semantics(mergeDescendants = true) {
                         with(state) {
                             // Provides semantics to interact with the bottomsheet if there is more
                             // than one anchor to swipe to and swiping is enabled.
@@ -285,10 +293,11 @@ private fun StandardBottomSheet(
                         }
                     }
                 ) {
-                    dragHandle()
+                    AnimatedVisibility(handleVisible, enter = fadeIn(), exit = fadeOut()) {
+                        dragHandle()
+                    }
                 }
             }
-            content()
         }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.favorites
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -100,7 +101,10 @@ fun FavoritesView(
         ErrorBanner(errorBannerViewModel)
         RouteCardList(
             routeCardData = routeCardData,
-            emptyView = { NoFavoritesView(::onAddFavorites) },
+            emptyView = {
+                NoFavoritesView(::onAddFavorites)
+                Spacer(Modifier.weight(1f))
+            },
             global = globalResponse,
             now = now,
             isFavorite = { favoriteBridge ->

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NoFavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NoFavoritesView.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -27,7 +29,7 @@ import com.mbta.tid.mbta_app.android.util.Typography
 @Composable
 fun NoFavoritesView(onAddStops: () -> Unit, showAddStops: Boolean = true) {
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min).padding(top = 24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(32.dp),
     ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -84,7 +84,7 @@ fun NearbyTransitView(
         }
     }
 
-    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         SheetHeader(title = stringResource(R.string.nearby_transit))
         ErrorBanner(errorBannerViewModel)
         LaunchedEffect(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -58,6 +58,7 @@ import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
@@ -191,6 +192,7 @@ fun RouteStopListView(
     Column {
         SheetHeader(
             title = lineOrRoute.name,
+            titleColor = Color.fromHex(lineOrRoute.textColor),
             closeText =
                 if (context is RouteDetailsContext.Favorites) stringResource(R.string.done)
                 else null,
@@ -212,7 +214,7 @@ fun RouteStopListView(
             lineOrRoute.sortRoute,
             selectedDirection,
             updateDirectionId = { selectedDirection = it },
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp).padding(top = 2.dp),
         )
 
         if (lineOrRoute is RouteCardData.LineOrRoute.Line && routes.size > 1) {
@@ -251,11 +253,20 @@ private fun RouteStops(
         return
     }
 
+    val haloColor =
+        if (lineOrRoute.type == RouteType.BUS) colorResource(R.color.halo_light)
+        else colorResource(R.color.halo_dark)
+
     ScrollSeparatorColumn(
         Modifier.padding(horizontal = 14.dp)
             .padding(top = 8.dp, bottom = 40.dp)
-            .haloContainer(2.dp, backgroundColor = colorResource(R.color.fill2))
+            .haloContainer(
+                2.dp,
+                outlineColor = haloColor,
+                backgroundColor = colorResource(R.color.fill2),
+            )
             .then(if (loading) Modifier.loadingShimmer() else Modifier),
+        haloColor = haloColor,
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start,
         scrollEnabled = !loading,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -139,12 +139,13 @@ fun RoutePickerView(
                 },
                 searchFocusRequester,
                 modifier = Modifier.padding(top = 8.dp, bottom = 14.dp),
+                haloColor = path.haloColor,
             ) {
                 Text(stringResource(R.string.filter_routes), style = Typography.callout)
             }
         }
         ScrollSeparatorColumn(
-            Modifier.imePadding().padding(start = 14.dp, top = 6.dp, end = 14.dp, bottom = 26.dp),
+            Modifier.imePadding().padding(start = 14.dp, top = 10.dp, end = 14.dp, bottom = 26.dp),
             Arrangement.spacedBy(4.dp),
             haloColor = path.haloColor,
             scrollState = routeScroll,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeader.kt
@@ -44,14 +44,16 @@ fun StopDetailsFilteredHeader(
     onClose: (() -> Unit)? = null,
 ) {
     Row(
-        Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp),
+        Arrangement.spacedBy(8.dp),
+        Alignment.CenterVertically,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.weight(1F).semantics(mergeDescendants = true) { heading() },
+            Modifier.weight(1f).padding(top = 4.dp).semantics(mergeDescendants = true) {
+                heading()
+            },
+            Arrangement.spacedBy(8.dp),
+            Alignment.CenterVertically,
         ) {
             if (line != null) {
                 RoutePill(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -76,7 +76,7 @@ fun StopDetailsUnfilteredRoutesView(
     ) {
         Column(Modifier.heightIn(min = 48.dp)) {
             SheetHeader(
-                if (!multiRoute) Modifier.padding(bottom = 16.dp) else Modifier,
+                if (!multiRoute) Modifier.padding(bottom = 8.dp) else Modifier,
                 title = stop.name,
                 onClose = onClose,
             )


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Refactor sheet handle](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210561875928843?focus=true)

Before this, the sheet handle at the top of the sheet was taking up vertical space that the sheet content could not access, which meant that the sheet background color couldn't easily be controlled on a per page level, and that the sheet headers couldn't take up space underneath the handle.

I realized in the middle of this that the hard part wasn't the sheet handle itself, but the excess space that the sheet takes up when expanded to max size. I got around this by wrapping all of the sheet route views in a simple `SheetPage` component, which conditionally adds the top padding but draws the background color based on a param passed in which has the context of the resolved sheet route, which makes it easier to do stuff like change the background of route details based on the selected route's color.

I also adjusted header padding to make things more consistent across the board, and made it so that the sheet handle disappears when the sheet is expanded to full size. I also removed some code which was resizing the sheet content, which was causing the content size to lag behind the actual expanded size when the sheet was expanded. This was added very early on and was no longer necessary, but it did require some repositioning of the empty favorites page.

<img width="250" height="542" alt="Screenshot_20250715_143049" src="https://github.com/user-attachments/assets/d951ce3a-04bf-4ade-8512-0117d54c401c" /> <img width="250" height="542" alt="Screenshot_20250715_143117" src="https://github.com/user-attachments/assets/f9a1bb0d-0386-4485-9830-92fb7720c11e" /> <img width="250" height="542" alt="Screenshot_20250715_143152" src="https://github.com/user-attachments/assets/99a64f3d-b22e-4432-bf96-92cd21c70061" />


android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Existing tests pass, all changes were purely visual