### PR TITLE
chore(Android): 1.2.7

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -44,7 +44,7 @@ android {
         targetSdk = 35
         versionCode =
             Integer.parseInt((findProperty("android.injected.version.code") ?: "1") as String)
-        versionName = "1.2.6"
+        versionName = "1.2.7"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

Bump to 1.2.7 to prep for the [Event buffer overflow MapViewModel](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210857402669010?focus=true) hotfix release