### PR TITLE
fix(Android): Downgrade defined sentry version

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -33,7 +33,7 @@ sentry {
     org = "mbtace"
     projectName = "mobile_app_android"
     authToken = System.getenv("SENTRY_AUTH_TOKEN")
-    autoInstallation { sentryVersion = "8.17.0" }
+    autoInstallation { sentryVersion = "8.15.1" }
 }
 
 android {


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

There were still mismatched versions in #1168, setting this to try to match `sentry-android`.

```
The Sentry SDK has been configured with mixed versions. Expected maven:io.sentry:sentry-android to match core SDK version 8.17.0 but was 8.15.1
```