### PR TITLE
chore: route branching cleanup

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -45,9 +45,9 @@ class CollapsableStopListTest {
             CollapsableStopList(
                 RouteCardData.LineOrRoute.Route(mainRoute),
                 segment =
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop1,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -94,15 +94,15 @@ class CollapsableStopListTest {
             CollapsableStopList(
                 RouteCardData.LineOrRoute.Route(mainRoute),
                 segment =
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop1,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
                                 connectingRoutes = emptyList(),
                             ),
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop2,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StickDiagram.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StickDiagram.kt
@@ -84,6 +84,10 @@ private fun Path.lineTo(point: SharedPath.Point) {
     lineTo(point.x, point.y)
 }
 
+private fun Path.quadraticTo(control: SharedPath.Point, to: SharedPath.Point) {
+    quadraticTo(control.x, control.y, to.x, to.y)
+}
+
 private fun Path.cubicTo(
     control1: SharedPath.Point,
     control2: SharedPath.Point,
@@ -105,7 +109,7 @@ fun RouteLineTwist(
     Box(
         modifier.width(40.dp).height(IntrinsicSize.Max).drawWithCache {
             onDrawBehind {
-                val shadowColor = lerp(color, Color.Companion.Black, 0.15f)
+                val shadowColor = lerp(color, Color.Companion.Black, 0.15f * proportionClosed)
                 for ((connection, isTwisted) in connections) {
                     if (isTwisted) {
                         // we need to draw the shadow, then the curves with round caps, then the
@@ -138,17 +142,14 @@ fun RouteLineTwist(
                                         lineTo(shape.curves.bottomCurveStart)
                                     }
                                 }
-                                cubicTo(
-                                    shape.curves.bottomCurveStartControl,
-                                    shape.curves.bottomNearTwistControl,
-                                    shape.curves.bottomNearTwist,
+                                quadraticTo(
+                                    shape.curves.bottomCurveControl,
+                                    shape.curves.shadowStart,
                                 )
                                 lineTo(shape.curves.shadowStart)
                                 moveTo(shape.curves.shadowEnd)
-                                lineTo(shape.curves.topNearTwist)
-                                cubicTo(
-                                    shape.curves.topNearTwistControl,
-                                    shape.curves.topCurveStartControl,
+                                quadraticTo(
+                                    shape.curves.topCurveControl,
                                     shape.curves.topCurveStart,
                                 )
                                 when (val top = shape.curves.top) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -37,12 +37,12 @@ import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 @Composable
 fun CollapsableStopList(
     lineOrRoute: RouteCardData.LineOrRoute,
-    segment: RouteDetailsStopList.NewSegment,
-    onClick: (RouteDetailsStopList.NewEntry) -> Unit,
-    onClickLabel: @Composable (RouteDetailsStopList.NewEntry) -> String? = { null },
+    segment: RouteDetailsStopList.Segment,
+    onClick: (RouteDetailsStopList.Entry) -> Unit,
+    onClickLabel: @Composable (RouteDetailsStopList.Entry) -> String? = { null },
     isFirstSegment: Boolean = false,
     isLastSegment: Boolean = false,
-    rightSideContent: @Composable RowScope.(RouteDetailsStopList.NewEntry, Modifier) -> Unit,
+    rightSideContent: @Composable RowScope.(RouteDetailsStopList.Entry, Modifier) -> Unit,
 ) {
 
     var stopsExpanded by rememberSaveable { mutableStateOf(false) }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -118,7 +118,7 @@ fun RouteStopListView(
 
     val stopList =
         rememberSuspend(selectedRouteId, selectedDirection, routeStops, globalData) {
-            RouteDetailsStopList.fromNewPieces(
+            RouteDetailsStopList.fromPieces(
                 selectedRouteId,
                 selectedDirection,
                 routeStops,
@@ -165,7 +165,7 @@ fun LoadingRouteStopListView(
             selectedRouteId = mockRoute.id,
             setRouteId = {},
             routes = listOf(mockRoute.route),
-            stopList = RouteDetailsStopList(0, listOf(), null),
+            stopList = RouteDetailsStopList(0, listOf()),
             context = context,
             globalData = GlobalResponse(objects),
             onClick = {},
@@ -379,17 +379,16 @@ private fun RouteStops(
         horizontalAlignment = Alignment.Start,
         scrollEnabled = !loading,
     ) {
-        val segments = stopList.newSegments.orEmpty()
-        val hasTypicalSegment = segments.any { it.isTypical }
+        val hasTypicalSegment = stopList.segments.any { it.isTypical }
 
-        segments.forEachIndexed { segmentIndex, segment ->
+        stopList.segments.forEachIndexed { segmentIndex, segment ->
             if (segment.isTypical || !hasTypicalSegment) {
                 segment.stops.forEachIndexed { stopIndex, stop ->
                     val stopPlacement =
                         StopPlacement(
                             isFirst = segmentIndex == 0 && stopIndex == 0,
                             isLast =
-                                segmentIndex == segments.lastIndex &&
+                                segmentIndex == stopList.segments.lastIndex &&
                                     stopIndex == segment.stops.lastIndex,
                         )
 
@@ -417,7 +416,7 @@ private fun RouteStops(
                     onClick = { onTapStop(stopRowContext(it.stop)) },
                     onClickLabel = { onClickLabel(stopRowContext(it.stop)) },
                     segmentIndex == 0,
-                    segmentIndex == segments.lastIndex,
+                    segmentIndex == stopList.segments.lastIndex,
                 ) { stop, modifier ->
                     rightSideContent(stopRowContext(stop.stop), modifier)
                 }
@@ -512,11 +511,10 @@ private fun RouteStopsPreview() {
         RouteCardData.LineOrRoute.Route(TestData.getRoute("Red")),
         RouteDetailsStopList(
             0,
-            null,
             listOf(
-                RouteDetailsStopList.NewSegment(
+                RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             TestData.getStop("place-alfcl"),
                             RouteBranchSegment.Lane.Center,
                             RouteBranchSegment.StickConnection.forward(
@@ -527,7 +525,7 @@ private fun RouteStopsPreview() {
                             ),
                             emptyList(),
                         ),
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             TestData.getStop("place-jfk"),
                             RouteBranchSegment.Lane.Center,
                             listOf(
@@ -561,9 +559,9 @@ private fun RouteStopsPreview() {
                     ),
                     isTypical = true,
                 ),
-                RouteDetailsStopList.NewSegment(
+                RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             TestData.getStop("place-asmnl"),
                             RouteBranchSegment.Lane.Left,
                             RouteBranchSegment.StickConnection.forward(
@@ -583,9 +581,9 @@ private fun RouteStopsPreview() {
                     ),
                     isTypical = true,
                 ),
-                RouteDetailsStopList.NewSegment(
+                RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             TestData.getStop("place-brntn"),
                             RouteBranchSegment.Lane.Right,
                             RouteBranchSegment.StickConnection.forward(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
-import com.mbta.tid.mbta_app.repositories.NewRouteStopsResult
+import com.mbta.tid.mbta_app.repositories.RouteStopsResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,13 +26,13 @@ class RouteStopsFetcher(
         routeId: String,
         directionId: Int,
         errorKey: String,
-        onSuccess: (NewRouteStopsResult) -> Unit,
+        onSuccess: (RouteStopsResult) -> Unit,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
                 errorKey = errorKey,
-                getData = { routeStopsRepository.getNewRouteSegments(routeId, directionId) },
+                getData = { routeStopsRepository.getRouteSegments(routeId, directionId) },
                 onSuccess = { onSuccess(it) },
                 onRefreshAfterError = { getRouteStops(routeId, directionId, errorKey, onSuccess) },
             )
@@ -46,8 +46,8 @@ class RouteStopsViewModel(
 ) : ViewModel() {
 
     private val routeStopsFetcher = RouteStopsFetcher(routeStopsRepository, errorBannerRepository)
-    private val _routeStops = MutableStateFlow<NewRouteStopsResult?>(null)
-    val routeStops: StateFlow<NewRouteStopsResult?> = _routeStops
+    private val _routeStops = MutableStateFlow<RouteStopsResult?>(null)
+    val routeStops: StateFlow<RouteStopsResult?> = _routeStops
 
     fun getRouteStops(routeId: String, directionId: Int, errorKey: String) {
         _routeStops.value = null
@@ -71,7 +71,7 @@ fun getRouteStops(
     errorKey: String,
     routeStopsRepository: IRouteStopsRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
-): NewRouteStopsResult? {
+): RouteStopsResult? {
     val viewModel: RouteStopsViewModel =
         viewModel(
             factory = RouteStopsViewModel.Factory(routeStopsRepository, errorBannerRepository)

--- a/iosApp/iosApp/ComponentViews/RouteLineTwist.swift
+++ b/iosApp/iosApp/ComponentViews/RouteLineTwist.swift
@@ -60,18 +60,12 @@ struct RouteLineTwist: View {
                 } else {
                     $0.move(to: shape.curves.bottomCurveStart.into())
                 }
-                $0.addCurve(
-                    to: shape.curves.bottomNearTwist.into(),
-                    control1: shape.curves.bottomCurveStartControl.into(),
-                    control2: shape.curves.bottomNearTwistControl.into()
-                )
+                $0.addQuadCurve(to: shape.curves.shadowStart.into(), control: shape.curves.bottomCurveControl.into())
                 $0.addLine(to: shape.curves.shadowStart.into())
                 $0.move(to: shape.curves.shadowEnd.into())
-                $0.addLine(to: shape.curves.topNearTwist.into())
-                $0.addCurve(
+                $0.addQuadCurve(
                     to: shape.curves.topCurveStart.into(),
-                    control1: shape.curves.topNearTwistControl.into(),
-                    control2: shape.curves.topCurveStartControl.into()
+                    control: shape.curves.topCurveControl.into()
                 )
                 if let top = shape.curves.top {
                     $0.addLine(to: top.into())
@@ -136,7 +130,7 @@ struct RouteLineTwist: View {
 
     var body: some View {
         let shadowColor = if #available(iOS 18.0, *) {
-            color.mix(with: .black, by: 0.15)
+            color.mix(with: .black, by: 0.15 * Double(proportionClosed))
         } else {
             color
         }
@@ -152,7 +146,10 @@ struct RouteLineTwist: View {
                         .stroke(shadowColor, style: .init(lineWidth: stickWidth, lineCap: .round))
                     if #unavailable(iOS 18.0) {
                         TwistShadowShape(proportionClosed: proportionClosed, connection: connection)
-                            .stroke(.black.opacity(0.15), style: .init(lineWidth: stickWidth, lineCap: .round))
+                            .stroke(
+                                .black.opacity(0.15 * Double(proportionClosed)),
+                                style: .init(lineWidth: stickWidth, lineCap: .round)
+                            )
                     }
                     TwistCurvesShape(proportionClosed: proportionClosed, connection: connection)
                         .stroke(color, style: .init(lineWidth: stickWidth, lineCap: .round, lineJoin: .round))

--- a/iosApp/iosApp/ComponentViews/RouteLineTwist.swift
+++ b/iosApp/iosApp/ComponentViews/RouteLineTwist.swift
@@ -165,14 +165,28 @@ struct RouteLineTwist: View {
     }
 }
 
-#Preview {
-    RouteLineTwist(
-        color: .init(hex: "FFC72C"),
-        proportionClosed: 1,
-        connections: [(
+private struct PreviewHelper: View {
+    @State var proportionClosed: Float = 1
+
+    var body: some View {
+        RouteLineTwist(color: .init(hex: "FFC72C"), proportionClosed: proportionClosed, connections: [(
             .init(fromStop: "", toStop: "", fromLane: .center, toLane: .center, fromVPos: .top, toVPos: .bottom),
             true
-        )]
-    )
-    .frame(height: 60)
+        )])
+        .task {
+            while true {
+                try? await Task.sleep(for: .seconds(1))
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    proportionClosed = 1 - proportionClosed
+                }
+                try? await Task.sleep(for: .milliseconds(500))
+            }
+        }
+    }
+}
+
+#Preview {
+    PreviewHelper()
+        .frame(height: 60)
+        .scaleEffect(6)
 }

--- a/iosApp/iosApp/ComponentViews/StickDiagram.swift
+++ b/iosApp/iosApp/ComponentViews/StickDiagram.swift
@@ -32,37 +32,20 @@ struct StickDiagram: View {
                 case .shuttle: (color, StrokeStyle(lineWidth: 4, dash: [8, 8], dashPhase: 14))
                 case .suspension: (Color.deemphasized, StrokeStyle(lineWidth: 4, dash: [8, 8], dashPhase: 14))
                 }
-                context.stroke(Path {
-                    let fromX = Self.x(connection.fromLane, size: size)
-                    let toX = Self.x(connection.toLane, size: size)
-                    let fromY = Self.y(connection.fromVPos, size: size)
-                    let toY = Self.y(connection.toVPos, size: size)
-                    let controlY = (fromY + toY) / 2
-                    $0.move(to: .init(x: fromX, y: fromY))
+                let shape = StickDiagramShapes.shared.connection(
+                    connection: connection,
+                    rect: .init(minX: 0, maxX: Float(size.width), minY: 0, maxY: Float(size.height))
+                )
+                context.stroke(SwiftUI.Path {
+                    $0.move(to: shape.start.into())
                     $0.addCurve(
-                        to: .init(x: toX, y: toY),
-                        control1: .init(x: fromX, y: controlY),
-                        control2: .init(x: toX, y: controlY)
+                        to: shape.end.into(),
+                        control1: shape.startControl.into(),
+                        control2: shape.endControl.into()
                     )
                 }, with: .color(color), style: style)
             }
         }
         .frame(width: 40)
-    }
-
-    static func x(_ lane: RouteBranchSegment.Lane, size: CGSize) -> CGFloat {
-        switch lane {
-        case .left: 10
-        case .center: size.width / 2
-        case .right: size.width - 10
-        }
-    }
-
-    static func y(_ vPos: RouteBranchSegment.VPos, size: CGSize) -> CGFloat {
-        switch vPos {
-        case .top: 0
-        case .center: size.height / 2
-        case .bottom: size.height
-        }
     }
 }

--- a/iosApp/iosApp/ComponentViews/StopListDisclosureGroup.swift
+++ b/iosApp/iosApp/ComponentViews/StopListDisclosureGroup.swift
@@ -14,7 +14,7 @@ struct StopListDisclosureGroup: DisclosureGroupStyle {
     let stickConnections: [(RouteBranchSegment.StickConnection, Bool)]
 
     @State var caretRotation: Angle = .zero
-    @State var twistFactor: Double = 1
+    @State var twistFactor: Float = 1
 
     func makeBody(configuration: Configuration) -> some View {
         VStack(spacing: 0) {

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -11,11 +11,11 @@ import SwiftUI
 
 struct CollapsableStopList<RightSideContent: View>: View {
     let lineOrRoute: RouteCardData.LineOrRoute
-    let segment: RouteDetailsStopList.NewSegment
-    let onClick: (RouteDetailsStopList.NewEntry) -> Void
+    let segment: RouteDetailsStopList.Segment
+    let onClick: (RouteDetailsStopList.Entry) -> Void
     let isFirstSegment: Bool
     let isLastSegment: Bool
-    let rightSideContent: (RouteDetailsStopList.NewEntry) -> RightSideContent
+    let rightSideContent: (RouteDetailsStopList.Entry) -> RightSideContent
 
     @State var stopsExpanded = false
 
@@ -23,11 +23,11 @@ struct CollapsableStopList<RightSideContent: View>: View {
 
     init(
         lineOrRoute: RouteCardData.LineOrRoute,
-        segment: RouteDetailsStopList.NewSegment,
-        onClick: @escaping (RouteDetailsStopList.NewEntry) -> Void,
+        segment: RouteDetailsStopList.Segment,
+        onClick: @escaping (RouteDetailsStopList.Entry) -> Void,
         isFirstSegment: Bool = false,
         isLastSegment: Bool = false,
-        rightSideContent: @escaping (RouteDetailsStopList.NewEntry) -> RightSideContent
+        rightSideContent: @escaping (RouteDetailsStopList.Entry) -> RightSideContent
     ) {
         self.lineOrRoute = lineOrRoute
         self.segment = segment

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -221,7 +221,7 @@ struct TripStops: View {
         }
     )
 
-    VStack {
+    ScrollView {
         TripStops(
             targetId: stops[4].id,
             stops: stopList,

--- a/iosApp/iosApp/Utils/CGRectExtension.swift
+++ b/iosApp/iosApp/Utils/CGRectExtension.swift
@@ -1,0 +1,16 @@
+//
+//  CGRectExtension.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/29/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreGraphics
+import Shared
+
+extension CGRect {
+    func into() -> Shared.Path.Rect {
+        .init(minX: Float(minX), maxX: Float(maxX), minY: Float(minY), maxY: Float(maxY))
+    }
+}

--- a/iosApp/iosApp/Utils/PathPointExtension.swift
+++ b/iosApp/iosApp/Utils/PathPointExtension.swift
@@ -1,0 +1,16 @@
+//
+//  PathPointExtension.swift
+//  iosApp
+//
+//  Created by Melody Horn on 7/29/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import CoreGraphics
+import Shared
+
+extension Shared.Path.Point {
+    func into() -> CGPoint {
+        .init(x: CGFloat(x), y: CGFloat(y))
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -191,8 +191,7 @@ class MockRepositories : IRepositories {
     override var pinnedRoutes: IPinnedRoutesRepository = PinnedRoutesRepository()
     override var predictions: IPredictionsRepository = MockPredictionsRepository()
     override var railRouteShapes: IRailRouteShapeRepository = IdleRailRouteShapeRepository()
-    override var routeStops: IRouteStopsRepository =
-        MockRouteStopsRepository(stopIds = emptyList(), segments = emptyList())
+    override var routeStops: IRouteStopsRepository = MockRouteStopsRepository(emptyList())
     override var schedules: ISchedulesRepository = IdleScheduleRepository()
     override var searchResults: ISearchResultRepository = IdleSearchResultRepository()
     override var sentry: ISentryRepository = MockSentryRepository()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -139,9 +139,7 @@ fun endToEndModule(): Module {
             // debug.
             IdleRailRouteShapeRepository()
         }
-        single<IRouteStopsRepository> {
-            MockRouteStopsRepository(stopIds = emptyList(), segments = emptyList())
-        }
+        single<IRouteStopsRepository> { MockRouteStopsRepository(emptyList()) }
         single<ISchedulesRepository> {
             MockScheduleRepository(scheduleResponse = ScheduleResponse(objects))
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -109,38 +109,16 @@ object LoadingPlaceholders {
 
         return RouteDetailsStopList(
             directionId = directionId,
-            oldSegments =
+            segments =
                 listOf(
-                    RouteDetailsStopList.OldSegment(
-                        (1..20).map {
-                            val stopName = randString(15, 30)
-                            val transferRoutes =
-                                (0..fixedRand.nextInt(0, 7)).map {
-                                    objects.route { shortName = randString(2, 5) }
-                                }
-                            RouteDetailsStopList.OldEntry(
-                                objects.stop { name = stopName },
-                                listOf(
-                                    objects.routePattern(lineOrRoute.sortRoute) {
-                                        typicality = RoutePattern.Typicality.Typical
-                                    }
-                                ),
-                                transferRoutes,
-                            )
-                        },
-                        hasRouteLine = true,
-                    )
-                ),
-            newSegments =
-                listOf(
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         (1..20).map { number ->
                             val stopName = randString(15, 30)
                             val transferRoutes =
                                 (0..fixedRand.nextInt(0, 7)).map {
                                     objects.route { shortName = randString(2, 5) }
                                 }
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 objects.stop { name = stopName },
                                 RouteBranchSegment.Lane.Center,
                                 RouteBranchSegment.StickConnection.forward(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.RouteStopsResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import io.ktor.client.call.body
 import io.ktor.http.path
@@ -14,53 +13,23 @@ import org.koin.core.component.inject
 // The response doesn't include the route ID and direction ID, which we need in the UI to ensure
 // that we're using the correct stop list for the selected route and direction.
 @Serializable
-data class OldRouteStopsResult(
-    val routeId: String,
-    val directionId: Int,
-    val stopIds: List<String>,
-)
-
-@Serializable
-data class NewRouteStopsResult(
+data class RouteStopsResult(
     val routeId: String,
     val directionId: Int,
     val segments: List<RouteBranchSegment>,
 )
 
 interface IRouteStopsRepository {
-    suspend fun getOldRouteStops(routeId: String, directionId: Int): ApiResult<OldRouteStopsResult>
-
-    suspend fun getNewRouteSegments(
-        routeId: String,
-        directionId: Int,
-    ): ApiResult<NewRouteStopsResult>
+    suspend fun getRouteSegments(routeId: String, directionId: Int): ApiResult<RouteStopsResult>
 }
 
 class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
-    override suspend fun getOldRouteStops(
+    override suspend fun getRouteSegments(
         routeId: String,
         directionId: Int,
-    ): ApiResult<OldRouteStopsResult> =
-        ApiResult.runCatching {
-            val response: RouteStopsResponse =
-                mobileBackendClient
-                    .get {
-                        url {
-                            path("api/route/stops")
-                            parameters.append("route_id", routeId)
-                            parameters.append("direction_id", directionId.toString())
-                        }
-                    }
-                    .body()
-            OldRouteStopsResult(routeId, directionId, response.stopIds)
-        }
-
-    override suspend fun getNewRouteSegments(
-        routeId: String,
-        directionId: Int,
-    ): ApiResult<NewRouteStopsResult> =
+    ): ApiResult<RouteStopsResult> =
         ApiResult.runCatching {
             val response: List<RouteBranchSegment> =
                 mobileBackendClient
@@ -72,41 +41,27 @@ class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
                         }
                     }
                     .body()
-            NewRouteStopsResult(routeId, directionId, response)
+            RouteStopsResult(routeId, directionId, response)
         }
 }
 
 class MockRouteStopsRepository(
-    private val oldResult: ApiResult<OldRouteStopsResult>?,
-    private val newResult: ApiResult<NewRouteStopsResult>?,
+    private val result: ApiResult<RouteStopsResult>,
     private val onGet: (String, Int) -> Unit = { _, _ -> },
 ) : IRouteStopsRepository {
     @DefaultArgumentInterop.Enabled
     constructor(
-        stopIds: List<String>? = null,
-        segments: List<RouteBranchSegment>? = null,
+        segments: List<RouteBranchSegment>,
         routeId: String = "",
         directionId: Int = 0,
         onGet: (String, Int) -> Unit = { _, _ -> },
-    ) : this(
-        stopIds?.let { ApiResult.Ok(OldRouteStopsResult(routeId, directionId, it)) },
-        segments?.let { ApiResult.Ok(NewRouteStopsResult(routeId, directionId, it)) },
-        onGet,
-    )
+    ) : this(ApiResult.Ok(RouteStopsResult(routeId, directionId, segments)), onGet)
 
-    override suspend fun getOldRouteStops(
+    override suspend fun getRouteSegments(
         routeId: String,
         directionId: Int,
-    ): ApiResult<OldRouteStopsResult> {
+    ): ApiResult<RouteStopsResult> {
         onGet(routeId, directionId)
-        return checkNotNull(oldResult) { "old result not defined" }
-    }
-
-    override suspend fun getNewRouteSegments(
-        routeId: String,
-        directionId: Int,
-    ): ApiResult<NewRouteStopsResult> {
-        onGet(routeId, directionId)
-        return checkNotNull(newResult) { "new result not defined" }
+        return result
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/CrossPlatformPathTypes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/CrossPlatformPathTypes.kt
@@ -1,0 +1,10 @@
+package com.mbta.tid.mbta_app.shape
+
+object Path {
+    data class Point(val x: Float, val y: Float)
+
+    data class Rect(val minX: Float, val maxX: Float, val minY: Float, val maxY: Float) {
+        val width = maxX - minX
+        val height = maxY - minY
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
@@ -141,7 +141,7 @@ object StickDiagramShapes {
         val base = twistBase(connection, rect, proportionClosed) ?: return null
         val height = base.bottomY - base.topY
         val twistSlantDY = height / 32 * proportionClosed
-        val nearTwistDY = height / 9 * proportionClosed
+        val nearTwistDY = height / 14 * proportionClosed
         val curveStartDY = height / 5
         val curveStartControlDY = rect.height / 13
         val curveEndControlDY = rect.height / 20

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
@@ -1,0 +1,199 @@
+package com.mbta.tid.mbta_app.shape
+
+import com.mbta.tid.mbta_app.model.RouteBranchSegment
+import kotlin.math.abs
+
+object StickDiagramShapes {
+    data class Connection(
+        val start: Path.Point,
+        val startControl: Path.Point,
+        val endControl: Path.Point,
+        val end: Path.Point,
+    )
+
+    private data class TwistBase(
+        val topCenterX: Float,
+        val bottomCenterX: Float,
+        val topY: Float,
+        val bottomY: Float,
+        val opensToNothing: Boolean,
+    ) {
+        val centerY = (topY + bottomY) / 2
+    }
+
+    data class NonTwisted(
+        val start: Path.Point,
+        val startControl: Path.Point,
+        val endControl: Path.Point,
+        val end: Path.Point,
+    )
+
+    data class Twisted(
+        val shadow: Shadow,
+        val curves: Curves,
+        val ends: Ends,
+        val opensToNothing: Boolean,
+    ) {
+        data class Shadow(val start: Path.Point, val end: Path.Point)
+
+        data class Curves(
+            val bottom: Path.Point?,
+            val bottomCurveStart: Path.Point,
+            val bottomCurveStartControl: Path.Point,
+            val bottomNearTwistControl: Path.Point,
+            val bottomNearTwist: Path.Point,
+            val shadowStart: Path.Point,
+            val shadowEnd: Path.Point,
+            val topNearTwist: Path.Point,
+            val topNearTwistControl: Path.Point,
+            val topCurveStartControl: Path.Point,
+            val topCurveStart: Path.Point,
+            val top: Path.Point?,
+        )
+
+        data class Ends(
+            val bottom: Path.Point?,
+            val bottomCurveStart: Path.Point,
+            val topCurveStart: Path.Point,
+            val top: Path.Point?,
+        )
+    }
+
+    private fun x(lane: RouteBranchSegment.Lane, rect: Path.Rect): Float =
+        when (lane) {
+            RouteBranchSegment.Lane.Left -> rect.minX + rect.width / 4
+            RouteBranchSegment.Lane.Center -> rect.minX + rect.width / 2
+            RouteBranchSegment.Lane.Right -> rect.maxX - rect.width / 4
+        }
+
+    private fun y(vPos: RouteBranchSegment.VPos, rect: Path.Rect): Float =
+        when (vPos) {
+            RouteBranchSegment.VPos.Top -> rect.minY
+            RouteBranchSegment.VPos.Center -> rect.minY + rect.height / 2
+            RouteBranchSegment.VPos.Bottom -> rect.maxY
+        }
+
+    private fun lerp(x1: Float, x2: Float, t: Float) = x1 * (1 - t) + x2 * t
+
+    fun connection(connection: RouteBranchSegment.StickConnection, rect: Path.Rect): Connection {
+        val fromX = x(connection.fromLane, rect)
+        val toX = x(connection.toLane, rect)
+        val fromY = y(connection.fromVPos, rect)
+        val toY = y(connection.toVPos, rect)
+        val controlY = (fromY + toY) / 2
+        return Connection(
+            start = Path.Point(fromX, fromY),
+            startControl = Path.Point(fromX, controlY),
+            endControl = Path.Point(toX, controlY),
+            end = Path.Point(toX, toY),
+        )
+    }
+
+    private fun twistBase(
+        connection: RouteBranchSegment.StickConnection,
+        rect: Path.Rect,
+        proportionClosed: Float,
+    ): TwistBase? {
+        // when the twist is untwisted, we want to copy the top half and ignore the bottom half
+        val openFromVPos =
+            if (connection.fromVPos == RouteBranchSegment.VPos.Center)
+                RouteBranchSegment.VPos.Bottom
+            else connection.fromVPos
+        val openToVPos =
+            if (connection.toVPos == RouteBranchSegment.VPos.Center) RouteBranchSegment.VPos.Bottom
+            else connection.toVPos
+        val opensToNothing = openFromVPos == openToVPos
+        if (opensToNothing && proportionClosed == 0f) return null
+        val topY = lerp(y(openFromVPos, rect), y(connection.fromVPos, rect), proportionClosed)
+        val bottomY = lerp(y(openToVPos, rect), y(connection.toVPos, rect), proportionClosed)
+        val topCenterX = x(connection.fromLane, rect)
+        // when the twist is untwisted, we want to keep using the from lane so that the segment
+        // below the toggle lines up right
+        val bottomCenterX = lerp(topCenterX, x(connection.toLane, rect), proportionClosed)
+        return TwistBase(
+            topCenterX = topCenterX,
+            bottomCenterX = bottomCenterX,
+            topY = topY,
+            bottomY = bottomY,
+            opensToNothing = opensToNothing,
+        )
+    }
+
+    fun nonTwisted(
+        connection: RouteBranchSegment.StickConnection,
+        rect: Path.Rect,
+        proportionClosed: Float,
+    ): NonTwisted? {
+        val base = twistBase(connection, rect, proportionClosed) ?: return null
+        return NonTwisted(
+            start = Path.Point(base.topCenterX, base.topY),
+            startControl = Path.Point(base.topCenterX, base.centerY),
+            endControl = Path.Point(base.bottomCenterX, base.centerY),
+            end = Path.Point(base.bottomCenterX, base.bottomY),
+        )
+    }
+
+    fun twisted(
+        connection: RouteBranchSegment.StickConnection,
+        rect: Path.Rect,
+        proportionClosed: Float,
+    ): Twisted? {
+        val base = twistBase(connection, rect, proportionClosed) ?: return null
+        val height = base.bottomY - base.topY
+        val twistSlantDY = height / 32 * proportionClosed
+        val nearTwistDY = height / 9 * proportionClosed
+        val curveStartDY = height / 5
+        val curveStartControlDY = rect.height / 13
+        val curveEndControlDY = rect.height / 20
+        val centerCenterX = (base.topCenterX + base.bottomCenterX) / 2
+        val twistSlantDX = rect.width / 8 * proportionClosed
+        val nearTwistDX = rect.width / 12 * proportionClosed
+        val curveEndControlDX = rect.width / 15 * proportionClosed
+        val shadowStart = Path.Point(centerCenterX + twistSlantDX, base.centerY + twistSlantDY)
+        val shadowEnd = Path.Point(centerCenterX - twistSlantDX, base.centerY - twistSlantDY)
+        val shadow = Twisted.Shadow(start = shadowStart, end = shadowEnd)
+        val bottom = Path.Point(base.bottomCenterX, base.bottomY)
+        val bottomCurveStart = Path.Point(base.bottomCenterX, base.bottomY - curveStartDY)
+        val topCurveStart = Path.Point(base.topCenterX, base.topY + curveStartDY)
+        val top = Path.Point(base.topCenterX, base.topY)
+        val roundedBottom = abs(rect.maxY - base.bottomY) > 1
+        val roundedTop = abs(base.topY - rect.minY) > 1
+        val curves =
+            Twisted.Curves(
+                bottom = bottom.takeIf { roundedBottom },
+                bottomCurveStart = bottomCurveStart,
+                bottomCurveStartControl =
+                    Path.Point(
+                        base.bottomCenterX,
+                        base.bottomY - curveStartDY - curveStartControlDY,
+                    ),
+                bottomNearTwistControl =
+                    Path.Point(
+                        centerCenterX + nearTwistDX - curveEndControlDX,
+                        base.centerY + nearTwistDY + curveEndControlDY,
+                    ),
+                bottomNearTwist =
+                    Path.Point(centerCenterX + nearTwistDX, base.centerY + nearTwistDY),
+                shadowStart = shadowStart,
+                shadowEnd = shadowEnd,
+                topNearTwist = Path.Point(centerCenterX - nearTwistDX, base.centerY - nearTwistDY),
+                topNearTwistControl =
+                    Path.Point(
+                        centerCenterX - nearTwistDX + curveEndControlDX,
+                        base.centerY - nearTwistDY - curveEndControlDY,
+                    ),
+                topCurveStartControl =
+                    Path.Point(base.topCenterX, base.topY + curveStartDY + curveStartControlDY),
+                topCurveStart = topCurveStart,
+                top = top.takeIf { roundedTop },
+            )
+        val ends =
+            Twisted.Ends(
+                bottom = bottom.takeIf { !roundedBottom },
+                bottomCurveStart = bottomCurveStart,
+                topCurveStart = topCurveStart,
+                top = top.takeIf { !roundedTop },
+            )
+        return Twisted(shadow, curves, ends, opensToNothing = base.opensToNothing)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -1,8 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.repositories.NewRouteStopsResult
-import com.mbta.tid.mbta_app.repositories.OldRouteStopsResult
+import com.mbta.tid.mbta_app.repositories.RouteStopsResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -135,9 +134,9 @@ class RouteDetailsStopListTest {
                     true,
                 )
             ),
-            RouteDetailsStopList.NewSegment(
+            RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop1,
                             lane,
                             stickConnections =
@@ -149,7 +148,7 @@ class RouteDetailsStopListTest {
                                 ),
                             connectingRoutes = emptyList(),
                         ),
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop2,
                             lane,
                             stickConnections =
@@ -189,9 +188,9 @@ class RouteDetailsStopListTest {
                     true,
                 )
             ),
-            RouteDetailsStopList.NewSegment(
+            RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop2,
                             lane,
                             stickConnections =
@@ -203,7 +202,7 @@ class RouteDetailsStopListTest {
                                 ),
                             connectingRoutes = emptyList(),
                         ),
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop3,
                             lane,
                             stickConnections =
@@ -257,9 +256,9 @@ class RouteDetailsStopListTest {
                     true,
                 ),
             ),
-            RouteDetailsStopList.NewSegment(
+            RouteDetailsStopList.Segment(
                     listOf(
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop2,
                             stopLane,
                             stickConnections =
@@ -271,7 +270,7 @@ class RouteDetailsStopListTest {
                                 ) + skip,
                             connectingRoutes = emptyList(),
                         ),
-                        RouteDetailsStopList.NewEntry(
+                        RouteDetailsStopList.Entry(
                             stop3,
                             stopLane,
                             stickConnections =
@@ -308,9 +307,9 @@ class RouteDetailsStopListTest {
                 RouteBranchSegment.Lane.Left,
             )
         val segment =
-            RouteDetailsStopList.NewSegment(
+            RouteDetailsStopList.Segment(
                 listOf(
-                    RouteDetailsStopList.NewEntry(
+                    RouteDetailsStopList.Entry(
                         stop1,
                         RouteBranchSegment.Lane.Right,
                         RouteBranchSegment.StickConnection.forward(
@@ -330,7 +329,7 @@ class RouteDetailsStopListTest {
                             ),
                         connectingRoutes = emptyList(),
                     ),
-                    RouteDetailsStopList.NewEntry(
+                    RouteDetailsStopList.Entry(
                         stop2,
                         RouteBranchSegment.Lane.Right,
                         RouteBranchSegment.StickConnection.forward(
@@ -341,7 +340,7 @@ class RouteDetailsStopListTest {
                         ),
                         connectingRoutes = emptyList(),
                     ),
-                    RouteDetailsStopList.NewEntry(
+                    RouteDetailsStopList.Entry(
                         stop3,
                         RouteBranchSegment.Lane.Right,
                         RouteBranchSegment.StickConnection.forward(
@@ -386,55 +385,7 @@ class RouteDetailsStopListTest {
     }
 
     @Test
-    fun `fromOldPieces finds transfer stops`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val connectingStop = objects.stop()
-        val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
-        val mainRoute = objects.route()
-        val connectingRoute = objects.route()
-
-        val mainPattern =
-            objects.routePattern(mainRoute) {
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(mainStop.id) }
-            }
-
-        val connectingPattern =
-            objects.routePattern(connectingRoute) {
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(connectingStop.id) }
-            }
-
-        val globalData = GlobalResponse(objects)
-
-        assertEquals(
-            RouteDetailsStopList(
-                0,
-                listOf(
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                mainStop,
-                                connectingRoutes = listOf(connectingRoute),
-                                patterns = listOf(mainPattern),
-                            )
-                        ),
-                        hasRouteLine = true,
-                    )
-                ),
-                null,
-            ),
-            RouteDetailsStopList.fromOldPieces(
-                mainRoute.id,
-                0,
-                OldRouteStopsResult(mainRoute.id, 0, listOf(mainStop.id)),
-                globalData,
-            ),
-        )
-    }
-
-    @Test
-    fun `fromNewPieces finds transfer stops`() = runBlocking {
+    fun `fromPieces finds transfer stops`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val connectingStop = objects.stop()
         val mainStop = objects.stop { connectingStopIds = listOf(connectingStop.id) }
@@ -456,11 +407,10 @@ class RouteDetailsStopListTest {
         assertEquals(
             RouteDetailsStopList(
                 0,
-                null,
                 listOf(
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 mainStop,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -471,10 +421,10 @@ class RouteDetailsStopListTest {
                     )
                 ),
             ),
-            RouteDetailsStopList.fromNewPieces(
+            RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                NewRouteStopsResult(
+                RouteStopsResult(
                     mainRoute.id,
                     0,
                     listOf(
@@ -497,7 +447,7 @@ class RouteDetailsStopListTest {
     }
 
     @Test
-    fun `fromOldPieces returns null if direction doesn't match`() = runBlocking {
+    fun `fromPieces returns null if direction doesn't match`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val mainStop = objects.stop {}
         val mainRoute = objects.route()
@@ -505,28 +455,10 @@ class RouteDetailsStopListTest {
         val globalData = GlobalResponse(objects)
 
         assertNull(
-            RouteDetailsStopList.fromOldPieces(
+            RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                OldRouteStopsResult(mainRoute.id, 1, listOf(mainStop.id)),
-                globalData,
-            )
-        )
-    }
-
-    @Test
-    fun `fromNewPieces returns null if direction doesn't match`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val mainStop = objects.stop {}
-        val mainRoute = objects.route()
-
-        val globalData = GlobalResponse(objects)
-
-        assertNull(
-            RouteDetailsStopList.fromNewPieces(
-                mainRoute.id,
-                0,
-                NewRouteStopsResult(
+                RouteStopsResult(
                     mainRoute.id,
                     1,
                     listOf(
@@ -549,154 +481,7 @@ class RouteDetailsStopListTest {
     }
 
     @Test
-    fun `fromOldPieces breaks segments by typicality`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val stop0 = objects.stop { id = "stop0" }
-        val stop1 = objects.stop { id = "stop1" }
-        val stop2NonTypical = objects.stop { id = "stop2NonTypical" }
-        val stop3NonTypical = objects.stop { id = "stop3NonTypical" }
-        val stop4 = objects.stop { id = "stop4" }
-        val stop5NonTypical = objects.stop { id = "stop5NonTypical" }
-        val stop6 = objects.stop { id = "stop6" }
-
-        val mainRoute = objects.route()
-        val patternTypical0 =
-            objects.routePattern(mainRoute) {
-                id = "typical_0"
-                sortOrder = 0
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop4.id) }
-            }
-
-        val patternTypical1 =
-            objects.routePattern(mainRoute) {
-                id = "typical_1"
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop6.id) }
-            }
-
-        val patternNonTypical0 =
-            objects.routePattern(mainRoute) {
-                id = "non_typical_0"
-                typicality = RoutePattern.Typicality.Atypical
-                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop2NonTypical.id) }
-            }
-
-        val patternNonTypical1 =
-            objects.routePattern(mainRoute) {
-                id = "non_typical_1"
-                typicality = RoutePattern.Typicality.Deviation
-                representativeTrip {
-                    stopIds =
-                        listOf(stop0.id, stop1.id, stop3NonTypical.id, stop5NonTypical.id, stop6.id)
-                }
-            }
-
-        val globalData = GlobalResponse(objects)
-
-        assertEquals(
-            RouteDetailsStopList(
-                0,
-                listOf(
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop0,
-                                connectingRoutes = listOf(),
-                                patterns =
-                                    listOf(
-                                        patternTypical0,
-                                        patternTypical1,
-                                        patternNonTypical0,
-                                        patternNonTypical1,
-                                    ),
-                            ),
-                            RouteDetailsStopList.OldEntry(
-                                stop1,
-                                connectingRoutes = listOf(),
-                                patterns =
-                                    listOf(
-                                        patternTypical0,
-                                        patternTypical1,
-                                        patternNonTypical0,
-                                        patternNonTypical1,
-                                    ),
-                            ),
-                        ),
-                        hasRouteLine = true,
-                    ),
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop2NonTypical,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternNonTypical0),
-                            ),
-                            RouteDetailsStopList.OldEntry(
-                                stop3NonTypical,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternNonTypical1),
-                            ),
-                        ),
-                        hasRouteLine = false,
-                    ),
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop4,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternTypical0),
-                            )
-                        ),
-                        hasRouteLine = true,
-                    ),
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop5NonTypical,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternNonTypical1),
-                            )
-                        ),
-                        hasRouteLine = false,
-                    ),
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop6,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternTypical1, patternNonTypical1),
-                            )
-                        ),
-                        hasRouteLine = false,
-                    ),
-                ),
-                null,
-            ),
-            RouteDetailsStopList.fromOldPieces(
-                mainRoute.id,
-                0,
-                OldRouteStopsResult(
-                    mainRoute.id,
-                    0,
-                    listOf(
-                        stop0.id,
-                        stop1.id,
-                        stop2NonTypical.id,
-                        stop3NonTypical.id,
-                        stop4.id,
-                        stop5NonTypical.id,
-                        stop6.id,
-                    ),
-                ),
-                globalData,
-            ),
-        )
-    }
-
-    @Test
-    fun `fromNewPieces breaks segments by typicality`() = runBlocking {
+    fun `fromPieces breaks segments by typicality`() = runBlocking {
         val objects = ObjectCollectionBuilder()
         val stop0 = objects.stop { id = "stop0" }
         val stop1 = objects.stop { id = "stop1" }
@@ -713,17 +498,16 @@ class RouteDetailsStopListTest {
         assertEquals(
             RouteDetailsStopList(
                 0,
-                null,
                 listOf(
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop0,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
                                 connectingRoutes = listOf(),
                             ),
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop1,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -732,15 +516,15 @@ class RouteDetailsStopListTest {
                         ),
                         isTypical = true,
                     ),
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop2NonTypical,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
                                 connectingRoutes = listOf(),
                             ),
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop3NonTypical,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -749,9 +533,9 @@ class RouteDetailsStopListTest {
                         ),
                         isTypical = false,
                     ),
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop4,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -760,9 +544,9 @@ class RouteDetailsStopListTest {
                         ),
                         isTypical = true,
                     ),
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop5NonTypical,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -771,9 +555,9 @@ class RouteDetailsStopListTest {
                         ),
                         isTypical = false,
                     ),
-                    RouteDetailsStopList.NewSegment(
+                    RouteDetailsStopList.Segment(
                         listOf(
-                            RouteDetailsStopList.NewEntry(
+                            RouteDetailsStopList.Entry(
                                 stop6,
                                 RouteBranchSegment.Lane.Center,
                                 stickConnections = emptyList(),
@@ -784,10 +568,10 @@ class RouteDetailsStopListTest {
                     ),
                 ),
             ),
-            RouteDetailsStopList.fromNewPieces(
+            RouteDetailsStopList.fromPieces(
                 mainRoute.id,
                 0,
-                NewRouteStopsResult(
+                RouteStopsResult(
                     mainRoute.id,
                     0,
                     listOf(
@@ -864,71 +648,6 @@ class RouteDetailsStopListTest {
                         ),
                     ),
                 ),
-                globalData,
-            ),
-        )
-    }
-
-    @Test
-    fun `fromOldPieces breaks segments by typicality in the selected direction`() = runBlocking {
-        val objects = ObjectCollectionBuilder()
-        val stop0 = objects.stop { id = "stop0" }
-        val stop1 = objects.stop { id = "stop1" }
-        val stop2 = objects.stop { id = "stop2" }
-
-        val mainRoute = objects.route()
-
-        val patternTypical0 =
-            objects.routePattern(mainRoute) {
-                id = "typical_0"
-                directionId = 0
-                sortOrder = 1
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(stop0.id, stop1.id, stop2.id) }
-            }
-
-        val patternTypicalOppositeDirection =
-            objects.routePattern(mainRoute) {
-                id = "typical_opposite_direction"
-                directionId = 1
-                sortOrder = 0
-                typicality = RoutePattern.Typicality.Typical
-                representativeTrip { stopIds = listOf(stop2.id, stop1.id, stop0.id) }
-            }
-
-        val globalData = GlobalResponse(objects)
-
-        assertEquals(
-            RouteDetailsStopList(
-                0,
-                listOf(
-                    RouteDetailsStopList.OldSegment(
-                        listOf(
-                            RouteDetailsStopList.OldEntry(
-                                stop0,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternTypical0),
-                            ),
-                            RouteDetailsStopList.OldEntry(
-                                stop1,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternTypical0),
-                            ),
-                            RouteDetailsStopList.OldEntry(
-                                stop2,
-                                connectingRoutes = listOf(),
-                                patterns = listOf(patternTypical0),
-                            ),
-                        ),
-                        hasRouteLine = true,
-                    )
-                ),
-                null,
-            ),
-            RouteDetailsStopList.fromOldPieces(
-                mainRoute.id,
-                0,
-                OldRouteStopsResult(mainRoute.id, 0, listOf(stop0.id, stop1.id, stop2.id)),
                 globalData,
             ),
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepositoryTest.kt
@@ -21,89 +21,6 @@ import org.koin.test.KoinTest
 
 class RouteStopsRepositoryTest : KoinTest {
     @Test
-    fun testGetOldStops() {
-        lateinit var requestUrl: Url
-        val mockEngine = MockEngine { request ->
-            requestUrl = request.url
-            respond(
-                content =
-                    ByteReadChannel(
-                        """
-                    {
-                        "stop_ids": [
-                            "place-ogmnl",
-                            "place-mlmnl",
-                            "place-welln",
-                            "place-astao",
-                            "place-sull",
-                            "place-ccmnl",
-                            "place-north",
-                            "place-haecl",
-                            "place-state",
-                            "place-dwnxg",
-                            "place-chncl",
-                            "place-tumnl",
-                            "place-bbsta",
-                            "place-masta",
-                            "place-rugg",
-                            "place-rcmnl",
-                            "place-jaksn",
-                            "place-sbmnl",
-                            "place-grnst",
-                            "place-forhl"
-                        ]
-                    }
-                    """
-                            .trimIndent()
-                    ),
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            )
-        }
-
-        startKoin {
-            modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
-        }
-        runBlocking {
-            val response = RouteStopsRepository().getOldRouteStops("Orange", 0)
-            assertEquals("/api/route/stops", requestUrl.encodedPath)
-            assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
-            assertEquals(
-                ApiResult.Ok(
-                    OldRouteStopsResult(
-                        "Orange",
-                        0,
-                        listOf(
-                            "place-ogmnl",
-                            "place-mlmnl",
-                            "place-welln",
-                            "place-astao",
-                            "place-sull",
-                            "place-ccmnl",
-                            "place-north",
-                            "place-haecl",
-                            "place-state",
-                            "place-dwnxg",
-                            "place-chncl",
-                            "place-tumnl",
-                            "place-bbsta",
-                            "place-masta",
-                            "place-rugg",
-                            "place-rcmnl",
-                            "place-jaksn",
-                            "place-sbmnl",
-                            "place-grnst",
-                            "place-forhl",
-                        ),
-                    )
-                ),
-                response,
-            )
-        }
-        stopKoin()
-    }
-
-    @Test
     fun testGetNewSegments() {
         lateinit var requestUrl: Url
         val mockEngine = MockEngine { request ->
@@ -556,12 +473,12 @@ class RouteStopsRepositoryTest : KoinTest {
             modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
         }
         runBlocking {
-            val response = RouteStopsRepository().getNewRouteSegments("Orange", 0)
+            val response = RouteStopsRepository().getRouteSegments("Orange", 0)
             assertEquals("/api/route/stop-graph", requestUrl.encodedPath)
             assertEquals("route_id=Orange&direction_id=0", requestUrl.encodedQuery)
             assertEquals(
                 ApiResult.Ok(
-                    NewRouteStopsResult(
+                    RouteStopsResult(
                         "Orange",
                         0,
                         listOf(


### PR DESCRIPTION
### Summary

_Ticket:_ none

Removes all the “Old” stop list logic, moves the branching diagram path math to shared code, and tweaks the twist/untwist animation a little bit.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the animation looks correct and smooth on both Android and iOS in both trip details and route details.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
