### PR TITLE
fix: stabilize a flaky FavoritesViewModel test

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -752,6 +752,7 @@ class FavoritesViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             awaitItemSatisfying { it.favorites == initialFavorites.routeStopDirection }
+            cancelAndIgnoreRemainingEvents()
         }
 
         advanceUntilIdle()


### PR DESCRIPTION
### Summary

_Ticket:_ none

I’ve had this fail on me a couple of times today because something new happens in the flow after the `awaitItemSatisfying` has found its item, and Turbine assumes by default that every event must be consumed in the test, which is usually correct but not correct for this test specifically.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this test still passes locally like it always has. This may or may not actually make this test start behaving correctly in CI.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
