### PR TITLE
fix(iOS): fix most Xcode preview crashes

### DIFF
--- a/iosApp/iosApp/ComponentViews/ErrorBanner.swift
+++ b/iosApp/iosApp/ComponentViews/ErrorBanner.swift
@@ -96,4 +96,5 @@ struct ErrorBanner: View {
             initialLoadingWhenPredictionsStale: true
         ))
     }
+    .withFixedSettings([:])
 }

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -165,4 +165,5 @@ private func cardForPreview(_ card: RouteCardData, _ previewData: RouteCardPrevi
         }
         .padding()
     }
+    .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -103,4 +103,5 @@ struct MorePage: View {
 #Preview {
     MorePage()
         .font(Typography.body)
+        .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Pages/NearbyTransit/NoNearbyStopsView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NoNearbyStopsView.swift
@@ -74,4 +74,5 @@ struct NoNearbyStopsView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(Color.fill2)
     .ignoresSafeArea()
+    .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingPage.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingPage.swift
@@ -56,5 +56,6 @@ struct OnboardingPage: View {
 }
 
 #Preview {
-    OnboardingPage(screens: OnboardingScreen.allCases, onFinish: {})
+    OnboardingPage(screens: OnboardingScreen.allCases, onFinish: {}, onboardingRepository: MockOnboardingRepository())
+        .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -243,16 +243,20 @@ struct OnboardingScreenView: View {
 
 #Preview("Feedback") {
     OnboardingScreenView(screen: .feedback, advance: {})
+        .withFixedSettings([:])
 }
 
 #Preview("Map Display") {
     OnboardingScreenView(screen: .hideMaps, advance: {})
+        .withFixedSettings([:])
 }
 
 #Preview("Location") {
     OnboardingScreenView(screen: .location, advance: {})
+        .withFixedSettings([:])
 }
 
 #Preview("Station Accessibility") {
     OnboardingScreenView(screen: .stationAccessibility, advance: {})
+        .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -94,7 +94,8 @@ struct DepartureTile: View {
         route.textColor = "FFFFFF"
         route.type = .lightRail
     }
-    let upcomingTrip = objects.upcomingTrip()
+    let trip = objects.trip { _ in }
+    let upcomingTrip = UpcomingTrip(trip: trip)
 
     HStack {
         DepartureTile(

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -259,4 +259,5 @@ struct TripStops: View {
     }
     .padding(12)
     .font(Typography.body)
+    .withFixedSettings([:])
 }

--- a/iosApp/iosApp/Utils/SettingsCache.swift
+++ b/iosApp/iosApp/Utils/SettingsCache.swift
@@ -62,6 +62,9 @@ struct SettingsCacheProvider<Content: View>: View {
 extension View {
     /// Sets the settings within this view to some fixed value.
     func withFixedSettings(_ settings: [Settings: Bool]) -> some View {
-        environmentObject(SettingsCache(cache: settings))
+        environmentObject(SettingsCache(
+            settingsRepo: MockSettingsRepository(settings: settings.mapValues { KotlinBoolean(bool: $0) }),
+            cache: settings
+        ))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ none

Stumbled onto this fix when working on iOS route branching.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the Xcode previews fixed here now work.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
