### PR TITLE
fix(Android): Add droppable events to VMs

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -37,7 +37,9 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.withContext
 
 interface IMapViewModel {
@@ -83,6 +85,7 @@ class MapViewModel(
 ) : MoleculeViewModel<Event, MapViewModel.State>(), IMapViewModel {
 
     private lateinit var viewportManager: ViewportManager
+    private val routeCardDataUpdates = MutableStateFlow<List<RouteCardData>?>(null)
 
     sealed interface Event {
 
@@ -109,8 +112,6 @@ class MapViewModel(
         data class ColorPaletteChanged(val isDarkMode: Boolean) : Event
 
         data class DensityChanged(val density: Float) : Event
-
-        data class RouteCardDataChanged(val data: List<RouteCardData>?) : Event
 
         data object MapStyleLoaded : Event
 
@@ -193,13 +194,18 @@ class MapViewModel(
             }
         }
 
+        LaunchedEffect(Unit) {
+            // Route card data is sent through a separate StateFlow rather than the event flow
+            // because frequent updates were causing buffer overflows.
+            routeCardDataUpdates.collectLatest { routeCardData = it }
+        }
+
         LaunchedEffect(null) {
             events.collect { event ->
                 when (event) {
                     is Event.AlertsChanged -> alerts = event.alerts
                     is Event.ColorPaletteChanged -> isDarkMode = event.isDarkMode
                     is Event.DensityChanged -> density = event.density
-                    is Event.RouteCardDataChanged -> routeCardData = event.data
                     is Event.NavChanged -> {
                         state =
                             handleNavChange(
@@ -331,8 +337,9 @@ class MapViewModel(
     override fun alertsChanged(alerts: AlertsStreamDataResponse?) =
         fireEvent(Event.AlertsChanged(alerts))
 
-    override fun routeCardDataChanged(routeCardData: List<RouteCardData>?) =
-        fireEvent(Event.RouteCardDataChanged(routeCardData))
+    override fun routeCardDataChanged(routeCardData: List<RouteCardData>?) {
+        routeCardDataUpdates.tryEmit(routeCardData)
+    }
 
     override fun colorPaletteChanged(isDarkMode: Boolean) =
         fireEvent(Event.ColorPaletteChanged(isDarkMode))


### PR DESCRIPTION
### Summary

_Ticket:_ [Event buffer overflow MapViewModel](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1210857402669010?focus=true)

Stop throwing exceptions when route card data events overflow the buffer, by making a separate parallel event stream which will drop the oldest events if the buffer overflows.

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

TODO