### PR TITLE
fix: increase MoleculeViewModel event buffer size

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
@@ -24,8 +24,8 @@ expect abstract class MoleculeScopeViewModel() {
 abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel() {
     private val events =
         MutableSharedFlow<Event>(
-            replay = 10,
-            extraBufferCapacity = 10,
+            replay = 20,
+            extraBufferCapacity = 20,
             onBufferOverflow = BufferOverflow.SUSPEND,
         )
 


### PR DESCRIPTION
### Summary

_Ticket:_ [IllegalStateException: Event buffer overflow in class com.mbta.tid.mbta_app.viewModel.MapViewModel](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210765767196265?focus=true)

I don’t think there’s an architectural issue here where we’re producing events but not consuming them; I think there are just a lot of events, in a way that’d be hard to reduce but easy to just accommodate.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

I couldn’t reproduce this crash, so I don’t actually know that this will fix it, but it Definitely Should™.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
