### PR TITLE
feat(android): Default to favorites first time only

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
@@ -1,0 +1,81 @@
+package com.mbta.tid.mbta_app.android
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.model.AppVersion
+import com.mbta.tid.mbta_app.repositories.DefaultTab
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
+import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
+import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.returns
+import dev.mokkery.everySuspend
+import dev.mokkery.matcher.any
+import dev.mokkery.mock
+import dev.mokkery.verify.VerifyMode
+import dev.mokkery.verifySuspend
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.koin.test.KoinTest
+
+class ContentViewModelTests : KoinTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testDefaultTabSetsToNearbyAfterFirstLaunchWithFavorites() = runBlocking {
+        val tabPreferencesRepository = mock<ITabPreferencesRepository>()
+        var setTabCalledWith: DefaultTab? = null
+        everySuspend { tabPreferencesRepository.getDefaultTab() } returns DefaultTab.Favorites
+        everySuspend { tabPreferencesRepository.hasSeenFavorites() } returns false
+
+        everySuspend { tabPreferencesRepository.setDefaultTab(any()) } calls
+            {
+                setTabCalledWith = it.arg(0)
+            }
+
+        composeTestRule.setContent {
+            val vm =
+                ContentViewModel(
+                    featurePromoUseCase =
+                        FeaturePromoUseCase(
+                            MockCurrentAppVersionRepository(AppVersion(3u, 0u, 0u)),
+                            MockLastLaunchedAppVersionRepository(AppVersion(1u, 0u, 0u)),
+                        ),
+                    onboardingRepository = MockOnboardingRepository(),
+                    tabPreferencesRepository = tabPreferencesRepository,
+                )
+        }
+
+        composeTestRule.waitUntil { setTabCalledWith == DefaultTab.Nearby }
+    }
+
+    @Test
+    fun testDefaultTabSNotSetIfFavoritesAlreadySeen() = runBlocking {
+        val tabPreferencesRepository = mock<ITabPreferencesRepository>()
+        everySuspend { tabPreferencesRepository.getDefaultTab() } returns DefaultTab.Favorites
+        everySuspend { tabPreferencesRepository.hasSeenFavorites() } returns true
+
+        everySuspend { tabPreferencesRepository.setDefaultTab(any()) } calls {}
+
+        composeTestRule.setContent {
+            val vm =
+                ContentViewModel(
+                    featurePromoUseCase =
+                        FeaturePromoUseCase(
+                            MockCurrentAppVersionRepository(AppVersion(3u, 0u, 0u)),
+                            MockLastLaunchedAppVersionRepository(AppVersion(1u, 0u, 0u)),
+                        ),
+                    onboardingRepository = MockOnboardingRepository(),
+                    tabPreferencesRepository = tabPreferencesRepository,
+                )
+        }
+
+        verifySuspend(VerifyMode.exhaustiveOrder) {
+            tabPreferencesRepository.getDefaultTab()
+            tabPreferencesRepository.hasSeenFavorites()
+        }
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
@@ -8,12 +8,9 @@ import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.usecases.FeaturePromoUseCase
-import dev.mokkery.answering.calls
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
-import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify.VerifyMode
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
@@ -25,16 +22,9 @@ class ContentViewModelTests : KoinTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testDefaultTabSetsToNearbyAfterFirstLaunchWithFavorites() = runBlocking {
+    fun testDefaultTabLoaded() = runBlocking {
         val tabPreferencesRepository = mock<ITabPreferencesRepository>()
-        var setTabCalledWith: DefaultTab? = null
         everySuspend { tabPreferencesRepository.getDefaultTab() } returns DefaultTab.Favorites
-        everySuspend { tabPreferencesRepository.hasSeenFavorites() } returns false
-
-        everySuspend { tabPreferencesRepository.setDefaultTab(any()) } calls
-            {
-                setTabCalledWith = it.arg(0)
-            }
 
         composeTestRule.setContent {
             val vm =
@@ -49,33 +39,6 @@ class ContentViewModelTests : KoinTest {
                 )
         }
 
-        composeTestRule.waitUntil { setTabCalledWith == DefaultTab.Nearby }
-    }
-
-    @Test
-    fun testDefaultTabSNotSetIfFavoritesAlreadySeen() = runBlocking {
-        val tabPreferencesRepository = mock<ITabPreferencesRepository>()
-        everySuspend { tabPreferencesRepository.getDefaultTab() } returns DefaultTab.Favorites
-        everySuspend { tabPreferencesRepository.hasSeenFavorites() } returns true
-
-        everySuspend { tabPreferencesRepository.setDefaultTab(any()) } calls {}
-
-        composeTestRule.setContent {
-            val vm =
-                ContentViewModel(
-                    featurePromoUseCase =
-                        FeaturePromoUseCase(
-                            MockCurrentAppVersionRepository(AppVersion(3u, 0u, 0u)),
-                            MockLastLaunchedAppVersionRepository(AppVersion(1u, 0u, 0u)),
-                        ),
-                    onboardingRepository = MockOnboardingRepository(),
-                    tabPreferencesRepository = tabPreferencesRepository,
-                )
-        }
-
-        verifySuspend(VerifyMode.exhaustiveOrder) {
-            tabPreferencesRepository.getDefaultTab()
-            tabPreferencesRepository.hasSeenFavorites()
-        }
+        verifySuspend { tabPreferencesRepository.getDefaultTab() }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
@@ -17,6 +17,7 @@ import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import com.mbta.tid.mbta_app.network.MockPhoenixSocket
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
+import com.mbta.tid.mbta_app.repositories.MockTabPreferencesRepository
 import com.mbta.tid.mbta_app.usecases.IFeaturePromoUseCase
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
@@ -68,6 +69,7 @@ class ContentViewTests : KoinTest {
             ContentViewModel(
                 featurePromoUseCase = mockFeaturePromos,
                 onboardingRepository = MockOnboardingRepository(),
+                tabPreferencesRepository = MockTabPreferencesRepository(),
             )
 
         composeTestRule.setContent {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -76,6 +76,8 @@ fun ContentView(
                         DefaultTab.Nearby -> SheetRoutes.NearbyTransit
                     }
                 }
+        } else if (sheetNavEntrypoint == null && enhancedFavorites == false) {
+            sheetNavEntrypoint = SheetRoutes.NearbyTransit
         }
         Log.i("KB", "New sheetNavEntrypoint ${sheetNavEntrypoint}")
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.android
 
-import android.util.Log
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -65,10 +64,7 @@ fun ContentView(
         }
 
     LaunchedEffect(defaultTab, enhancedFavorites) {
-        Log.i("KB", "Default Tab changed ${defaultTab} ${enhancedFavorites} ${sheetNavEntrypoint}")
         if (sheetNavEntrypoint == null && enhancedFavorites == true) {
-            Log.i("KB", "Sheetnav entrypoint setting ${defaultTab}")
-
             sheetNavEntrypoint =
                 defaultTab?.let {
                     when (it) {
@@ -79,7 +75,6 @@ fun ContentView(
         } else if (sheetNavEntrypoint == null && enhancedFavorites == false) {
             sheetNavEntrypoint = SheetRoutes.NearbyTransit
         }
-        Log.i("KB", "New sheetNavEntrypoint ${sheetNavEntrypoint}")
     }
 
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -37,7 +37,6 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.network.PhoenixSocket
-import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.viewModel.MapViewModel
@@ -65,13 +64,7 @@ fun ContentView(
 
     LaunchedEffect(defaultTab, enhancedFavorites) {
         if (sheetNavEntrypoint == null && enhancedFavorites == true) {
-            sheetNavEntrypoint =
-                defaultTab?.let {
-                    when (it) {
-                        DefaultTab.Favorites -> SheetRoutes.Favorites
-                        DefaultTab.Nearby -> SheetRoutes.NearbyTransit
-                    }
-                }
+            sheetNavEntrypoint = defaultTab?.toEntrypoint()
         } else if (sheetNavEntrypoint == null && enhancedFavorites == false) {
             sheetNavEntrypoint = SheetRoutes.NearbyTransit
         }
@@ -171,7 +164,7 @@ fun ContentView(
                     BottomNavBar(
                         currentDestination =
                             Routes.fromNavBackStackEntry(navController.currentBackStackEntry),
-                        sheetNavEntrypoint = sheetNavEntrypoint ?: SheetRoutes.NearbyTransit,
+                        sheetNavEntrypoint = sheetNavEntrypoint,
                         navigateToFavorites = {
                             navController.popBackStack()
                             sheetNavEntrypoint = SheetRoutes.Favorites

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -64,7 +64,7 @@ fun ContentView(
 
     LaunchedEffect(defaultTab, enhancedFavorites) {
         if (sheetNavEntrypoint == null && enhancedFavorites == true) {
-            sheetNavEntrypoint = defaultTab?.toEntrypoint()
+            sheetNavEntrypoint = defaultTab?.entrypoint
         } else if (sheetNavEntrypoint == null && enhancedFavorites == false) {
             sheetNavEntrypoint = SheetRoutes.NearbyTransit
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -23,21 +23,22 @@ class ContentViewModel(
     val pendingFeaturePromos: StateFlow<List<FeaturePromo>?> = _pendingFeaturePromos
     private val _pendingOnboarding: MutableStateFlow<List<OnboardingScreen>?> =
         MutableStateFlow(null)
+
     val pendingOnboarding: StateFlow<List<OnboardingScreen>?> = _pendingOnboarding
 
     private val _defaultTab: MutableStateFlow<DefaultTab?> = MutableStateFlow(null)
     val defaultTab: StateFlow<DefaultTab?> = _defaultTab
 
     init {
-        loadDefaultTabState()
-        loadPendingFeaturePromos()
+        loadPendingFeaturePromosAndTabPreferences()
         loadPendingOnboarding()
     }
 
-    fun loadPendingFeaturePromos() {
+    fun loadPendingFeaturePromosAndTabPreferences() {
         CoroutineScope(Dispatchers.IO).launch {
             val data = featurePromoUseCase.getFeaturePromos()
             _pendingFeaturePromos.value = data
+            loadTabPreferences(data.contains(FeaturePromo.EnhancedFavorites))
         }
     }
 
@@ -48,10 +49,14 @@ class ContentViewModel(
         }
     }
 
-    fun loadDefaultTabState() {
+    fun loadTabPreferences(hasPendingFavoritesPromo: Boolean) {
         CoroutineScope(Dispatchers.IO).launch {
-            val defaultTab = tabPreferencesRepository.getDefaultTab()
-            _defaultTab.value = defaultTab
+            if (hasPendingFavoritesPromo) {
+                _defaultTab.value = DefaultTab.Favorites
+                tabPreferencesRepository.setDefaultTab(DefaultTab.Favorites)
+            } else {
+                _defaultTab.value = tabPreferencesRepository.getDefaultTab()
+            }
         }
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.DefaultTab
-import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
 import com.mbta.tid.mbta_app.usecases.IFeaturePromoUseCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 class ContentViewModel(
     private val featurePromoUseCase: IFeaturePromoUseCase,
     private val onboardingRepository: IOnboardingRepository,
-    private val defaultTabRepository: IDefaultTabRepository,
+    private val tabPreferencesRepository: ITabPreferencesRepository,
 ) : ViewModel() {
     private val _pendingFeaturePromos: MutableStateFlow<List<FeaturePromo>?> =
         MutableStateFlow(null)
@@ -50,13 +50,13 @@ class ContentViewModel(
 
     fun loadDefaultTabState() {
         CoroutineScope(Dispatchers.IO).launch {
-            _defaultTab.value = defaultTabRepository.getDefaultTab()
+            val defaultTab = tabPreferencesRepository.getDefaultTab()
+            val hasSeenFavorites = tabPreferencesRepository.hasSeenFavorites()
+            if (!hasSeenFavorites && defaultTab == DefaultTab.Favorites) {
+                tabPreferencesRepository.setDefaultTab(DefaultTab.Nearby)
+            }
+            _defaultTab.value = defaultTab
         }
-    }
-
-    suspend fun setDefaultTab(tab: DefaultTab) {
-        defaultTabRepository.setDefaultTab(tab)
-        loadDefaultTabState()
     }
 
     fun clearPendingOnboarding() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -51,10 +51,6 @@ class ContentViewModel(
     fun loadDefaultTabState() {
         CoroutineScope(Dispatchers.IO).launch {
             val defaultTab = tabPreferencesRepository.getDefaultTab()
-            val hasSeenFavorites = tabPreferencesRepository.hasSeenFavorites()
-            if (!hasSeenFavorites && defaultTab == DefaultTab.Favorites) {
-                tabPreferencesRepository.setDefaultTab(DefaultTab.Nearby)
-            }
             _defaultTab.value = defaultTab
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentViewModel.kt
@@ -3,6 +3,8 @@ package com.mbta.tid.mbta_app.android
 import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import com.mbta.tid.mbta_app.model.OnboardingScreen
+import com.mbta.tid.mbta_app.repositories.DefaultTab
+import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.usecases.IFeaturePromoUseCase
 import kotlinx.coroutines.CoroutineScope
@@ -14,6 +16,7 @@ import kotlinx.coroutines.launch
 class ContentViewModel(
     private val featurePromoUseCase: IFeaturePromoUseCase,
     private val onboardingRepository: IOnboardingRepository,
+    private val defaultTabRepository: IDefaultTabRepository,
 ) : ViewModel() {
     private val _pendingFeaturePromos: MutableStateFlow<List<FeaturePromo>?> =
         MutableStateFlow(null)
@@ -22,7 +25,11 @@ class ContentViewModel(
         MutableStateFlow(null)
     val pendingOnboarding: StateFlow<List<OnboardingScreen>?> = _pendingOnboarding
 
+    private val _defaultTab: MutableStateFlow<DefaultTab?> = MutableStateFlow(null)
+    val defaultTab: StateFlow<DefaultTab?> = _defaultTab
+
     init {
+        loadDefaultTabState()
         loadPendingFeaturePromos()
         loadPendingOnboarding()
     }
@@ -39,6 +46,17 @@ class ContentViewModel(
             val data = onboardingRepository.getPendingOnboarding()
             _pendingOnboarding.value = data
         }
+    }
+
+    fun loadDefaultTabState() {
+        CoroutineScope(Dispatchers.IO).launch {
+            _defaultTab.value = defaultTabRepository.getDefaultTab()
+        }
+    }
+
+    suspend fun setDefaultTab(tab: DefaultTab) {
+        defaultTabRepository.setDefaultTab(tab)
+        loadDefaultTabState()
     }
 
     fun clearPendingOnboarding() {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
@@ -15,9 +15,9 @@ import kotlin.reflect.typeOf
 
 val SheetRoutes.Companion.EntrypointSaver
     get() =
-        Saver<SheetRoutes.Entrypoint, String>(
-            save = { json.encodeToString<SheetRoutes.Entrypoint>(it) },
-            restore = { json.decodeFromString<SheetRoutes.Entrypoint>(it) },
+        Saver<SheetRoutes.Entrypoint?, String>(
+            save = { json.encodeToString<SheetRoutes.Entrypoint?>(it) },
+            restore = { json.decodeFromString<SheetRoutes.Entrypoint?>(it) },
         )
 
 val SheetRoutes.Companion.typeMap

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
@@ -31,7 +31,7 @@ import com.mbta.tid.mbta_app.repositories.Settings
 @Composable
 fun BottomNavBar(
     currentDestination: Routes,
-    sheetNavEntrypoint: SheetRoutes.Entrypoint,
+    sheetNavEntrypoint: SheetRoutes.Entrypoint?,
     navigateToFavorites: () -> Unit,
     navigateToNearby: () -> Unit,
     navigateToMore: () -> Unit,
@@ -45,6 +45,7 @@ fun BottomNavBar(
                     when (sheetNavEntrypoint) {
                         SheetRoutes.Favorites -> 0
                         SheetRoutes.NearbyTransit -> 1
+                        null -> -1
                     }
                 is Routes.More -> 2
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -45,12 +45,13 @@ fun SheetHeader(
     closeText: String? = null,
     onBack: (() -> Unit)? = null,
     onClose: (() -> Unit)? = null,
-    rightActionContents: @Composable () -> Unit = {},
+    rightActionContents: @Composable (() -> Unit)? = null,
     buttonColors: ButtonColors = ButtonDefaults.contrast(),
 ) {
     val context = LocalContext.current
     val buttonSize = 32.dp
     val touchTarget = 48.dp
+    var hasButtons = onBack != null || onClose != null || rightActionContents != null
     var buttonPadding by remember { mutableStateOf(0.dp) }
     var textPadding by remember { mutableStateOf(0.dp) }
 
@@ -59,21 +60,23 @@ fun SheetHeader(
      * always aligned with the first line of text, even if the text breaks to multiple lines.
      */
     fun alignButtons(layout: TextLayoutResult) {
-        val lineHeight = (layout.getLineBottom(0) - layout.getLineTop(0)).toDp(context)
-        val padding = (lineHeight / 2) - (touchTarget / 2)
-        if (padding < 0.dp) {
-            buttonPadding = 0.dp
-            textPadding = abs(padding.value).dp
-        } else {
-            buttonPadding = padding + layout.getLineTop(0).toDp(context)
-            textPadding = 0.dp
+        if (hasButtons) {
+            val lineHeight = (layout.getLineBottom(0) - layout.getLineTop(0)).toDp(context)
+            val padding = (lineHeight / 2) - (touchTarget / 2)
+            if (padding < 0.dp) {
+                buttonPadding = 0.dp
+                textPadding = abs(padding.value).dp
+            } else {
+                buttonPadding = padding + layout.getLineTop(0).toDp(context)
+                textPadding = 0.dp
+            }
         }
     }
 
     Row(
         modifier.padding(horizontal = 16.dp).heightIn(min = touchTarget),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = if (hasButtons) Alignment.Top else Alignment.CenterVertically,
     ) {
         if (onBack != null) {
             ActionButton(
@@ -101,7 +104,9 @@ fun SheetHeader(
             Spacer(Modifier.weight(1f))
         }
 
-        Row(modifier = Modifier.padding(top = buttonPadding)) { rightActionContents() }
+        if (rightActionContents != null) {
+            Row(modifier = Modifier.padding(top = buttonPadding)) { rightActionContents() }
+        }
 
         if (onClose != null) {
             if (closeText != null)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -583,8 +583,7 @@ fun MapAndSheetPage(
 
     @Composable
     fun NearbyTransitSheetContents() {
-        // for ViewModel reasons, must be within the `composable` to be the same
-        // instance
+        // for ViewModel reasons, must be within the `composable` to be the same instance
         val nearbyViewModel: NearbyTransitViewModel = koinViewModel()
         LaunchedEffect(Unit) {
             if (!navBarVisible && !searchExpanded) showNavBar()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -153,7 +153,7 @@ fun MapAndSheetPage(
     val hideMaps = SettingsCache.get(Settings.HideMaps)
 
     val currentNavBackStackEntry by
-    navController.currentBackStackEntryFlow.collectAsStateWithLifecycle(initialValue = null)
+        navController.currentBackStackEntryFlow.collectAsStateWithLifecycle(initialValue = null)
 
     val currentNavEntry = currentNavBackStackEntry?.let { SheetRoutes.fromNavBackStackEntry(it) }
     val previousNavEntry: SheetRoutes? = rememberPrevious(currentNavEntry)
@@ -219,8 +219,8 @@ fun MapAndSheetPage(
     LaunchedEffect(currentNavEntry) {
         if (
             previousNavEntry is SheetRoutes.StopDetails &&
-            currentNavEntry is SheetRoutes.StopDetails &&
-            (previousNavEntry.stopId != currentNavEntry.stopId ||
+                currentNavEntry is SheetRoutes.StopDetails &&
+                (previousNavEntry.stopId != currentNavEntry.stopId ||
                     previousNavEntry.stopFilter != currentNavEntry.stopFilter)
         ) {
             tileScrollState.scrollTo(0)
@@ -405,7 +405,7 @@ fun MapAndSheetPage(
     LaunchedEffect(currentNavEntry) {
         if (
             !SheetRoutes.retainSheetSize(previousNavEntry, currentNavEntry) &&
-            SheetRoutes.pageChanged(previousNavEntry, currentNavEntry)
+                SheetRoutes.pageChanged(previousNavEntry, currentNavEntry)
         ) {
             nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Medium)
         }
@@ -413,7 +413,7 @@ fun MapAndSheetPage(
 
     val modalSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var currentModal by
-    rememberSaveable(saver = stateJsonSaver()) { mutableStateOf<ModalRoutes?>(null) }
+        rememberSaveable(saver = stateJsonSaver()) { mutableStateOf<ModalRoutes?>(null) }
 
     fun openModal(modal: ModalRoutes) {
         currentModal = modal
@@ -497,9 +497,9 @@ fun MapAndSheetPage(
                     // Skip animation if navigating within a single stop
                     if (
                         initialStopId != null &&
-                        targetStopId != null &&
-                        initialStopId == targetStopId &&
-                        initialStopFilter?.routeId == targetStopFilter?.routeId
+                            targetStopId != null &&
+                            initialStopId == targetStopId &&
+                            initialStopFilter?.routeId == targetStopFilter?.routeId
                     ) {
                         EnterTransition.None
                     }
@@ -541,7 +541,8 @@ fun MapAndSheetPage(
                         )
                     }
                 }
-                composable<SheetRoutes.StopDetails>(typeMap = SheetRoutes.typeMap) { backStackEntry ->
+                composable<SheetRoutes.StopDetails>(typeMap = SheetRoutes.typeMap) { backStackEntry
+                    ->
                     val navRoute: SheetRoutes.StopDetails = backStackEntry.toRoute()
                     val filters =
                         StopDetailsPageFilters(
@@ -579,7 +580,8 @@ fun MapAndSheetPage(
                     }
                 }
 
-                composable<SheetRoutes.RoutePicker>(typeMap = SheetRoutes.typeMap) { backStackEntry ->
+                composable<SheetRoutes.RoutePicker>(typeMap = SheetRoutes.typeMap) { backStackEntry
+                    ->
                     val navRoute: SheetRoutes.RoutePicker = backStackEntry.toRoute()
 
                     LaunchedEffect(Unit) {
@@ -594,32 +596,34 @@ fun MapAndSheetPage(
                             onOpenPickerPath = { newPath, context ->
                                 val currentPickerRoute =
                                     navController.currentRouteAs(SheetRoutes.RoutePicker::class)
-                                if (currentPickerRoute == null || currentPickerRoute.path != newPath) {
+                                if (
+                                    currentPickerRoute == null || currentPickerRoute.path != newPath
+                                ) {
                                     navController.navigate(
-                                        SheetRoutes.RoutePicker(
-                                            newPath,
-                                            context
-                                        )
+                                        SheetRoutes.RoutePicker(newPath, context)
                                     )
                                 }
                             },
                             onOpenRouteDetails = ::handlePickRouteNavigation,
                             onRouteSearchExpandedChange = ::handleRouteSearchExpandedChange,
                             onBack = onBack@{
-                                val currentPickerRoute =
-                                    navController.currentRouteAs(SheetRoutes.RoutePicker::class)
-                                        ?: return@onBack
-                                if (currentPickerRoute.path != RoutePickerPath.Root) {
-                                    navController.popBackStackFrom(SheetRoutes.RoutePicker::class)
-                                }
-                            },
+                                    val currentPickerRoute =
+                                        navController.currentRouteAs(SheetRoutes.RoutePicker::class)
+                                            ?: return@onBack
+                                    if (currentPickerRoute.path != RoutePickerPath.Root) {
+                                        navController.popBackStackFrom(
+                                            SheetRoutes.RoutePicker::class
+                                        )
+                                    }
+                                },
                             onClose = { navigateToEntrypointFrom(SheetRoutes.RoutePicker::class) },
                             errorBannerViewModel = errorBannerViewModel,
                         )
                     }
                 }
 
-                composable<SheetRoutes.RouteDetails>(typeMap = SheetRoutes.typeMap) { backStackEntry ->
+                composable<SheetRoutes.RouteDetails>(typeMap = SheetRoutes.typeMap) { backStackEntry
+                    ->
                     val navRoute: SheetRoutes.RouteDetails = backStackEntry.toRoute()
 
                     val lineOrRoute = nearbyTransit.globalResponse?.getLineOrRoute(navRoute.routeId)
@@ -646,7 +650,8 @@ fun MapAndSheetPage(
                 }
 
                 composable<SheetRoutes.NearbyTransit>(typeMap = SheetRoutes.typeMap) {
-                    // for ViewModel reasons, must be within the `composable` to be the same instance
+                    // for ViewModel reasons, must be within the `composable` to be the same
+                    // instance
                     val nearbyViewModel: NearbyTransitViewModel = koinViewModel()
                     LaunchedEffect(Unit) {
                         if (!navBarVisible && !searchExpanded) showNavBar()
@@ -659,11 +664,7 @@ fun MapAndSheetPage(
                             onOpenStopDetails = { stopId, filter ->
                                 updateVisitHistory(stopId)
                                 navController.navigate(
-                                    SheetRoutes.StopDetails(
-                                        stopId,
-                                        filter,
-                                        null
-                                    )
+                                    SheetRoutes.StopDetails(stopId, filter, null)
                                 )
                             },
                             openSearch = ::openSearch,
@@ -679,7 +680,7 @@ fun MapAndSheetPage(
         // when not fully expanded https://stackoverflow.com/a/77361483
         BarAndToastScaffold(
             bottomBar = bottomBar,
-            contentWindowInsets = WindowInsets(top = 0.dp)
+            contentWindowInsets = WindowInsets(top = 0.dp),
         ) { outerSheetPadding ->
             val showSearchBar = remember(currentNavEntry) { currentNavEntry?.showSearchBar ?: true }
             if (hideMaps) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -78,7 +78,6 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.currentRouteAs
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
-import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.android.util.navigateFrom
 import com.mbta.tid.mbta_app.android.util.plus
 import com.mbta.tid.mbta_app.android.util.popBackStackFrom
@@ -440,10 +439,7 @@ fun MapAndSheetPage(
     fun LoadingSheetContents() {
         CompositionLocalProvider(IsLoadingSheetContents provides true) {
             SheetPage {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.loadingShimmer(),
-                ) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     SheetHeader(title = stringResource(R.string.nearby_transit))
                     ErrorBanner(errorBannerViewModel)
                     RouteCardList(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -192,7 +192,6 @@ fun MapAndSheetPage(
                     currentNavEntry.stopFilter,
                     currentNavEntry.tripFilter,
                 )
-
             else -> null
         })
     val stopDetailsVM =
@@ -315,7 +314,6 @@ fun MapAndSheetPage(
                         currentNavEntry.stopFilter,
                         currentNavEntry.tripFilter,
                     )
-
                 else -> null
             } ?: return
         if (stopFilter == null || tripFilter?.tripId == tripId) return
@@ -349,7 +347,6 @@ fun MapAndSheetPage(
 
     fun navigateToEntrypoint(entrypoint: SheetRoutes.Entrypoint) {
         try {
-            Log.i("KB", "navigateToEntrypoint ${entrypoint}")
             navController.navigate(entrypoint, popUp)
         } catch (e: IllegalStateException) {
             // This should only happen in tests when the navigation graph hasn't been initialized
@@ -377,7 +374,6 @@ fun MapAndSheetPage(
         backgroundTimestamp?.let {
             val timeSinceBackground = clock.now().minus(Instant.fromEpochMilliseconds(it))
             if (timeSinceBackground > 1.hours && sheetNavEntrypoint != null) {
-                Log.i("KB", "lifeCycleResume navigateToEntrypoint")
                 navigateToEntrypoint(sheetNavEntrypoint)
                 if (nearbyTransit.locationDataManager.hasPermission) {
                     coroutineScope.launch { nearbyTransit.viewportProvider.follow() }
@@ -397,8 +393,6 @@ fun MapAndSheetPage(
 
     LaunchedEffect(sheetNavEntrypoint) {
         if (sheetNavEntrypoint != null && previousNavEntry != null) {
-            Log.i("KB", "sheetNavEntrypoint changed navigateToEntrypoint")
-
             navigateToEntrypoint(sheetNavEntrypoint)
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
@@ -33,7 +33,7 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
      * loading in the background if the cache is empty.
      *
      * Will not automatically see changes made directly to the [settingsRepository]; make sure all
-     * changes are made via [set]. Defaults to fallse if setting not yet loaded
+     * changes are made via [set]. Defaults to false if setting not yet loaded
      */
     @Composable
     fun get(setting: Settings): Boolean {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
@@ -33,10 +33,23 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
      * loading in the background if the cache is empty.
      *
      * Will not automatically see changes made directly to the [settingsRepository]; make sure all
-     * changes are made via [set].
+     * changes are made via [set]. Defaults to fallse if setting not yet loaded
      */
     @Composable
     fun get(setting: Settings): Boolean {
+
+        return getNullable(setting) ?: false
+    }
+
+    /**
+     * Retrieves the value of a [Settings], updating automatically when this cache is updated, and
+     * loading in the background if the cache is empty.
+     *
+     * Will not automatically see changes made directly to the [settingsRepository]; make sure all
+     * changes are made via [set].
+     */
+    @Composable
+    fun getNullable(setting: Settings): Boolean? {
         val cachedData by cache.collectAsState()
 
         LaunchedEffect(cachedData == null) {
@@ -45,11 +58,18 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
             }
         }
 
-        return cachedData?.get(setting) ?: false
+        return cachedData?.get(setting)
     }
 
     companion object {
         /** Gets the value of a [setting] from the current Koin context’s [SettingsCache]. */
         @Composable fun get(setting: Settings) = koinInject<SettingsCache>().get(setting)
+
+        /**
+         * Gets the value of a [setting] from the current Koin context’s [SettingsCache]. Returns
+         * null if not yet loaded
+         */
+        @Composable
+        fun getNullable(setting: Settings) = koinInject<SettingsCache>().getNullable(setting)
     }
 }

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -8,7 +8,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual fun viewModelModule() = module {
-    single { FavoritesViewModel(get(), get(named("coroutineDispatcherDefault")), get()) }
+    single { FavoritesViewModel(get(), get(), get(named("coroutineDispatcherDefault")), get()) }
         .bind(IFavoritesViewModel::class)
     viewModel {
         MapViewModel(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -59,7 +59,7 @@ fun appModule(appVariant: AppVariant) = module {
 fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IConfigRepository> { repositories.config }
-        single<ITabPreferencesRepository> { repositories.defaultTab }
+        single<ITabPreferencesRepository> { repositories.tabPreferences }
         single<IErrorBannerStateRepository> { repositories.errorBanner }
         single<IGlobalRepository> { repositories.global }
         single<ILastLaunchedAppVersionRepository> { repositories.lastLaunchedAppVersion }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -58,6 +59,7 @@ fun appModule(appVariant: AppVariant) = module {
 fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IConfigRepository> { repositories.config }
+        single<IDefaultTabRepository> { repositories.defaultTab }
         single<IErrorBannerStateRepository> { repositories.errorBanner }
         single<IGlobalRepository> { repositories.global }
         single<ILastLaunchedAppVersionRepository> { repositories.lastLaunchedAppVersion }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -6,7 +6,6 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
-import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -22,6 +21,7 @@ import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
@@ -59,7 +59,7 @@ fun appModule(appVariant: AppVariant) = module {
 fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IConfigRepository> { repositories.config }
-        single<IDefaultTabRepository> { repositories.defaultTab }
+        single<ITabPreferencesRepository> { repositories.defaultTab }
         single<IErrorBannerStateRepository> { repositories.errorBanner }
         single<IGlobalRepository> { repositories.global }
         single<ILastLaunchedAppVersionRepository> { repositories.lastLaunchedAppVersion }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -91,7 +91,7 @@ interface IRepositories {
     val accessibilityStatus: IAccessibilityStatusRepository?
     val alerts: IAlertsRepository?
     val config: IConfigRepository
-    val defaultTab: ITabPreferencesRepository
+    val tabPreferences: ITabPreferencesRepository
     val currentAppVersion: ICurrentAppVersionRepository?
     val errorBanner: IErrorBannerStateRepository
     val global: IGlobalRepository
@@ -120,7 +120,7 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
     override val currentAppVersion: ICurrentAppVersionRepository by inject()
-    override val defaultTab: ITabPreferencesRepository by inject()
+    override val tabPreferences: ITabPreferencesRepository by inject()
     override val errorBanner: IErrorBannerStateRepository by inject()
     override val global: IGlobalRepository by inject()
     override val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository by inject()
@@ -151,7 +151,7 @@ class RealRepositories : IRepositories {
     override val alerts = null
     override val config = ConfigRepository()
     override val currentAppVersion = null
-    override val defaultTab = TabPreferencesRepository()
+    override val tabPreferences = TabPreferencesRepository()
     override val errorBanner = ErrorBannerStateRepository()
     override val global = GlobalRepository()
     override val lastLaunchedAppVersion = LastLaunchedAppVersionRepository()
@@ -181,7 +181,7 @@ class MockRepositories : IRepositories {
     override var config: IConfigRepository = MockConfigRepository()
     override var currentAppVersion: ICurrentAppVersionRepository =
         MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u))
-    override var defaultTab: ITabPreferencesRepository = MockTabPreferencesRepository()
+    override var tabPreferences: ITabPreferencesRepository = MockTabPreferencesRepository()
     override var errorBanner: IErrorBannerStateRepository = MockErrorBannerStateRepository()
     override var global: IGlobalRepository = IdleGlobalRepository()
     override var lastLaunchedAppVersion: ILastLaunchedAppVersionRepository =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -13,7 +13,6 @@ import com.mbta.tid.mbta_app.model.response.TripResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ConfigRepository
-import com.mbta.tid.mbta_app.repositories.DefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.FavoritesRepository
 import com.mbta.tid.mbta_app.repositories.GlobalRepository
@@ -21,7 +20,6 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
-import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -37,6 +35,7 @@ import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
@@ -54,7 +53,6 @@ import com.mbta.tid.mbta_app.repositories.MockAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
 import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
-import com.mbta.tid.mbta_app.repositories.MockDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -68,6 +66,7 @@ import com.mbta.tid.mbta_app.repositories.MockScheduleRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockStopRepository
+import com.mbta.tid.mbta_app.repositories.MockTabPreferencesRepository
 import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockTripRepository
 import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
@@ -82,6 +81,7 @@ import com.mbta.tid.mbta_app.repositories.SearchResultRepository
 import com.mbta.tid.mbta_app.repositories.SentryRepository
 import com.mbta.tid.mbta_app.repositories.SettingsRepository
 import com.mbta.tid.mbta_app.repositories.StopRepository
+import com.mbta.tid.mbta_app.repositories.TabPreferencesRepository
 import com.mbta.tid.mbta_app.repositories.TripRepository
 import com.mbta.tid.mbta_app.repositories.VisitHistoryRepository
 import org.koin.core.component.KoinComponent
@@ -91,7 +91,7 @@ interface IRepositories {
     val accessibilityStatus: IAccessibilityStatusRepository?
     val alerts: IAlertsRepository?
     val config: IConfigRepository
-    val defaultTab: IDefaultTabRepository
+    val defaultTab: ITabPreferencesRepository
     val currentAppVersion: ICurrentAppVersionRepository?
     val errorBanner: IErrorBannerStateRepository
     val global: IGlobalRepository
@@ -120,7 +120,7 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
     override val currentAppVersion: ICurrentAppVersionRepository by inject()
-    override val defaultTab: IDefaultTabRepository by inject()
+    override val defaultTab: ITabPreferencesRepository by inject()
     override val errorBanner: IErrorBannerStateRepository by inject()
     override val global: IGlobalRepository by inject()
     override val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository by inject()
@@ -151,7 +151,7 @@ class RealRepositories : IRepositories {
     override val alerts = null
     override val config = ConfigRepository()
     override val currentAppVersion = null
-    override val defaultTab = DefaultTabRepository()
+    override val defaultTab = TabPreferencesRepository()
     override val errorBanner = ErrorBannerStateRepository()
     override val global = GlobalRepository()
     override val lastLaunchedAppVersion = LastLaunchedAppVersionRepository()
@@ -181,7 +181,7 @@ class MockRepositories : IRepositories {
     override var config: IConfigRepository = MockConfigRepository()
     override var currentAppVersion: ICurrentAppVersionRepository =
         MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u))
-    override var defaultTab: IDefaultTabRepository = MockDefaultTabRepository()
+    override var defaultTab: ITabPreferencesRepository = MockTabPreferencesRepository()
     override var errorBanner: IErrorBannerStateRepository = MockErrorBannerStateRepository()
     override var global: IGlobalRepository = IdleGlobalRepository()
     override var lastLaunchedAppVersion: ILastLaunchedAppVersionRepository =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -13,6 +13,7 @@ import com.mbta.tid.mbta_app.model.response.TripResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ConfigRepository
+import com.mbta.tid.mbta_app.repositories.DefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.FavoritesRepository
 import com.mbta.tid.mbta_app.repositories.GlobalRepository
@@ -20,6 +21,7 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.IDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -52,6 +54,7 @@ import com.mbta.tid.mbta_app.repositories.MockAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
 import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.MockDefaultTabRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -88,6 +91,7 @@ interface IRepositories {
     val accessibilityStatus: IAccessibilityStatusRepository?
     val alerts: IAlertsRepository?
     val config: IConfigRepository
+    val defaultTab: IDefaultTabRepository
     val currentAppVersion: ICurrentAppVersionRepository?
     val errorBanner: IErrorBannerStateRepository
     val global: IGlobalRepository
@@ -116,6 +120,7 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
     override val currentAppVersion: ICurrentAppVersionRepository by inject()
+    override val defaultTab: IDefaultTabRepository by inject()
     override val errorBanner: IErrorBannerStateRepository by inject()
     override val global: IGlobalRepository by inject()
     override val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository by inject()
@@ -146,6 +151,7 @@ class RealRepositories : IRepositories {
     override val alerts = null
     override val config = ConfigRepository()
     override val currentAppVersion = null
+    override val defaultTab = DefaultTabRepository()
     override val errorBanner = ErrorBannerStateRepository()
     override val global = GlobalRepository()
     override val lastLaunchedAppVersion = LastLaunchedAppVersionRepository()
@@ -175,6 +181,7 @@ class MockRepositories : IRepositories {
     override var config: IConfigRepository = MockConfigRepository()
     override var currentAppVersion: ICurrentAppVersionRepository =
         MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u))
+    override var defaultTab: IDefaultTabRepository = MockDefaultTabRepository()
     override var errorBanner: IErrorBannerStateRepository = MockErrorBannerStateRepository()
     override var global: IGlobalRepository = IdleGlobalRepository()
     override var lastLaunchedAppVersion: ILastLaunchedAppVersionRepository =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -38,7 +38,11 @@ object LoadingPlaceholders {
                 typicality = RoutePattern.Typicality.Typical
                 directionId = 1
             }
-        val stop = objects.stop { name = "Loading" }
+        val stop =
+            objects.stop {
+                name = "Loading"
+                wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+            }
 
         fun newTrip(routePattern: RoutePattern, departsIn: Duration): UpcomingTrip {
             val trip = objects.trip(routePattern)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DefaultTabRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DefaultTabRepository.kt
@@ -1,0 +1,50 @@
+package com.mbta.tid.mbta_app.repositories
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+enum class DefaultTab {
+    Favorites,
+    Nearby,
+}
+
+interface IDefaultTabRepository {
+
+    suspend fun getDefaultTab(): DefaultTab
+
+    suspend fun setDefaultTab(defaultTab: DefaultTab)
+
+    suspend fun hasSeenFavorites(): Boolean
+
+    suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean)
+}
+
+class DefaultTabRepository : IDefaultTabRepository, KoinComponent {
+    private val dataStore: DataStore<Preferences> by inject()
+
+    private val defaultTabKey = stringPreferencesKey("default_tab")
+    private val hasSeenFavoritesKey = stringPreferencesKey("has_seen_favoirtes")
+
+    override suspend fun getDefaultTab(): DefaultTab {
+        return dataStore.data.map { it[defaultTabKey] }.first()?.let { DefaultTab.valueOf(it) }
+            ?: DefaultTab.Favorites
+    }
+
+    override suspend fun setDefaultTab(defaultTab: DefaultTab) {
+        dataStore.edit { it[defaultTabKey] = defaultTab.name }
+    }
+
+    override suspend fun hasSeenFavorites(): Boolean {
+        return dataStore.data.map { it[hasSeenFavoritesKey] }.first()?.let { it == "true" } ?: false
+    }
+
+    override suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean) {
+        dataStore.edit { it[hasSeenFavoritesKey] = hasSeenFavorites.toString() }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -14,7 +14,7 @@ enum class DefaultTab {
     Nearby,
 }
 
-interface IDefaultTabRepository {
+interface ITabPreferencesRepository {
 
     suspend fun getDefaultTab(): DefaultTab
 
@@ -25,7 +25,7 @@ interface IDefaultTabRepository {
     suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean)
 }
 
-class DefaultTabRepository : IDefaultTabRepository, KoinComponent {
+class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     private val defaultTabKey = stringPreferencesKey("default_tab")
@@ -49,7 +49,7 @@ class DefaultTabRepository : IDefaultTabRepository, KoinComponent {
     }
 }
 
-class MockDefaultTabRepository : IDefaultTabRepository {
+class MockTabPreferencesRepository : ITabPreferencesRepository {
     override suspend fun getDefaultTab(): DefaultTab {
         return DefaultTab.Nearby
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -10,16 +10,9 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-enum class DefaultTab {
-    Favorites,
-    Nearby;
-
-    fun toEntrypoint(): SheetRoutes.Entrypoint {
-        return when (this) {
-            Favorites -> SheetRoutes.Favorites
-            Nearby -> SheetRoutes.NearbyTransit
-        }
-    }
+enum class DefaultTab(val entrypoint: SheetRoutes.Entrypoint) {
+    Favorites(SheetRoutes.Favorites),
+    Nearby(SheetRoutes.NearbyTransit),
 }
 
 interface ITabPreferencesRepository {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.repositories
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.mbta.tid.mbta_app.model.SheetRoutes
@@ -28,33 +27,20 @@ interface ITabPreferencesRepository {
     suspend fun getDefaultTab(): DefaultTab
 
     suspend fun setDefaultTab(defaultTab: DefaultTab)
-
-    suspend fun hasSeenFavorites(): Boolean
-
-    suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean)
 }
 
 class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     private val defaultTabKey = stringPreferencesKey("default_tab")
-    private val hasSeenFavoritesKey = booleanPreferencesKey("has_seen_favorites")
 
     override suspend fun getDefaultTab(): DefaultTab {
         return dataStore.data.map { it[defaultTabKey] }.first()?.let { DefaultTab.valueOf(it) }
-            ?: DefaultTab.Favorites
+            ?: DefaultTab.Nearby
     }
 
     override suspend fun setDefaultTab(defaultTab: DefaultTab) {
         dataStore.edit { it[defaultTabKey] = defaultTab.name }
-    }
-
-    override suspend fun hasSeenFavorites(): Boolean {
-        return dataStore.data.map { it[hasSeenFavoritesKey] }.first() ?: false
-    }
-
-    override suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean) {
-        dataStore.edit { it[hasSeenFavoritesKey] = hasSeenFavorites }
     }
 }
 
@@ -64,10 +50,4 @@ class MockTabPreferencesRepository : ITabPreferencesRepository {
     }
 
     override suspend fun setDefaultTab(defaultTab: DefaultTab) {}
-
-    override suspend fun hasSeenFavorites(): Boolean {
-        return true
-    }
-
-    override suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean) {}
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.repositories
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
@@ -29,7 +30,7 @@ class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     private val defaultTabKey = stringPreferencesKey("default_tab")
-    private val hasSeenFavoritesKey = stringPreferencesKey("has_seen_favoirtes")
+    private val hasSeenFavoritesKey = booleanPreferencesKey("has_seen_favorites")
 
     override suspend fun getDefaultTab(): DefaultTab {
         return dataStore.data.map { it[defaultTabKey] }.first()?.let { DefaultTab.valueOf(it) }
@@ -41,11 +42,11 @@ class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     }
 
     override suspend fun hasSeenFavorites(): Boolean {
-        return dataStore.data.map { it[hasSeenFavoritesKey] }.first()?.let { it == "true" } ?: false
+        return dataStore.data.map { it[hasSeenFavoritesKey] }.first() ?: false
     }
 
     override suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean) {
-        dataStore.edit { it[hasSeenFavoritesKey] = hasSeenFavorites.toString() }
+        dataStore.edit { it[hasSeenFavoritesKey] = hasSeenFavorites }
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.mbta.tid.mbta_app.model.SheetRoutes
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
@@ -12,7 +13,14 @@ import org.koin.core.component.inject
 
 enum class DefaultTab {
     Favorites,
-    Nearby,
+    Nearby;
+
+    fun toEntrypoint(): SheetRoutes.Entrypoint {
+        return when (this) {
+            Favorites -> SheetRoutes.Favorites
+            Nearby -> SheetRoutes.NearbyTransit
+        }
+    }
 }
 
 interface ITabPreferencesRepository {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -48,3 +48,17 @@ class DefaultTabRepository : IDefaultTabRepository, KoinComponent {
         dataStore.edit { it[hasSeenFavoritesKey] = hasSeenFavorites.toString() }
     }
 }
+
+class MockDefaultTabRepository : IDefaultTabRepository {
+    override suspend fun getDefaultTab(): DefaultTab {
+        return DefaultTab.Nearby
+    }
+
+    override suspend fun setDefaultTab(defaultTab: DefaultTab) {}
+
+    override suspend fun hasSeenFavorites(): Boolean {
+        return true
+    }
+
+    override suspend fun setHasSeenFavorites(hasSeenFavorites: Boolean) {}
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -12,7 +12,12 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+<<<<<<< HEAD
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
+=======
+import com.mbta.tid.mbta_app.repositories.DefaultTab
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
+>>>>>>> aae8ab3f1 (refactor: Move recording hasSeenFavorites into FavoritesVM)
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
@@ -49,6 +54,7 @@ interface IFavoritesViewModel {
 
 class FavoritesViewModel(
     private val favoritesUsecases: FavoritesUsecases,
+    private val tabPreferencesRepository: ITabPreferencesRepository,
     private val coroutineDispatcher: CoroutineDispatcher,
     private val analytics: Analytics,
 ) : MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
@@ -122,6 +128,12 @@ class FavoritesViewModel(
             val fetchedFavorites = favoritesUsecases.getRouteStopDirectionFavorites()
             favorites = fetchedFavorites
             analytics.recordSession(fetchedFavorites.count())
+            val hasSeenFavoritesPrior = tabPreferencesRepository.hasSeenFavorites()
+            if (!hasSeenFavoritesPrior) {
+                // first time seeing favorites, default to nearby going forward
+                tabPreferencesRepository.setHasSeenFavorites(true)
+                tabPreferencesRepository.setDefaultTab(DefaultTab.Nearby)
+            }
         }
 
         LaunchedEffect(Unit) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -125,12 +125,8 @@ class FavoritesViewModel(
             val fetchedFavorites = favoritesUsecases.getRouteStopDirectionFavorites()
             favorites = fetchedFavorites
             analytics.recordSession(fetchedFavorites.count())
-            val hasSeenFavoritesPrior = tabPreferencesRepository.hasSeenFavorites()
-            if (!hasSeenFavoritesPrior) {
-                // first time seeing favorites, default to nearby going forward
-                tabPreferencesRepository.setHasSeenFavorites(true)
-                tabPreferencesRepository.setDefaultTab(DefaultTab.Nearby)
-            }
+            // first time seeing favorites, default to nearby going forward
+            tabPreferencesRepository.setDefaultTab(DefaultTab.Nearby)
         }
 
         LaunchedEffect(Unit) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -12,12 +12,9 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-<<<<<<< HEAD
-import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
-=======
 import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
->>>>>>> aae8ab3f1 (refactor: Move recording hasSeenFavorites into FavoritesVM)
+import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -11,7 +11,6 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
-import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
@@ -22,19 +22,19 @@ class TabPreferencesRepositoryTest {
     }
 
     @Test
-    fun testDefaultTabIsFavorites() = runBlocking {
+    fun testDefaultTabIsNearby() = runBlocking {
         startKoinWithPreferences(preferencesOf())
         val repo = TabPreferencesRepository()
-        assertEquals(DefaultTab.Favorites, repo.getDefaultTab())
+        assertEquals(DefaultTab.Nearby, repo.getDefaultTab())
     }
 
     @Test
     fun testReadsDefaultTab() = runBlocking {
         startKoinWithPreferences(
-            preferencesOf(stringPreferencesKey("default_tab") to DefaultTab.Nearby.name)
+            preferencesOf(stringPreferencesKey("default_tab") to DefaultTab.Favorites.name)
         )
         val repo = TabPreferencesRepository()
-        assertEquals(DefaultTab.Nearby, repo.getDefaultTab())
+        assertEquals(DefaultTab.Favorites, repo.getDefaultTab())
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
@@ -1,0 +1,64 @@
+package com.mbta.tid.mbta_app.repositories
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.preferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.mbta.tid.mbta_app.mocks.MockDatastoreStorage
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+class TabPreferencesRepositoryTest {
+
+    @AfterTest
+    fun cleanup() {
+        stopKoin()
+    }
+
+    @Test
+    fun testDefaultTabIsFavorites() = runBlocking {
+        startKoinWithPreferences(preferencesOf())
+        val repo = TabPreferencesRepository()
+        assertEquals(DefaultTab.Favorites, repo.getDefaultTab())
+    }
+
+    @Test
+    fun testReadsDefaultTab() = runBlocking {
+        startKoinWithPreferences(
+            preferencesOf(stringPreferencesKey("default_tab") to DefaultTab.Nearby.name)
+        )
+        val repo = TabPreferencesRepository()
+        assertEquals(DefaultTab.Nearby, repo.getDefaultTab())
+    }
+
+    @Test
+    fun testSetDefaultTab() = runBlocking {
+        startKoinWithPreferences(
+            preferencesOf(stringPreferencesKey("default_tab") to DefaultTab.Nearby.name)
+        )
+        val repo = TabPreferencesRepository()
+        repo.setDefaultTab(DefaultTab.Favorites)
+        assertEquals(DefaultTab.Favorites, repo.getDefaultTab())
+    }
+
+    @Test
+    fun testHasSeenFavorites() = runBlocking {
+        startKoinWithPreferences(preferencesOf(booleanPreferencesKey("has_seen_favorites") to true))
+        val repo = TabPreferencesRepository()
+        assertEquals(true, repo.hasSeenFavorites())
+    }
+
+    fun startKoinWithPreferences(preferences: Preferences) {
+        val storage = MockDatastoreStorage()
+        storage.preferences = preferences
+        val dataStore = DataStoreFactory.create(storage)
+        startKoin { modules(module { single<DataStore<Preferences>> { dataStore } }) }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepositoryTest.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.preferencesOf
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.mbta.tid.mbta_app.mocks.MockDatastoreStorage
@@ -46,13 +45,6 @@ class TabPreferencesRepositoryTest {
         val repo = TabPreferencesRepository()
         repo.setDefaultTab(DefaultTab.Favorites)
         assertEquals(DefaultTab.Favorites, repo.getDefaultTab())
-    }
-
-    @Test
-    fun testHasSeenFavorites() = runBlocking {
-        startKoinWithPreferences(preferencesOf(booleanPreferencesKey("has_seen_favorites") to true))
-        val repo = TabPreferencesRepository()
-        assertEquals(true, repo.hasSeenFavorites())
     }
 
     fun startKoinWithPreferences(preferences: Preferences) {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -175,9 +175,8 @@ class FavoritesViewModelTest : KoinTest {
     }
 
     @Test
-    fun `sets default tab to nearby if first time seeing favorites`() = runTest {
+    fun `sets default tab to nearby`() = runTest {
         val mockTabPreferencesRepo = mock<ITabPreferencesRepository>(MockMode.autofill)
-        everySuspend { mockTabPreferencesRepo.hasSeenFavorites() } returns false
 
         val dispatcher = StandardTestDispatcher(testScheduler)
         setUpKoin(objects, dispatcher) {
@@ -201,10 +200,7 @@ class FavoritesViewModelTest : KoinTest {
             }
         }
 
-        verifySuspend {
-            mockTabPreferencesRepo.setHasSeenFavorites(true)
-            mockTabPreferencesRepo.setDefaultTab(DefaultTab.Nearby)
-        }
+        verifySuspend { mockTabPreferencesRepo.setDefaultTab(DefaultTab.Nearby) }
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -13,7 +13,9 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
+import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
+import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
@@ -23,6 +25,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.answering.sequentially
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import dev.mokkery.verifySuspend
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -168,6 +171,39 @@ class FavoritesViewModelTest : KoinTest {
                 ),
                 awaitItem(),
             )
+        }
+    }
+
+    @Test
+    fun `sets default tab to nearby if first time seeing favorites`() = runTest {
+        val mockTabPreferencesRepo = mock<ITabPreferencesRepository>(MockMode.autofill)
+        everySuspend { mockTabPreferencesRepo.hasSeenFavorites() } returns false
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        setUpKoin(objects, dispatcher) {
+            favorites = MockFavoritesRepository(Favorites(emptySet()))
+            tabPreferences = mockTabPreferencesRepo
+        }
+        val viewModel: FavoritesViewModel = get()
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+        viewModel.setNow(Clock.System.now())
+        viewModel.setLocation(stop1.position)
+
+        testViewModelFlow(viewModel).test {
+            awaitItemSatisfying {
+                it ==
+                    FavoritesViewModel.State(
+                        awaitingPredictionsAfterBackground = false,
+                        favorites = emptySet(),
+                        routeCardData = emptyList(),
+                        staticRouteCardData = emptyList(),
+                    )
+            }
+        }
+
+        verifySuspend {
+            mockTabPreferencesRepo.setHasSeenFavorites(true)
+            mockTabPreferencesRepo.setDefaultTab(DefaultTab.Nearby)
         }
     }
 

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -5,7 +5,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 actual fun viewModelModule() = module {
-    single { FavoritesViewModel(get(), get(named("coroutineDispatcherDefault")), get()) }
+    single { FavoritesViewModel(get(), get(), get(named("coroutineDispatcherDefault")), get()) }
     single {
         MapViewModel(
             get(),

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -6,7 +6,7 @@ import org.koin.dsl.bind
 import org.koin.dsl.module
 
 actual fun viewModelModule() = module {
-    single { FavoritesViewModel(get(), get(named("coroutineDispatcherDefault")), get()) }
+    single { FavoritesViewModel(get(), get(), get(named("coroutineDispatcherDefault")), get()) }
     single {
         MapViewModel(
             get(),


### PR DESCRIPTION
### Summary

_Ticket:_ [ 🤖 | Favorites | Default to favorites first time only](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210767320164830?focus=true)

What is this PR for?

This PR includes the android implementation for defaulting to favorites the first time only. As [discussed in slack](https://mbta.slack.com/archives/C062QNAJZ2M/p1753384488495949), using a new repo to determine whether the user has viewed favorites or not rather than tying it to the launch promo. 

There was a bit of UI jankiness to work through for this new loading state on android, so breaking it off here for review before addressing possible UI jank on the iOS side. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests
* Ran locally, simulating version 2.0.0 with enhancedFavorites setting forced to true. Confirmed that favorites is shown by default the first time, but not the second time.
https://github.com/user-attachments/assets/b5be686c-bb44-437e-a2ae-e83cb6b1a5c9

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
