### PR TITLE
fix: misc. route-specific edge case favorites QA 

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -278,6 +278,31 @@ class SaveFavoritesFlowTest {
     }
 
     @Test
+    fun testFavoritingWhenDropOffOnlyPresentsDialog() {
+        var onCloseCalled = false
+
+        composeTestRule.setContent {
+            SaveFavoritesFlow(
+                lineOrRoute = line,
+                stop = stop,
+                directions = listOf(),
+                selectedDirection = 0,
+                isFavorite = { false },
+                context = SaveFavoritesContext.Favorites,
+                updateFavorites = {},
+                onClose = { onCloseCalled = true },
+            )
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("This stop is drop-off only").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Okay").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilDefaultTimeout { onCloseCalled }
+        assertTrue(onCloseCalled)
+    }
+
+    @Test
     fun testDialogTitleFavoritesContext() {
         composeTestRule.setContent {
             SaveFavoritesFlow(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
@@ -157,8 +157,7 @@ fun FavoriteConfirmationDialog(
             if (directions.isEmpty()) {
                 Column {
                     Text(
-                        // TODO: Update copy, make resource, port to iOS & translate
-                        "This stop has no departures",
+                        stringResource(R.string.this_stop_is_drop_off_only),
                         textAlign = TextAlign.Center,
                         style = Typography.footnoteSemibold,
                         modifier =
@@ -167,52 +166,58 @@ fun FavoriteConfirmationDialog(
                                 .fillMaxWidth(),
                     )
                     HaloSeparator()
-                }
-            }
-            Column() {
-                HaloSeparator()
-                directions.mapIndexed { idx, direction ->
-                    Button(
-                        onClick = {
-                            favoritesToSave =
-                                favoritesToSave.plus(
-                                    direction.id to
-                                        !favoritesToSave.getOrDefault(direction.id, false)
-                                )
-                        },
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = colorResource(R.color.fill3),
-                                contentColor = colorResource(R.color.text),
-                            ),
-                        shape = RectangleShape,
-                        modifier =
-                            Modifier.background(color = colorResource(R.color.fill3)).semantics {
-                                selected = favoritesToSave.getOrDefault(direction.id, false)
-                            },
-                    ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            DirectionLabel(direction, Modifier.weight(1f))
-                            StarIcon(
-                                favoritesToSave.getOrDefault(direction.id, false),
-                                color = Color.fromHex(lineOrRoute.backgroundColor),
-                                Modifier.padding(start = 16.dp),
-                            )
-                        }
+                    Row(modifier = Modifier.padding(16.dp)) {
+                        Spacer(Modifier.weight(1F))
+                        TextButton(onClose) { Text(stringResource(R.string.okay)) }
                     }
-                    HaloSeparator()
                 }
-            }
+            } else {
+                Column() {
+                    HaloSeparator()
+                    directions.mapIndexed { idx, direction ->
+                        Button(
+                            onClick = {
+                                favoritesToSave =
+                                    favoritesToSave.plus(
+                                        direction.id to
+                                            !favoritesToSave.getOrDefault(direction.id, false)
+                                    )
+                            },
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = colorResource(R.color.fill3),
+                                    contentColor = colorResource(R.color.text),
+                                ),
+                            shape = RectangleShape,
+                            modifier =
+                                Modifier.background(color = colorResource(R.color.fill3))
+                                    .semantics {
+                                        selected = favoritesToSave.getOrDefault(direction.id, false)
+                                    },
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                DirectionLabel(direction, Modifier.weight(1f))
+                                StarIcon(
+                                    favoritesToSave.getOrDefault(direction.id, false),
+                                    color = Color.fromHex(lineOrRoute.backgroundColor),
+                                    Modifier.padding(start = 16.dp),
+                                )
+                            }
+                        }
+                        HaloSeparator()
+                    }
+                }
 
-            Row(modifier = Modifier.padding(16.dp)) {
-                Spacer(Modifier.weight(1F))
-                TextButton(onClose) { Text("Cancel") }
-                TextButton({ saveAndClose() }, enabled = favoritesToSave.values.any { it }) {
-                    Text(stringResource(R.string.add_confirmation_button))
+                Row(modifier = Modifier.padding(16.dp)) {
+                    Spacer(Modifier.weight(1F))
+                    TextButton(onClose) { Text(stringResource(R.string.cancel)) }
+                    TextButton({ saveAndClose() }, enabled = favoritesToSave.values.any { it }) {
+                        Text(stringResource(R.string.add_confirmation_button))
+                    }
                 }
             }
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
@@ -153,6 +153,22 @@ fun FavoriteConfirmationDialog(
                         Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp).fillMaxWidth(),
                 )
             }
+
+            if (directions.isEmpty()) {
+                Column {
+                    Text(
+                        // TODO: Update copy, make resource, port to iOS & translate
+                        "This stop has no departures",
+                        textAlign = TextAlign.Center,
+                        style = Typography.footnoteSemibold,
+                        modifier =
+                            Modifier.padding(horizontal = 16.dp)
+                                .padding(bottom = 8.dp)
+                                .fillMaxWidth(),
+                    )
+                    HaloSeparator()
+                }
+            }
             Column() {
                 HaloSeparator()
                 directions.mapIndexed { idx, direction ->

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.items
@@ -153,31 +152,37 @@ private fun FavoriteDepartures(
                             verticalArrangement =
                                 Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
                         ) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
                                 DirectionLabel(
                                     direction,
                                     pillDecoration =
                                         formatted.route?.let {
                                             PillDecoration.OnDirectionDestination(it)
                                         },
+                                    modifier = Modifier.weight(1f),
                                 )
-                                Spacer(Modifier.weight(1f))
                                 DeleteIcon(action = { onClick(leaf) })
                             }
                         }
                     }
 
                     is LeafFormat.Branched -> {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                        ) {
                             Column(
                                 horizontalAlignment = Alignment.Start,
                                 verticalArrangement =
                                     Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
+                                modifier = Modifier.weight(1f),
                             ) {
                                 DirectionLabel(direction, showDestination = false)
                                 BranchRows(formatted)
                             }
-                            Spacer(Modifier.weight(1f))
                             DeleteIcon(action = { onClick(leaf) })
                         }
                     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -364,8 +364,10 @@ private fun RouteStops(
         horizontalAlignment = Alignment.Start,
         scrollEnabled = !loading,
     ) {
+        val hasTypicalSegment = stopList.segments.any { it.isTypical }
+
         stopList.segments.forEachIndexed { segmentIndex, segment ->
-            if (segment.isTypical) {
+            if (segment.isTypical || !hasTypicalSegment) {
                 segment.stops.forEachIndexed { stopIndex, stop ->
                     val stopPlacement =
                         StopPlacement(

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -225,6 +225,7 @@
     <string name="not_accessible_stop_card">Esta parada no es accesible</string>
     <string name="now">Ahora</string>
     <string name="now_at">Ahora en</string>
+    <string name="okay">Bueno</string>
     <string name="onboarding_continue">Continuar</string>
     <string name="onboarding_feedback_advance">Empezar</string>
     <string name="onboarding_feedback_body">MBTA Go está en su etapa inicial. Queremos recibir sus comentarios mientras seguimos realizando mejoras y agregando nuevas características.</string>
@@ -352,6 +353,7 @@
     <string name="tap_favorites_hint">Toca las estrellas para añadirlas a Favoritos</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="technical_problem_lowercase">problema técnico</string>
+    <string name="this_stop_is_drop_off_only">Esta parada es solo para dejar pasajeros.</string>
     <string name="tie_replacement">Reemplazo de traviesas</string>
     <string name="tie_replacement_lowercase">reemplazo de traviesas</string>
     <string name="track_change">Cambio de pista</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -225,6 +225,7 @@
     <string name="not_accessible_stop_card">Cet arrêt n’est pas accessible</string>
     <string name="now">Maintenant</string>
     <string name="now_at">Maintenant à</string>
+    <string name="okay">D’accord</string>
     <string name="onboarding_continue">Continuer</string>
     <string name="onboarding_feedback_advance">Commencer</string>
     <string name="onboarding_feedback_body">MBTA Go est encore en développement ! Votre avis est précieux pour continuer à l’améliorer et ajouter de nouvelles fonctionnalités.</string>
@@ -352,6 +353,7 @@
     <string name="tap_favorites_hint">Appuyez sur les étoiles pour ajouter aux favoris</string>
     <string name="technical_problem">Problème technique</string>
     <string name="technical_problem_lowercase">problème technique</string>
+    <string name="this_stop_is_drop_off_only">Cet arrêt est uniquement destiné au dépôt</string>
     <string name="tie_replacement">Remplacement de traverses</string>
     <string name="tie_replacement_lowercase">remplacement de traverses</string>
     <string name="track_change">Changement de voie</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -234,6 +234,7 @@
     <string name="not_accessible_stop_card">Estasyon sa a pa aksesib</string>
     <string name="now">Kounye a</string>
     <string name="now_at">Kounye a li nan</string>
+    <string name="okay">Oke</string>
     <string name="onboarding_continue">Kontinye</string>
     <string name="onboarding_feedback_advance">Kòmanse</string>
     <string name="onboarding_feedback_body">MBTA Go nan etap kòmansman yo! Nou vle kòmantè w pandan n ap kontinye fè amelyorasyon epi ajoute nouvo opsyon.</string>
@@ -364,6 +365,7 @@
     <string name="tap_favorites_hint">Tape zetwal yo pou ajoute nan Favori yo</string>
     <string name="technical_problem">Pwoblèm Teknik</string>
     <string name="technical_problem_lowercase">pwoblèm teknik</string>
+    <string name="this_stop_is_drop_off_only">Estasyon sa a se depoze sèlman</string>
     <string name="tie_replacement">Ranplasman kòd</string>
     <string name="tie_replacement_lowercase">ranplasman mare</string>
     <string name="track_change">Suiv Chanjman</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -225,6 +225,7 @@
     <string name="not_accessible_stop_card">Esta parada não é acessível</string>
     <string name="now">Agora</string>
     <string name="now_at">Agora em</string>
+    <string name="okay">OK</string>
     <string name="onboarding_continue">Continuar</string>
     <string name="onboarding_feedback_advance">Comece aqui</string>
     <string name="onboarding_feedback_body">O MBTA Go está no estágio inicial! Queremos seus comentários enquanto continuamos a fazer melhorias e adicionar novos recursos.</string>
@@ -352,6 +353,7 @@
     <string name="tap_favorites_hint">Toque nas estrelas para adicionar aos favoritos</string>
     <string name="technical_problem">Problema técnico</string>
     <string name="technical_problem_lowercase">problema técnico</string>
+    <string name="this_stop_is_drop_off_only">Esta parada é somente para desembarque</string>
     <string name="tie_replacement">Troca de pneu</string>
     <string name="tie_replacement_lowercase">substituição de dormentes</string>
     <string name="track_change">Alteração de trilho</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -219,6 +219,7 @@
     <string name="not_accessible_stop_card">Điểm dừng này không có lối vào cho người khuyết tật</string>
     <string name="now">Hiện nay</string>
     <string name="now_at">Hiện giờ tại</string>
+    <string name="okay">Đồng ý</string>
     <string name="onboarding_continue">Tiếp tục</string>
     <string name="onboarding_feedback_advance">Bắt đầu</string>
     <string name="onboarding_feedback_body">MBTA Go đang trong giai đoạn đầu! Chúng tôi muốn nghe ý kiến đóng góp của bạn để tiếp tục cải thiện và bổ sung các tính năng mới.</string>
@@ -344,6 +345,7 @@
     <string name="tap_favorites_hint">Nhấn vào các ngôi sao để thêm vào mục Yêu thích</string>
     <string name="technical_problem">Vấn đề kỹ thuật</string>
     <string name="technical_problem_lowercase">vấn đề kỹ thuật</string>
+    <string name="this_stop_is_drop_off_only">Điểm dừng này chỉ dành cho việc trả khách</string>
     <string name="tie_replacement">Thay tà vẹt</string>
     <string name="tie_replacement_lowercase">thay tà vẹt</string>
     <string name="track_change">Thay đổi đường ray</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -219,6 +219,7 @@
     <string name="not_accessible_stop_card">此车站不适合轮椅通行</string>
     <string name="now">现在</string>
     <string name="now_at">现在停靠</string>
+    <string name="okay">好的</string>
     <string name="onboarding_continue">继续</string>
     <string name="onboarding_feedback_advance">开始</string>
     <string name="onboarding_feedback_body">MBTA Go尚处于试运行阶段！我们希望收到您的反馈，以便我们继续改进和新增功能。</string>
@@ -344,6 +345,7 @@
     <string name="tap_favorites_hint">点按星星即可添加到收藏夹</string>
     <string name="technical_problem">技术故障</string>
     <string name="technical_problem_lowercase">技术故障</string>
+    <string name="this_stop_is_drop_off_only">此站仅供下客</string>
     <string name="tie_replacement">更换轨枕</string>
     <string name="tie_replacement_lowercase">更换轨枕</string>
     <string name="track_change">轨道变更</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -219,6 +219,7 @@
     <string name="not_accessible_stop_card">此車站不適合輪椅通行</string>
     <string name="now">現在</string>
     <string name="now_at">現在停靠</string>
+    <string name="okay">好的</string>
     <string name="onboarding_continue">繼續</string>
     <string name="onboarding_feedback_advance">開始</string>
     <string name="onboarding_feedback_body">MBTA Go尚處於試運行階段！我們希望收到您的回饋，以便我們繼續改進和新增功能。</string>
@@ -344,6 +345,7 @@
     <string name="tap_favorites_hint">點按星星即可加入收藏夾</string>
     <string name="technical_problem">技術故障</string>
     <string name="technical_problem_lowercase">技術故障</string>
+    <string name="this_stop_is_drop_off_only">此站僅供下客</string>
     <string name="tie_replacement">更換軌枕</string>
     <string name="tie_replacement_lowercase">更換軌枕</string>
     <string name="track_change">軌道變更</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -409,4 +409,6 @@
     <string name="weather">Weather</string>
     <string name="weather_lowercase">weather</string>
     <string name="westbound">Westbound</string>
+    <string name="okay">Okay</string>
+    <string name="this_stop_is_drop_off_only">This stop is drop-off only</string>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="onboarding_map_display_header">Set map display preference</string>
     <string name="onboarding_station_accessibility_body">By opting in, we can show you which stations are inaccessible or have elevator closures.</string>
     <string name="onboarding_station_accessibility_header">Set station accessibility info preference</string>
+    <string name="okay">Okay</string>
     <string name="only_served_at_certain_times">Only served at certain times of day</string>
     <string name="open_for_more_arrivals">Open for more arrivals</string>
     <string name="other_link_privacy_policy">Privacy Policy</string>
@@ -350,6 +351,7 @@
     <string name="tap_favorites_hint">Tap stars to add to Favorites</string>
     <string name="technical_problem">Technical Problem</string>
     <string name="technical_problem_lowercase">technical problem</string>
+    <string name="this_stop_is_drop_off_only">This stop is drop-off only</string>
     <string name="tie_replacement">Tie Replacement</string>
     <string name="tie_replacement_lowercase">tie replacement</string>
     <string name="track_change">Track Change</string>
@@ -409,6 +411,4 @@
     <string name="weather">Weather</string>
     <string name="weather_lowercase">weather</string>
     <string name="westbound">Westbound</string>
-    <string name="okay">Okay</string>
-    <string name="this_stop_is_drop_off_only">This stop is drop-off only</string>
 </resources>

--- a/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
+++ b/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
@@ -112,12 +112,20 @@ struct FavoriteConfirmationDialog: View {
                                                        })
                 },
                 actions: {
-                    MultiButton {
-                        FavoriteConfirmationDialogActions(lineOrRoute: lineOrRoute,
-                                                          stop: stop,
-                                                          favoritesToSave: favoritesToSave,
-                                                          updateFavorites: updateFavorites,
-                                                          onClose: onClose)
+                    if directions.isEmpty {
+                        Button {
+                            onClose()
+                        } label: {
+                            Text("Okay")
+                        }
+                    } else {
+                        MultiButton {
+                            FavoriteConfirmationDialogActions(lineOrRoute: lineOrRoute,
+                                                              stop: stop,
+                                                              favoritesToSave: favoritesToSave,
+                                                              updateFavorites: updateFavorites,
+                                                              onClose: onClose)
+                        }
                     }
                 }
             )
@@ -159,10 +167,18 @@ struct FavoriteConfirmationDialogContents: View {
                     .padding(.horizontal, 16)
                     .padding(.top, 8)
             }
-            VStack(spacing: 0) {
-                DirectionButtons(lineOrRoute: lineOrRoute,
-                                 favorites: favoritesToSave,
-                                 updateLocalFavorite: updateLocalFavorite)
+
+            if directions.isEmpty {
+                Text("This stop is drop-off only")
+                    .font(Typography.footnoteSemibold)
+                    .padding(.horizontal, 16)
+                    .padding(.top, 8)
+            } else {
+                VStack(spacing: 0) {
+                    DirectionButtons(lineOrRoute: lineOrRoute,
+                                     favorites: favoritesToSave,
+                                     updateLocalFavorite: updateLocalFavorite)
+                }
             }
         }.accessibilityAddTraits(.isModal)
     }
@@ -232,26 +248,24 @@ struct FavoriteConfirmationDialogActions: View {
     let onClose: () -> Void
 
     var body: some View {
-        HStack {
-            Button {
-                onClose()
-            } label: {
-                Text("Cancel")
-            }
-
-            Button {
-                updateFavorites(favoritesToSave
-                    .reduce(into: [RouteStopDirection: Bool]()) { partialResult, entry in
-                        partialResult[RouteStopDirection(
-                            route: lineOrRoute.id,
-                            stop: stop.id,
-                            direction: entry.key.id
-                        )] = entry.value
-                    })
-                onClose()
-            } label: {
-                Text("Add")
-            }.disabled(favoritesToSave.values.allSatisfy { $0 == false })
+        Button {
+            onClose()
+        } label: {
+            Text("Cancel")
         }
+
+        Button {
+            updateFavorites(favoritesToSave
+                .reduce(into: [RouteStopDirection: Bool]()) { partialResult, entry in
+                    partialResult[RouteStopDirection(
+                        route: lineOrRoute.id,
+                        stop: stop.id,
+                        direction: entry.key.id
+                    )] = entry.value
+                })
+            onClose()
+        } label: {
+            Text("Add")
+        }.disabled(favoritesToSave.values.allSatisfy { $0 == false })
     }
 }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -12565,6 +12565,52 @@
         }
       }
     },
+    "Okay" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bueno"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "D’accord"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Oke"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "OK"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Đồng ý"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "好的"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "好的"
+          }
+        }
+      }
+    },
     "On time" : {
       "comment" : "Status for a commuter rail train",
       "extractionState" : "manual",
@@ -18439,6 +18485,52 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "This stop is drop-off only" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta parada es solo para dejar pasajeros."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cet arrêt est uniquement destiné au dépôt"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Estasyon sa a se depoze sèlman"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Esta parada é somente para desembarque"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Điểm dừng này chỉ dành cho việc trả khách"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此站仅供下客"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此站僅供下客"
           }
         }
       }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -274,10 +274,11 @@ struct RouteStopListContentView<RightSideContent: View>: View {
         onTapStop: @escaping (RouteDetailsRowContext) -> Void
     ) -> some View {
         if let stopList, stopList.directionId == Int32(selectedDirection) {
+            let hasTypicalSegment = stopList.segments.contains(where: \.isTypical)
             ScrollView {
                 VStack {
                     ForEach(Array(stopList.segments.enumerated()), id: \.offset) { segmentIndex, segment in
-                        if segment.isTypical {
+                        if segment.isTypical || !hasTypicalSegment {
                             ForEach(Array(segment.stops.enumerated()), id: \.offset) { stopIndex, stop in
                                 let stopPlacement = StopPlacement(
                                     isFirst: segmentIndex == stopList.segments.startIndex && stopIndex == segment.stops

--- a/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
+++ b/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
@@ -218,4 +218,18 @@ final class SaveFavoritesFlowTest: XCTestCase {
 
         try XCTAssertNotNil(sut.inspect().find(text: "Westbound service only"))
     }
+
+    func testFavoritingWhenDropOffOnlyHasDisclaimer() throws {
+        var updateFavoritesCalledFor: [RouteStopDirection: Bool] = [:]
+
+        let sut = FavoriteConfirmationDialogContents(lineOrRoute: line,
+                                                     stop: stop,
+                                                     directions: [],
+                                                     selectedDirection: 0,
+                                                     context: .favorites,
+                                                     favoritesToSave: [direction0: false],
+                                                     updateLocalFavorite: { _, _ in })
+
+        try XCTAssertNotNil(sut.inspect().find(text: "This stop is drop-off only"))
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Fix: route-specific findings](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210755319204273?focus=true)

What is this PR for?
This PR addresses 3 small QA findings for edge case routes
1. Disclaimer when trying to add a stop with no service
2. Android only - trash icon missing in edit favorites when long headsign
3. All stops collapsed as less common when no typical pattern

iOS
- [X] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [X] Add temporary machine translations, marked "Needs Review"

android
- [X] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

| Case | Android | iOS |
|--------|--------|--------|
| 1. Drop-of only (also unit tested) Forced case for iOS at park st since add favorites not implemented yet for SL | <img width="640" height="1386" alt="image" src="https://github.com/user-attachments/assets/abc49a9e-5074-4226-8954-9836876a9746" /> | <img width="1170" height="2532" alt="IMG_0337" src="https://github.com/user-attachments/assets/3ac1643c-aba6-4cea-9cb4-63f14c0517a5" /> |
| 2. Android trash icon | <img width="640" height="1386" alt="image" src="https://github.com/user-attachments/assets/207cae61-a728-440e-95a8-9b27a66cf43f" />| N/A |
| 3.  no typical patterns (also unit tested) | <img width="640" height="1386" alt="image" src="https://github.com/user-attachments/assets/288f0a45-bba2-4044-a85b-9009d0e9a2f0" />  | <img width="1170" height="2532" alt="IMG_0338" src="https://github.com/user-attachments/assets/6dc1eedc-d3a2-4e7a-838c-489a2cc14afc" /> |

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
