### PR TITLE
fix: Don't prioritize subway in favorites

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -28,11 +28,16 @@ object PatternSorting {
     fun compareRouteCards(
         pinnedRoutes: Set<String>,
         sortByDistanceFrom: Position?,
+        context: RouteCardData.Context,
     ): Comparator<RouteCardData> =
         compareBy(
             { pinnedRouteBucket(it.lineOrRoute.sortRoute, pinnedRoutes) },
             { patternServiceBucket(it.stopData.first().data.first()) },
-            { subwayBucket(it.lineOrRoute.sortRoute) },
+            if (context != RouteCardData.Context.Favorites) {
+                { subwayBucket(it.lineOrRoute.sortRoute) }
+            } else {
+                { 0 }
+            },
             if (sortByDistanceFrom != null) {
                 { it.distanceFrom(sortByDistanceFrom) }
             } else {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -688,7 +688,7 @@ data class RouteCardData(
                         globalData,
                     )
                     .build(sortByDistanceFrom)
-                    .sort(sortByDistanceFrom, pinnedRoutes)
+                    .sort(sortByDistanceFrom, pinnedRoutes, context)
             }
 
         /**
@@ -723,7 +723,7 @@ data class RouteCardData(
                         globalData = globalData,
                     )
                     .build(sortByDistanceFrom)
-                    .sort(sortByDistanceFrom, emptySet())
+                    .sort(sortByDistanceFrom, emptySet(), context)
             }
 
         fun filterStopsByPatterns(
@@ -1226,8 +1226,9 @@ fun List<RouteCardData>.hasContext(context: RouteCardData.Context): Boolean =
 fun List<RouteCardData>.sort(
     distanceFrom: Position?,
     pinnedRoutes: Set<String>,
+    context: RouteCardData.Context,
 ): List<RouteCardData> =
-    this.sortedWith(PatternSorting.compareRouteCards(pinnedRoutes, distanceFrom))
+    this.sortedWith(PatternSorting.compareRouteCards(pinnedRoutes, distanceFrom, context))
 
 fun List<RouteCardData.RouteStopData>.sort(
     distanceFrom: Position?

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -268,11 +268,17 @@ class PatternSortingTest {
 
         assertEquals(
             0,
-            PatternSorting.compareRouteCards(emptySet(), null).compare(routeCard1, routeCard3),
+            PatternSorting.compareRouteCards(emptySet(), null, RouteCardData.Context.NearbyTransit)
+                .compare(routeCard1, routeCard3),
         )
         assertEquals(
             0,
-            PatternSorting.compareRouteCards(emptySet(), position).compare(routeCard1, routeCard7),
+            PatternSorting.compareRouteCards(
+                    emptySet(),
+                    position,
+                    RouteCardData.Context.NearbyTransit,
+                )
+                .compare(routeCard1, routeCard7),
         )
 
         val expected =
@@ -287,7 +293,80 @@ class PatternSortingTest {
             )
         assertEquals(
             expected,
-            expected.reversed().sortedWith(PatternSorting.compareRouteCards(pinnedRoutes, position)),
+            expected
+                .reversed()
+                .sortedWith(
+                    PatternSorting.compareRouteCards(
+                        pinnedRoutes,
+                        position,
+                        RouteCardData.Context.NearbyTransit,
+                    )
+                ),
+        )
+    }
+
+    @Test
+    fun compareRouteCardsOnFavoritesIgnoresRouteType() {
+        val position = Position(latitude = 0.0, longitude = 0.0)
+        val nearStop =
+            objects.stop {
+                latitude = 0.1
+                longitude = 0.1
+            }
+        val farStop =
+            objects.stop {
+                latitude = 2.0
+                longitude = 2.0
+            }
+        fun routeCard(subway: Boolean, near: Boolean, sortOrder: Int): RouteCardData {
+            val route =
+                objects.route {
+                    type = if (subway) RouteType.HEAVY_RAIL else RouteType.BUS
+                    this.sortOrder = sortOrder
+                }
+            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val stop = if (near) nearStop else farStop
+            return routeCard(
+                route,
+                stopData(
+                    stop,
+                    RouteCardData.LineOrRoute.Route(route),
+                    leaf(
+                        lineOrRoute,
+                        stop,
+                        pattern(route, 0, 0),
+                        trips = 1,
+                        hasSchedulesToday = true,
+                    ),
+                ),
+            )
+        }
+        val routeCard1 = routeCard(subway = false, near = true, sortOrder = 10)
+        val routeCard2 = routeCard(subway = true, near = false, sortOrder = 1)
+
+        val expected = listOf(routeCard1, routeCard2)
+        assertEquals(
+            expected,
+            expected
+                .reversed()
+                .sortedWith(
+                    PatternSorting.compareRouteCards(
+                        emptySet(),
+                        position,
+                        RouteCardData.Context.Favorites,
+                    )
+                ),
+        )
+
+        assertEquals(
+            expected.reversed(),
+            expected.sortedWith(
+                PatternSorting.compareRouteCards(
+                    emptySet(),
+                    position,
+                    RouteCardData.Context.NearbyTransit,
+                )
+            ),
         )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Favorites | Don't prioritize subway in favorites](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210790450001356?focus=true)

Pass the context through into the route card sort function, and when the context is set to favorites, don't take subway route types into account and leave subway routes sorted by distance.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a new test to check that subway is not sorted above other route types in favorites.