### PR TITLE
fix: show status for CR even for times in the past

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -220,6 +220,30 @@ fun UpcomingTripView(
                             else Typography.footnoteSemibold,
                     )
 
+                is TripInstantDisplay.ScheduleTimeWithStatus ->
+                    Column(
+                        modifier.clearAndSetSemantics { contentDescription = tripDescription },
+                        horizontalAlignment = Alignment.End,
+                    ) {
+                        Text(
+                            state.trip.scheduledTime.formattedTime(),
+                            modifier
+                                .alpha(min(maxTextAlpha, 0.6F))
+                                .semantics { contentDescription = tripDescription }
+                                .placeholderIfLoading(),
+                            textAlign = TextAlign.End,
+                            style =
+                                if (state.trip.headline) Typography.headlineSemibold
+                                else Typography.footnoteSemibold,
+                        )
+                        Text(
+                            state.trip.status,
+                            color = LocalContentColor.current.copy(alpha = min(maxTextAlpha, 0.6f)),
+                            textAlign = TextAlign.End,
+                            style = Typography.footnoteSemibold,
+                        )
+                    }
+
                 is TripInstantDisplay.Minutes ->
                     WithRealtimeIndicator(modifier.then(maxAlphaModifier), hideRealtimeIndicators) {
                         Text(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
@@ -33,6 +33,7 @@ fun TripInstantDisplay.containsWrappableText() =
         is TripInstantDisplay.TimeWithSchedule -> false
         is TripInstantDisplay.Minutes -> false
         is TripInstantDisplay.ScheduleTime -> false
+        is TripInstantDisplay.ScheduleTimeWithStatus -> true
         is TripInstantDisplay.ScheduleMinutes -> false
         is TripInstantDisplay.Skipped -> false
         is TripInstantDisplay.Cancelled -> false

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -120,6 +120,18 @@ struct UpcomingTripView: View {
                 .opacity(min(0.6, maxTextAlpha))
                 .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
                 .accessibilityLabel(label)
+        case let .scheduleTimeWithStatus(format):
+            VStack(alignment: .trailing, spacing: 0) {
+                Text(format.scheduledTime, style: .time)
+                    .opacity(min(0.6, maxTextAlpha))
+                    .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
+                Text(format.status)
+                    .font(Typography.footnoteSemibold)
+                    .opacity(min(0.6, maxTextAlpha))
+                    .multilineTextAlignment(.trailing)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
         case let .scheduleMinutes(format):
             PredictionText(minutes: format.minutes)
                 .opacity(min(0.6, maxTextAlpha))

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -41,8 +41,8 @@ struct UpcomingTripView: View {
             .padding(.trailing, 4)
     }
 
-    @ViewBuilder
-    func tripInstantView(_ prediction: TripInstantDisplay) -> some View {
+    // swiftlint:disable:next function_body_length
+    @ViewBuilder func tripInstantView(_ prediction: TripInstantDisplay) -> some View {
         let label = prediction.accessibilityLabel(
             isFirst: isFirst,
             vehicleType: routeType?.typeText(isOnly: isOnly) ?? ""

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -39,7 +39,8 @@ constructor(
     val time =
         if (
             prediction != null &&
-                prediction.scheduleRelationship != Prediction.ScheduleRelationship.Cancelled
+                prediction.scheduleRelationship != Prediction.ScheduleRelationship.Cancelled &&
+                !(prediction.stopTime == null && prediction.status != null)
         ) {
             prediction.stopTime
         } else {
@@ -74,12 +75,14 @@ constructor(
 
     /**
      * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet
-     * left this stop.
+     * left this stop or a custom status string is still set.
      */
     fun isUpcomingWithin(currentTime: EasternTimeInstant, cutoffTime: EasternTimeInstant): Boolean =
         time != null &&
             time < cutoffTime &&
-            (time >= currentTime || (prediction != null && prediction.stopId == vehicle?.stopId))
+            (time >= currentTime ||
+                (prediction != null &&
+                    (prediction.stopId == vehicle?.stopId || prediction.status != null)))
 
     override fun compareTo(other: UpcomingTrip) =
         nullsLast<EasternTimeInstant>().compare(time, other.time)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -59,7 +59,7 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `commuter rail status is non-null, prediction time null, schedule in past`() {
+    fun `commuter rail status is non-null and prediction time null and schedule in past`() {
         val now = EasternTimeInstant.now()
         val scheduleTime = now - 3.minutes
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -38,6 +38,44 @@ class TripInstantDisplayTest {
     }
 
     @Test
+    fun `commuter rail status is non-null and prediction is in past`() {
+        val now = EasternTimeInstant.now()
+        val predictionTime = now - 3.minutes
+        assertEquals(
+            TripInstantDisplay.TimeWithStatus(predictionTime, "Custom Text", headline = true),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = predictionTime
+                        status = "Custom Text"
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now = now,
+                context = TripInstantDisplay.Context.StopDetailsFiltered,
+            ),
+        )
+    }
+
+    @Test
+    fun `commuter rail status is non-null, prediction time null, schedule in past`() {
+        val now = EasternTimeInstant.now()
+        val scheduleTime = now - 3.minutes
+        assertEquals(
+            TripInstantDisplay.ScheduleTimeWithStatus(scheduleTime, "Custom Text", headline = true),
+            TripInstantDisplay.from(
+                prediction = ObjectCollectionBuilder.Single.prediction { status = "Custom Text" },
+                schedule = ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime },
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now = now,
+                context = TripInstantDisplay.Context.StopDetailsFiltered,
+            ),
+        )
+    }
+
+    @Test
     fun `scheduled trip skipped`() = parametricTest {
         val now = EasternTimeInstant.now()
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ [Display scheduled Commuter Rail times with status when prediction has null times but non-null boarding_status](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210826290372849?focus=true)

It seems like, if we want to show schedules in the past that still have a status, it’d also be correct to show predictions in the past that still have a status.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests for new logic. Verified that old CR schedules with a current status are correctly shown in the filtered stop details tile list.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
