### PR TITLE
fix(ios.SettingsCache): Load settings as MainActor

### DIFF
--- a/iosApp/iosApp/Utils/SettingsCache.swift
+++ b/iosApp/iosApp/Utils/SettingsCache.swift
@@ -27,6 +27,7 @@ class SettingsCache: ObservableObject {
     }
 
     /// Loads the cache from the settings repository. Should be called by `SettingsCacheProvider` in the full app.
+    @MainActor
     func load() async throws {
         cache = try await settingsRepo.getSettings().mapValues { $0.boolValue }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [EXC_BREAKPOINT: calling into SwiftUI on a non-main thread is not supported > Fatal error > SwiftUI/ThreadUtils.swift](https://app.asana.com/1/15492006741476/project/1209332220656329/task/1210848967577589?focus=true)

What is this PR for?

This fixes a crash on prod due to setting the published `cache` var from a background thread. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally, confirmed I no longer see a purple warning about the background thread at this line, whereas I do on main. 

I did see some other purple run warnings at one point which I'm also no longer seeing (on this branch or on main), so want to see if I can trigger those again, but this contains the immediate fix. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
