### PR TITLE
feat: show TTY/ASL instructions alongside support number

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreSectionView.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.more
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -38,20 +39,24 @@ fun MoreSectionView(section: MoreSection, settingsCache: SettingsCache = koinInj
             else -> null
         }
 
-    val note = section.note
+    val noteAbove = section.noteAbove
+    val noteBelow = section.noteBelow
 
     if (!(section.hiddenOnProd && appVariant == AppVariant.Prod)) {
-        Column {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             if (name != null) {
-                Column(modifier = Modifier.padding(2.dp)) {
+                Column(
+                    modifier = Modifier.padding(2.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
                     Text(
                         name,
                         style = Typography.subheadlineSemibold,
                         modifier = Modifier.semantics { heading() },
                     )
 
-                    if (note != null) {
-                        Text(note, style = Typography.footnote)
+                    if (noteAbove != null) {
+                        Text(noteAbove, style = Typography.footnote)
                     }
                 }
             }
@@ -100,6 +105,10 @@ fun MoreSectionView(section: MoreSection, settingsCache: SettingsCache = koinInj
                         androidx.compose.material3.HorizontalDivider()
                     }
                 }
+            }
+
+            if (noteBelow != null) {
+                Text(noteBelow, style = Typography.footnote)
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/more/MoreViewModel.kt
@@ -128,7 +128,8 @@ class MoreViewModel(private val context: Context, private val licensesCallback: 
             MoreSection(
                 id = MoreSection.Category.Support,
                 items = listOf(MoreItem.Phone("617-222-3200", "6172223200")),
-                note = context.resources.getString(R.string.more_section_support_note),
+                noteAbove = context.getString(R.string.more_section_support_note_hours),
+                noteBelow = context.getString(R.string.more_section_support_note_accessibility),
             ),
         )
     }

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -211,7 +211,8 @@
     <string name="more_section_resources">Recursos</string>
     <string name="more_section_settings">Configuración</string>
     <string name="more_section_support">Información general y soporte de MBTA</string>
-    <string name="more_section_support_note">De lunes a viernes de 6:30 a. m. a 8:00 p. m.</string>
+    <string name="more_section_support_note_accessibility">711 para quienes llaman por TTY; VRS para quienes llaman por ASL</string>
+    <string name="more_section_support_note_hours">De lunes a viernes de 6:30 a. m. a 8:00 p. m.</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Tránsito cercano</string>
     <string name="nearby_transit_link">Cerca</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -211,7 +211,8 @@
     <string name="more_section_resources">Ressources</string>
     <string name="more_section_settings">Paramètres</string>
     <string name="more_section_support">Informations générales et assistance MBTA</string>
-    <string name="more_section_support_note">Du lundi au vendredi : de 6 h 30 à 20 h</string>
+    <string name="more_section_support_note_accessibility">711 pour les appelants TTY ; VRS pour les appelants ASL</string>
+    <string name="more_section_support_note_hours">Du lundi au vendredi : de 6 h 30 à 20 h</string>
     <string name="more_title">MTBA Go</string>
     <string name="nearby_transit">Transports à proximité</string>
     <string name="nearby_transit_link">Proche</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -220,7 +220,8 @@
     <string name="more_section_resources">Resous</string>
     <string name="more_section_settings">Paramèt</string>
     <string name="more_section_support">Enfòmasyon ak Sipò Jeneral MBTA</string>
-    <string name="more_section_support_note">Lendi rive vandredi: 6:30 AM - 8 PM</string>
+    <string name="more_section_support_note_accessibility">711 pou moun ki rele TTY; VRS pou moun kap rele ASL</string>
+    <string name="more_section_support_note_hours">Lendi rive vandredi: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Transpò piblik ki toupre</string>
     <string name="nearby_transit_link">Toupre</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -211,7 +211,8 @@
     <string name="more_section_resources">Recursos</string>
     <string name="more_section_settings">Configurações</string>
     <string name="more_section_support">Informações Gerais e Suporte da MBTA</string>
-    <string name="more_section_support_note">De segunda a sexta: 6:30 AM - 8 PM</string>
+    <string name="more_section_support_note_accessibility">711 para chamadores TTY; VRS para chamadores ASL</string>
+    <string name="more_section_support_note_hours">De segunda a sexta: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Trânsito próximo</string>
     <string name="nearby_transit_link">Próximo</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -205,7 +205,8 @@
     <string name="more_section_resources">Nguồn</string>
     <string name="more_section_settings">Cài đặt</string>
     <string name="more_section_support">Thông tin &amp; Hỗ trợ chung của MBTA</string>
-    <string name="more_section_support_note">Từ thứ Hai đến thứ Sáu: 6:30 sáng - 8:00 tối</string>
+    <string name="more_section_support_note_accessibility">711 dành cho người gọi TTY; VRS dành cho người gọi ASL</string>
+    <string name="more_section_support_note_hours">Từ thứ Hai đến thứ Sáu: 6:30 sáng - 8:00 tối</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Phương tiện công cộng ở gần</string>
     <string name="nearby_transit_link">Ở gần</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -205,7 +205,8 @@
     <string name="more_section_resources">资源</string>
     <string name="more_section_settings">设置</string>
     <string name="more_section_support">MBTA通用信息与支持</string>
-    <string name="more_section_support_note">周一至周五：上午6:30至晚上8:00</string>
+    <string name="more_section_support_note_accessibility">TTY 呼叫者请拨打 711；ASL 呼叫者请拨打 VRS</string>
+    <string name="more_section_support_note_hours">周一至周五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -205,7 +205,8 @@
     <string name="more_section_resources">資源</string>
     <string name="more_section_settings">設定</string>
     <string name="more_section_support">MBTA通用資訊與支援</string>
-    <string name="more_section_support_note">週一至週五：上午6:30至晚上8:00</string>
+    <string name="more_section_support_note_accessibility">TTY 來電者請撥打 711；ASL 來電者請撥打 VRS</string>
+    <string name="more_section_support_note_hours">週一至週五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -210,7 +210,8 @@
     <string name="more_section_resources">Resources</string>
     <string name="more_section_settings">Settings</string>
     <string name="more_section_support">General MBTA Information &amp; Support</string>
-    <string name="more_section_support_note">Monday through Friday: 6:30 AM - 8 PM</string>
+    <string name="more_section_support_note_accessibility">711 for TTY callers; VRS for ASL callers</string>
+    <string name="more_section_support_note_hours">Monday through Friday: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Nearby Transit</string>
     <string name="nearby_transit_link">Nearby</string>

--- a/bin/placeholder-translations.py
+++ b/bin/placeholder-translations.py
@@ -64,3 +64,6 @@ for body_row in sheet_in[1:]:
 
 with open("iosApp/iosApp/Localizable.xcstrings", mode="w", encoding="utf-8") as f:
     json.dump(xcstrings, f, ensure_ascii=False, indent=2, separators=(",", " : "))
+
+print("Running Android localization conversion")
+subprocess.run(["./gradlew", "--quiet", ":androidApp:convertIosLocalization"], check=True)

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2608,6 +2608,53 @@
         }
       }
     },
+    "711 for TTY callers; VRS for ASL callers" : {
+      "comment" : "Footnote under the More page support phone number, these are the instructions for accessible support via teletypewriter or video relay service",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "711 para quienes llaman por TTY; VRS para quienes llaman por ASL"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "711 pour les appelants TTY ; VRS pour les appelants ASL"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "711 pou moun ki rele TTY; VRS pou moun kap rele ASL"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "711 para chamadores TTY; VRS para chamadores ASL"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "711 dành cho người gọi TTY; VRS dành cho người gọi ASL"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TTY 呼叫者请拨打 711；ASL 呼叫者请拨打 VRS"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "TTY 來電者請撥打 711；ASL 來電者請撥打 VRS"
+          }
+        }
+      }
+    },
     "Access issue" : {
       "comment" : "Possible alert effect",
       "localizations" : {

--- a/iosApp/iosApp/Pages/More/MoreSection.swift
+++ b/iosApp/iosApp/Pages/More/MoreSection.swift
@@ -45,11 +45,21 @@ struct MoreSection: Identifiable, Equatable {
         }
     }
 
-    var note: String? {
+    var noteAbove: String? {
         switch id {
         case .support: NSLocalizedString(
                 "Monday through Friday: 6:30 AM - 8 PM",
                 comment: "Footnote under the More page support header, these are the hours for the support call center"
+            )
+        default: nil
+        }
+    }
+
+    var noteBelow: String? {
+        switch id {
+        case .support: NSLocalizedString(
+                "711 for TTY callers; VRS for ASL callers",
+                comment: "Footnote under the More page support phone number, these are the instructions for accessible support via teletypewriter or video relay service"
             )
         default: nil
         }

--- a/iosApp/iosApp/Pages/More/MoreSectionView.swift
+++ b/iosApp/iosApp/Pages/More/MoreSectionView.swift
@@ -18,21 +18,20 @@ struct MoreSectionView: View {
         if !(section.hiddenOnProd && appVariant == .prod) {
             VStack(alignment: .leading, spacing: 8) {
                 if let name = section.name {
-                    VStack(alignment: .leading, spacing: 0) {
+                    VStack(alignment: .leading, spacing: 2) {
                         Text(name)
                             .foregroundStyle(Color.text)
                             .font(Typography.subheadlineSemibold)
                             .listRowInsets(EdgeInsets())
                             .accessibilityAddTraits(.isHeader)
                             .accessibilityHeading(.h2)
-                        if let note = section.note {
-                            Text(note)
+                        if let noteAbove = section.noteAbove {
+                            Text(noteAbove)
                                 .foregroundStyle(Color.text)
                                 .font(Typography.footnote)
-                                .padding(.top, 2)
                         }
                     }
-                    .padding(.bottom, 2)
+                    .padding(2)
                 }
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(section.items.enumerated()), id: \.element.id) { index, row in
@@ -67,6 +66,12 @@ struct MoreSectionView: View {
                 }
                 .background(section.id == .feedback ? Color.key : Color.fill3)
                 .withRoundedBorder()
+                if let noteBelow = section.noteBelow {
+                    Text(noteBelow)
+                        .foregroundStyle(Color.text)
+                        .font(Typography.footnote)
+                        .padding(.top, 2)
+                }
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
@@ -1,6 +1,11 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-class MoreSection(var id: Category, var items: List<MoreItem>, var note: String? = null) {
+class MoreSection(
+    var id: Category,
+    var items: List<MoreItem>,
+    var noteAbove: String? = null,
+    var noteBelow: String? = null,
+) {
 
     enum class Category {
         Feedback,


### PR DESCRIPTION
### Summary

_Ticket:_ [Add TTY/ASL contact info to More tab](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210919282215089?focus=true)

Screenshots [in Slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1753891258860369?thread_ts=1753891214.362909&cid=C05QMG9GS9M).

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that the new text is displayed on both Android and iOS.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
