### PR TITLE
fix: Prevent all reordering on edit favorites

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -30,6 +30,7 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
+import com.mbta.tid.mbta_app.viewModel.FavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.time.Duration.Companion.seconds
@@ -55,6 +56,7 @@ fun FavoritesView(
     LaunchedEffect(targetLocation) { favoritesViewModel.setLocation(targetLocation) }
 
     LaunchedEffect(Unit) {
+        favoritesViewModel.setContext(FavoritesViewModel.Context.Favorites)
         favoritesViewModel.setActive(active = true, wasSentToBackground = false)
         favoritesViewModel.reloadFavorites()
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -47,6 +48,7 @@ import com.mbta.tid.mbta_app.model.LeafFormat
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.viewModel.FavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import kotlin.time.Clock
 
@@ -58,6 +60,8 @@ fun EditFavoritesPage(
 ) {
     val state by favoritesViewModel.models.collectAsState()
 
+    LaunchedEffect(Unit) { favoritesViewModel.setContext(FavoritesViewModel.Context.Edit) }
+
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         SheetHeader(
             title = stringResource(R.string.edit_favorites),
@@ -65,7 +69,7 @@ fun EditFavoritesPage(
             buttonColors = ButtonDefaults.key(),
             onClose = onClose,
         )
-        EditFavoritesList(state.routeCardData, global) {
+        EditFavoritesList(state.staticRouteCardData, global) {
             favoritesViewModel.updateFavorites(mapOf(it to false))
         }
     }

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -40,6 +40,7 @@ struct EditFavoritesPage: View {
                 Spacer()
             }
             .onAppear {
+                viewModel.setContext(context: FavoritesViewModel.ContextEdit())
                 loadGlobal()
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -53,6 +53,7 @@ struct FavoritesView: View {
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)
+            favoritesVM.setContext(context: FavoritesViewModel.ContextFavorites())
             favoritesVM.setLocation(location: location?.positionKt)
             favoritesVM.setNow(now: now.toKotlinInstant())
             favoritesVM.reloadFavorites()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -32,6 +32,8 @@ interface IFavoritesViewModel {
 
     fun setAlerts(alerts: AlertsStreamDataResponse?)
 
+    fun setContext(context: FavoritesViewModel.Context)
+
     fun setLocation(location: Position?)
 
     fun setNow(now: Instant)
@@ -44,12 +46,20 @@ class FavoritesViewModel(
     private val coroutineDispatcher: CoroutineDispatcher,
 ) : MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
 
+    sealed class Context {
+        data object Favorites : Context()
+
+        data object Edit : Context()
+    }
+
     sealed interface Event {
         data object ReloadFavorites : Event
 
         data class SetActive(val active: Boolean, val wasSentToBackground: Boolean) : Event
 
         data class SetAlerts(val alerts: AlertsStreamDataResponse?) : Event
+
+        data class SetContext(val context: Context) : Event
 
         data class SetLocation(val location: Position?) : Event
 
@@ -76,6 +86,7 @@ class FavoritesViewModel(
 
         var active: Boolean by remember { mutableStateOf(true) }
         var alerts: AlertsStreamDataResponse? by remember { mutableStateOf(null) }
+        var context: Context? by remember { mutableStateOf(null) }
         var location: Position? by remember { mutableStateOf(null) }
         var now: Instant by remember { mutableStateOf(Clock.System.now()) }
 
@@ -110,6 +121,7 @@ class FavoritesViewModel(
                         }
                     }
                     is Event.SetAlerts -> alerts = event.alerts
+                    is Event.SetContext -> context = event.context
                     is Event.SetLocation -> location = event.location
                     is Event.SetNow -> now = event.now
                     is Event.UpdateFavorites -> {
@@ -134,6 +146,9 @@ class FavoritesViewModel(
                 routeCardData = null
             } else if (stopIds.isEmpty()) {
                 routeCardData = emptyList()
+            } else if (context == Context.Edit) {
+                // When editing, only filter the existing route card data, to preserve route order
+                routeCardData = filterRouteAndDirection(routeCardData, globalData, favorites)
             } else {
                 val loadedRouteCardData =
                     RouteCardData.routeCardsForStopList(
@@ -157,6 +172,10 @@ class FavoritesViewModel(
                 staticRouteCardData = null
             } else if (stopIds.isEmpty()) {
                 staticRouteCardData = emptyList()
+            } else if (context == Context.Edit) {
+                // When editing, only filter the existing route card data, to preserve route order
+                staticRouteCardData =
+                    filterRouteAndDirection(staticRouteCardData, globalData, favorites)
             } else {
                 val loadedRouteCardData =
                     RouteCardData.routeCardsForStaticStopList(
@@ -190,6 +209,8 @@ class FavoritesViewModel(
         fireEvent(Event.SetActive(active, wasSentToBackground))
 
     override fun setAlerts(alerts: AlertsStreamDataResponse?) = fireEvent(Event.SetAlerts(alerts))
+
+    override fun setContext(context: Context) = fireEvent(Event.SetContext(context))
 
     override fun setLocation(location: Position?) = fireEvent(Event.SetLocation(location))
 
@@ -237,6 +258,7 @@ constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State())
     var onReloadFavorites = {}
     var onSetActive = { _: Boolean, _: Boolean -> }
     var onSetAlerts = { _: AlertsStreamDataResponse? -> }
+    var onSetContext = { _: FavoritesViewModel.Context -> }
     var onSetLocation = { _: Position? -> }
     var onSetNow = { _: Instant -> }
     var onUpdateFavorites = { _: Map<RouteStopDirection, Boolean> -> }
@@ -253,6 +275,10 @@ constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State())
 
     override fun setAlerts(alerts: AlertsStreamDataResponse?) {
         onSetAlerts(alerts)
+    }
+
+    override fun setContext(context: FavoritesViewModel.Context) {
+        onSetContext(context)
     }
 
     override fun setLocation(location: Position?) {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Fix: Edit order doesn't match view order](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210755319204265?focus=true)

Don't generate new RouteCardData when on the edit favorites page, simply filter out deleted stops and routes from the existing data. This prevents reordering when a closer stop gets deleted, which would result in the route cards being sorted differently than displayed. Also made the update to set context in iOS as well.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added a unit test for the VM, existing tests pass