### PR TITLE
fix(ios.SearchResultViewTests): Stabilize flaky test

### DIFF
--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
@@ -15,7 +15,7 @@ struct SearchResultsContainer: View {
     let query: String
 
     @ObservedObject var nearbyVM: NearbyViewModel
-    @State var searchVM: SearchViewModel
+    @State var searchVM: ISearchViewModel
     @State var searchVMState: SearchViewModel.State = SearchViewModel.StateLoading.shared
 
     var didAppear: ((Self) -> Void)?
@@ -24,7 +24,7 @@ struct SearchResultsContainer: View {
     init(
         query: String,
         nearbyVM: NearbyViewModel,
-        searchVM: SearchViewModel,
+        searchVM: ISearchViewModel,
         didAppear: ((Self) -> Void)? = nil,
         didChange: ((Self) -> Void)? = nil
     ) {


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, fixes a flaky test that has prevented a couple of merges, like in https://github.com/mbta/mobile_app/pull/1198

What is this PR for?

The failing test runs had a confusing error that was a mix of two tests
```
[19:33:32]: ▸ ::error file=/Users/runner/work/mobile_app/mobile_app/iosApp/iosAppTests/Views/SearchResultViewTests.swift,line=54::    testDisplaysTrips, API violation - multiple calls made to -[XCTestExpectation fulfill] for getSearchResults. (NSInternalInconsistencyException)
```

In the referenced SearchResultViewTest, it *is* possible for `getSearchResults` to be called multiple times, because it is [triggered from a LaunchedEffect with 3 inputs](https://github.com/mbta/mobile_app/blob/d99d345f1582a20a315c009dfddf704f004f05de/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt#L171). 

I was unable to reproduce this error locally while running repeatedly on my physical device, but did hit it once while running on simulators.

This could also be fixed by setting `getSearchResults.assertForOverFulfill = false`, but I think it is clearer to just mock the relevant VM for the test and make sure that `setQuery` is called only once as expected.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran this test locally

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
