### PR TITLE
fix: avoid and handle on Android “1 hr” schedules

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -395,6 +395,19 @@ class UpcomingTripViewTest {
     }
 
     @Test
+    fun testUpcomingTripViewWithSomeScheduleMinutesOver60() {
+        composeTestRule.setContent {
+            UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.ScheduleMinutes(75)))
+        }
+        composeTestRule
+            .onNodeWithText("1 hr 15 min")
+            .assertIsDisplayed()
+            .assertContentDescriptionContains("arriving in 1 hr 15 min scheduled", substring = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertDoesNotExist()
+    }
+
+    @Test
     fun testUpcomingTripViewWithSomeMinutesOtherBus() {
         composeTestRule.setContent {
             UpcomingTripView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/TripInstantDisplayExtension.kt
@@ -6,7 +6,6 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.formatTime
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.utils.MinutesFormat
-import io.sentry.Sentry
 import kotlin.time.Instant
 
 @Composable
@@ -28,15 +27,38 @@ fun TripInstantDisplay.contentDescription(isFirst: Boolean, vehicleType: String)
         }
         is TripInstantDisplay.ScheduleMinutes -> {
             val format = MinutesFormat.from(this.minutes)
-            if (format !is MinutesFormat.Minute) {
-                Sentry.captureMessage(
-                    "Schedules displayed as minutes should never be over 1 hour, " +
-                        "content description text is not supported for this case"
-                )
-                ""
-            } else if (isFirst)
-                stringResource(R.string.vehicle_schedule_minutes_first, vehicleType, format.minutes)
-            else stringResource(R.string.vehicle_schedule_minutes_other, format.minutes)
+            when (format) {
+                is MinutesFormat.Hour ->
+                    if (isFirst)
+                        stringResource(
+                            R.string.vehicle_schedule_hours_first,
+                            vehicleType,
+                            format.hours,
+                        )
+                    else stringResource(R.string.vehicle_schedule_hours_other, format.hours)
+                is MinutesFormat.HourMinute ->
+                    if (isFirst)
+                        stringResource(
+                            R.string.vehicle_schedule_hours_minutes_first,
+                            vehicleType,
+                            format.hours,
+                            format.minutes,
+                        )
+                    else
+                        stringResource(
+                            R.string.vehicle_schedule_hours_minutes_other,
+                            format.hours,
+                            format.minutes,
+                        )
+                is MinutesFormat.Minute ->
+                    if (isFirst)
+                        stringResource(
+                            R.string.vehicle_schedule_minutes_first,
+                            vehicleType,
+                            format.minutes,
+                        )
+                    else stringResource(R.string.vehicle_schedule_minutes_other, format.minutes)
+            }
         }
         is TripInstantDisplay.ScheduleTime -> {
             val time = formatTime(this.scheduledTime)

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -415,6 +415,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">y %1$s %2$s temprano</string>
     <string name="vehicle_prediction_time_first">%1$s llegará a la(s) %2$s</string>
     <string name="vehicle_prediction_time_other">y a la(s) %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s llegando en %2$d h programado</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s llegando en %2$d h %3$d min programado</string>
+    <string name="vehicle_schedule_hours_minutes_other">y en %1$d h %2$d min programado</string>
+    <string name="vehicle_schedule_hours_other">y en %1$d h programado</string>
     <string name="vehicle_schedule_minutes_first">%1$s llegará en %2$d min programado</string>
     <string name="vehicle_schedule_minutes_other">y en %1$d min programado</string>
     <string name="vehicle_schedule_time_first">%1$s llegará a la(s) %2$s como se programó</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -415,6 +415,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">et %1$s %2$s tôt</string>
     <string name="vehicle_prediction_time_first">%1$s arrivant à %2$s</string>
     <string name="vehicle_prediction_time_other">et à %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s arrive dans %2$d heure prévu</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s arrive dans %2$d h %3$d min prévu</string>
+    <string name="vehicle_schedule_hours_minutes_other">et dans %1$d h et %2$d min prévu</string>
+    <string name="vehicle_schedule_hours_other">et dans %1$d h prévu</string>
     <string name="vehicle_schedule_minutes_first">%1$s arrivant dans %2$d min est prévu</string>
     <string name="vehicle_schedule_minutes_other">et dans %1$d min est prévu</string>
     <string name="vehicle_schedule_time_first">%1$s arrivant à %2$s est prévu</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -430,6 +430,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">ak %1$s %2$s byen bonè</string>
     <string name="vehicle_prediction_time_first">%1$s ap rive a %2$s</string>
     <string name="vehicle_prediction_time_other">epi a %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s ap rive nan %2$d èdtan pwograme</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s rive nan %2$d è %3$d min pwograme</string>
+    <string name="vehicle_schedule_hours_minutes_other">epi nan %1$d è %2$d min pwograme</string>
+    <string name="vehicle_schedule_hours_other">epi nan %1$d èdtan pwograme</string>
     <string name="vehicle_schedule_minutes_first">%1$s ap rive nan %2$d min pwograme</string>
     <string name="vehicle_schedule_minutes_other">epi nan %1$d min pwograme</string>
     <string name="vehicle_schedule_time_first">%1$s ap rive a %2$s pwograme</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -415,6 +415,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">e %1$s %2$s cedo</string>
     <string name="vehicle_prediction_time_first">%1$s chegando às %2$s</string>
     <string name="vehicle_prediction_time_other">e às %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s chegando em %2$d h programado</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s chegando em %2$d h %3$d min programado</string>
+    <string name="vehicle_schedule_hours_minutes_other">e em %1$d h %2$d min programado</string>
+    <string name="vehicle_schedule_hours_other">e em %1$d h programado</string>
     <string name="vehicle_schedule_minutes_first">%1$s chegando em %2$d min programado</string>
     <string name="vehicle_schedule_minutes_other">e em %1$d min programado</string>
     <string name="vehicle_schedule_time_first">%1$s chegando às %2$s programado</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -405,6 +405,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">và %1$s %2$s sớm</string>
     <string name="vehicle_prediction_time_first">%1$s sẽ đến lúc %2$s</string>
     <string name="vehicle_prediction_time_other">và lúc %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s sẽ đến trong %2$d giờ theo lịch trình</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s sẽ đến trong %2$d giờ %3$d phút theo lịch trình</string>
+    <string name="vehicle_schedule_hours_minutes_other">và trong %1$d giờ %2$d phút theo lịch trình</string>
+    <string name="vehicle_schedule_hours_other">và trong %1$d giờ theo lịch trình</string>
     <string name="vehicle_schedule_minutes_first">%1$s sẽ đến sau %2$d phút nữa theo lịch trình</string>
     <string name="vehicle_schedule_minutes_other">và sau %1$d phút nữa theo lịch trình</string>
     <string name="vehicle_schedule_time_first">%1$s sẽ đến lúc %2$s theo lịch trình</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -405,6 +405,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">下一趟%1$s%2$s提前</string>
     <string name="vehicle_prediction_time_first">%1$s于%2$s到站</string>
     <string name="vehicle_prediction_time_other">下一趟车将于%1$s到站</string>
+    <string name="vehicle_schedule_hours_first">%1$s预计在%2$d小时内到站</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s预计在%2$d小时%3$d分钟内到站</string>
+    <string name="vehicle_schedule_hours_minutes_other">下一趟车预计将在%1$d小时%2$d分钟内抵达</string>
+    <string name="vehicle_schedule_hours_other">下一趟车预计将在%1$d小时内抵达</string>
     <string name="vehicle_schedule_minutes_first">%1$s预定将于%2$d分钟内到站</string>
     <string name="vehicle_schedule_minutes_other">下一趟车预定将在%1$d分钟内抵达</string>
     <string name="vehicle_schedule_time_first">%1$s预定于%2$s到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -405,6 +405,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">下一趟%1$s%2$s提前</string>
     <string name="vehicle_prediction_time_first">%1$s於%2$s到站</string>
     <string name="vehicle_prediction_time_other">下一趟車將於%1$s到站</string>
+    <string name="vehicle_schedule_hours_first">%1$s預定將於%2$d小時內到站</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s預定將於%2$d小時%3$d分鐘內到站</string>
+    <string name="vehicle_schedule_hours_minutes_other">下一趟車預定將在%1$d小時%2$d分鐘內抵達</string>
+    <string name="vehicle_schedule_hours_other">下一趟車預定將在%1$d小時內抵達</string>
     <string name="vehicle_schedule_minutes_first">%1$s預定將於%2$d分鐘內到站</string>
     <string name="vehicle_schedule_minutes_other">下一趟車預定將在%1$d分鐘內抵達</string>
     <string name="vehicle_schedule_time_first">%1$s預定於%2$s到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -412,6 +412,10 @@
     <string name="vehicle_prediction_schedule_status_early_other">and %1$s %2$s early</string>
     <string name="vehicle_prediction_time_first">%1$s arriving at %2$s</string>
     <string name="vehicle_prediction_time_other">and at %1$s</string>
+    <string name="vehicle_schedule_hours_first">%1$s arriving in %2$d hr scheduled</string>
+    <string name="vehicle_schedule_hours_minutes_first">%1$s arriving in %2$d hr %3$d min scheduled</string>
+    <string name="vehicle_schedule_hours_minutes_other">and in %1$d hr %2$d min scheduled</string>
+    <string name="vehicle_schedule_hours_other">and in %1$d hr scheduled</string>
     <string name="vehicle_schedule_minutes_first">%1$s arriving in %2$d min scheduled</string>
     <string name="vehicle_schedule_minutes_other">and in %1$d min scheduled</string>
     <string name="vehicle_schedule_time_first">%1$s arriving at %2$s scheduled</string>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -103,13 +103,15 @@ sealed class TripInstantDisplay {
                 ) {
                     Hidden
                 } else {
-                    val scheduleTimeRemaining = scheduleTime.minus(now)
-                    if (scheduleTimeRemaining > SCHEDULE_CLOCK_CUTOFF || forceAsTime) {
+                    val scheduleMinutesRemaining =
+                        scheduleTime.minus(now).toDouble(DurationUnit.MINUTES).roundToInt()
+                    if (
+                        scheduleMinutesRemaining >=
+                            SCHEDULE_CLOCK_CUTOFF.toDouble(DurationUnit.MINUTES) || forceAsTime
+                    ) {
                         ScheduleTime(scheduleTime, headline = showTimeAsHeadline)
                     } else {
-                        val scheduleMinutes =
-                            scheduleTimeRemaining.toDouble(DurationUnit.MINUTES).roundToInt()
-                        ScheduleMinutes(scheduleMinutes)
+                        ScheduleMinutes(scheduleMinutesRemaining)
                     }
                 }
             }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -205,6 +205,37 @@ class TripInstantDisplayTest {
     }
 
     @Test
+    fun `schedule rounding`() = parametricTest {
+        val now = Clock.System.now()
+        assertEquals(
+            TripInstantDisplay.ScheduleMinutes(59),
+            TripInstantDisplay.from(
+                prediction = null,
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule {
+                        departureTime = now + 59.4999.minutes
+                    },
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = nonTripDetails(),
+            ),
+        )
+        assertEquals(
+            TripInstantDisplay.ScheduleTime(now + 59.5.minutes),
+            TripInstantDisplay.from(
+                prediction = null,
+                schedule =
+                    ObjectCollectionBuilder.Single.schedule { departureTime = now + 59.5.minutes },
+                vehicle = null,
+                routeType = RouteType.BUS,
+                now = now,
+                context = nonTripDetails(),
+            ),
+        )
+    }
+
+    @Test
     fun `departure_time in the past`() = parametricTest {
         val now = Clock.System.now()
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ [Support TalkBack text if schedules displayed over 1 hour](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210765282940758?focus=true)

Found the issue causing this case to appear and went ahead and fixed it too.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests for logic fix and TalkBack fix.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
