### PR TITLE
fix(Android): Recenter map when location changes

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -213,10 +213,8 @@ class MapViewModel(
                     }
                     is Event.Recenter -> {
                         when (state) {
+                            is State.Overview,
                             is State.StopSelected -> {
-                                viewportManager.follow(null)
-                            }
-                            is State.Overview -> {
                                 viewportManager.follow(null)
                             }
                             is State.TripSelected -> {


### PR DESCRIPTION


### Summary

_Ticket:_ No ticket

The map was not updating the viewport when location updates were sent. This was happening because the `following` boolean was set to a stale value in the `locationDataManager.currentLocation.collect` callback, and was never being updated when the following state changed. There was also an interconnected issue where `following` was always set to false when the VM state was `TripSelected`, which shouldn't be the case because you can be following current location when a trip is selected, and it was causing the recenter button to never disappear on stop details, even when following. Changing every use of following back to `viewportProvider.isFollowingPuck` solved both issues.


### Testing

