### PR TITLE
fix: Order nearby stops after filtering

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
@@ -40,7 +40,7 @@ class NearbyRepository : KoinComponent, INearbyRepository {
             nearbyLeafStops = findLeafStops()
         }
 
-        var allNearbyStops =
+        val allNearbyStops =
             nearbyLeafStops
                 .flatMapTo(mutableSetOf()) { (stopId, distance) ->
                     val stop = global.stops[stopId] ?: return@flatMapTo emptyList()
@@ -71,6 +71,8 @@ class NearbyRepository : KoinComponent, INearbyRepository {
         globalData: GlobalResponse,
     ): List<String> {
         val originalStopIdSet = stopIds.toSet()
+        val originalStopOrder = stopIds.mapIndexed { index, id -> Pair(id, index) }.toMap()
+
         val parentToAllStops = Stop.resolvedParentToAllStops(stopIds, globalData)
 
         return RoutePattern.patternsGroupedByLineOrRouteAndStop(
@@ -84,6 +86,7 @@ class NearbyRepository : KoinComponent, INearbyRepository {
                 }
             }
             .distinct()
+            .sortedBy { originalStopOrder[it] }
     }
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: nearby stop sort order](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210845316775461?focus=true)

The list of stop IDs going into `filterStopsWithRedundantPatterns` was sorted by distance, but the list coming out gets pieced together from a set and map, which lost the distance context. In most cases this was fine, because another distance sort happens during route card data creation, but in cases like the GL at Hynes, there are multiple bus routes which have a nearest stop at Kenmore. Since the GL Kenmore platforms were also within the radius and the bus routes patterns were being processed first, the GL Kenmore platforms were being returned above Hynes, then the route card processing would assume that was the closest GL stop and filter out Hynes.

This change simply sorts the filtered stop IDs based on the original stop ID list.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified that Hynes now shows up properly when it's the nearest GL stop