### PR TITLE
feat(iOS): Search for add stops flow

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -12358,6 +12358,9 @@
         }
       }
     },
+    "No matching %@ routes" : {
+      "comment" : "Text to indicate there's no matching results in route picker view"
+    },
     "No matching %1$@ routes" : {
       "comment" : "Text for the empty state on the route picker page when the filter text doesn't match any routes. The interpolated value can be \"bus\", \"ferry\", or \"train\" (localized).",
       "extractionState" : "manual",

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -12358,9 +12358,6 @@
         }
       }
     },
-    "No matching %@ routes" : {
-      "comment" : "Text to indicate there's no matching results in route picker view"
-    },
     "No matching %1$@ routes" : {
       "comment" : "Text for the empty state on the route picker page when the filter text doesn't match any routes. The interpolated value can be \"bus\", \"ferry\", or \"train\" (localized).",
       "extractionState" : "manual",

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -14,7 +14,7 @@ struct RoutePickerView: View {
     let context: RouteDetailsContext
     let path: RoutePickerPath
     let errorBannerVM: ErrorBannerViewModel
-    let searchRoutesViewModel: SearchRoutesViewModel = ViewModelDI().searchRoutes
+    var searchRoutesViewModel: ISearchRoutesViewModel = ViewModelDI().searchRoutes
     let onOpenRouteDetails: (String, RouteDetailsContext) -> Void
     let onOpenPickerPath: (RoutePickerPath, RouteDetailsContext) -> Void
     let onClose: () -> Void

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -14,6 +14,7 @@ struct RoutePickerView: View {
     let context: RouteDetailsContext
     let path: RoutePickerPath
     let errorBannerVM: ErrorBannerViewModel
+    let searchRoutesViewModel: SearchRoutesViewModel = ViewModelDI().searchRoutes
     let onOpenRouteDetails: (String, RouteDetailsContext) -> Void
     let onOpenPickerPath: (RoutePickerPath, RouteDetailsContext) -> Void
     let onClose: () -> Void
@@ -21,6 +22,8 @@ struct RoutePickerView: View {
 
     @State var globalData: GlobalResponse?
     @State var routes: [RouteCardData.LineOrRoute] = []
+    @State var searchVMState: SearchRoutesViewModel.State = SearchRoutesViewModel.StateUnfiltered()
+    @StateObject var searchObserver = TextFieldObserver()
     let globalRepository: IGlobalRepository = RepositoryDI().global
     var errorBannerRepository = RepositoryDI().errorBanner
 
@@ -51,18 +54,40 @@ struct RoutePickerView: View {
         }
     }
 
+    private var isRootPath: Bool { path is RoutePickerPath.Root }
+
     var body: some View {
         ZStack {
             path.backgroundColor.edgesIgnoringSafeArea(.all)
-            VStack {
+            VStack(spacing: 0) {
                 header
                 ErrorBanner(errorBannerVM)
+                if !isRootPath {
+                    SearchInput(
+                        searchObserver: searchObserver,
+                        hint: NSLocalizedString(
+                            "Filter routes",
+                            comment: "Hint text for the search input in the route picker view"
+                        ),
+                        onClear: { searchObserver.isFocused = false }
+                    )
+                    .padding(.top, 16)
+                    .padding(.bottom, 8)
+                    .padding(.horizontal, 16)
+                }
                 ScrollView {
                     Group {
-                        if path is RoutePickerPath.Root {
+                        if isRootPath {
                             rootContent
+                                .padding(.top, 16)
                         } else {
-                            let displayedRoutes = routes // TODO: Search result state
+                            let displayedRoutes = switch onEnum(of: searchVMState) {
+                            case .unfiltered, .error: routes
+                            case let .results(state):
+                                state.routeIds.compactMap { routeId in
+                                    routes.first(where: { route in route.id == routeId })
+                                }
+                            }
                             VStack(spacing: 0) {
                                 if !displayedRoutes.isEmpty {
                                     ForEach(displayedRoutes, id: \.self) { route in
@@ -73,10 +98,12 @@ struct RoutePickerView: View {
                             }
                             .background(Color.fill3)
                             .withRoundedBorder(color: path.haloColor, width: 2)
+                            .padding(.top, 16)
+                            footer(emptyResults: displayedRoutes.isEmpty)
+                                .padding(.top, 16)
                         }
                     }
                     .padding(.horizontal, 14)
-                    .padding(.top, 10)
                 }
             }
         }
@@ -90,6 +117,14 @@ struct RoutePickerView: View {
             }
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        .task {
+            for await model in searchRoutesViewModel.models {
+                searchVMState = model
+            }
+        }
+        .onChange(of: searchObserver.searchText) { query in
+            searchRoutesViewModel.setQuery(query: query)
+        }
     }
 
     private var header: some View {
@@ -126,6 +161,31 @@ struct RoutePickerView: View {
                     }
                 )
             }
+        }
+    }
+
+    @ViewBuilder
+    private func footer(emptyResults: Bool) -> some View {
+        if searchVMState is SearchRoutesViewModel.StateResults {
+            VStack(spacing: 2) {
+                if emptyResults {
+                    Text(
+                        String(
+                            format: NSLocalizedString(
+                                "No matching %@ routes",
+                                comment: "Text to indicate there's no matching results in route picker view"
+                            ),
+                            path.routeType.typeText(isOnly: true)
+                        )
+                    )
+                    .foregroundColor(path.textColor)
+                    .font(Typography.bodySemibold)
+                }
+                Text("To find stops, select a route first")
+                    .foregroundColor(path.textColor)
+                    .font(Typography.body)
+            }
+            .frame(maxWidth: .infinity)
         }
     }
 

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -172,7 +172,7 @@ struct RoutePickerView: View {
                     Text(
                         String(
                             format: NSLocalizedString(
-                                "No matching %@ routes",
+                                "No matching %1$@ routes",
                                 comment: "Text to indicate there's no matching results in route picker view"
                             ),
                             path.routeType.typeText(isOnly: true)

--- a/iosApp/iosApp/Pages/Search/SearchField.swift
+++ b/iosApp/iosApp/Pages/Search/SearchField.swift
@@ -11,55 +11,13 @@ import SwiftUI
 struct SearchField: View {
     @ObservedObject var searchObserver: TextFieldObserver
 
-    // Don't update this FocusState isFocused directly, only toggle through searchObserver.isFocused,
-    // otherwise it's possible for the update in searchObserver to get skipped. It's also not
-    // possible to test state variable changes, while testing this will stay set to false.
-    @FocusState var isFocused: Bool
-
-    @ScaledMetric var searchIconSize: CGFloat = 16
-
     var body: some View {
         HStack(spacing: 14) {
-            HStack(alignment: .center, spacing: 0) {
-                Image(.faMagnifyingGlassSolid)
-                    .resizable()
-                    .frame(width: searchIconSize, height: searchIconSize)
-                    .padding(.all, 4)
-                    .foregroundStyle(Color.deemphasized)
-                    .accessibilityHidden(true)
-                TextField(
-                    NSLocalizedString("Stops", comment: "Placeholder text in the empty search field"),
-                    text: $searchObserver.searchText
-                )
-                .accessibilityAddTraits(.isSearchField)
-                .focused($isFocused)
-                .submitLabel(.done)
-                .padding(.horizontal, 2)
-                .padding(.vertical, 8)
-                .animation(.smooth, value: searchObserver.isSearching)
-                if !searchObserver.searchText.isEmpty {
-                    ActionButton(kind: .clear) {
-                        searchObserver.isFocused = true
-                        searchObserver.clear()
-                    }
-                    .accessibilityLabel(Text(
-                        "clear search text",
-                        comment: "VoiceOver label for clear search text button"
-                    ))
-                    .padding(.all, 4)
-                }
-            }
-            .padding(.leading, 8)
-            .padding(.trailing, 6)
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .background(Color.fill3)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
-            .overlay(RoundedRectangle(cornerRadius: 8)
-                .stroke(
-                    searchObserver.isSearching ? Color.key : Color.halo,
-                    lineWidth: searchObserver.isSearching ? 3 : 2
-                ))
-
+            SearchInput(
+                searchObserver: searchObserver,
+                hint: NSLocalizedString("Stops", comment: "Placeholder text in the empty search field"),
+                onClear: { searchObserver.isFocused = true }
+            )
             if searchObserver.isSearching {
                 Button(action: {
                     searchObserver.isFocused = false
@@ -71,8 +29,5 @@ struct SearchField: View {
             }
         }
         .padding(.horizontal, 16)
-        .onAppear { isFocused = searchObserver.isFocused }
-        .onChange(of: isFocused) { searchObserver.isFocused = $0 }
-        .onChange(of: searchObserver.isFocused) { isFocused = $0 }
     }
 }

--- a/iosApp/iosApp/Pages/Search/SearchInput.swift
+++ b/iosApp/iosApp/Pages/Search/SearchInput.swift
@@ -1,0 +1,67 @@
+//
+//  SearchInput.swift
+//  iosApp
+//
+//  Created by Brandon Rodriguez on 8/1/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct SearchInput: View {
+    @ObservedObject var searchObserver: TextFieldObserver
+    var hint: String
+    var onClear: (() -> Void)? = nil
+
+    // Don't update this FocusState isFocused directly, only toggle through searchObserver.isFocused,
+    // otherwise it's possible for the update in searchObserver to get skipped. It's also not
+    // possible to test state variable changes, while testing this will stay set to false.
+    @FocusState var isFocused: Bool
+
+    @ScaledMetric var searchIconSize: CGFloat = 16
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            Image(.faMagnifyingGlassSolid)
+                .resizable()
+                .frame(width: searchIconSize, height: searchIconSize)
+                .padding(.all, 4)
+                .foregroundStyle(Color.deemphasized)
+                .accessibilityHidden(true)
+            TextField(
+                hint,
+                text: $searchObserver.searchText
+            )
+            .accessibilityAddTraits(.isSearchField)
+            .focused($isFocused)
+            .submitLabel(.done)
+            .padding(.horizontal, 2)
+            .padding(.vertical, 8)
+            .animation(.smooth, value: searchObserver.isSearching)
+            if !searchObserver.searchText.isEmpty {
+                ActionButton(kind: .clear) {
+                    onClear?()
+                    searchObserver.clear()
+                }
+                .accessibilityLabel(Text(
+                    "clear search text",
+                    comment: "VoiceOver label for clear search text button"
+                ))
+                .padding(.all, 4)
+            }
+        }
+        .padding(.leading, 8)
+        .padding(.trailing, 6)
+        .frame(maxWidth: .infinity, minHeight: 44)
+        .background(Color.fill3)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8)
+            .stroke(
+                searchObserver.isSearching ? Color.key : Color.halo,
+                lineWidth: searchObserver.isSearching ? 3 : 2
+            ))
+        .onAppear { isFocused = searchObserver.isFocused }
+        .onChange(of: isFocused) { searchObserver.isFocused = $0 }
+        .onChange(of: searchObserver.isFocused) { isFocused = $0 }
+    }
+}

--- a/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerViewTests.swift
@@ -395,4 +395,115 @@ final class RoutePickerViewTests: XCTestCase {
         ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 2)
     }
+
+    @MainActor func testFilterInputRequests() {
+        let objects = ObjectCollectionBuilder()
+        let route1 =
+            objects.route { route in
+                route.shortName = "1"
+                route.longName = "Harvard Square - Nubian Station"
+                route.type = RouteType.bus
+            }
+        let route71 =
+            objects.route { route in
+                route.shortName = "71"
+                route.longName = "Watertown Square - Harvard Station"
+                route.type = RouteType.bus
+            }
+
+        let gotGlobalData = PassthroughSubject<Void, Never>()
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.global = MockGlobalRepository(
+            response: GlobalResponse(objects: objects),
+            onGet: { gotGlobalData.send() }
+        )
+        let gotSearchResults = PassthroughSubject<Void, Never>()
+        repositories.searchResults = MockSearchResultRepository(
+            routeResults: [RouteResult(route: route1, rank: 0)],
+            stopResults: [],
+            onGetRouteFilterResults: { gotSearchResults.send() }
+        )
+        repositories.errorBanner = MockErrorBannerStateRepository()
+        loadKoinMocks(repositories: repositories)
+        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+
+        let sut = RoutePickerView(
+            context: RouteDetailsContext.Favorites(),
+            path: RoutePickerPath.Bus(),
+            errorBannerVM: errorBannerVM,
+            onOpenRouteDetails: { _, _ in },
+            onOpenPickerPath: { _, _ in },
+            onClose: {},
+            onBack: {}
+        )
+
+        let exp = sut.inspection.inspect(onReceive: gotGlobalData, after: 1) { view in
+            XCTAssertNoThrow(try view.find(text: route71.longName))
+            XCTAssertNoThrow(try view.find(text: "Filter routes"))
+            try view.zStack().callOnChange(newValue: "Nubian")
+        }
+        let exp2 = sut.inspection.inspect(onReceive: gotSearchResults, after: 1) { view in
+            XCTAssertNoThrow(try view.find(text: "To find stops, select a route first"))
+            XCTAssertNoThrow(try view.find(text: route1.longName))
+            XCTAssertThrowsError(try view.find(text: route71.longName))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp, exp2], timeout: 3)
+    }
+
+    @MainActor func testNoFilterResults() {
+        let objects = ObjectCollectionBuilder()
+        let route1 =
+            objects.route { route in
+                route.shortName = "1"
+                route.longName = "Harvard Square - Nubian Station"
+                route.type = RouteType.bus
+            }
+        let route71 =
+            objects.route { route in
+                route.shortName = "71"
+                route.longName = "Watertown Square - Harvard Station"
+                route.type = RouteType.bus
+            }
+
+        let gotGlobalData = PassthroughSubject<Void, Never>()
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.global = MockGlobalRepository(
+            response: GlobalResponse(objects: objects),
+            onGet: { gotGlobalData.send() }
+        )
+        let gotSearchResults = PassthroughSubject<Void, Never>()
+        repositories.searchResults = MockSearchResultRepository(
+            onGetRouteFilterResults: { gotSearchResults.send() }
+        )
+        repositories.errorBanner = MockErrorBannerStateRepository()
+        loadKoinMocks(repositories: repositories)
+        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+
+        let sut = RoutePickerView(
+            context: RouteDetailsContext.Favorites(),
+            path: RoutePickerPath.Bus(),
+            errorBannerVM: errorBannerVM,
+            onOpenRouteDetails: { _, _ in },
+            onOpenPickerPath: { _, _ in },
+            onClose: {},
+            onBack: {}
+        )
+
+        let exp = sut.inspection.inspect(onReceive: gotGlobalData, after: 1) { view in
+            XCTAssertNoThrow(try view.find(text: route71.longName))
+            XCTAssertNoThrow(try view.find(text: "Filter routes"))
+            try view.zStack().callOnChange(newValue: "Nubian")
+        }
+        let exp2 = sut.inspection.inspect(onReceive: gotSearchResults, after: 1) { view in
+            XCTAssertNoThrow(try view.find(text: "To find stops, select a route first"))
+            XCTAssertNoThrow(try view.find(text: "No matching bus routes"))
+            XCTAssertThrowsError(try view.find(text: route1.longName))
+            XCTAssertThrowsError(try view.find(text: route71.longName))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+        wait(for: [exp, exp2], timeout: 3)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.RouteResult
 import com.mbta.tid.mbta_app.model.SearchResults
 import com.mbta.tid.mbta_app.model.StopResult
@@ -43,15 +44,21 @@ class SearchResultRepository : KoinComponent, ISearchResultRepository {
         searchRequest("api/search/query", query)
 }
 
-class MockSearchResultRepository(
+class MockSearchResultRepository
+@DefaultArgumentInterop.Enabled
+constructor(
     private val routeResults: List<RouteResult> = emptyList(),
     private val stopResults: List<StopResult> = emptyList(),
+    private val onGetRouteFilterResults: () -> Unit = {},
+    private val onGetSearchResults: () -> Unit = {},
 ) : ISearchResultRepository {
     override suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults> {
+        onGetRouteFilterResults()
         return ApiResult.Ok(SearchResults(routeResults, emptyList()))
     }
 
     override suspend fun getSearchResults(query: String): ApiResult<SearchResults> {
+        onGetSearchResults()
         return ApiResult.Ok(SearchResults(routeResults, stopResults))
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -14,13 +15,24 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
+
+interface ISearchRoutesViewModel {
+
+    val models: StateFlow<SearchRoutesViewModel.State>
+
+    fun setQuery(query: String)
+}
 
 class SearchRoutesViewModel(
     private val analytics: Analytics,
     private val globalRepository: IGlobalRepository,
     private val searchResultRepository: ISearchResultRepository,
-) : MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>() {
+) :
+    MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>(),
+    ISearchRoutesViewModel {
     sealed interface Event {
         data class SetQuery(val query: String) : Event
     }
@@ -84,8 +96,19 @@ class SearchRoutesViewModel(
         return state
     }
 
-    val models
+    override val models
         get() = internalModels
 
-    fun setQuery(query: String) = fireEvent(Event.SetQuery(query))
+    override fun setQuery(query: String) = fireEvent(Event.SetQuery(query))
+}
+
+class MockSearchRoutesViewModel
+@DefaultArgumentInterop.Enabled
+constructor(initialState: SearchRoutesViewModel.State) : ISearchRoutesViewModel {
+    var onSetQuery = { _: String -> }
+    override val models = MutableStateFlow(initialState)
+
+    override fun setQuery(query: String) {
+        onSetQuery(query)
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites |  Add stops flow - search / filter](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210765282940767?focus=true)

Adds search/filter functionality to the add stops flow.
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-04 at 13 58 04" src="https://github.com/user-attachments/assets/f2765126-e4a4-47f7-826c-18fed291646a" />


iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

### Testing

Added tests for new states.
