### PR TITLE
feat: shared code for final route branching approach

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -45,8 +45,8 @@ class CollapsableStopListTest {
             CollapsableStopList(
                 RouteCardData.LineOrRoute.Route(mainRoute),
                 segment =
-                    RouteDetailsStopList.Segment(
-                        listOf(RouteDetailsStopList.Entry(stop1, listOf(), listOf())),
+                    RouteDetailsStopList.OldSegment(
+                        listOf(RouteDetailsStopList.OldEntry(stop1, listOf(), listOf())),
                         hasRouteLine = false,
                     ),
                 onClick = { clicked = true },
@@ -88,10 +88,10 @@ class CollapsableStopListTest {
             CollapsableStopList(
                 RouteCardData.LineOrRoute.Route(mainRoute),
                 segment =
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(stop1, listOf(), listOf()),
-                            RouteDetailsStopList.Entry(stop2, listOf(), listOf()),
+                            RouteDetailsStopList.OldEntry(stop1, listOf(), listOf()),
+                            RouteDetailsStopList.OldEntry(stop2, listOf(), listOf()),
                         ),
                         hasRouteLine = false,
                     ),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -48,12 +48,12 @@ import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 @Composable
 fun CollapsableStopList(
     lineOrRoute: RouteCardData.LineOrRoute,
-    segment: RouteDetailsStopList.Segment,
-    onClick: (RouteDetailsStopList.Entry) -> Unit,
-    onClickLabel: @Composable (RouteDetailsStopList.Entry) -> String? = { null },
+    segment: RouteDetailsStopList.OldSegment,
+    onClick: (RouteDetailsStopList.OldEntry) -> Unit,
+    onClickLabel: @Composable (RouteDetailsStopList.OldEntry) -> String? = { null },
     isFirstSegment: Boolean = false,
     isLastSegment: Boolean = false,
-    rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
+    rightSideContent: @Composable RowScope.(RouteDetailsStopList.OldEntry, Modifier) -> Unit,
 ) {
 
     var stopsExpanded by rememberSaveable { mutableStateOf(false) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -111,7 +111,7 @@ fun RouteStopListView(
 
     val stopList =
         rememberSuspend(selectedRouteId, selectedDirection, routeStops, globalData) {
-            RouteDetailsStopList.fromPieces(
+            RouteDetailsStopList.fromOldPieces(
                 selectedRouteId,
                 selectedDirection,
                 routeStops,
@@ -158,7 +158,7 @@ fun LoadingRouteStopListView(
             selectedRouteId = mockRoute.id,
             setRouteId = {},
             routes = listOf(mockRoute.route),
-            stopList = RouteDetailsStopList(0, listOf()),
+            stopList = RouteDetailsStopList(0, listOf(), null),
             context = context,
             globalData = GlobalResponse(objects),
             onClick = {},
@@ -364,16 +364,17 @@ private fun RouteStops(
         horizontalAlignment = Alignment.Start,
         scrollEnabled = !loading,
     ) {
-        val hasTypicalSegment = stopList.segments.any { it.isTypical }
+        val segments = stopList.oldSegments.orEmpty()
+        val hasTypicalSegment = segments.any { it.isTypical }
 
-        stopList.segments.forEachIndexed { segmentIndex, segment ->
+        segments.forEachIndexed { segmentIndex, segment ->
             if (segment.isTypical || !hasTypicalSegment) {
                 segment.stops.forEachIndexed { stopIndex, stop ->
                     val stopPlacement =
                         StopPlacement(
                             isFirst = segmentIndex == 0 && stopIndex == 0,
                             isLast =
-                                segmentIndex == stopList.segments.lastIndex &&
+                                segmentIndex == segments.lastIndex &&
                                     stopIndex == segment.stops.lastIndex,
                             includeLineDiagram = segment.hasRouteLine,
                         )
@@ -400,7 +401,7 @@ private fun RouteStops(
                     onClick = { onTapStop(stopRowContext(it.stop)) },
                     onClickLabel = { onClickLabel(stopRowContext(it.stop)) },
                     segmentIndex == 0,
-                    segmentIndex == stopList.segments.lastIndex,
+                    segmentIndex == segments.lastIndex,
                 ) { stop, modifier ->
                     rightSideContent(stopRowContext(stop.stop), modifier)
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
-import com.mbta.tid.mbta_app.repositories.RouteStopsResult
+import com.mbta.tid.mbta_app.repositories.OldRouteStopsResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,13 +26,13 @@ class RouteStopsFetcher(
         routeId: String,
         directionId: Int,
         errorKey: String,
-        onSuccess: (RouteStopsResult) -> Unit,
+        onSuccess: (OldRouteStopsResult) -> Unit,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
                 errorKey = errorKey,
-                getData = { routeStopsRepository.getRouteStops(routeId, directionId) },
+                getData = { routeStopsRepository.getOldRouteStops(routeId, directionId) },
                 onSuccess = { onSuccess(it) },
                 onRefreshAfterError = { getRouteStops(routeId, directionId, errorKey, onSuccess) },
             )
@@ -46,8 +46,8 @@ class RouteStopsViewModel(
 ) : ViewModel() {
 
     private val routeStopsFetcher = RouteStopsFetcher(routeStopsRepository, errorBannerRepository)
-    private val _routeStops = MutableStateFlow<RouteStopsResult?>(null)
-    val routeStops: StateFlow<RouteStopsResult?> = _routeStops
+    private val _routeStops = MutableStateFlow<OldRouteStopsResult?>(null)
+    val routeStops: StateFlow<OldRouteStopsResult?> = _routeStops
 
     fun getRouteStops(routeId: String, directionId: Int, errorKey: String) {
         _routeStops.value = null
@@ -71,7 +71,7 @@ fun getRouteStops(
     errorKey: String,
     routeStopsRepository: IRouteStopsRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
-): RouteStopsResult? {
+): OldRouteStopsResult? {
     val viewModel: RouteStopsViewModel =
         viewModel(
             factory = RouteStopsViewModel.Factory(routeStopsRepository, errorBannerRepository)

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -11,11 +11,11 @@ import SwiftUI
 
 struct CollapsableStopList<RightSideContent: View>: View {
     let lineOrRoute: RouteCardData.LineOrRoute
-    let segment: RouteDetailsStopList.Segment
-    let onClick: (RouteDetailsStopList.Entry) -> Void
+    let segment: RouteDetailsStopList.OldSegment
+    let onClick: (RouteDetailsStopList.OldEntry) -> Void
     let isFirstSegment: Bool
     let isLastSegment: Bool
-    let rightSideContent: (RouteDetailsStopList.Entry) -> RightSideContent
+    let rightSideContent: (RouteDetailsStopList.OldEntry) -> RightSideContent
 
     @State var stopsExpanded = false
 
@@ -23,11 +23,11 @@ struct CollapsableStopList<RightSideContent: View>: View {
 
     init(
         lineOrRoute: RouteCardData.LineOrRoute,
-        segment: RouteDetailsStopList.Segment,
-        onClick: @escaping (RouteDetailsStopList.Entry) -> Void,
+        segment: RouteDetailsStopList.OldSegment,
+        onClick: @escaping (RouteDetailsStopList.OldEntry) -> Void,
         isFirstSegment: Bool = false,
         isLastSegment: Bool = false,
-        rightSideContent: @escaping (RouteDetailsStopList.Entry) -> RightSideContent
+        rightSideContent: @escaping (RouteDetailsStopList.OldEntry) -> RightSideContent
     ) {
         self.lineOrRoute = lineOrRoute
         self.segment = segment

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -184,7 +184,8 @@ class MockRepositories : IRepositories {
     override var pinnedRoutes: IPinnedRoutesRepository = PinnedRoutesRepository()
     override var predictions: IPredictionsRepository = MockPredictionsRepository()
     override var railRouteShapes: IRailRouteShapeRepository = IdleRailRouteShapeRepository()
-    override var routeStops: IRouteStopsRepository = MockRouteStopsRepository(emptyList())
+    override var routeStops: IRouteStopsRepository =
+        MockRouteStopsRepository(stopIds = emptyList(), segments = emptyList())
     override var schedules: ISchedulesRepository = IdleScheduleRepository()
     override var searchResults: ISearchResultRepository = IdleSearchResultRepository()
     override var sentry: ISentryRepository = MockSentryRepository()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -139,7 +139,9 @@ fun endToEndModule(): Module {
             // debug.
             IdleRailRouteShapeRepository()
         }
-        single<IRouteStopsRepository> { MockRouteStopsRepository(emptyList()) }
+        single<IRouteStopsRepository> {
+            MockRouteStopsRepository(stopIds = emptyList(), segments = emptyList())
+        }
         single<ISchedulesRepository> {
             MockScheduleRepository(scheduleResponse = ScheduleResponse(objects))
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -106,16 +106,16 @@ object LoadingPlaceholders {
 
         return RouteDetailsStopList(
             directionId = directionId,
-            segments =
+            oldSegments =
                 listOf(
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         (1..20).map {
                             val stopName = randString(15, 30)
                             val transferRoutes =
                                 (0..fixedRand.nextInt(0, 7)).map {
                                     objects.route { shortName = randString(2, 5) }
                                 }
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 objects.stop { name = stopName },
                                 listOf(
                                     objects.routePattern(lineOrRoute.sortRoute) {
@@ -126,6 +126,30 @@ object LoadingPlaceholders {
                             )
                         },
                         hasRouteLine = true,
+                    )
+                ),
+            newSegments =
+                listOf(
+                    RouteDetailsStopList.NewSegment(
+                        (1..20).map { number ->
+                            val stopName = randString(15, 30)
+                            val transferRoutes =
+                                (0..fixedRand.nextInt(0, 7)).map {
+                                    objects.route { shortName = randString(2, 5) }
+                                }
+                            RouteDetailsStopList.NewEntry(
+                                objects.stop { name = stopName },
+                                RouteBranchSegment.Lane.Center,
+                                RouteBranchSegment.StickConnection.forward(
+                                    stopBefore = "".takeUnless { number == 1 },
+                                    stop = "",
+                                    stopAfter = "".takeUnless { number == 20 },
+                                    lane = RouteBranchSegment.Lane.Center,
+                                ),
+                                transferRoutes,
+                            )
+                        },
+                        isTypical = true,
                     )
                 ),
         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteBranchSegment.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteBranchSegment.kt
@@ -1,0 +1,104 @@
+package com.mbta.tid.mbta_app.model
+
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RouteBranchSegment(
+    val stops: List<BranchStop>,
+    val name: String?,
+    @SerialName("typical?") val isTypical: Boolean,
+) {
+    @Serializable
+    enum class Lane {
+        @SerialName("left") Left,
+        @SerialName("center") Center,
+        @SerialName("right") Right,
+    }
+
+    @Serializable
+    data class BranchStop(
+        @SerialName("stop_id") val stopId: String,
+        @SerialName("stop_lane") val stopLane: Lane,
+        val connections: List<StickConnection>,
+    )
+
+    @Serializable
+    data class StickConnection(
+        @SerialName("from_stop") val fromStop: String,
+        @SerialName("to_stop") val toStop: String,
+        @SerialName("from_lane") val fromLane: Lane,
+        @SerialName("to_lane") val toLane: Lane,
+        @SerialName("from_vpos") val fromVPos: VPos,
+        @SerialName("to_vpos") val toVPos: VPos,
+    ) {
+        companion object {
+            fun forward(stopBefore: String?, stop: String?, stopAfter: String?, lane: Lane) =
+                listOfNotNull(
+                    if (stopBefore != null && stop != null)
+                        StickConnection(
+                            fromStop = stopBefore,
+                            toStop = stop,
+                            fromLane = lane,
+                            toLane = lane,
+                            fromVPos = VPos.Top,
+                            toVPos = VPos.Center,
+                        )
+                    else null,
+                    if (stop != null && stopAfter != null)
+                        StickConnection(
+                            fromStop = stop,
+                            toStop = stopAfter,
+                            fromLane = lane,
+                            toLane = lane,
+                            fromVPos = VPos.Center,
+                            toVPos = VPos.Bottom,
+                        )
+                    else null,
+                    if (stopBefore != null && stop == null && stopAfter != null)
+                        StickConnection(
+                            fromStop = stopBefore,
+                            toStop = stopAfter,
+                            fromLane = lane,
+                            toLane = lane,
+                            fromVPos = VPos.Top,
+                            toVPos = VPos.Bottom,
+                        )
+                    else null,
+                )
+        }
+    }
+
+    enum class VPos {
+        @SerialName("top") Top,
+        @SerialName("center") Center,
+        @SerialName("bottom") Bottom,
+    }
+
+    companion object {
+        @DefaultArgumentInterop.Enabled
+        fun of(
+            stopIds: List<String>,
+            name: String? = null,
+            isTypical: Boolean = true,
+            lane: Lane = Lane.Center,
+        ) =
+            RouteBranchSegment(
+                stopIds.mapIndexed { index, stopId ->
+                    BranchStop(
+                        stopId,
+                        lane,
+                        StickConnection.Companion.forward(
+                            stopIds.elementAtOrNull(index - 1),
+                            stopId,
+                            stopIds.elementAtOrNull(index + 1),
+                            lane,
+                        ),
+                    )
+                },
+                name = name,
+                isTypical = isTypical,
+            )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
@@ -13,19 +14,35 @@ import org.koin.core.component.inject
 // The response doesn't include the route ID and direction ID, which we need in the UI to ensure
 // that we're using the correct stop list for the selected route and direction.
 @Serializable
-data class RouteStopsResult(val routeId: String, val directionId: Int, val stopIds: List<String>)
+data class OldRouteStopsResult(
+    val routeId: String,
+    val directionId: Int,
+    val stopIds: List<String>,
+)
+
+@Serializable
+data class NewRouteStopsResult(
+    val routeId: String,
+    val directionId: Int,
+    val segments: List<RouteBranchSegment>,
+)
 
 interface IRouteStopsRepository {
-    suspend fun getRouteStops(routeId: String, directionId: Int): ApiResult<RouteStopsResult>
+    suspend fun getOldRouteStops(routeId: String, directionId: Int): ApiResult<OldRouteStopsResult>
+
+    suspend fun getNewRouteSegments(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<NewRouteStopsResult>
 }
 
 class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
-    override suspend fun getRouteStops(
+    override suspend fun getOldRouteStops(
         routeId: String,
         directionId: Int,
-    ): ApiResult<RouteStopsResult> =
+    ): ApiResult<OldRouteStopsResult> =
         ApiResult.runCatching {
             val response: RouteStopsResponse =
                 mobileBackendClient
@@ -37,27 +54,59 @@ class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
                         }
                     }
                     .body()
-            RouteStopsResult(routeId, directionId, response.stopIds)
+            OldRouteStopsResult(routeId, directionId, response.stopIds)
+        }
+
+    override suspend fun getNewRouteSegments(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<NewRouteStopsResult> =
+        ApiResult.runCatching {
+            val response: List<RouteBranchSegment> =
+                mobileBackendClient
+                    .get {
+                        url {
+                            path("api/route/stop-graph")
+                            parameters.append("route_id", routeId)
+                            parameters.append("direction_id", directionId.toString())
+                        }
+                    }
+                    .body()
+            NewRouteStopsResult(routeId, directionId, response)
         }
 }
 
 class MockRouteStopsRepository(
-    private val result: ApiResult<RouteStopsResult>,
+    private val oldResult: ApiResult<OldRouteStopsResult>?,
+    private val newResult: ApiResult<NewRouteStopsResult>?,
     private val onGet: (String, Int) -> Unit = { _, _ -> },
 ) : IRouteStopsRepository {
     @DefaultArgumentInterop.Enabled
     constructor(
-        stopIds: List<String>,
+        stopIds: List<String>? = null,
+        segments: List<RouteBranchSegment>? = null,
         routeId: String = "",
         directionId: Int = 0,
         onGet: (String, Int) -> Unit = { _, _ -> },
-    ) : this(ApiResult.Ok(RouteStopsResult(routeId, directionId, stopIds)), onGet)
+    ) : this(
+        stopIds?.let { ApiResult.Ok(OldRouteStopsResult(routeId, directionId, it)) },
+        segments?.let { ApiResult.Ok(NewRouteStopsResult(routeId, directionId, it)) },
+        onGet,
+    )
 
-    override suspend fun getRouteStops(
+    override suspend fun getOldRouteStops(
         routeId: String,
         directionId: Int,
-    ): ApiResult<RouteStopsResult> {
+    ): ApiResult<OldRouteStopsResult> {
         onGet(routeId, directionId)
-        return result
+        return checkNotNull(oldResult) { "old result not defined" }
+    }
+
+    override suspend fun getNewRouteSegments(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<NewRouteStopsResult> {
+        onGet(routeId, directionId)
+        return checkNotNull(newResult) { "new result not defined" }
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -1,7 +1,8 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.repositories.RouteStopsResult
+import com.mbta.tid.mbta_app.repositories.NewRouteStopsResult
+import com.mbta.tid.mbta_app.repositories.OldRouteStopsResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -179,7 +180,278 @@ class RouteDetailsStopListTest {
     }
 
     @Test
-    fun `fromPieces finds transfer stops`() = runBlocking {
+    fun `twistedConnections handles branch starting`() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop()
+        val stop2 = objects.stop()
+        val stop3 = objects.stop()
+        val lane = RouteBranchSegment.Lane.Left
+        assertEquals(
+            listOf(
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = stop2.id,
+                        toStop = stop3.id,
+                        fromLane = lane,
+                        toLane = lane,
+                        fromVPos = RouteBranchSegment.VPos.Center,
+                        toVPos = RouteBranchSegment.VPos.Bottom,
+                    ),
+                    true,
+                )
+            ),
+            RouteDetailsStopList.NewSegment(
+                    listOf(
+                        RouteDetailsStopList.NewEntry(
+                            stop1,
+                            lane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    null,
+                                    stop1.id,
+                                    stop2.id,
+                                    lane,
+                                ),
+                            connectingRoutes = emptyList(),
+                        ),
+                        RouteDetailsStopList.NewEntry(
+                            stop2,
+                            lane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    stop1.id,
+                                    stop2.id,
+                                    stop3.id,
+                                    lane,
+                                ),
+                            connectingRoutes = emptyList(),
+                        ),
+                    ),
+                    isTypical = false,
+                )
+                .twistedConnections(),
+        )
+    }
+
+    @Test
+    fun `twistedConnections handles branch ending`() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop()
+        val stop2 = objects.stop()
+        val stop3 = objects.stop()
+        val lane = RouteBranchSegment.Lane.Left
+        assertEquals(
+            listOf(
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = stop1.id,
+                        toStop = stop2.id,
+                        fromLane = lane,
+                        toLane = lane,
+                        fromVPos = RouteBranchSegment.VPos.Top,
+                        toVPos = RouteBranchSegment.VPos.Center,
+                    ),
+                    true,
+                )
+            ),
+            RouteDetailsStopList.NewSegment(
+                    listOf(
+                        RouteDetailsStopList.NewEntry(
+                            stop2,
+                            lane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    stop1.id,
+                                    stop2.id,
+                                    stop3.id,
+                                    lane,
+                                ),
+                            connectingRoutes = emptyList(),
+                        ),
+                        RouteDetailsStopList.NewEntry(
+                            stop3,
+                            lane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    stop2.id,
+                                    stop3.id,
+                                    null,
+                                    lane,
+                                ),
+                            connectingRoutes = emptyList(),
+                        ),
+                    ),
+                    isTypical = false,
+                )
+                .twistedConnections(),
+        )
+    }
+
+    @Test
+    fun `twistedConnections handles branch continuing and skipping`() {
+        val objects = ObjectCollectionBuilder()
+        val stop1 = objects.stop()
+        val stop2 = objects.stop()
+        val stop3 = objects.stop()
+        val stop4 = objects.stop()
+        val stopLane = RouteBranchSegment.Lane.Left
+        val skipLane = RouteBranchSegment.Lane.Right
+        val skip = RouteBranchSegment.StickConnection.forward(stop1.id, null, stop4.id, skipLane)
+        assertEquals(
+            listOf(
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = stop1.id,
+                        toStop = stop4.id,
+                        fromLane = skipLane,
+                        toLane = skipLane,
+                        fromVPos = RouteBranchSegment.VPos.Top,
+                        toVPos = RouteBranchSegment.VPos.Bottom,
+                    ),
+                    false,
+                ),
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = stop1.id,
+                        toStop = stop4.id,
+                        fromLane = stopLane,
+                        toLane = stopLane,
+                        fromVPos = RouteBranchSegment.VPos.Top,
+                        toVPos = RouteBranchSegment.VPos.Bottom,
+                    ),
+                    true,
+                ),
+            ),
+            RouteDetailsStopList.NewSegment(
+                    listOf(
+                        RouteDetailsStopList.NewEntry(
+                            stop2,
+                            stopLane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    stop1.id,
+                                    stop2.id,
+                                    stop3.id,
+                                    stopLane,
+                                ) + skip,
+                            connectingRoutes = emptyList(),
+                        ),
+                        RouteDetailsStopList.NewEntry(
+                            stop3,
+                            stopLane,
+                            stickConnections =
+                                RouteBranchSegment.StickConnection.forward(
+                                    stop2.id,
+                                    stop3.id,
+                                    stop4.id,
+                                    stopLane,
+                                ) + skip,
+                            connectingRoutes = emptyList(),
+                        ),
+                    ),
+                    isTypical = false,
+                )
+                .twistedConnections(),
+        )
+    }
+
+    @Test
+    fun `twistedConnections handles the 33 inbound case`() {
+        val objects = ObjectCollectionBuilder()
+        val parentRight = objects.stop()
+        val parentCenter = objects.stop()
+        val parentLeft = objects.stop()
+        val stop1 = objects.stop()
+        val stop2 = objects.stop()
+        val stop3 = objects.stop()
+        val child = objects.stop()
+        val skip =
+            RouteBranchSegment.StickConnection.forward(
+                parentLeft.id,
+                null,
+                child.id,
+                RouteBranchSegment.Lane.Left,
+            )
+        val segment =
+            RouteDetailsStopList.NewSegment(
+                listOf(
+                    RouteDetailsStopList.NewEntry(
+                        stop1,
+                        RouteBranchSegment.Lane.Right,
+                        RouteBranchSegment.StickConnection.forward(
+                            parentRight.id,
+                            stop1.id,
+                            stop2.id,
+                            RouteBranchSegment.Lane.Right,
+                        ) +
+                            skip +
+                            RouteBranchSegment.StickConnection(
+                                fromStop = parentCenter.id,
+                                toStop = stop1.id,
+                                fromLane = RouteBranchSegment.Lane.Center,
+                                toLane = RouteBranchSegment.Lane.Right,
+                                fromVPos = RouteBranchSegment.VPos.Top,
+                                toVPos = RouteBranchSegment.VPos.Center,
+                            ),
+                        connectingRoutes = emptyList(),
+                    ),
+                    RouteDetailsStopList.NewEntry(
+                        stop2,
+                        RouteBranchSegment.Lane.Right,
+                        RouteBranchSegment.StickConnection.forward(
+                            stop1.id,
+                            stop2.id,
+                            stop3.id,
+                            RouteBranchSegment.Lane.Right,
+                        ),
+                        connectingRoutes = emptyList(),
+                    ),
+                    RouteDetailsStopList.NewEntry(
+                        stop3,
+                        RouteBranchSegment.Lane.Right,
+                        RouteBranchSegment.StickConnection.forward(
+                            stop2.id,
+                            stop3.id,
+                            child.id,
+                            RouteBranchSegment.Lane.Right,
+                        ),
+                        connectingRoutes = emptyList(),
+                    ),
+                ),
+                isTypical = false,
+            )
+        assertEquals(
+            listOf(
+                Pair(skip.single(), false),
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = parentRight.id,
+                        toStop = child.id,
+                        fromLane = RouteBranchSegment.Lane.Right,
+                        toLane = RouteBranchSegment.Lane.Right,
+                        fromVPos = RouteBranchSegment.VPos.Top,
+                        toVPos = RouteBranchSegment.VPos.Bottom,
+                    ),
+                    true,
+                ),
+                Pair(
+                    RouteBranchSegment.StickConnection(
+                        fromStop = parentCenter.id,
+                        toStop = child.id,
+                        fromLane = RouteBranchSegment.Lane.Center,
+                        toLane = RouteBranchSegment.Lane.Right,
+                        fromVPos = RouteBranchSegment.VPos.Top,
+                        toVPos = RouteBranchSegment.VPos.Bottom,
+                    ),
+                    false,
+                ),
+            ),
+            segment.twistedConnections(),
+        )
+    }
+
+    @Test
+    fun `fromOldPieces finds transfer stops`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val connectingStop = objects.stop()
         val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
@@ -204,9 +476,9 @@ class RouteDetailsStopListTest {
             RouteDetailsStopList(
                 0,
                 listOf(
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 mainStop,
                                 connectingRoutes = listOf(connectingRoute),
                                 patterns = listOf(mainPattern),
@@ -215,18 +487,82 @@ class RouteDetailsStopListTest {
                         hasRouteLine = true,
                     )
                 ),
+                null,
             ),
-            RouteDetailsStopList.fromPieces(
+            RouteDetailsStopList.fromOldPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResult(mainRoute.id, 0, listOf(mainStop.id)),
+                OldRouteStopsResult(mainRoute.id, 0, listOf(mainStop.id)),
                 globalData,
             ),
         )
     }
 
     @Test
-    fun `fromPieces returns null if direction doesn't match`() = runBlocking {
+    fun `fromNewPieces finds transfer stops`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val connectingStop = objects.stop()
+        val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
+        val mainRoute = objects.route()
+        val connectingRoute = objects.route()
+
+        objects.routePattern(mainRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(mainStop.id) }
+        }
+
+        objects.routePattern(connectingRoute) {
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip { stopIds = listOf(connectingStop.id) }
+        }
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteDetailsStopList(
+                0,
+                null,
+                listOf(
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                mainStop,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(connectingRoute),
+                            )
+                        ),
+                        isTypical = true,
+                    )
+                ),
+            ),
+            RouteDetailsStopList.fromNewPieces(
+                mainRoute.id,
+                0,
+                NewRouteStopsResult(
+                    mainRoute.id,
+                    0,
+                    listOf(
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    mainStop.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    connections = emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = true,
+                        )
+                    ),
+                ),
+                globalData,
+            ),
+        )
+    }
+
+    @Test
+    fun `fromOldPieces returns null if direction doesn't match`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val mainStop = objects.stop {}
         val mainRoute = objects.route()
@@ -234,17 +570,51 @@ class RouteDetailsStopListTest {
         val globalData = GlobalResponse(objects)
 
         assertNull(
-            RouteDetailsStopList.fromPieces(
+            RouteDetailsStopList.fromOldPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResult(mainRoute.id, 1, listOf(mainStop.id)),
+                OldRouteStopsResult(mainRoute.id, 1, listOf(mainStop.id)),
                 globalData,
             )
         )
     }
 
     @Test
-    fun `fromPieces breaks segments by typicality`() = runBlocking {
+    fun `fromNewPieces returns null if direction doesn't match`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val mainStop = objects.stop {}
+        val mainRoute = objects.route()
+
+        val globalData = GlobalResponse(objects)
+
+        assertNull(
+            RouteDetailsStopList.fromNewPieces(
+                mainRoute.id,
+                0,
+                NewRouteStopsResult(
+                    mainRoute.id,
+                    1,
+                    listOf(
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    mainStop.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = true,
+                        )
+                    ),
+                ),
+                globalData,
+            )
+        )
+    }
+
+    @Test
+    fun `fromOldPieces breaks segments by typicality`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val stop0 = objects.stop { id = "stop0" }
         val stop1 = objects.stop { id = "stop1" }
@@ -294,9 +664,9 @@ class RouteDetailsStopListTest {
             RouteDetailsStopList(
                 0,
                 listOf(
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop0,
                                 connectingRoutes = listOf(),
                                 patterns =
@@ -307,7 +677,7 @@ class RouteDetailsStopListTest {
                                         patternNonTypical1,
                                     ),
                             ),
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop1,
                                 connectingRoutes = listOf(),
                                 patterns =
@@ -321,14 +691,14 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = true,
                     ),
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop2NonTypical,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical0),
                             ),
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop3NonTypical,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
@@ -336,9 +706,9 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = false,
                     ),
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop4,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
@@ -346,9 +716,9 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = true,
                     ),
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop5NonTypical,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternNonTypical1),
@@ -356,9 +726,9 @@ class RouteDetailsStopListTest {
                         ),
                         hasRouteLine = false,
                     ),
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop6,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical1, patternNonTypical1),
@@ -367,11 +737,12 @@ class RouteDetailsStopListTest {
                         hasRouteLine = false,
                     ),
                 ),
+                null,
             ),
-            RouteDetailsStopList.fromPieces(
+            RouteDetailsStopList.fromOldPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResult(
+                OldRouteStopsResult(
                     mainRoute.id,
                     0,
                     listOf(
@@ -390,7 +761,181 @@ class RouteDetailsStopListTest {
     }
 
     @Test
-    fun `fromPieces breaks segments by typicality in the selected direction`() = runBlocking {
+    fun `fromNewPieces breaks segments by typicality`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val stop0 = objects.stop { id = "stop0" }
+        val stop1 = objects.stop { id = "stop1" }
+        val stop2NonTypical = objects.stop { id = "stop2NonTypical" }
+        val stop3NonTypical = objects.stop { id = "stop3NonTypical" }
+        val stop4 = objects.stop { id = "stop4" }
+        val stop5NonTypical = objects.stop { id = "stop5NonTypical" }
+        val stop6 = objects.stop { id = "stop6" }
+
+        val mainRoute = objects.route()
+
+        val globalData = GlobalResponse(objects)
+
+        assertEquals(
+            RouteDetailsStopList(
+                0,
+                null,
+                listOf(
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                stop0,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            ),
+                            RouteDetailsStopList.NewEntry(
+                                stop1,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            ),
+                        ),
+                        isTypical = true,
+                    ),
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                stop2NonTypical,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            ),
+                            RouteDetailsStopList.NewEntry(
+                                stop3NonTypical,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            ),
+                        ),
+                        isTypical = false,
+                    ),
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                stop4,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            )
+                        ),
+                        isTypical = true,
+                    ),
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                stop5NonTypical,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            )
+                        ),
+                        isTypical = false,
+                    ),
+                    RouteDetailsStopList.NewSegment(
+                        listOf(
+                            RouteDetailsStopList.NewEntry(
+                                stop6,
+                                RouteBranchSegment.Lane.Center,
+                                stickConnections = emptyList(),
+                                connectingRoutes = listOf(),
+                            )
+                        ),
+                        isTypical = true,
+                    ),
+                ),
+            ),
+            RouteDetailsStopList.fromNewPieces(
+                mainRoute.id,
+                0,
+                NewRouteStopsResult(
+                    mainRoute.id,
+                    0,
+                    listOf(
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop0.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                ),
+                                RouteBranchSegment.BranchStop(
+                                    stop1.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                ),
+                            ),
+                            name = null,
+                            isTypical = true,
+                        ),
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop2NonTypical.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = false,
+                        ),
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop3NonTypical.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = false,
+                        ),
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop4.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = true,
+                        ),
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop5NonTypical.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = false,
+                        ),
+                        RouteBranchSegment(
+                            listOf(
+                                RouteBranchSegment.BranchStop(
+                                    stop6.id,
+                                    RouteBranchSegment.Lane.Center,
+                                    emptyList(),
+                                )
+                            ),
+                            name = null,
+                            isTypical = true,
+                        ),
+                    ),
+                ),
+                globalData,
+            ),
+        )
+    }
+
+    @Test
+    fun `fromOldPieces breaks segments by typicality in the selected direction`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val stop0 = objects.stop { id = "stop0" }
         val stop1 = objects.stop { id = "stop1" }
@@ -422,19 +967,19 @@ class RouteDetailsStopListTest {
             RouteDetailsStopList(
                 0,
                 listOf(
-                    RouteDetailsStopList.Segment(
+                    RouteDetailsStopList.OldSegment(
                         listOf(
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop0,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
                             ),
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop1,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
                             ),
-                            RouteDetailsStopList.Entry(
+                            RouteDetailsStopList.OldEntry(
                                 stop2,
                                 connectingRoutes = listOf(),
                                 patterns = listOf(patternTypical0),
@@ -443,11 +988,12 @@ class RouteDetailsStopListTest {
                         hasRouteLine = true,
                     )
                 ),
+                null,
             ),
-            RouteDetailsStopList.fromPieces(
+            RouteDetailsStopList.fromOldPieces(
                 mainRoute.id,
                 0,
-                RouteStopsResult(mainRoute.id, 0, listOf(stop0.id, stop1.id, stop2.id)),
+                OldRouteStopsResult(mainRoute.id, 0, listOf(stop0.id, stop1.id, stop2.id)),
                 globalData,
             ),
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.engine.mock.MockEngine
@@ -20,7 +21,7 @@ import org.koin.test.KoinTest
 
 class RouteStopsRepositoryTest : KoinTest {
     @Test
-    fun testGetSchedule() {
+    fun testGetOldStops() {
         lateinit var requestUrl: Url
         val mockEngine = MockEngine { request ->
             requestUrl = request.url
@@ -64,12 +65,12 @@ class RouteStopsRepositoryTest : KoinTest {
             modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
         }
         runBlocking {
-            val response = RouteStopsRepository().getRouteStops("Orange", 0)
+            val response = RouteStopsRepository().getOldRouteStops("Orange", 0)
             assertEquals("/api/route/stops", requestUrl.encodedPath)
             assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
             assertEquals(
                 ApiResult.Ok(
-                    RouteStopsResult(
+                    OldRouteStopsResult(
                         "Orange",
                         0,
                         listOf(
@@ -93,6 +94,691 @@ class RouteStopsRepositoryTest : KoinTest {
                             "place-sbmnl",
                             "place-grnst",
                             "place-forhl",
+                        ),
+                    )
+                ),
+                response,
+            )
+        }
+        stopKoin()
+    }
+
+    @Test
+    fun testGetNewSegments() {
+        lateinit var requestUrl: Url
+        val mockEngine = MockEngine { request ->
+            requestUrl = request.url
+            respond(
+                content =
+                    ByteReadChannel(
+                        """
+                    [
+                      {
+                        "name": null,
+                        "stops": [
+                          {
+                            "stop_id": "place-ogmnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-ogmnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-mlmnl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-mlmnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-ogmnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-mlmnl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-mlmnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-welln",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-welln",
+                            "connections": [
+                              {
+                                "from_stop": "place-mlmnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-welln",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-welln",
+                                "from_vpos": "center",
+                                "to_stop": "place-astao",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-astao",
+                            "connections": [
+                              {
+                                "from_stop": "place-welln",
+                                "from_vpos": "top",
+                                "to_stop": "place-astao",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-astao",
+                                "from_vpos": "center",
+                                "to_stop": "place-sull",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-sull",
+                            "connections": [
+                              {
+                                "from_stop": "place-astao",
+                                "from_vpos": "top",
+                                "to_stop": "place-sull",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-sull",
+                                "from_vpos": "center",
+                                "to_stop": "place-ccmnl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-ccmnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-sull",
+                                "from_vpos": "top",
+                                "to_stop": "place-ccmnl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-ccmnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-north",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-north",
+                            "connections": [
+                              {
+                                "from_stop": "place-ccmnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-north",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-north",
+                                "from_vpos": "center",
+                                "to_stop": "place-haecl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-haecl",
+                            "connections": [
+                              {
+                                "from_stop": "place-north",
+                                "from_vpos": "top",
+                                "to_stop": "place-haecl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-haecl",
+                                "from_vpos": "center",
+                                "to_stop": "place-state",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-state",
+                            "connections": [
+                              {
+                                "from_stop": "place-haecl",
+                                "from_vpos": "top",
+                                "to_stop": "place-state",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-state",
+                                "from_vpos": "center",
+                                "to_stop": "place-dwnxg",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-dwnxg",
+                            "connections": [
+                              {
+                                "from_stop": "place-state",
+                                "from_vpos": "top",
+                                "to_stop": "place-dwnxg",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-dwnxg",
+                                "from_vpos": "center",
+                                "to_stop": "place-chncl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-chncl",
+                            "connections": [
+                              {
+                                "from_stop": "place-dwnxg",
+                                "from_vpos": "top",
+                                "to_stop": "place-chncl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-chncl",
+                                "from_vpos": "center",
+                                "to_stop": "place-tumnl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-tumnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-chncl",
+                                "from_vpos": "top",
+                                "to_stop": "place-tumnl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-tumnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-bbsta",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-bbsta",
+                            "connections": [
+                              {
+                                "from_stop": "place-tumnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-bbsta",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-bbsta",
+                                "from_vpos": "center",
+                                "to_stop": "place-masta",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-masta",
+                            "connections": [
+                              {
+                                "from_stop": "place-bbsta",
+                                "from_vpos": "top",
+                                "to_stop": "place-masta",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-masta",
+                                "from_vpos": "center",
+                                "to_stop": "place-rugg",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-rugg",
+                            "connections": [
+                              {
+                                "from_stop": "place-masta",
+                                "from_vpos": "top",
+                                "to_stop": "place-rugg",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-rugg",
+                                "from_vpos": "center",
+                                "to_stop": "place-rcmnl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-rcmnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-rugg",
+                                "from_vpos": "top",
+                                "to_stop": "place-rcmnl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-rcmnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-jaksn",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-jaksn",
+                            "connections": [
+                              {
+                                "from_stop": "place-rcmnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-jaksn",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-jaksn",
+                                "from_vpos": "center",
+                                "to_stop": "place-sbmnl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-sbmnl",
+                            "connections": [
+                              {
+                                "from_stop": "place-jaksn",
+                                "from_vpos": "top",
+                                "to_stop": "place-sbmnl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-sbmnl",
+                                "from_vpos": "center",
+                                "to_stop": "place-grnst",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-grnst",
+                            "connections": [
+                              {
+                                "from_stop": "place-sbmnl",
+                                "from_vpos": "top",
+                                "to_stop": "place-grnst",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              },
+                              {
+                                "from_stop": "place-grnst",
+                                "from_vpos": "center",
+                                "to_stop": "place-forhl",
+                                "to_vpos": "bottom",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          },
+                          {
+                            "stop_id": "place-forhl",
+                            "connections": [
+                              {
+                                "from_stop": "place-grnst",
+                                "from_vpos": "top",
+                                "to_stop": "place-forhl",
+                                "to_vpos": "center",
+                                "from_lane": "center",
+                                "to_lane": "center"
+                              }
+                            ],
+                            "stop_lane": "center"
+                          }
+                        ],
+                        "typical?": true
+                      }
+                    ]
+                    """
+                            .trimIndent()
+                    ),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+
+        startKoin {
+            modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
+        }
+        runBlocking {
+            val response = RouteStopsRepository().getNewRouteSegments("Orange", 0)
+            assertEquals("/api/route/stop-graph", requestUrl.encodedPath)
+            assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
+            assertEquals(
+                ApiResult.Ok(
+                    NewRouteStopsResult(
+                        "Orange",
+                        0,
+                        listOf(
+                            RouteBranchSegment(
+                                listOf(
+                                    RouteBranchSegment.BranchStop(
+                                        "place-ogmnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        listOf(
+                                            RouteBranchSegment.StickConnection(
+                                                fromStop = "place-ogmnl",
+                                                fromLane = RouteBranchSegment.Lane.Center,
+                                                fromVPos = RouteBranchSegment.VPos.Center,
+                                                toStop = "place-mlmnl",
+                                                toLane = RouteBranchSegment.Lane.Center,
+                                                toVPos = RouteBranchSegment.VPos.Bottom,
+                                            )
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-mlmnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-ogmnl",
+                                            "place-mlmnl",
+                                            "place-welln",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-welln",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-mlmnl",
+                                            "place-welln",
+                                            "place-astao",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-astao",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-welln",
+                                            "place-astao",
+                                            "place-sull",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-sull",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-astao",
+                                            "place-sull",
+                                            "place-ccmnl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-ccmnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-sull",
+                                            "place-ccmnl",
+                                            "place-north",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-north",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-ccmnl",
+                                            "place-north",
+                                            "place-haecl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-haecl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-north",
+                                            "place-haecl",
+                                            "place-state",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-state",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-haecl",
+                                            "place-state",
+                                            "place-dwnxg",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-dwnxg",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-state",
+                                            "place-dwnxg",
+                                            "place-chncl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-chncl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-dwnxg",
+                                            "place-chncl",
+                                            "place-tumnl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-tumnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-chncl",
+                                            "place-tumnl",
+                                            "place-bbsta",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-bbsta",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-tumnl",
+                                            "place-bbsta",
+                                            "place-masta",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-masta",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-bbsta",
+                                            "place-masta",
+                                            "place-rugg",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-rugg",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-masta",
+                                            "place-rugg",
+                                            "place-rcmnl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-rcmnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-rugg",
+                                            "place-rcmnl",
+                                            "place-jaksn",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-jaksn",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-rcmnl",
+                                            "place-jaksn",
+                                            "place-sbmnl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-sbmnl",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-jaksn",
+                                            "place-sbmnl",
+                                            "place-grnst",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-grnst",
+                                        RouteBranchSegment.Lane.Center,
+                                        RouteBranchSegment.StickConnection.forward(
+                                            "place-sbmnl",
+                                            "place-grnst",
+                                            "place-forhl",
+                                            RouteBranchSegment.Lane.Center,
+                                        ),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        "place-forhl",
+                                        RouteBranchSegment.Lane.Center,
+                                        listOf(
+                                            RouteBranchSegment.StickConnection(
+                                                fromStop = "place-grnst",
+                                                fromLane = RouteBranchSegment.Lane.Center,
+                                                fromVPos = RouteBranchSegment.VPos.Top,
+                                                toStop = "place-forhl",
+                                                toLane = RouteBranchSegment.Lane.Center,
+                                                toVPos = RouteBranchSegment.VPos.Center,
+                                            )
+                                        ),
+                                    ),
+                                ),
+                                name = null,
+                                isTypical = true,
+                            )
                         ),
                     )
                 ),


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites | Route Details Branching implementation](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210764630199366?focus=true)

Consumes https://github.com/mbta/mobile_app_backend/pull/341 / https://github.com/mbta/mobile_app_backend/pull/342 in a parallel code path that nothing calls yet. I’ve already done the Android work, so I know this is the set of functionality that’s needed for the Android work, but I rearranged a couple of things as part of splitting out this PR separately, so it may be another bit before the Android stacked PR appears.

Also, I know I said this wasn’t going to be a 2,000 line PR, but after splitting out the shared work I added back in the old path (and adding is more lines than replacing) and I wrote tests for `NewSegment.twistedConnections`, plus the branching segment list is verbose enough that the repo test with the hardcoded JSON literal is larger than any other file diff in this PR.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests. Checked that all tests pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
