### PR TITLE
fix(Android): Set specific Sentry version

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -33,6 +33,7 @@ sentry {
     org = "mbtace"
     projectName = "mobile_app_android"
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
+    autoInstallation { sentryVersion = "8.17.0" }
 }
 
 android {


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

Try to fix the sentry version mismatch crashes by specifying the version in the gradle config. 

This is recommended in [the sentry docs](https://docs.sentry.io/platforms/android/troubleshooting/mixed-versions/).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210210024736992