### PR TITLE
fix: Filter favorites during route card creation

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -655,6 +655,7 @@ data class RouteCardData(
             now: Instant,
             pinnedRoutes: Set<String>,
             context: Context,
+            favorites: Set<RouteStopDirection>? = null,
             coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
         ): List<RouteCardData>? =
             withContext(coroutineDispatcher) {
@@ -678,7 +679,7 @@ data class RouteCardData(
                 val allDataLoaded = schedules != null
 
                 ListBuilder(allDataLoaded, context, now)
-                    .addStaticStopsData(stopIds, globalData, context)
+                    .addStaticStopsData(stopIds, globalData, context, favorites)
                     .addUpcomingTrips(schedules, predictions, now, globalData)
                     .filterIrrelevantData(now, cutoffTime, context, globalData)
                     .addAlerts(
@@ -706,6 +707,7 @@ data class RouteCardData(
             context: Context,
             now: Instant = Clock.System.now(),
             sortByDistanceFrom: Position? = null,
+            favorites: Set<RouteStopDirection>? = null,
             coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
         ): List<RouteCardData>? =
             withContext(coroutineDispatcher) {
@@ -714,7 +716,7 @@ data class RouteCardData(
                 if (globalData == null) return@withContext null
 
                 ListBuilder(true, context, now)
-                    .addStaticStopsData(stopIds, globalData, context)
+                    .addStaticStopsData(stopIds, globalData, context, favorites)
                     // We don't need alerts here, this is just to satisfy the null check
                     .addAlerts(
                         alerts = AlertsStreamDataResponse(emptyMap()),
@@ -757,6 +759,7 @@ data class RouteCardData(
             stopIds: List<String>,
             globalData: GlobalResponse,
             context: Context,
+            favorites: Set<RouteStopDirection>?,
         ): ListBuilder {
 
             val parentToAllStops = Stop.resolvedParentToAllStops(stopIds, globalData)
@@ -766,6 +769,7 @@ data class RouteCardData(
                     parentToAllStops,
                     globalData,
                     context,
+                    favorites,
                 )
 
             val builderData =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -11,7 +11,6 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
-import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
@@ -166,7 +165,7 @@ class FavoritesViewModel(
             } else if (stopIds.isEmpty()) {
                 routeCardData = emptyList()
             } else {
-                val loadedRouteCardData =
+                routeCardData =
                     RouteCardData.routeCardsForStopList(
                         stopIds,
                         globalData,
@@ -177,9 +176,9 @@ class FavoritesViewModel(
                         now,
                         emptySet(),
                         RouteCardData.Context.Favorites,
+                        favorites,
                         coroutineDispatcher,
                     )
-                routeCardData = filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }
         }
 
@@ -189,7 +188,7 @@ class FavoritesViewModel(
             } else if (stopIds.isEmpty()) {
                 staticRouteCardData = emptyList()
             } else {
-                val loadedRouteCardData =
+                staticRouteCardData =
                     RouteCardData.routeCardsForStaticStopList(
                         stopIds,
                         globalData,
@@ -197,10 +196,9 @@ class FavoritesViewModel(
                         // not depending on now because it only matters for testing
                         now,
                         location,
+                        favorites,
                         coroutineDispatcher,
                     )
-                staticRouteCardData =
-                    filterRouteAndDirection(loadedRouteCardData, globalData, favorites)
             }
         }
 
@@ -234,36 +232,6 @@ class FavoritesViewModel(
         defaultDirection: Int,
     ) {
         fireEvent(Event.UpdateFavorites(updatedFavorites, context, defaultDirection))
-    }
-
-    companion object {
-        fun filterRouteAndDirection(
-            routeCardData: List<RouteCardData>?,
-            global: GlobalResponse,
-            favorites: Set<RouteStopDirection>?,
-        ): List<RouteCardData>? {
-            return routeCardData
-                ?.map { data ->
-                    val filteredStopData =
-                        data.stopData
-                            .map { stopData ->
-                                val filteredLeafData =
-                                    stopData.data.filter { leafData ->
-                                        val routeStopDirection =
-                                            RouteStopDirection(
-                                                leafData.lineOrRoute.id,
-                                                leafData.stop.resolveParent(global).id,
-                                                leafData.directionId,
-                                            )
-                                        favorites?.contains(routeStopDirection) == true
-                                    }
-                                stopData.copy(data = filteredLeafData)
-                            }
-                            .filter { it.data.isNotEmpty() }
-                    data.copy(stopData = filteredStopData)
-                }
-                ?.filter { it.stopData.any { it.data.isNotEmpty() } }
-        }
     }
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Favorites | Investigate favorites ordering further stops above closer ones](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210846540627388?focus=true)

We were seeing an issue where some routes in favorites were being sorted higher than other routes when their closest stop was further away. This was happening when there was a favorite at a closer stop which also served the further route (ex, with a location set near Harvard, the 71 bus at Harvard would cause RL at Park to be sorted to the top). 

This was caused because we were performing the full route card creation (and sorting) with every route at any favorited stop, then filtering the route card data down at within the favorites VM to the actual set of favorites. After this change, the filtering at the end is removed, and irrelevant patterns are filtered out at the first opportunity, within `addStaticStopsData`.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for updated behavior.