### PR TITLE
fix(android.RoutePill): Scale down text when needed for large font sizes

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
@@ -22,6 +24,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -128,17 +131,22 @@ fun RoutePill(
     when (pillContent) {
         RoutePillSpec.Content.Empty -> {}
         is RoutePillSpec.Content.Text ->
-            Text(
+            BasicText(
                 if (route?.type == RouteType.COMMUTER_RAIL) pillContent.text
                 else pillContent.text.uppercase(),
                 modifier = finalModifier,
-                color = if (isActive) textColor else Color.Unspecified,
-                fontSize = fontSize,
-                fontWeight = FontWeight.Bold,
-                letterSpacing = 0.5.sp,
-                textAlign = TextAlign.Center,
                 maxLines = 1,
+                autoSize = TextAutoSize.StepBased(8.sp, fontSize, 0.25.sp),
+                style =
+                    TextStyle(
+                        color = if (isActive) textColor else Color.Unspecified,
+                        fontSize = fontSize,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 0.5.sp,
+                        textAlign = TextAlign.Center,
+                    ),
             )
+
         is RoutePillSpec.Content.ModeImage -> {
             val (painter, contentDescription) = routeIcon(routeType = pillContent.mode)
             Icon(


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Fix: Longer bus pills cut off](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210755319204271?focus=true)

What is this PR for?

Shrinks text to fit the available space in route pills. Made this change for all pills rather than just those with `Size.FixedPill` - [confirming that looks good with design in slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1752780735787569?thread_ts=1752692215.232169&cid=C05QMG9GS9M).

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally at large text sizes, confirmed pills not cut off
<img width="301" height="652" alt="image" src="https://github.com/user-attachments/assets/43544ea5-3eeb-477b-80ce-64bc7c565484" />
<img width="301" height="652" alt="image" src="https://github.com/user-attachments/assets/3c8837ac-32ab-4f4d-9842-ce4d41df9a2a" />
<img width="301" height="652" alt="image" src="https://github.com/user-attachments/assets/b79e30e7-c6c5-4f1c-8091-7baa264d4b8b" />
<img width="301" height="652" alt="image" src="https://github.com/user-attachments/assets/85d62176-852e-4c47-aa19-6fe9ca2004a5" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
