### PR TITLE
fix(iOS): Stop using markdown alert string

### DIFF
--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -40,7 +40,7 @@ struct FormattedAlert: Equatable {
                 text: NSLocalizedString("Suspension", comment: "Possible alert effect"),
                 accessibilityLabel: NSLocalizedString("Service suspended", comment: "Suspension alert VoiceOver text")
             )
-        default: .init(text: effect, accessibilityLabel: nil)
+        default: .init(text: alert.effectString, accessibilityLabel: nil)
         }
         self.alertSummary = alertSummary
     }

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -237,6 +237,17 @@ final class UpcomingTripViewTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabel: "Service suspended"))
     }
 
+    func testDetourLabel() throws {
+        let sut = UpcomingTripView(
+            prediction: .disruption(
+                .init(alert: ObjectCollectionBuilder.Single.shared.alert { $0.effect = .detour }),
+                iconName: "alert-large-red-issue"
+            ),
+            isFirst: false
+        )
+        XCTAssertNotNil(try sut.inspect().find(text: "Detour"))
+    }
+
     func testDisruptionIconName() throws {
         let alert = ObjectCollectionBuilder.Single.shared.alert { $0.effect = .snowRoute }
         let disruption = UpcomingFormat.Disruption(alert: alert, mapStopRoute: .bus)


### PR DESCRIPTION
### Summary

_Ticket:_ [ | v1.2.6 QA | Detour alert shown with asterisks](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210793281349697?focus=true)

The `FormattedAlert.effect` string includes the asterisks around it for markdown bold formatting, but the alert's prediction replacement text shouldn't have the markdown formatting, this just switches to using to alert's `effectString` to set the prediction replacement text instead.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Added a new test case for a detour alert, which covers cases like it which have separate replacement text