### PR TITLE
feat(Android): Keep favorites order consistent when navigating into edit

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -1,11 +1,14 @@
 package com.mbta.tid.mbta_app.android.favorites
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.pages.EditFavoritesPage
@@ -23,6 +26,7 @@ import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import dev.mokkery.spy
 import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
+import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
@@ -34,6 +38,12 @@ import org.koin.test.KoinTest
 class EditFavoritesPageTest : KoinTest {
     val builder = ObjectCollectionBuilder()
     val now = Instant.fromEpochMilliseconds(System.currentTimeMillis())
+    val line =
+        builder.line {
+            id = "line_1"
+            color = "FF0000"
+            textColor = "FFFFFF"
+        }
     val route =
         builder.route {
             id = "route_1"
@@ -44,7 +54,7 @@ class EditFavoritesPageTest : KoinTest {
             longName = "Sample Route Long Name"
             shortName = "Sample Route"
             textColor = "000000"
-            lineId = "line_1"
+            lineId = line.id
             routePatternIds = mutableListOf("pattern_1", "pattern_2")
         }
     val routePatternOne =
@@ -52,7 +62,7 @@ class EditFavoritesPageTest : KoinTest {
             id = "pattern_1"
             directionId = 0
             name = "Sample Route Pattern"
-            routeId = "route_1"
+            routeId = route.id
             representativeTripId = "trip_1"
         }
     val routePatternTwo =
@@ -60,66 +70,56 @@ class EditFavoritesPageTest : KoinTest {
             id = "pattern_2"
             directionId = 1
             name = "Sample Route Pattern Two"
-            routeId = "route_1"
-            representativeTripId = "trip_1"
+            routeId = route.id
+            representativeTripId = "trip_2"
         }
     val sampleStop =
         builder.stop {
             id = "stop_1"
-            name = "Sample Stop"
+            name = "Sample Stop 1"
             locationType = LocationType.STOP
             latitude = 0.0
             longitude = 0.0
         }
-    val line =
-        builder.line {
-            id = "line_1"
-            color = "FF0000"
-            textColor = "FFFFFF"
+    val farStop =
+        builder.stop {
+            id = "stop_2"
+            name = "Sample Stop 2"
+            locationType = LocationType.STOP
+            latitude = 1.0
+            longitude = 1.0
         }
-    val trip =
+    val trip1 =
         builder.trip {
             id = "trip_1"
-            routeId = "route_1"
+            routeId = route.id
             directionId = 0
             headsign = "Sample Headsign"
-            routePatternId = "pattern_1"
+            routePatternId = routePatternOne.id
             stopIds = listOf(sampleStop.id)
+        }
+    val trip2 =
+        builder.trip {
+            id = "trip_2"
+            routeId = route.id
+            directionId = 1
+            headsign = "Other Headsign"
+            routePatternId = routePatternTwo.id
+            stopIds = listOf(farStop.id)
         }
     val prediction =
         builder.prediction {
             id = "prediction_1"
             revenue = true
-            stopId = "stop_1"
-            tripId = "trip_1"
-            routeId = "route_1"
+            stopId = sampleStop.id
+            tripId = trip1.id
+            routeId = route.id
             stopSequence = 1
             directionId = 0
             arrivalTime = now.plus(1.minutes)
             departureTime = now.plus(1.5.minutes)
         }
 
-    val greenLineRoute =
-        builder.route {
-            id = "route_2"
-            type = RouteType.LIGHT_RAIL
-            color = "008000"
-            directionNames = listOf("Inbound", "Outbound")
-            directionDestinations = listOf("Park Street", "Lechmere")
-            longName = "Green Line Long Name"
-            shortName = "Green Line"
-            textColor = "FFFFFF"
-            lineId = "line-Green"
-            routePatternIds = mutableListOf("pattern_3", "pattern_4")
-        }
-    val greenLineRoutePatternOne =
-        builder.routePattern(greenLineRoute) {
-            id = "pattern_3"
-            directionId = 0
-            name = "Green Line Pattern"
-            routeId = "route_2"
-            representativeTripId = "trip_2"
-        }
     val greenLine =
         builder.line {
             id = "line-Green"
@@ -128,30 +128,51 @@ class EditFavoritesPageTest : KoinTest {
             color = "008000"
             textColor = "FFFFFF"
         }
+    val greenLineRoute =
+        builder.route {
+            id = "route_gl"
+            type = RouteType.LIGHT_RAIL
+            color = "008000"
+            directionNames = listOf("Inbound", "Outbound")
+            directionDestinations = listOf("Park Street", "Lechmere")
+            longName = "Green Line Long Name"
+            shortName = "Green Line"
+            textColor = "FFFFFF"
+            lineId = greenLine.id
+            routePatternIds = mutableListOf("pattern_gl")
+        }
+    val greenLineRoutePatternOne =
+        builder.routePattern(greenLineRoute) {
+            id = "pattern_gl"
+            directionId = 0
+            name = "Green Line Pattern"
+            routeId = greenLineRoute.id
+            representativeTripId = "trip_gl"
+        }
     val greenLineStop =
         builder.stop {
-            id = "stop_2"
+            id = "stop_gl"
             name = "Green Line Stop"
             locationType = LocationType.STOP
-            latitude = 0.0
-            longitude = 0.0
+            latitude = 2.0
+            longitude = 2.0
         }
     val greenLineTrip =
         builder.trip {
-            id = "trip_2"
-            routeId = "route_2"
+            id = "trip_gl"
+            routeId = greenLineRoute.id
             directionId = 0
             headsign = "Green Line Head Sign"
-            routePatternId = "pattern_3"
+            routePatternId = greenLineRoutePatternOne.id
             stopIds = listOf(greenLineStop.id)
         }
     val greenLinePrediction =
         builder.prediction {
-            id = "prediction_2"
+            id = "prediction_gl"
             revenue = true
-            stopId = "stop_2"
-            tripId = "trip_2"
-            routeId = "route_2"
+            stopId = greenLineStop.id
+            tripId = greenLineTrip.id
+            routeId = greenLineRoute.id
             stopSequence = 1
             directionId = 0
             arrivalTime = now.plus(5.minutes)
@@ -167,14 +188,16 @@ class EditFavoritesPageTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testFavoritesDisplayCorrectly(): Unit = runBlocking {
-        val favorites = setOf(RouteStopDirection("route_1", "stop_1", 0))
+        val favorites = setOf(RouteStopDirection(route.id, sampleStop.id, 0))
         val repository = MockFavoritesRepository(Favorites(favorites))
         val usecase = FavoritesUsecases(repository)
         val viewModel = FavoritesViewModel(usecase)
         viewModel.favorites = favorites
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
+            KoinContext(koinApplication.koin) {
+                EditFavoritesPage(globalResponse, null, viewModel) {}
+            }
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
@@ -194,7 +217,9 @@ class EditFavoritesPageTest : KoinTest {
         val viewModel = FavoritesViewModel(usecase)
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
+            KoinContext(koinApplication.koin) {
+                EditFavoritesPage(globalResponse, null, viewModel) {}
+            }
         }
 
         composeTestRule.waitForIdle()
@@ -207,8 +232,8 @@ class EditFavoritesPageTest : KoinTest {
     fun testDeleteFavorite(): Unit = runBlocking {
         val favorites =
             setOf(
-                RouteStopDirection("route_1", "stop_1", 0),
-                RouteStopDirection("line-Green", "stop_2", 0),
+                RouteStopDirection(route.id, sampleStop.id, 0),
+                RouteStopDirection(greenLine.id, greenLineStop.id, 0),
             )
         val repository = MockFavoritesRepository(Favorites(favorites))
         val spiedRepo = spy<IFavoritesRepository>(repository)
@@ -217,7 +242,9 @@ class EditFavoritesPageTest : KoinTest {
         viewModel.favorites = favorites
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
+            KoinContext(koinApplication.koin) {
+                EditFavoritesPage(globalResponse, null, viewModel) {}
+            }
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
@@ -230,7 +257,9 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.onAllNodesWithTag("trashCan")[0].performClick()
         composeTestRule.awaitIdle()
         verifySuspend(VerifyMode.exactly(1)) {
-            spiedRepo.setFavorites(Favorites(setOf(RouteStopDirection("line-Green", "stop_2", 0))))
+            spiedRepo.setFavorites(
+                Favorites(setOf(RouteStopDirection(greenLine.id, greenLineStop.id, 0)))
+            )
         }
 
         // Should be deleted
@@ -240,5 +269,32 @@ class EditFavoritesPageTest : KoinTest {
         // Should remain
         composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
         composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testFavoritesOrderStopsBasedOnPosition(): Unit = runBlocking {
+        val favorites =
+            setOf(
+                RouteStopDirection(greenLine.id, greenLineStop.id, 0),
+                RouteStopDirection(route.id, farStop.id, 1),
+                RouteStopDirection(route.id, sampleStop.id, 0),
+            )
+        val repository = MockFavoritesRepository(Favorites(favorites))
+        val usecase = FavoritesUsecases(repository)
+        val viewModel = FavoritesViewModel(usecase)
+        viewModel.favorites = favorites
+
+        composeTestRule.setContent {
+            KoinContext(koinApplication.koin) {
+                EditFavoritesPage(globalResponse, Position(0.0, 0.0), viewModel) {}
+            }
+        }
+
+        val stops = composeTestRule.onAllNodesWithText("Stop", substring = true)
+        stops[0].assertTextEquals("Sample Stop 1")
+        stops[1].assertTextEquals("Sample Stop 2")
+        stops[2].assertTextEquals("Green Line Stop")
+        stops.assertCountEquals(3)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewModel.kt
@@ -59,7 +59,10 @@ class FavoritesViewModel(
         routeCardData = filterRouteAndDirection(loadedRouteCardData, global, favorites)
     }
 
-    suspend fun loadStaticRouteCardData(global: GlobalResponse?): List<RouteCardData>? {
+    suspend fun loadStaticRouteCardData(
+        global: GlobalResponse?,
+        position: Position?,
+    ): List<RouteCardData>? {
         val stopIds = stopIds(global)
         if (stopIds.isEmpty()) {
             return emptyList()
@@ -72,6 +75,7 @@ class FavoritesViewModel(
                 stopIds,
                 global,
                 RouteCardData.Context.Favorites,
+                sortByDistanceFrom = position,
             )
         return filterRouteAndDirection(loadedRouteCardData, global, favorites)
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -52,11 +52,13 @@ import com.mbta.tid.mbta_app.model.LeafFormat
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Clock
 
 @Composable
 fun EditFavoritesPage(
     global: GlobalResponse?,
+    targetLocation: Position?,
     favoritesViewModel: FavoritesViewModel,
     onClose: () -> Unit,
 ) {
@@ -65,7 +67,10 @@ fun EditFavoritesPage(
         mutableStateMapOf(*initialState.map { it to true }.toTypedArray())
     }
     var routeCardData: List<RouteCardData>? by remember { mutableStateOf(null) }
-    LaunchedEffect(Unit) { routeCardData = favoritesViewModel.loadStaticRouteCardData(global) }
+    LaunchedEffect(Unit) {
+        // Don't update when global/target location changes to prevent reorders while editing
+        routeCardData = favoritesViewModel.loadStaticRouteCardData(global, targetLocation)
+    }
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         SheetHeader(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
@@ -2,30 +2,21 @@ package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.favorites.FavoritesView
 import com.mbta.tid.mbta_app.android.favorites.FavoritesViewModel
-import com.mbta.tid.mbta_app.android.util.managedTargetLocation
 import com.mbta.tid.mbta_app.model.SheetRoutes
 import io.github.dellisd.spatialk.geojson.Position
 
 @Composable
 fun FavoritesPage(
     openSheetRoute: (SheetRoutes) -> Unit,
+    targetLocation: Position?,
     favoritesViewModel: FavoritesViewModel,
     errorBannerViewModel: ErrorBannerViewModel,
     nearbyTransit: NearbyTransit,
 ) {
-    var targetLocation by remember { mutableStateOf<Position?>(null) }
-    managedTargetLocation(
-        nearbyTransit = nearbyTransit,
-        updateTargetLocation = { targetLocation = it },
-        reset = { /* no-op */ },
-    )
-
     FavoritesView(
         openSheetRoute,
         favoritesViewModel,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -72,6 +72,7 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.currentRouteAs
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
+import com.mbta.tid.mbta_app.android.util.managedTargetLocation
 import com.mbta.tid.mbta_app.android.util.navigateFrom
 import com.mbta.tid.mbta_app.android.util.plus
 import com.mbta.tid.mbta_app.android.util.popBackStackFrom
@@ -151,6 +152,7 @@ fun MapAndSheetPage(
     val currentNavEntry = currentNavBackStackEntry?.let { SheetRoutes.fromNavBackStackEntry(it) }
     val previousNavEntry: SheetRoutes? = rememberPrevious(currentNavEntry)
 
+    val favoritesLocation by managedTargetLocation(nearbyTransit)
     val (pinnedRoutes) = managePinnedRoutes()
 
     val density = LocalDensity.current
@@ -469,6 +471,7 @@ fun MapAndSheetPage(
                 SheetPage {
                     FavoritesPage(
                         openSheetRoute = ::navigate,
+                        targetLocation = favoritesLocation,
                         favoritesViewModel = favoritesViewModel,
                         errorBannerViewModel = errorBannerViewModel,
                         nearbyTransit = nearbyTransit,
@@ -478,15 +481,15 @@ fun MapAndSheetPage(
             composable<SheetRoutes.EditFavorites>(typeMap = SheetRoutes.typeMap) {
                 SheetPage {
                     EditFavoritesPage(
+                        global = nearbyTransit.globalResponse,
+                        targetLocation = favoritesLocation,
+                        favoritesViewModel = favoritesViewModel,
                         onClose = {
                             navController.popBackStackFrom(SheetRoutes.EditFavorites::class)
                         },
-                        global = nearbyTransit.globalResponse,
-                        favoritesViewModel = favoritesViewModel,
                     )
                 }
             }
-
             composable<SheetRoutes.StopDetails>(typeMap = SheetRoutes.typeMap) { backStackEntry ->
                 val navRoute: SheetRoutes.StopDetails = backStackEntry.toRoute()
                 val filters =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/NearbyTransitPage.kt
@@ -2,19 +2,13 @@ package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitView
 import com.mbta.tid.mbta_app.android.nearbyTransit.NearbyTransitViewModel
 import com.mbta.tid.mbta_app.android.nearbyTransit.NoNearbyStopsView
 import com.mbta.tid.mbta_app.android.util.managedTargetLocation
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
-import io.github.dellisd.spatialk.geojson.Position
-import kotlinx.coroutines.FlowPreview
 
-@OptIn(FlowPreview::class)
 @Composable
 fun NearbyTransitPage(
     nearbyTransit: NearbyTransit,
@@ -23,12 +17,7 @@ fun NearbyTransitPage(
     nearbyViewModel: NearbyTransitViewModel,
     errorBannerViewModel: ErrorBannerViewModel,
 ) {
-    var targetLocation by remember { mutableStateOf<Position?>(null) }
-    managedTargetLocation(
-        nearbyTransit = nearbyTransit,
-        updateTargetLocation = { targetLocation = it },
-        reset = { nearbyViewModel.reset() },
-    )
+    val targetLocation by managedTargetLocation(nearbyTransit) { nearbyViewModel.reset() }
 
     NearbyTransitView(
         alertData = nearbyTransit.alertData,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/managedTargetLocation.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/managedTargetLocation.kt
@@ -2,24 +2,26 @@ package com.mbta.tid.mbta_app.android.util
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.debounce
 
 @Composable
-fun managedTargetLocation(
-    nearbyTransit: NearbyTransit,
-    updateTargetLocation: (Position?) -> Unit,
-    reset: () -> Unit,
-) {
+fun managedTargetLocation(nearbyTransit: NearbyTransit, reset: () -> Unit = {}): State<Position?> {
+    var position = remember { mutableStateOf<Position?>(null) }
     LaunchedEffect(nearbyTransit.locationDataManager) {
         nearbyTransit.locationDataManager.currentLocation.collect { location ->
             if (
                 nearbyTransit.viewportProvider.isFollowingPuck &&
                     !nearbyTransit.viewportProvider.isManuallyCentering
             ) {
-                updateTargetLocation(location?.let { Position(it.longitude, it.latitude) })
+                position.value = location?.let { Position(it.longitude, it.latitude) }
             }
         }
     }
@@ -28,24 +30,25 @@ fun managedTargetLocation(
             // since this LaunchedEffect is cancelled when not on the page
             // we don't need to check
             if (!nearbyTransit.viewportProvider.isFollowingPuck) {
-                updateTargetLocation(it.center.toPosition())
+                position.value = it.center.toPosition()
             }
         }
     }
     LaunchedEffect(nearbyTransit.viewportProvider.isManuallyCentering) {
         if (nearbyTransit.viewportProvider.isManuallyCentering) {
             reset()
-            updateTargetLocation(null)
+            position.value = null
         }
     }
     LaunchedEffect(nearbyTransit.viewportProvider.isFollowingPuck) {
         if (nearbyTransit.viewportProvider.isFollowingPuck) {
             reset()
-            updateTargetLocation(
+            position.value =
                 nearbyTransit.locationDataManager.currentLocation.value?.let {
                     Position(it.longitude, it.latitude)
                 }
-            )
         }
     }
+
+    return position
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Fix: Edit order doesn't match view order](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210755319204265?focus=true)

We don't want to reorder the route cards or stops within cards when the user taps into the edit page. 

This required moving the current favorites nearby position up a level into `MapAndSheetPage`, because without that, the edit page would need to reinitialize the position itself, which was leading to a flash of the unordered list which would then animate into the correctly ordered one. Unfortunately, we can't use the same position for nearby, because that uses a reset callback to modify internal state when the location is reset.

In the process, I streamlined the `managedTargetLocation` composable to directly modify and return a state object, rather than using a callback.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a new test to check the correct ordering, which turned into some minor refactoring in that test to hardcode fewer IDs.