### PR TITLE
feat(iOS): Route details UI implementation

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -69,6 +69,7 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
+import com.mbta.tid.mbta_app.model.silverRoutes
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.TestData
@@ -362,7 +363,8 @@ private fun RouteStops(
     }
 
     val haloColor =
-        if (lineOrRoute.type == RouteType.BUS) colorResource(R.color.halo_light)
+        if (lineOrRoute.type == RouteType.BUS && !silverRoutes.contains(lineOrRoute.id))
+            colorResource(R.color.halo_light)
         else colorResource(R.color.halo_dark)
 
     ScrollSeparatorColumn(

--- a/iosApp/iosApp/ComponentViews/HaloSeparator.swift
+++ b/iosApp/iosApp/ComponentViews/HaloSeparator.swift
@@ -10,8 +10,9 @@ import SwiftUI
 
 struct HaloSeparator: View {
     var height: CGFloat = 1
+    var haloColor: Color = .halo
 
     var body: some View {
-        Color.halo.frame(height: height)
+        haloColor.frame(height: height)
     }
 }

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
@@ -21,7 +21,7 @@ struct RouteCardList<EmptyView: View>: View {
 
     var body: some View {
         if let routeCardData, !routeCardData.isEmpty {
-            ScrollView {
+            HaloScrollView {
                 LazyVStack(alignment: .center, spacing: 18) {
                     ForEach(routeCardData, id: \.lineOrRoute.id) { routeCardData in
                         RouteCard(
@@ -39,7 +39,7 @@ struct RouteCardList<EmptyView: View>: View {
                 .padding(.horizontal, 16)
             }
         } else if let routeCardData, routeCardData.isEmpty {
-            ScrollView {
+            HaloScrollView {
                 VStack {
                     emptyView()
                     Spacer()
@@ -47,7 +47,7 @@ struct RouteCardList<EmptyView: View>: View {
                 .padding(.horizontal, 16)
             }
         } else {
-            ScrollView {
+            ScrollView([]) {
                 LazyVStack(alignment: .center, spacing: 14) {
                     ForEach(0 ..< 5) { _ in
                         LoadingRouteCard()

--- a/iosApp/iosApp/ComponentViews/SheetHeader.swift
+++ b/iosApp/iosApp/ComponentViews/SheetHeader.swift
@@ -12,6 +12,8 @@ import SwiftUI
 struct SheetHeader<Content: View>: View {
     let title: String?
     let titleColor: Color
+    let buttonColor: Color
+    let buttonTextColor: Color
     let onBack: (() -> Void)?
     let onClose: (() -> Void)?
     let closeText: String?
@@ -20,6 +22,8 @@ struct SheetHeader<Content: View>: View {
     init(
         title: String?,
         titleColor: Color = Color.text,
+        buttonColor: Color = Color.contrast,
+        buttonTextColor: Color = Color.fill2,
         onBack: (() -> Void)? = nil,
         onClose: (() -> Void)? = nil,
         closeText: String? = nil,
@@ -27,6 +31,8 @@ struct SheetHeader<Content: View>: View {
     ) {
         self.title = title
         self.titleColor = titleColor
+        self.buttonColor = buttonColor
+        self.buttonTextColor = buttonTextColor
         self.onBack = onBack
         self.onClose = onClose
         self.closeText = closeText
@@ -36,11 +42,11 @@ struct SheetHeader<Content: View>: View {
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
             if let onBack {
-                ActionButton(kind: .back, action: { onBack() })
+                ActionButton(kind: .back, circleColor: buttonColor, iconColor: buttonTextColor, action: { onBack() })
             }
             if let title {
                 Text(title)
-                    .font(Typography.title3Semibold)
+                    .font(Typography.title2Bold)
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h1)
                     .foregroundColor(titleColor)
@@ -49,11 +55,16 @@ struct SheetHeader<Content: View>: View {
             rightActionContents()
             if let onClose {
                 if let closeText {
-                    NavTextButton(string: closeText, backgroundColor: Color.key, textColor: Color.fill3) {
+                    NavTextButton(string: closeText, backgroundColor: buttonColor, textColor: buttonTextColor) {
                         onClose()
                     }
                 } else {
-                    ActionButton(kind: .close, action: { onClose() })
+                    ActionButton(
+                        kind: .close,
+                        circleColor: buttonColor,
+                        iconColor: buttonTextColor,
+                        action: { onClose() }
+                    )
                 }
             }
         }

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -115,7 +115,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                 }
             }
         }
-        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, 6)
+        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, stopListContext == .trip ? 6 : 0)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -15133,53 +15133,6 @@
         }
       }
     },
-    "Select location" : {
-      "comment" : "Visible when the user is panning the map to search for nearby transit",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seleccionar ubicación"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélectionner une localisation"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chwazi pozisyon"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecionar local"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chọn vị trí"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择位置"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選擇位置"
-          }
-        }
-      }
-    },
     "Select to call" : {
       "comment" : "Screen reader text for a link to call a phone number",
       "localizations" : {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -28,6 +28,8 @@ struct EditFavoritesPage: View {
             VStack(alignment: .leading, spacing: 16) {
                 SheetHeader(
                     title: NSLocalizedString("Edit Favorites", comment: "Title for flow to edit favorites"),
+                    buttonColor: Color.key,
+                    buttonTextColor: Color.fill3,
                     onClose: {
                         onClose()
                     },
@@ -38,7 +40,6 @@ struct EditFavoritesPage: View {
                                       viewModel.updateFavorites(updatedFavorites: [rsd: false],
                                                                 context: .favorites, defaultDirection: rsd.direction)
                                   })
-                Spacer()
             }
             .onAppear {
                 viewModel.setContext(context: FavoritesViewModel.ContextEdit())
@@ -86,8 +87,8 @@ struct EditFavoritesList: View {
 
     var body: some View {
         if let routeCardData, !routeCardData.isEmpty {
-            ScrollView {
-                LazyVStack(alignment: .center, spacing: 18) {
+            HaloScrollView {
+                LazyVStack(alignment: .center, spacing: 14) {
                     ForEach(routeCardData) { cardData in
                         RouteCardContainer(cardData: cardData, onPin: { _ in
                         }, pinned: false, showStopHeader: true) { stopData in
@@ -98,15 +99,16 @@ struct EditFavoritesList: View {
                                 deleteFavorite(favToDelete)
                             }
                         }
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 16)
                     }
                 }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+                .frame(maxHeight: .infinity, alignment: .top)
             }
         }
 
         else if routeCardData != nil {
-            ScrollView {
+            HaloScrollView {
                 NoFavoritesView()
                     .frame(maxWidth: .infinity)
                     .padding(.top, 16)
@@ -114,7 +116,7 @@ struct EditFavoritesList: View {
         }
 
         else {
-            ScrollView {
+            ScrollView([]) {
                 LazyVStack(alignment: .center, spacing: 14) {
                     ForEach(0 ..< 5) { _ in
                         LoadingRouteCard()

--- a/iosApp/iosApp/Pages/Favorites/FavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesPage.swift
@@ -29,6 +29,7 @@ struct FavoritesPage: View {
                 toastVM: toastVM,
                 location: $location
             )
+            .toolbarBackground(.visible, for: .tabBar)
             .onReceive(
                 viewportProvider.cameraStatePublisher
                     .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
@@ -42,31 +42,23 @@ struct NearbyTransitPage: View {
             VStack(spacing: 16) {
                 SheetHeader(title: NSLocalizedString("Nearby Transit", comment: "Header for nearby transit sheet"))
                 ErrorBanner(errorBannerVM).padding(.horizontal, 16)
-                if viewportProvider.isManuallyCentering {
-                    LoadingCard {
-                        Text(
-                            "Select location",
-                            comment: "Visible when the user is panning the map to search for nearby transit"
-                        )
-                    }.padding(.horizontal, 16).padding(.bottom, 16)
-                } else {
-                    NearbyTransitView(
-                        location: $location,
-                        isReturningFromBackground: $errorBannerVM.loadingWhenPredictionsStale,
-                        nearbyVM: nearbyVM,
-                        noNearbyStops: noNearbyStops
-                    )
-                    .onReceive(
-                        viewportProvider.cameraStatePublisher
-                            .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+                NearbyTransitView(
+                    location: $location,
+                    isReturningFromBackground: $errorBannerVM.loadingWhenPredictionsStale,
+                    nearbyVM: nearbyVM,
+                    noNearbyStops: noNearbyStops
+                )
+                .onReceive(
+                    viewportProvider.cameraStatePublisher
+                        .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
 
-                    ) { newCameraState in
-                        guard nearbyVM.isNearbyVisible() else { return }
-                        location = newCameraState.center
-                    }
-                    .onReceive(inspection.notice) { inspection.visit(self, $0) }
+                ) { newCameraState in
+                    guard nearbyVM.isNearbyVisible() else { return }
+                    location = newCameraState.center
                 }
+                .onReceive(inspection.notice) { inspection.visit(self, $0) }
             }
+            .toolbarBackground(.visible, for: .tabBar)
             .onChange(of: viewportProvider.isManuallyCentering) { isManuallyCentering in
                 if isManuallyCentering {
                     // The user is manually moving the map, clear the nearby state and

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -134,7 +134,7 @@ struct NearbyTransitView: View {
             }
         } else {
             ScrollViewReader { proxy in
-                ScrollView {
+                HaloScrollView {
                     LazyVStack(spacing: 18) {
                         ForEach(routeCardData) { cardData in
                             RouteCard(
@@ -161,7 +161,7 @@ struct NearbyTransitView: View {
     }
 
     @ViewBuilder private func loadingBody() -> some View {
-        ScrollView {
+        ScrollView([]) {
             LazyVStack(spacing: 18) {
                 ForEach(1 ... 5, id: \.self) { _ in
                     RouteCard(

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -22,7 +22,7 @@ struct RouteDetailsView: View {
     var errorBannerRepository = RepositoryDI().errorBanner
 
     var body: some View {
-        Group {
+        ScrollView([]) {
             if let globalData, let lineOrRoute = globalData.getLineOrRoute(
                 lineOrRouteId: selectionId
             ) {
@@ -46,6 +46,7 @@ struct RouteDetailsView: View {
                 loadingBody()
             }
         }
+        .ignoresSafeArea()
         .onAppear {
             getGlobal()
         }

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -16,8 +16,11 @@ struct DirectionPicker: View {
     let selectedDirectionId: Int32?
     let updateDirectionId: (Int32) -> Void
 
-    init(stopData: RouteCardData.RouteStopData, filter: StopDetailsFilter?,
-         setFilter: @escaping (StopDetailsFilter?) -> Void) {
+    init(
+        stopData: RouteCardData.RouteStopData,
+        filter: StopDetailsFilter?,
+        setFilter: @escaping (StopDetailsFilter?) -> Void
+    ) {
         availableDirections = Set(stopData.data.map(\.directionId)).sorted()
         directions = stopData.directions
         let route = stopData.lineOrRoute.sortRoute
@@ -51,11 +54,16 @@ struct DirectionPicker: View {
                 ForEach(availableDirections, id: \.hashValue) { direction in
                     let isSelected = selectedDirectionId == direction
                     let action = { updateDirectionId(direction) }
+                    let selectedDirection = directions[Int(direction)]
 
                     Button(action: action) {
-                        DirectionLabel(direction: directions[Int(direction)])
+                        DirectionLabel(direction: selectedDirection)
                             .padding(8)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity,
+                                alignment: selectedDirection.destination == nil ? .center : .leading
+                            )
                     }
                     .simultaneousGesture(TapGesture())
                     .accessibilityAddTraits(isSelected ? [.isSelected, .isHeader] : [])
@@ -70,6 +78,7 @@ struct DirectionPicker: View {
                     .clipShape(.rect(cornerRadius: 6))
                 }
             }
+            .frame(minHeight: 44)
             .padding(2)
             .background(deselectedBackroundColor)
             .clipShape(.rect(cornerRadius: 8))

--- a/iosApp/iosApp/Utils/HaloScrollView.swift
+++ b/iosApp/iosApp/Utils/HaloScrollView.swift
@@ -1,0 +1,71 @@
+//
+//  HaloScrollView.swift
+//  iosApp
+//
+//  Created by esimon on 7/31/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value += nextValue()
+    }
+}
+
+struct HaloScrollView<Content>: View where Content: View {
+    public var content: Content
+    public var axes: Axis.Set
+
+    public var haloColor: Color
+    public var haloHeight: CGFloat
+
+    public init(
+        _ axes: Axis.Set = .vertical,
+        haloColor: Color = .halo,
+        haloHeight: CGFloat = 2,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.axes = axes
+        self.haloColor = haloColor
+        self.haloHeight = haloHeight
+        self.content = content()
+    }
+
+    @State private var haloVisible = false
+
+    @MainActor @preconcurrency public var body: some View {
+        ZStack(alignment: .top) {
+            ScrollView(axes) {
+                content
+                    .background(
+                        GeometryReader { inner in
+                            // Invisible background to programmatically check the scroll position
+                            // Unfortunately there's no better way to do this until iOS 18
+                            Color.clear.preference(
+                                key: ScrollOffsetPreferenceKey.self,
+                                value: inner.frame(in: .named("scroll")).origin.y
+                            )
+                        }
+                    )
+            }
+            .coordinateSpace(name: "scroll")
+            .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+                if haloVisible, value == 0 {
+                    withAnimation {
+                        haloVisible = false
+                    }
+                } else if !haloVisible, value != 0 {
+                    withAnimation {
+                        haloVisible = true
+                    }
+                }
+            }
+            if haloVisible {
+                HaloSeparator(height: haloHeight, haloColor: haloColor).transition(.opacity)
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Utils/Typography.swift
+++ b/iosApp/iosApp/Utils/Typography.swift
@@ -48,6 +48,7 @@ struct Typography {
 
     static let title3 = Typography(size: 20, lineHeight: 28, relativeTo: .title3)
     static let title3Semibold = title3.weight(.semibold)
+    static let title3Bold = title3.bold()
 
     static let headline = Typography(size: 17, lineHeight: 24, relativeTo: .headline)
     static let headlineSemibold = headline.weight(.semibold)

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageTests.swift
@@ -25,18 +25,6 @@ final class NearbyTransitPageTests: XCTestCase {
         executionTimeAllowance = 60
     }
 
-    func testMessageWhenManuallyCentering() throws {
-        let viewportProvider = ViewportProvider(viewport: nil,
-                                                isManuallyCentering: true)
-        let sut = NearbyTransitPage(
-            errorBannerVM: .init(),
-            nearbyVM: .init(),
-            viewportProvider: viewportProvider,
-            noNearbyStops: noNearbyStops
-        )
-        XCTAssertNotNil(try sut.inspect().find(text: "Select location"))
-    }
-
     func testClearsNearbyStateWhenManuallyCentering() throws {
         let viewportProvider = ViewportProvider(
             viewport: nil,


### PR DESCRIPTION
### Summary

_Ticket:_ Prep for [ Favorites | UI Polish](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210710490021005?focus=true)

In addition to getting route details closer to spec, this also adds a HaloScrollView which displays a halo separator at the top of the scroll area when the contents are scrolled down, and this was added in most of the places where it makes sense (I didn't add it to the route picker since that's actively being worked on).

I also removed the nearby transit "Select location" loading spinner and card, since it's not in the spec, was broken at small detent, was inconsistent with Android (and favorites), and resulted in multiple loading states flickering when moving the map.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~
Stale string was removed

### Testing

N/A