### PR TITLE
fix: speed up toString calls

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
@@ -172,4 +172,6 @@ data class GlobalMapData(
             .toMap(),
         alertsByStop,
     )
+
+    override fun toString() = "[GlobalMapData]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
@@ -64,9 +64,7 @@ sealed class LeafFormat {
         val branchRows: List<BranchRow>,
         val secondaryAlert: UpcomingFormat.SecondaryAlert? = null,
     ) : LeafFormat() {
-        data class BranchRow
-        @OptIn(ExperimentalUuidApi::class)
-        constructor(
+        data class BranchRow(
             /**
              * The route to display next to [headsign] and [format]. Only set if the
              * [RouteCardData.Leaf] comes from a grouped line, and therefore always worth showing if
@@ -75,8 +73,13 @@ sealed class LeafFormat {
             val route: Route?,
             val headsign: String,
             val format: UpcomingFormat,
-            val id: String = "$headsign-$format-${Uuid.random()}",
-        )
+        ) {
+            /**
+             * SwiftUI needs to be able to distinguish rows with the same headsign, but that
+             * shouldn’t be included in equality checks or computed eagerly.
+             */
+            @OptIn(ExperimentalUuidApi::class) val id by lazy { "$headsign-${Uuid.random()}" }
+        }
 
         override fun tileData(directionDestination: String?): List<TileData> {
             return branchRows.mapNotNull { branch ->

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -624,6 +624,8 @@ data class RouteCardData(
     /** The distance from the given position to the first stop in this route card. */
     fun distanceFrom(position: Position): Double = this.stopData.first().stop.distanceFrom(position)
 
+    override fun toString() = "[RouteCardData]"
+
     companion object {
         // For regular non-branching service, we always show up to 2 departure rows for each leaf
         const val TYPICAL_LEAF_ROWS = 2

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -143,6 +143,8 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
         val vehicle: Vehicle? = null,
     )
 
+    override fun toString() = "[TripDetailsStopList]"
+
     companion object {
 
         // TODO: Remove hardcoded IDs once the `listed_route` field is exposed by the API.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -75,6 +75,8 @@ sealed class UpcomingFormat {
                 now: EasternTimeInstant,
                 context: TripInstantDisplay.Context,
             ) : this(trip, routeType, trip.display(now, routeType, context))
+
+            override fun toString() = format.toString()
         }
 
         constructor(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -27,4 +27,6 @@ data class Vehicle(
         @SerialName("stopped_at") StoppedAt,
         @SerialName("in_transit_to") InTransitTo,
     }
+
+    override fun toString() = "Vehicle(id=$id)"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -24,6 +24,8 @@ data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
                 }
             )
         } ?: this
+
+    override fun toString() = "[AlertsStreamDataResponse]"
 }
 
 fun AlertsStreamDataResponse?.isNullOrEmpty() = this == null || this.isEmpty()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -179,4 +179,6 @@ data class GlobalResponse(
             routeEntities.mapNotNull { this.stops[it.stop]?.resolveParent(this.stops) }
         return parentStops.distinct()
     }
+
+    override fun toString() = "[GlobalResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/MapFriendlyRouteResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/MapFriendlyRouteResponse.kt
@@ -15,4 +15,6 @@ data class MapFriendlyRouteResponse(
         @SerialName("route_id") val routeId: String,
         @SerialName("route_shapes") val segmentedShapes: List<SegmentedRouteShape>,
     )
+
+    override fun toString() = "[MapFriendlyRouteResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -78,6 +78,8 @@ data class PredictionsByStopJoinResponse(
 
     fun predictionQuantity() = predictionsByStop.map { it.value.size }.sum()
 
+    override fun toString() = "[PredictionsByStopJoinResponse]"
+
     companion object {
         val empty = PredictionsByStopJoinResponse(emptyMap(), emptyMap(), emptyMap())
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
@@ -20,4 +20,6 @@ data class PredictionsByStopMessageResponse(
         objects: ObjectCollectionBuilder,
         stopId: String = objects.stops.keys.single(),
     ) : this(stopId, objects.predictions, objects.trips, objects.vehicles)
+
+    override fun toString() = "[PredictionsByStopMessageResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
@@ -17,4 +17,6 @@ data class PredictionsStreamDataResponse(
     ) : this(objects.predictions, objects.trips, objects.vehicles)
 
     fun predictionQuantity() = predictions.size
+
+    override fun toString() = "[PredictionsStreamDataResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
@@ -24,4 +24,6 @@ data class ScheduleResponse(
         }
         return hasSchedules
     }
+
+    override fun toString() = "[ScheduleResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/SearchResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/SearchResponse.kt
@@ -3,4 +3,7 @@ package com.mbta.tid.mbta_app.model.response
 import com.mbta.tid.mbta_app.model.SearchResults
 import kotlinx.serialization.Serializable
 
-@Serializable data class SearchResponse(val data: SearchResults)
+@Serializable
+data class SearchResponse(val data: SearchResults) {
+    override fun toString() = "[SearchResponse]"
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/StopMapResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/StopMapResponse.kt
@@ -9,4 +9,6 @@ data class StopMapResponse(
     @SerialName("map_friendly_route_shapes")
     val routeShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
     @SerialName("child_stops") val childStops: Map<String, Stop>,
-)
+) {
+    override fun toString() = "[StopMapResponse]"
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
@@ -14,6 +14,8 @@ sealed class TripSchedulesResponse {
             schedules.mapNotNull { globalData.stops[it.stopId] }
 
         override fun routeId(): String? = schedules.map { it.routeId }.distinct().singleOrNull()
+
+        override fun toString() = "[TripSchedulesResponse.Schedules]"
     }
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehiclesStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehiclesStreamDataResponse.kt
@@ -3,4 +3,7 @@ package com.mbta.tid.mbta_app.model.response
 import com.mbta.tid.mbta_app.model.Vehicle
 import kotlinx.serialization.Serializable
 
-@Serializable data class VehiclesStreamDataResponse(val vehicles: Map<String, Vehicle>)
+@Serializable
+data class VehiclesStreamDataResponse(val vehicles: Map<String, Vehicle>) {
+    override fun toString() = "[VehiclesStreamDataResponse]"
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
@@ -81,9 +81,7 @@ private constructor(private val instant: Instant, val local: LocalDateTime) :
         return instant.hashCode()
     }
 
-    override fun toString(): String {
-        return local.toString() + timeZone.offsetAt(instant).toString()
-    }
+    override fun toString() = local.toString() + timeZone.offsetAt(instant).toString()
 
     enum class ServiceDateRounding {
         FORWARDS,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -16,23 +16,6 @@ class RouteCardDataLeafTest {
     private fun ParametricTest.anyNonScheduleBasedRouteType() =
         anyEnumValueExcept(RouteType.COMMUTER_RAIL, RouteType.FERRY)
 
-    /**
-     * Helper function to get rid of auto generated UUIDs in the branch format IDs in generated
-     * format objects. These are required for SwiftUI ForEach views, but when we're generating
-     * separate expected and actual objects in tests, they get in the way.
-     */
-    private fun wipeBranchUUID(format: LeafFormat): LeafFormat {
-        return when (format) {
-            is LeafFormat.Single -> format
-            is LeafFormat.Branched ->
-                format.copy(
-                    format.branchRows.map {
-                        it.copy(id = it.id.split("-").subList(0, 2).joinToString("-"))
-                    }
-                )
-        }
-    }
-
     @Test
     fun `formats as alert with no trips and major alert`() = parametricTest {
         val now = EasternTimeInstant.now()
@@ -590,64 +573,60 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.branched {
-                    branchRow(
-                        "Ashmont",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction1),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Approaching,
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Braintree",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction2),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Minutes(2),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Ashmont",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction3),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Minutes(9),
-                            ),
-                            null,
-                        ),
-                    )
-                }
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        RedLine.lineOrRoute,
-                        RedLine.jfkUmass.itself,
-                        0,
-                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                        setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
-                        listOf(
+            LeafFormat.branched {
+                branchRow(
+                    "Ashmont",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2),
-                            objects.upcomingTrip(prediction3),
-                            objects.upcomingTrip(prediction4),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Approaching,
                         ),
-                        emptyList(),
-                        allDataLoaded = true,
-                        hasSchedulesToday = true,
-                        emptyList(),
-                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                    )
-                    .format(now, RedLine.global)
-            ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Braintree",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction2),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Minutes(2),
+                        ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Ashmont",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction3),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Minutes(9),
+                        ),
+                        null,
+                    ),
+                )
+            },
+            RouteCardData.Leaf(
+                    RedLine.lineOrRoute,
+                    RedLine.jfkUmass.itself,
+                    0,
+                    listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                    setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                        objects.upcomingTrip(prediction4),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                )
+                .format(now, RedLine.global),
         )
     }
 
@@ -688,66 +667,62 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        secondaryAlert =
-                            UpcomingFormat.SecondaryAlert(StopAlertState.Issue, MapStopRoute.RED)
-                        branchRow(
-                            "Ashmont",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction1),
-                                    RouteType.HEAVY_RAIL,
-                                    TripInstantDisplay.Approaching,
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            "Braintree",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction2),
-                                    RouteType.HEAVY_RAIL,
-                                    TripInstantDisplay.Minutes(2),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            "Ashmont",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction3),
-                                    RouteType.HEAVY_RAIL,
-                                    TripInstantDisplay.Minutes(9),
-                                ),
-                                null,
-                            ),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            RedLine.lineOrRoute,
-                            RedLine.jfkUmass.itself,
-                            0,
-                            listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                            setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
-                            listOf(
+                LeafFormat.branched {
+                    secondaryAlert =
+                        UpcomingFormat.SecondaryAlert(StopAlertState.Issue, MapStopRoute.RED)
+                    branchRow(
+                        "Ashmont",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
                                 objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
-                                objects.upcomingTrip(prediction3),
-                                objects.upcomingTrip(prediction4),
+                                RouteType.HEAVY_RAIL,
+                                TripInstantDisplay.Approaching,
                             ),
-                            emptyList(),
-                            allDataLoaded = true,
-                            hasSchedulesToday = true,
-                            listOf(downstreamAlert),
-                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                        )
-                        .format(now, RedLine.global)
-                ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        "Braintree",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction2),
+                                RouteType.HEAVY_RAIL,
+                                TripInstantDisplay.Minutes(2),
+                            ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        "Ashmont",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction3),
+                                RouteType.HEAVY_RAIL,
+                                TripInstantDisplay.Minutes(9),
+                            ),
+                            null,
+                        ),
+                    )
+                },
+                RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        RedLine.jfkUmass.itself,
+                        0,
+                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                        setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3),
+                            objects.upcomingTrip(prediction4),
+                        ),
+                        emptyList(),
+                        allDataLoaded = true,
+                        hasSchedulesToday = true,
+                        listOf(downstreamAlert),
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, RedLine.global),
             )
         }
 
@@ -845,63 +820,59 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.branched {
-                    branchRow(
-                        "Ashmont",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction1),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Minutes(2),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Ashmont",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction2),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Minutes(5),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Ashmont",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction3),
-                                RouteType.HEAVY_RAIL,
-                                TripInstantDisplay.Minutes(9),
-                            ),
-                            null,
-                        ),
-                    )
-                }
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        RedLine.lineOrRoute,
-                        RedLine.jfkUmass.itself,
-                        0,
-                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                        setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
-                        listOf(
+            LeafFormat.branched {
+                branchRow(
+                    "Ashmont",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2),
-                            objects.upcomingTrip(prediction3),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Minutes(2),
                         ),
-                        emptyList(),
-                        allDataLoaded = true,
-                        hasSchedulesToday = true,
-                        emptyList(),
-                        anyEnumValue(),
-                    )
-                    .format(now, RedLine.global)
-            ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Ashmont",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction2),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Minutes(5),
+                        ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Ashmont",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction3),
+                            RouteType.HEAVY_RAIL,
+                            TripInstantDisplay.Minutes(9),
+                        ),
+                        null,
+                    ),
+                )
+            },
+            RouteCardData.Leaf(
+                    RedLine.lineOrRoute,
+                    RedLine.jfkUmass.itself,
+                    0,
+                    listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                    setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    anyEnumValue(),
+                )
+                .format(now, RedLine.global),
         )
     }
 
@@ -949,60 +920,56 @@ class RouteCardDataLeafTest {
             val mapStopRoute = MapStopRoute.matching(RedLine.route)
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.Branched(
-                        listOf(
-                            LeafFormat.Branched.BranchRow(
-                                null,
-                                "Ashmont",
-                                UpcomingFormat.Some(
-                                    UpcomingFormat.Some.FormattedTrip(
-                                        objects.upcomingTrip(prediction1),
-                                        RouteType.HEAVY_RAIL,
-                                        TripInstantDisplay.Minutes(3),
-                                    ),
-                                    null,
+                LeafFormat.Branched(
+                    listOf(
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Ashmont",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction1),
+                                    RouteType.HEAVY_RAIL,
+                                    TripInstantDisplay.Minutes(3),
                                 ),
-                            ),
-                            LeafFormat.Branched.BranchRow(
                                 null,
-                                "Ashmont",
-                                UpcomingFormat.Some(
-                                    UpcomingFormat.Some.FormattedTrip(
-                                        objects.upcomingTrip(prediction2),
-                                        RouteType.HEAVY_RAIL,
-                                        TripInstantDisplay.Minutes(12),
-                                    ),
-                                    null,
+                            ),
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Ashmont",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction2),
+                                    RouteType.HEAVY_RAIL,
+                                    TripInstantDisplay.Minutes(12),
                                 ),
-                            ),
-                            LeafFormat.Branched.BranchRow(
                                 null,
-                                "Braintree",
-                                UpcomingFormat.Disruption(alert, mapStopRoute),
                             ),
-                        )
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Braintree",
+                            UpcomingFormat.Disruption(alert, mapStopRoute),
+                        ),
                     )
                 ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            RedLine.lineOrRoute,
-                            RedLine.jfkUmass.itself,
-                            0,
-                            listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                            setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
-                            listOf(
-                                objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
-                            ),
-                            listOf(alert),
-                            allDataLoaded = true,
-                            hasSchedulesToday = true,
-                            emptyList(),
-                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                        )
-                        .format(now, RedLine.global)
-                ),
+                RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        RedLine.jfkUmass.itself,
+                        0,
+                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                        setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                        ),
+                        listOf(alert),
+                        allDataLoaded = true,
+                        hasSchedulesToday = true,
+                        emptyList(),
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, RedLine.global),
             )
         }
 
@@ -1066,72 +1033,68 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.branched {
-                    branchRow(
-                        GreenLine.c,
-                        "Cleveland Circle",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction1),
-                                RouteType.LIGHT_RAIL,
-                                TripInstantDisplay.Minutes(3),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        GreenLine.b,
-                        "Boston College",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction2),
-                                RouteType.LIGHT_RAIL,
-                                TripInstantDisplay.Minutes(5),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        GreenLine.d,
-                        "Riverside",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction3),
-                                RouteType.LIGHT_RAIL,
-                                TripInstantDisplay.Minutes(10),
-                            ),
-                            null,
-                        ),
-                    )
-                }
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        GreenLine.lineOrRoute,
-                        GreenLine.boylston,
-                        0,
-                        listOf(
-                            GreenLine.bWestbound,
-                            GreenLine.cWestbound,
-                            GreenLine.dWestbound,
-                            GreenLine.eWestbound,
-                        ),
-                        emptySet(),
-                        listOf(
+            LeafFormat.branched {
+                branchRow(
+                    GreenLine.c,
+                    "Cleveland Circle",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2),
-                            objects.upcomingTrip(prediction3),
-                            objects.upcomingTrip(prediction4),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Minutes(3),
                         ),
-                        emptyList(),
-                        allDataLoaded = true,
-                        hasSchedulesToday = true,
-                        emptyList(),
-                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                    )
-                    .format(now, GreenLine.global)
-            ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    GreenLine.b,
+                    "Boston College",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction2),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Minutes(5),
+                        ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    GreenLine.d,
+                    "Riverside",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction3),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Minutes(10),
+                        ),
+                        null,
+                    ),
+                )
+            },
+            RouteCardData.Leaf(
+                    GreenLine.lineOrRoute,
+                    GreenLine.boylston,
+                    0,
+                    listOf(
+                        GreenLine.bWestbound,
+                        GreenLine.cWestbound,
+                        GreenLine.dWestbound,
+                        GreenLine.eWestbound,
+                    ),
+                    emptySet(),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                        objects.upcomingTrip(prediction4),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                )
+                .format(now, GreenLine.global),
         )
     }
 
@@ -1264,67 +1227,63 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.branched {
-                    branchRow(
-                        "Stoughton",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction1),
-                                RouteType.COMMUTER_RAIL,
-                                TripInstantDisplay.Time(prediction1.departureTime!!, true),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Providence",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(schedule2),
-                                RouteType.COMMUTER_RAIL,
-                                TripInstantDisplay.ScheduleTime(schedule2.departureTime!!, true),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Wickford Junction",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(schedule3),
-                                RouteType.COMMUTER_RAIL,
-                                TripInstantDisplay.ScheduleTime(schedule3.departureTime!!, true),
-                            ),
-                            null,
-                        ),
-                    )
-                }
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        ProvidenceStoughtonLine.lineOrRoute,
-                        ProvidenceStoughtonLine.ruggles,
-                        0,
-                        listOf(
-                            ProvidenceStoughtonLine.toProvidence,
-                            ProvidenceStoughtonLine.toStoughton,
-                            ProvidenceStoughtonLine.toWickford,
-                        ),
-                        emptySet(),
-                        listOf(
+            LeafFormat.branched {
+                branchRow(
+                    "Stoughton",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(schedule2),
-                            objects.upcomingTrip(schedule3),
+                            RouteType.COMMUTER_RAIL,
+                            TripInstantDisplay.Time(prediction1.departureTime!!, true),
                         ),
-                        emptyList(),
-                        true,
-                        true,
-                        emptyList(),
-                        anyEnumValue(),
-                    )
-                    .format(now, ProvidenceStoughtonLine.global)
-            ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Providence",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(schedule2),
+                            RouteType.COMMUTER_RAIL,
+                            TripInstantDisplay.ScheduleTime(schedule2.departureTime!!, true),
+                        ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Wickford Junction",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(schedule3),
+                            RouteType.COMMUTER_RAIL,
+                            TripInstantDisplay.ScheduleTime(schedule3.departureTime!!, true),
+                        ),
+                        null,
+                    ),
+                )
+            },
+            RouteCardData.Leaf(
+                    ProvidenceStoughtonLine.lineOrRoute,
+                    ProvidenceStoughtonLine.ruggles,
+                    0,
+                    listOf(
+                        ProvidenceStoughtonLine.toProvidence,
+                        ProvidenceStoughtonLine.toStoughton,
+                        ProvidenceStoughtonLine.toWickford,
+                    ),
+                    emptySet(),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(schedule2),
+                        objects.upcomingTrip(schedule3),
+                    ),
+                    emptyList(),
+                    true,
+                    true,
+                    emptyList(),
+                    anyEnumValue(),
+                )
+                .format(now, ProvidenceStoughtonLine.global),
         )
     }
 
@@ -1498,70 +1457,66 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.Branched(
-                    branchRows =
-                        listOf(
-                            LeafFormat.Branched.BranchRow(
-                                null,
-                                "Arlington Center",
-                                UpcomingFormat.Some(
-                                    UpcomingFormat.Some.FormattedTrip(
-                                        objects.upcomingTrip(prediction1),
-                                        RouteType.BUS,
-                                        TripInstantDisplay.Minutes(3),
-                                    ),
-                                    null,
+            LeafFormat.Branched(
+                branchRows =
+                    listOf(
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Arlington Center",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction1),
+                                    RouteType.BUS,
+                                    TripInstantDisplay.Minutes(3),
                                 ),
-                            ),
-                            LeafFormat.Branched.BranchRow(
                                 null,
-                                "Arlington Center",
-                                UpcomingFormat.Some(
-                                    UpcomingFormat.Some.FormattedTrip(
-                                        objects.upcomingTrip(prediction2),
-                                        RouteType.BUS,
-                                        TripInstantDisplay.Minutes(12),
-                                    ),
-                                    null,
-                                ),
-                            ),
-                            LeafFormat.Branched.BranchRow(
-                                null,
-                                "Clarendon Hill",
-                                UpcomingFormat.Some(
-                                    UpcomingFormat.Some.FormattedTrip(
-                                        objects.upcomingTrip(prediction3),
-                                        RouteType.BUS,
-                                        TripInstantDisplay.Minutes(35),
-                                    ),
-                                    null,
-                                ),
                             ),
                         ),
-                    null,
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Arlington Center",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction2),
+                                    RouteType.BUS,
+                                    TripInstantDisplay.Minutes(12),
+                                ),
+                                null,
+                            ),
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Clarendon Hill",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction3),
+                                    RouteType.BUS,
+                                    TripInstantDisplay.Minutes(35),
+                                ),
+                                null,
+                            ),
+                        ),
+                    ),
+                null,
+            ),
+            RouteCardData.Leaf(
+                    `87`.lineOrRoute,
+                    objects.stop(),
+                    0,
+                    listOf(`87`.outboundTypical, `87`.outboundDeviation),
+                    emptySet(),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    RouteCardData.Context.StopDetailsFiltered,
                 )
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        `87`.lineOrRoute,
-                        objects.stop(),
-                        0,
-                        listOf(`87`.outboundTypical, `87`.outboundDeviation),
-                        emptySet(),
-                        listOf(
-                            objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2),
-                            objects.upcomingTrip(prediction3),
-                        ),
-                        emptyList(),
-                        allDataLoaded = true,
-                        hasSchedulesToday = true,
-                        emptyList(),
-                        RouteCardData.Context.StopDetailsFiltered,
-                    )
-                    .format(now, `87`.global)
-            ),
+                .format(now, `87`.global),
         )
     }
 
@@ -1588,52 +1543,48 @@ class RouteCardDataLeafTest {
             }
 
         assertEquals(
-            wipeBranchUUID(
-                LeafFormat.branched {
-                    branchRow(
-                        "Arlington Center",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction1),
-                                RouteType.BUS,
-                                TripInstantDisplay.Minutes(1),
-                            ),
-                            null,
-                        ),
-                    )
-                    branchRow(
-                        "Clarendon Hill",
-                        UpcomingFormat.Some(
-                            UpcomingFormat.Some.FormattedTrip(
-                                objects.upcomingTrip(prediction2),
-                                RouteType.BUS,
-                                TripInstantDisplay.Minutes(32),
-                            ),
-                            null,
-                        ),
-                    )
-                }
-            ),
-            wipeBranchUUID(
-                RouteCardData.Leaf(
-                        `87`.lineOrRoute,
-                        objects.stop(),
-                        0,
-                        listOf(`87`.outboundTypical, `87`.outboundDeviation),
-                        emptySet(),
-                        listOf(
+            LeafFormat.branched {
+                branchRow(
+                    "Arlington Center",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
                             objects.upcomingTrip(prediction1),
-                            objects.upcomingTrip(prediction2),
-                            objects.upcomingTrip(prediction3),
+                            RouteType.BUS,
+                            TripInstantDisplay.Minutes(1),
                         ),
-                        emptyList(),
-                        allDataLoaded = true,
-                        hasSchedulesToday = true,
-                        emptyList(),
-                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                    )
-                    .format(now, `87`.global)
-            ),
+                        null,
+                    ),
+                )
+                branchRow(
+                    "Clarendon Hill",
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            objects.upcomingTrip(prediction2),
+                            RouteType.BUS,
+                            TripInstantDisplay.Minutes(32),
+                        ),
+                        null,
+                    ),
+                )
+            },
+            RouteCardData.Leaf(
+                    `87`.lineOrRoute,
+                    objects.stop(),
+                    0,
+                    listOf(`87`.outboundTypical, `87`.outboundDeviation),
+                    emptySet(),
+                    listOf(
+                        objects.upcomingTrip(prediction1),
+                        objects.upcomingTrip(prediction2),
+                        objects.upcomingTrip(prediction3),
+                    ),
+                    emptyList(),
+                    allDataLoaded = true,
+                    hasSchedulesToday = true,
+                    emptyList(),
+                    anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                )
+                .format(now, `87`.global),
         )
     }
 
@@ -1655,51 +1606,47 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        branchRow(
-                            "Ashmont",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction1),
-                                    RouteType.HEAVY_RAIL,
-                                    TripInstantDisplay.Approaching,
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            "Ashmont",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction2),
-                                    RouteType.HEAVY_RAIL,
-                                    TripInstantDisplay.Minutes(2),
-                                ),
-                                null,
-                            ),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            RedLine.lineOrRoute,
-                            objects.stop(),
-                            0,
-                            listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
-                            emptySet(),
-                            listOf(
+                LeafFormat.branched {
+                    branchRow(
+                        "Ashmont",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
                                 objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
+                                RouteType.HEAVY_RAIL,
+                                TripInstantDisplay.Approaching,
                             ),
-                            emptyList(),
-                            allDataLoaded = true,
-                            hasSchedulesToday = true,
-                            emptyList(),
-                            anyEnumValue(),
-                        )
-                        .format(now, RedLine.global)
-                ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        "Ashmont",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction2),
+                                RouteType.HEAVY_RAIL,
+                                TripInstantDisplay.Minutes(2),
+                            ),
+                            null,
+                        ),
+                    )
+                },
+                RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        objects.stop(),
+                        0,
+                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                        emptySet(),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                        ),
+                        emptyList(),
+                        allDataLoaded = true,
+                        hasSchedulesToday = true,
+                        emptyList(),
+                        anyEnumValue(),
+                    )
+                    .format(now, RedLine.global),
             )
         }
 
@@ -1755,71 +1702,67 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        branchRow(
-                            GreenLine.c,
-                            "Cleveland Circle",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction1),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(3),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.b,
-                            "Boston College",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction2),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(5),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.b,
-                            "Boston College",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction3),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(10),
-                                ),
-                                null,
-                            ),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            GreenLine.lineOrRoute,
-                            GreenLine.boylston,
-                            0,
-                            listOf(
-                                GreenLine.bWestbound,
-                                GreenLine.cWestbound,
-                                GreenLine.dWestbound,
-                                GreenLine.eWestbound,
-                            ),
-                            emptySet(),
-                            listOf(
+                LeafFormat.branched {
+                    branchRow(
+                        GreenLine.c,
+                        "Cleveland Circle",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
                                 objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
-                                objects.upcomingTrip(prediction3),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(3),
                             ),
-                            emptyList(),
-                            true,
-                            true,
-                            emptyList(),
-                            anyEnumValue(),
-                        )
-                        .format(now, GreenLine.global)
-                ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.b,
+                        "Boston College",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction2),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(5),
+                            ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.b,
+                        "Boston College",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction3),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(10),
+                            ),
+                            null,
+                        ),
+                    )
+                },
+                RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.boylston,
+                        0,
+                        listOf(
+                            GreenLine.bWestbound,
+                            GreenLine.cWestbound,
+                            GreenLine.dWestbound,
+                            GreenLine.eWestbound,
+                        ),
+                        emptySet(),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3),
+                        ),
+                        emptyList(),
+                        true,
+                        true,
+                        emptyList(),
+                        anyEnumValue(),
+                    )
+                    .format(now, GreenLine.global),
             )
         }
 
@@ -1909,64 +1852,60 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        branchRow(
-                            GreenLine.c,
-                            "Cleveland Circle",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction1),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(3),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.b,
-                            "Boston College",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction2),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(5),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.d,
-                            "Riverside",
-                            UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            GreenLine.lineOrRoute,
-                            GreenLine.kenmore,
-                            0,
-                            listOf(
-                                GreenLine.bWestbound,
-                                GreenLine.cWestbound,
-                                GreenLine.dWestbound,
-                                GreenLine.eWestbound,
-                            ),
-                            setOf(GreenLine.kenmore.id),
-                            listOf(
+                LeafFormat.branched {
+                    branchRow(
+                        GreenLine.c,
+                        "Cleveland Circle",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
                                 objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
-                                objects.upcomingTrip(prediction3),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(3),
                             ),
-                            listOf(alert),
-                            true,
-                            true,
-                            emptyList(),
-                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                        )
-                        .format(now, GreenLine.global)
-                ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.b,
+                        "Boston College",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
+                                objects.upcomingTrip(prediction2),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(5),
+                            ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.d,
+                        "Riverside",
+                        UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
+                    )
+                },
+                RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.kenmore,
+                        0,
+                        listOf(
+                            GreenLine.bWestbound,
+                            GreenLine.cWestbound,
+                            GreenLine.dWestbound,
+                            GreenLine.eWestbound,
+                        ),
+                        setOf(GreenLine.kenmore.id),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3),
+                        ),
+                        listOf(alert),
+                        true,
+                        true,
+                        emptyList(),
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, GreenLine.global),
             )
         }
 
@@ -2014,56 +1953,52 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        branchRow(
-                            GreenLine.c,
-                            "Cleveland Circle",
-                            UpcomingFormat.Some(
-                                UpcomingFormat.Some.FormattedTrip(
-                                    objects.upcomingTrip(prediction1),
-                                    RouteType.LIGHT_RAIL,
-                                    TripInstantDisplay.Minutes(3),
-                                ),
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.b,
-                            "Boston College",
-                            UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.b)),
-                        )
-                        branchRow(
-                            GreenLine.d,
-                            "Riverside",
-                            UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            GreenLine.lineOrRoute,
-                            GreenLine.kenmore,
-                            0,
-                            listOf(
-                                GreenLine.bWestbound,
-                                GreenLine.cWestbound,
-                                GreenLine.dWestbound,
-                                GreenLine.eWestbound,
-                            ),
-                            setOf(GreenLine.kenmore.id),
-                            listOf(
+                LeafFormat.branched {
+                    branchRow(
+                        GreenLine.c,
+                        "Cleveland Circle",
+                        UpcomingFormat.Some(
+                            UpcomingFormat.Some.FormattedTrip(
                                 objects.upcomingTrip(prediction1),
-                                objects.upcomingTrip(prediction2),
+                                RouteType.LIGHT_RAIL,
+                                TripInstantDisplay.Minutes(3),
                             ),
-                            listOf(alert),
-                            true,
-                            true,
-                            emptyList(),
-                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                        )
-                        .format(now, GreenLine.global)
-                ),
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.b,
+                        "Boston College",
+                        UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.b)),
+                    )
+                    branchRow(
+                        GreenLine.d,
+                        "Riverside",
+                        UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
+                    )
+                },
+                RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.kenmore,
+                        0,
+                        listOf(
+                            GreenLine.bWestbound,
+                            GreenLine.cWestbound,
+                            GreenLine.dWestbound,
+                            GreenLine.eWestbound,
+                        ),
+                        setOf(GreenLine.kenmore.id),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                        ),
+                        listOf(alert),
+                        true,
+                        true,
+                        emptyList(),
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, GreenLine.global),
             )
         }
 
@@ -2118,62 +2053,58 @@ class RouteCardDataLeafTest {
                 }
 
             assertEquals(
-                wipeBranchUUID(
-                    LeafFormat.branched {
-                        branchRow(
-                            GreenLine.b,
-                            "Boston College",
-                            UpcomingFormat.NoTrips(
-                                UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.c,
-                            "Cleveland Circle",
-                            UpcomingFormat.NoTrips(
-                                UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                                null,
-                            ),
-                        )
-                        branchRow(
-                            GreenLine.d,
-                            "Riverside",
-                            UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
-                        )
-                    }
-                ),
-                wipeBranchUUID(
-                    RouteCardData.Leaf(
-                            GreenLine.lineOrRoute,
-                            GreenLine.boylston,
-                            0,
-                            listOf(
-                                GreenLine.bWestbound,
-                                GreenLine.cWestbound,
-                                GreenLine.dWestbound,
-                                GreenLine.eWestbound,
-                            ),
-                            setOf(GreenLine.boylston.id),
-                            listOf(
-                                objects.upcomingTrip(schedB),
-                                objects.upcomingTrip(schedC),
-                                objects.upcomingTrip(schedD),
-                                objects.upcomingTrip(schedE),
-                            ),
-                            listOf(alert),
-                            true,
-                            mapOf(
-                                GreenLine.bWestbound.id to true,
-                                GreenLine.cWestbound.id to true,
-                                GreenLine.dWestbound.id to true,
-                                GreenLine.eWestbound.id to true,
-                            ),
-                            emptyList(),
-                            anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
-                        )
-                        .format(now, GreenLine.global)
-                ),
+                LeafFormat.branched {
+                    branchRow(
+                        GreenLine.b,
+                        "Boston College",
+                        UpcomingFormat.NoTrips(
+                            UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.c,
+                        "Cleveland Circle",
+                        UpcomingFormat.NoTrips(
+                            UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
+                            null,
+                        ),
+                    )
+                    branchRow(
+                        GreenLine.d,
+                        "Riverside",
+                        UpcomingFormat.Disruption(alert, MapStopRoute.matching(GreenLine.d)),
+                    )
+                },
+                RouteCardData.Leaf(
+                        GreenLine.lineOrRoute,
+                        GreenLine.boylston,
+                        0,
+                        listOf(
+                            GreenLine.bWestbound,
+                            GreenLine.cWestbound,
+                            GreenLine.dWestbound,
+                            GreenLine.eWestbound,
+                        ),
+                        setOf(GreenLine.boylston.id),
+                        listOf(
+                            objects.upcomingTrip(schedB),
+                            objects.upcomingTrip(schedC),
+                            objects.upcomingTrip(schedD),
+                            objects.upcomingTrip(schedE),
+                        ),
+                        listOf(alert),
+                        true,
+                        mapOf(
+                            GreenLine.bWestbound.id to true,
+                            GreenLine.cWestbound.id to true,
+                            GreenLine.dWestbound.id to true,
+                            GreenLine.eWestbound.id to true,
+                        ),
+                        emptyList(),
+                        anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, GreenLine.global),
             )
         }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Improve shared object comparisons to eliminate slow `.toString` operations](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210790508156212?focus=true)

I don’t think this comes from comparisons, but I’m not sure anymore what it comes from instead. I was having trouble finding any massive time costs in `toString`s at all, and then I added View Properties profiling and started seeing more time in `toString`s, so I thought it was the View Properties profiling retrieving the debugDescriptions of state objects, but then I removed the View Properties profiling and was still seeing more time in `toString`s. 🤷‍♀️ 

This may make debugging test failures slightly more difficult, but commenting out the overridden `toString` of the relevant class will restore the previous behavior.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all tests still pass and that the time spent on the main thread in `toString` calls when opening the app, waiting ten seconds, tapping a direction to open filtered stop details, and waiting ten more seconds has fallen from 345ms to 1ms.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
