### PR TITLE
fix(iOS): hideMaps sheet navigation bug

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -346,6 +346,8 @@ struct ContentView: View {
         if hideMaps {
             navSheetContents
                 .fullScreenCover(item: .constant(nav.coverItemIdentifiable()), onDismiss: {
+                    // Don't navigate back if hideMaps has been changed and the cover is being switched over
+                    if hideMaps == false { return }
                     switch nearbyVM.navigationStack.last {
                     case .alertDetails, .more: nearbyVM.goBack()
                     default: break
@@ -378,6 +380,8 @@ struct ContentView: View {
                         .fullScreenCover(
                             item: .constant(nav.coverItemIdentifiable()),
                             onDismiss: {
+                                // Don't navigate back if hideMaps has been changed and the cover is being switched over
+                                if hideMaps { return }
                                 switch nearbyVM.navigationStack.last {
                                 case .alertDetails, .more: nearbyVM.goBack()
                                 default: break


### PR DESCRIPTION


### Summary

_Ticket:_ [ | v1.2.6 QA | Toggling from map display off → on breaks map](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210793281349699?focus=true)

When hideMaps was switched from false to true, the navigation was getting stuck in a mismatched state because when the fullScreenCover switched to the other one, the old one being dismissed and navigating backwards, even though it should have been staying on the more page.

It took me a while to find but I'm so glad the fix was this simple.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Manually toggled hide maps on and off repeatedly, switching back and forth between all possible navigation, with favorites turned on and off, and no longer see any issues