### PR TITLE
fix: follow-up work on commuter rail status

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -339,6 +339,60 @@ class UpcomingTripViewTest {
     }
 
     @Test
+    fun testUpcomingTripViewWithSomeScheduleTimeWithStatusColumn() {
+        val instant = EasternTimeInstant(2025, Month.AUGUST, 5, 14, 14)
+        val status = "Delayed"
+
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.ScheduleTimeWithStatusColumn(instant, status)
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
+            )
+        }
+        composeTestRule
+            .onNode(hasTextMatching(Regex("2:14\\sPM")), useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delayed", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasContentDescriptionMatching(Regex("2:14\\sPM train delayed")))
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun testUpcomingTripViewWithSomeScheduleTimeWithStatusRow() {
+        val instant = EasternTimeInstant(2025, Month.AUGUST, 5, 14, 14)
+        val status = "Anomalous"
+
+        composeTestRule.setContent {
+            UpcomingTripView(
+                UpcomingTripViewState.Some(
+                    TripInstantDisplay.ScheduleTimeWithStatusRow(instant, status)
+                ),
+                routeType = RouteType.COMMUTER_RAIL,
+            )
+        }
+        composeTestRule
+            .onNode(hasTextMatching(Regex("2:14\\sPM")), useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Anomalous", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("train arriving at 2:14\\sPM scheduled, Anomalous")
+                )
+            )
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
     fun testUpcomingTripViewWithSomeMinutes() {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(5)))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -34,6 +34,8 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlinx.datetime.Month
 
 sealed interface PillDecoration {
     data class OnRow(val route: Route) : PillDecoration
@@ -136,16 +138,46 @@ private fun PredictionRowViewPreview() {
     val trip = objects.trip()
 
     MyApplicationTheme {
-        Column(Modifier.background(MaterialTheme.colorScheme.background)) {
+        Column(
+            Modifier.background(MaterialTheme.colorScheme.background)
+                .padding(start = 16.dp, end = 8.dp)
+                .padding(vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp),
+        ) {
             PredictionRowView(
                 predictions =
                     UpcomingFormat.Some(
                         listOf(
                             UpcomingFormat.Some.FormattedTrip(
                                 UpcomingTrip(trip),
-                                RouteType.LIGHT_RAIL,
-                                TripInstantDisplay.Boarding,
-                            )
+                                RouteType.COMMUTER_RAIL,
+                                TripInstantDisplay.ScheduleTimeWithStatusRow(
+                                    EasternTimeInstant(2025, Month.AUGUST, 5, 12, 10),
+                                    "Delayed",
+                                ),
+                            ),
+                            UpcomingFormat.Some.FormattedTrip(
+                                UpcomingTrip(trip),
+                                RouteType.COMMUTER_RAIL,
+                                TripInstantDisplay.Time(
+                                    EasternTimeInstant(2025, Month.AUGUST, 5, 12, 45),
+                                    true,
+                                ),
+                            ),
+                        ),
+                        null,
+                    )
+            ) {
+                Text("Needham Heights")
+            }
+
+            PredictionRowView(
+                predictions =
+                    UpcomingFormat.Some(
+                        UpcomingFormat.Some.FormattedTrip(
+                            UpcomingTrip(trip),
+                            RouteType.LIGHT_RAIL,
+                            TripInstantDisplay.Boarding,
                         ),
                         null,
                     )
@@ -155,12 +187,10 @@ private fun PredictionRowViewPreview() {
 
             PredictionRowView(
                 UpcomingFormat.Some(
-                    listOf(
-                        UpcomingFormat.Some.FormattedTrip(
-                            UpcomingTrip(trip),
-                            RouteType.LIGHT_RAIL,
-                            TripInstantDisplay.Overridden("Stopped 10 stops away"),
-                        )
+                    UpcomingFormat.Some.FormattedTrip(
+                        UpcomingTrip(trip),
+                        RouteType.LIGHT_RAIL,
+                        TripInstantDisplay.Overridden("Stopped 10 stops away"),
                     ),
                     null,
                 ),
@@ -171,12 +201,10 @@ private fun PredictionRowViewPreview() {
 
             PredictionRowView(
                 UpcomingFormat.Some(
-                    listOf(
-                        UpcomingFormat.Some.FormattedTrip(
-                            UpcomingTrip(trip),
-                            RouteType.LIGHT_RAIL,
-                            TripInstantDisplay.Overridden("Stopped 10 stops away"),
-                        )
+                    UpcomingFormat.Some.FormattedTrip(
+                        UpcomingTrip(trip),
+                        RouteType.LIGHT_RAIL,
+                        TripInstantDisplay.Overridden("Stopped 10 stops away"),
                     ),
                     null,
                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/UpcomingTripView.kt
@@ -220,7 +220,7 @@ fun UpcomingTripView(
                             else Typography.footnoteSemibold,
                     )
 
-                is TripInstantDisplay.ScheduleTimeWithStatus ->
+                is TripInstantDisplay.ScheduleTimeWithStatusColumn ->
                     Column(
                         modifier.clearAndSetSemantics { contentDescription = tripDescription },
                         horizontalAlignment = Alignment.End,
@@ -244,6 +244,28 @@ fun UpcomingTripView(
                         )
                     }
 
+                is TripInstantDisplay.ScheduleTimeWithStatusRow ->
+                    Row(
+                        modifier.clearAndSetSemantics { contentDescription = tripDescription },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(
+                            state.trip.status,
+                            color = LocalContentColor.current.copy(alpha = min(maxTextAlpha, 0.6f)),
+                            textAlign = TextAlign.End,
+                            style = Typography.footnote,
+                        )
+                        Text(
+                            state.trip.scheduledTime.formattedTime(),
+                            modifier
+                                .alpha(min(maxTextAlpha, 0.6F))
+                                .semantics { contentDescription = tripDescription }
+                                .placeholderIfLoading(),
+                            textAlign = TextAlign.End,
+                            style = Typography.footnoteSemibold,
+                        )
+                    }
                 is TripInstantDisplay.Minutes ->
                     WithRealtimeIndicator(modifier.then(maxAlphaModifier), hideRealtimeIndicators) {
                         Text(
@@ -377,7 +399,10 @@ fun DisruptionView(
 @Composable
 fun UpcomingTripViewPreview() {
     MyApplicationTheme {
-        Column(horizontalAlignment = Alignment.End) {
+        Column(
+            Modifier.background(colorResource(R.color.fill3)).padding(8.dp),
+            horizontalAlignment = Alignment.End,
+        ) {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Now))
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(5)))
             UpcomingTripView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -18,6 +18,7 @@ import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.RouteCardPreviewData
@@ -93,7 +94,14 @@ fun RouteCard(
 
 class Previews() {
     val data = RouteCardPreviewData()
-    val koin = koinApplication { modules(module { single<Analytics> { MockAnalytics() } }) }
+    val koin = koinApplication {
+        modules(
+            module {
+                single<Analytics> { MockAnalytics() }
+                single<SettingsCache> { SettingsCache(MockSettingsRepository()) }
+            }
+        )
+    }
 
     @Composable
     fun CardForPreview(card: RouteCardData) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
@@ -44,6 +45,7 @@ import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Duration.Companion.minutes
 
 @Composable
 fun DepartureTile(
@@ -128,7 +130,8 @@ private fun DepartureTilePreview() {
             Modifier.background(Color.fromHex("00843D"))
                 .padding(16.dp)
                 .horizontalScroll(rememberScrollState())
-                .padding(horizontal = 10.dp),
+                .padding(horizontal = 10.dp)
+                .height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             DepartureTile(
@@ -173,6 +176,29 @@ private fun DepartureTilePreview() {
                 ),
                 onTap = {},
                 showHeadsign = true,
+            )
+            DepartureTile(
+                TileData(
+                    route1,
+                    "Framingham",
+                    UpcomingFormat.Some(
+                        listOf(
+                            UpcomingFormat.Some.FormattedTrip(
+                                UpcomingTrip(trip1),
+                                RouteType.COMMUTER_RAIL,
+                                TripInstantDisplay.ScheduleTimeWithStatusColumn(
+                                    EasternTimeInstant.now() - 15.minutes,
+                                    "Delay",
+                                    true,
+                                ),
+                            )
+                        ),
+                        secondaryAlert = null,
+                    ),
+                    objects.upcomingTrip(schedule1),
+                ),
+                onTap = {},
+                showHeadsign = false,
             )
             DepartureTile(
                 TileData(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/containsWrappableText.kt
@@ -33,7 +33,8 @@ fun TripInstantDisplay.containsWrappableText() =
         is TripInstantDisplay.TimeWithSchedule -> false
         is TripInstantDisplay.Minutes -> false
         is TripInstantDisplay.ScheduleTime -> false
-        is TripInstantDisplay.ScheduleTimeWithStatus -> true
+        is TripInstantDisplay.ScheduleTimeWithStatusColumn -> true
+        is TripInstantDisplay.ScheduleTimeWithStatusRow -> true
         is TripInstantDisplay.ScheduleMinutes -> false
         is TripInstantDisplay.Skipped -> false
         is TripInstantDisplay.Cancelled -> false

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -76,3 +76,72 @@ struct PredictionRowView: View {
         }
     }
 }
+
+#Preview {
+    let objects = ObjectCollectionBuilder()
+    let trip1 = UpcomingTrip(trip: objects.trip { _ in })
+    let trip2 = UpcomingTrip(trip: objects.trip { _ in })
+    VStack(alignment: .leading, spacing: 20) {
+        PredictionRowView(
+            predictions: .Some(trips: [
+                .init(
+                    trip: trip1,
+                    routeType: .commuterRail,
+                    format: .ScheduleTimeWithStatusRow(
+                        scheduledTime: .init(year: 2025, month: .august, day: 5, hour: 12, minute: 10, second: 0),
+                        status: "Delayed"
+                    )
+                ),
+                .init(
+                    trip: trip2,
+                    routeType: .commuterRail,
+                    format: .Time(
+                        predictionTime: .init(year: 2025, month: .august, day: 5, hour: 12, minute: 45, second: 0),
+                        headline: true
+                    )
+                ),
+            ], secondaryAlert: nil),
+            destination: { Text("Needham Heights") }
+        )
+
+        PredictionRowView(
+            predictions: .Some(trip: .init(trip: trip1, routeType: .lightRail, format: .Boarding.shared),
+                               secondaryAlert: nil),
+            destination: { Text("Longer Destination than That") }
+        )
+
+        PredictionRowView(
+            predictions: .Some(trip: .init(
+                trip: trip1,
+                routeType: .lightRail,
+                format: .Overridden(text: "Stopped 10 stops away")
+            ), secondaryAlert: nil),
+            pillDecoration: .onRow(route: TestData.getRoute(id: "Green-B")),
+            destination: { Text("Destination") }
+        )
+
+        PredictionRowView(
+            predictions: .Some(trip: .init(
+                trip: trip1,
+                routeType: .lightRail,
+                format: .Overridden(text: "Stopped 10 stops away")
+            ), secondaryAlert: nil),
+            destination: { Text("Destination") }
+        )
+
+        PredictionRowView(
+            predictions: .Some(trips: [
+                .init(trip: trip1, routeType: .bus, format: .ScheduleMinutes(minutes: 6)),
+                .init(trip: trip2, routeType: .bus, format: .ScheduleMinutes(minutes: 15)),
+            ], secondaryAlert: nil),
+            destination: { Text("Destination") }
+        )
+
+        PredictionRowView(
+            predictions: .Disruption(alert: objects.alert { $0.effect = .detour }, mapStopRoute: .green),
+            destination: { Text("Destination") }
+        )
+    }
+    .padding(.leading, 16)
+    .padding(.trailing, 8)
+}

--- a/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
+++ b/iosApp/iosApp/ComponentViews/UpcomingTripView.swift
@@ -120,7 +120,7 @@ struct UpcomingTripView: View {
                 .opacity(min(0.6, maxTextAlpha))
                 .font(format.headline ? Typography.headlineSemibold : Typography.footnoteSemibold)
                 .accessibilityLabel(label)
-        case let .scheduleTimeWithStatus(format):
+        case let .scheduleTimeWithStatusColumn(format):
             VStack(alignment: .trailing, spacing: 0) {
                 Text(format.scheduledTime, style: .time)
                     .opacity(min(0.6, maxTextAlpha))
@@ -129,6 +129,18 @@ struct UpcomingTripView: View {
                     .font(Typography.footnoteSemibold)
                     .opacity(min(0.6, maxTextAlpha))
                     .multilineTextAlignment(.trailing)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
+        case let .scheduleTimeWithStatusRow(format):
+            HStack(alignment: .center, spacing: 4) {
+                Text(format.status)
+                    .font(Typography.footnoteSemibold)
+                    .opacity(min(0.6, maxTextAlpha))
+                    .multilineTextAlignment(.trailing)
+                Text(format.scheduledTime, style: .time)
+                    .opacity(min(0.6, maxTextAlpha))
+                    .font(Typography.footnoteSemibold)
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(label)

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -97,54 +97,78 @@ struct DepartureTile: View {
     let trip = objects.trip { _ in }
     let upcomingTrip = UpcomingTrip(trip: trip)
 
-    HStack {
-        DepartureTile(
-            data: .init(
-                route: route1,
-                headsign: "Framingham",
-                formatted: UpcomingFormat.Some(trips: [
-                    .init(
-                        trip: upcomingTrip,
-                        routeType: .commuterRail,
-                        format: .TimeWithStatus(
-                            predictionTime: EasternTimeInstant.now(),
-                            status: "Delay",
-                            headline: true
-                        )
+    ScrollView(.horizontal) {
+        HStack {
+            DepartureTile(
+                data: .init(
+                    route: route1,
+                    headsign: nil,
+                    formatted: UpcomingFormat.Some(trips: [
+                        .init(
+                            trip: upcomingTrip,
+                            routeType: .commuterRail,
+                            format: .TimeWithStatus(
+                                predictionTime: EasternTimeInstant.now(),
+                                status: "Delay",
+                                headline: true
+                            )
+                        ),
+                    ], secondaryAlert: nil),
+                    upcoming: upcomingTrip
+                ),
+                onTap: {},
+                isSelected: true
+            )
+            DepartureTile(
+                data: .init(
+                    route: route1,
+                    headsign: "Harvard",
+                    formatted: UpcomingFormat.Some(trips: [
+                        .init(trip: upcomingTrip, routeType: .bus, format: .Minutes(minutes: 9)),
+                    ], secondaryAlert: nil),
+                    upcoming: upcomingTrip
+                ),
+                onTap: {},
+                isSelected: false
+            )
+            DepartureTile(
+                data: .init(
+                    route: route1,
+                    headsign: nil,
+                    formatted: UpcomingFormat.Some(
+                        trips: [
+                            .init(
+                                trip: upcomingTrip,
+                                routeType: .commuterRail,
+                                format: .ScheduleTimeWithStatusColumn(
+                                    scheduledTime: .now().minus(minutes: 15),
+                                    status: "Delay",
+                                    headline: true
+                                )
+                            ),
+                        ],
+                        secondaryAlert: nil
                     ),
-                ], secondaryAlert: nil),
-                upcoming: upcomingTrip
-            ),
-            onTap: {},
-            isSelected: true
-        )
-        DepartureTile(
-            data: .init(
-                route: route1,
-                headsign: "Harvard",
-                formatted: UpcomingFormat.Some(trips: [
-                    .init(trip: upcomingTrip, routeType: .bus, format: .Minutes(minutes: 9)),
-                ], secondaryAlert: nil),
-                upcoming: upcomingTrip
-            ),
-            onTap: {},
-            isSelected: false
-        )
-        DepartureTile(
-            data: .init(
-                route: routeB,
-                headsign: "Government Center",
-                formatted: UpcomingFormat.Some(trips: [
-                    .init(trip: upcomingTrip, routeType: .lightRail, format: .Minutes(minutes: 12)),
-                ], secondaryAlert: nil),
-                upcoming: upcomingTrip
-            ),
-            onTap: {},
-            pillDecoration: .onPrediction(route: routeB),
-            isSelected: false
-        )
+                    upcoming: upcomingTrip
+                ),
+                onTap: {},
+            )
+            DepartureTile(
+                data: .init(
+                    route: routeB,
+                    headsign: "Government Center",
+                    formatted: UpcomingFormat.Some(trips: [
+                        .init(trip: upcomingTrip, routeType: .lightRail, format: .Minutes(minutes: 12)),
+                    ], secondaryAlert: nil),
+                    upcoming: upcomingTrip
+                ),
+                onTap: {},
+                pillDecoration: .onPrediction(route: routeB),
+                isSelected: false
+            )
+        }
+        .padding(16)
+        .background(Color(hex: "00843D"))
+        .fixedSize(horizontal: false, vertical: true)
     }
-    .padding(16)
-    .background(Color(hex: "00843D"))
-    .fixedSize(horizontal: true, vertical: true)
 }

--- a/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
+++ b/iosApp/iosAppTests/Views/UpcomingTripViewTests.swift
@@ -90,6 +90,27 @@ final class UpcomingTripViewTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "All aboard"))
     }
 
+    func testScheduleWithStatusColumn() throws {
+        let date = EasternTimeInstant(year: 2025, month: .august, day: 5, hour: 14, minute: 26, second: 0)
+        let sut = UpcomingTripView(
+            prediction: .some(.ScheduleTimeWithStatusColumn(scheduledTime: date, status: "Delayed", headline: true)),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect().find(viewWithAccessibilityLabelMatching: #/2:26\sPM train delayed/#))
+        XCTAssertNotNil(try sut.inspect().find(text: "Delayed"))
+    }
+
+    func testScheduleWithStatusRow() throws {
+        let date = EasternTimeInstant(year: 2025, month: .august, day: 5, hour: 14, minute: 26, second: 0)
+        let sut = UpcomingTripView(
+            prediction: .some(.ScheduleTimeWithStatusRow(scheduledTime: date, status: "Anomalous")),
+            routeType: .commuterRail
+        )
+        XCTAssertNotNil(try sut.inspect()
+            .find(viewWithAccessibilityLabelMatching: #/train arriving at 2:26\sPM scheduled, Anomalous/#))
+        XCTAssertNotNil(try sut.inspect().find(text: "Anomalous"))
+    }
+
     func testTimeWithStatusLate() throws {
         let date = EasternTimeInstant(year: 2024, month: .may, day: 1, hour: 16, minute: 0, second: 0)
         let sut = UpcomingTripView(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -42,10 +42,15 @@ sealed class TripInstantDisplay {
     data class ScheduleTime(val scheduledTime: EasternTimeInstant, val headline: Boolean = false) :
         TripInstantDisplay()
 
-    data class ScheduleTimeWithStatus(
+    data class ScheduleTimeWithStatusColumn(
         val scheduledTime: EasternTimeInstant,
         val status: String,
         val headline: Boolean = false,
+    ) : TripInstantDisplay()
+
+    data class ScheduleTimeWithStatusRow(
+        val scheduledTime: EasternTimeInstant,
+        val status: String,
     ) : TripInstantDisplay()
 
     data class ScheduleMinutes(val minutes: Int) : TripInstantDisplay()
@@ -62,7 +67,7 @@ sealed class TripInstantDisplay {
     }
 
     companion object {
-        val delayStatuses = setOf("Delay", "Late")
+        val delayStatuses = setOf("Delay", "Delayed", "Late")
 
         fun from(
             prediction: Prediction?,
@@ -78,7 +83,31 @@ sealed class TripInstantDisplay {
             val forceAsTime = context == Context.TripDetails || scheduleBasedRouteType
             val allowTimeWithStatus =
                 context == Context.StopDetailsFiltered && routeType == RouteType.COMMUTER_RAIL
-            if (prediction?.status != null && routeType != RouteType.COMMUTER_RAIL) {
+            val showTimeAsHeadline = scheduleBasedRouteType && context != Context.TripDetails
+            val predictionTime = prediction?.stopTimeAfter(now)
+            val scheduleTime = schedule?.stopTimeAfter(now)
+            if (prediction?.status != null) {
+                if (routeType == RouteType.COMMUTER_RAIL) {
+                    when {
+                        predictionTime != null && allowTimeWithStatus ->
+                            return TimeWithStatus(
+                                predictionTime,
+                                prediction.status,
+                                showTimeAsHeadline,
+                            )
+                        predictionTime != null -> return Time(predictionTime, showTimeAsHeadline)
+                        scheduleTime != null && allowTimeWithStatus ->
+                            return ScheduleTimeWithStatusColumn(
+                                scheduleTime,
+                                prediction.status,
+                                showTimeAsHeadline,
+                            )
+                        scheduleTime != null && scheduleTime < now ->
+                            return ScheduleTimeWithStatusRow(scheduleTime, prediction.status)
+                        scheduleTime != null ->
+                            return ScheduleTime(scheduleTime, showTimeAsHeadline)
+                    }
+                }
                 return Overridden(prediction.status)
             }
             if (prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Skipped) {
@@ -88,19 +117,17 @@ sealed class TripInstantDisplay {
                 return Hidden
             }
 
-            val scheduleStopTime = schedule?.stopTime
-            val isScheduleUpcoming = scheduleStopTime?.let { it >= now } ?: false
+            val isScheduleUpcoming = scheduleTime?.let { it >= now } ?: false
             if (
                 prediction?.scheduleRelationship == Prediction.ScheduleRelationship.Cancelled &&
-                    scheduleStopTime != null &&
+                    scheduleTime != null &&
                     isScheduleUpcoming &&
                     routeType?.isSubway() == false &&
                     context == Context.StopDetailsFiltered
             ) {
-                return Cancelled(scheduleStopTime)
+                return Cancelled(scheduleTime)
             }
 
-            val showTimeAsHeadline = scheduleBasedRouteType && context != Context.TripDetails
             if (prediction == null) {
                 val scheduleTime = schedule?.stopTimeAfter(now)
                 return if (
@@ -119,20 +146,6 @@ sealed class TripInstantDisplay {
                         ScheduleMinutes(scheduleMinutesRemaining)
                     }
                 }
-            }
-            val predictionTime = prediction.stopTimeAfter(now)
-            if (allowTimeWithStatus && prediction.status != null) {
-                if (predictionTime != null) {
-                    return TimeWithStatus(predictionTime, prediction.status, showTimeAsHeadline)
-                }
-                if (scheduleStopTime != null) {
-                    return ScheduleTimeWithStatus(
-                        scheduleStopTime,
-                        prediction.status,
-                        showTimeAsHeadline,
-                    )
-                }
-                return Overridden(prediction.status)
             }
             if (predictionTime == null || (prediction.departureTime == null && !allowArrivalOnly)) {
                 return Hidden

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -81,22 +81,20 @@ sealed class TripInstantDisplay {
             val scheduleBasedRouteType =
                 routeType == RouteType.COMMUTER_RAIL || routeType == RouteType.FERRY
             val forceAsTime = context == Context.TripDetails || scheduleBasedRouteType
-            val allowTimeWithStatus =
-                context == Context.StopDetailsFiltered && routeType == RouteType.COMMUTER_RAIL
             val showTimeAsHeadline = scheduleBasedRouteType && context != Context.TripDetails
             val predictionTime = prediction?.stopTimeAfter(now)
             val scheduleTime = schedule?.stopTimeAfter(now)
             if (prediction?.status != null) {
                 if (routeType == RouteType.COMMUTER_RAIL) {
                     when {
-                        predictionTime != null && allowTimeWithStatus ->
+                        predictionTime != null && context == Context.StopDetailsFiltered ->
                             return TimeWithStatus(
                                 predictionTime,
                                 prediction.status,
                                 showTimeAsHeadline,
                             )
                         predictionTime != null -> return Time(predictionTime, showTimeAsHeadline)
-                        scheduleTime != null && allowTimeWithStatus ->
+                        scheduleTime != null && context == Context.StopDetailsFiltered ->
                             return ScheduleTimeWithStatusColumn(
                                 scheduleTime,
                                 prediction.status,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -230,7 +230,7 @@ class RouteCardDataLeafTest {
                         UpcomingFormat.Some.FormattedTrip(
                             upcomingTrip,
                             route.type,
-                            TripInstantDisplay.ScheduleTimeWithStatus(
+                            TripInstantDisplay.ScheduleTimeWithStatusColumn(
                                 scheduleTime,
                                 status,
                                 headline = true,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -38,9 +38,28 @@ class TripInstantDisplayTest {
     }
 
     @Test
-    fun `commuter rail status is non-null and prediction is in past`() {
+    fun `commuter rail status is non-null and prediction is in past`() = parametricTest {
         val now = EasternTimeInstant.now()
         val predictionTime = now - 3.minutes
+        assertEquals(
+            TripInstantDisplay.Time(predictionTime, headline = true),
+            TripInstantDisplay.from(
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = predictionTime
+                        status = "Custom Text"
+                    },
+                schedule = null,
+                vehicle = null,
+                routeType = RouteType.COMMUTER_RAIL,
+                now = now,
+                context =
+                    anyOf(
+                        TripInstantDisplay.Context.NearbyTransit,
+                        TripInstantDisplay.Context.StopDetailsUnfiltered,
+                    ),
+            ),
+        )
         assertEquals(
             TripInstantDisplay.TimeWithStatus(predictionTime, "Custom Text", headline = true),
             TripInstantDisplay.from(
@@ -56,24 +75,59 @@ class TripInstantDisplayTest {
                 context = TripInstantDisplay.Context.StopDetailsFiltered,
             ),
         )
-    }
-
-    @Test
-    fun `commuter rail status is non-null and prediction time null and schedule in past`() {
-        val now = EasternTimeInstant.now()
-        val scheduleTime = now - 3.minutes
         assertEquals(
-            TripInstantDisplay.ScheduleTimeWithStatus(scheduleTime, "Custom Text", headline = true),
+            TripInstantDisplay.Time(predictionTime, headline = false),
             TripInstantDisplay.from(
-                prediction = ObjectCollectionBuilder.Single.prediction { status = "Custom Text" },
-                schedule = ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime },
+                prediction =
+                    ObjectCollectionBuilder.Single.prediction {
+                        departureTime = predictionTime
+                        status = "Custom Text"
+                    },
+                schedule = null,
                 vehicle = null,
                 routeType = RouteType.COMMUTER_RAIL,
                 now = now,
-                context = TripInstantDisplay.Context.StopDetailsFiltered,
+                context = TripInstantDisplay.Context.TripDetails,
             ),
         )
     }
+
+    @Test
+    fun `commuter rail status is non-null and prediction time null and schedule in past`() =
+        parametricTest {
+            val now = EasternTimeInstant.now()
+            val scheduleTime = now - 3.minutes
+            assertEquals(
+                TripInstantDisplay.ScheduleTimeWithStatusRow(scheduleTime, "Custom Text"),
+                TripInstantDisplay.from(
+                    prediction =
+                        ObjectCollectionBuilder.Single.prediction { status = "Custom Text" },
+                    schedule =
+                        ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime },
+                    vehicle = null,
+                    routeType = RouteType.COMMUTER_RAIL,
+                    now = now,
+                    context = anyEnumValueExcept(TripInstantDisplay.Context.StopDetailsFiltered),
+                ),
+            )
+            assertEquals(
+                TripInstantDisplay.ScheduleTimeWithStatusColumn(
+                    scheduleTime,
+                    "Custom Text",
+                    headline = true,
+                ),
+                TripInstantDisplay.from(
+                    prediction =
+                        ObjectCollectionBuilder.Single.prediction { status = "Custom Text" },
+                    schedule =
+                        ObjectCollectionBuilder.Single.schedule { departureTime = scheduleTime },
+                    vehicle = null,
+                    routeType = RouteType.COMMUTER_RAIL,
+                    now = now,
+                    context = TripInstantDisplay.Context.StopDetailsFiltered,
+                ),
+            )
+        }
 
     @Test
     fun `scheduled trip skipped`() = parametricTest {

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/ProjectUtils.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/ProjectUtils.kt
@@ -128,6 +128,7 @@ object ProjectUtils {
                                     route.directionDestinations[0],
                                     route.directionDestinations[1],
                                 )
+                                addStatement("isListedRoute = %L,", route.isListedRoute)
                                 addStatement("longName = %S,", route.longName)
                                 addStatement("shortName = %S,", route.shortName)
                                 addStatement("sortOrder = %L,", route.sortOrder)


### PR DESCRIPTION
### Summary

_Ticket:_ [Display scheduled Commuter Rail times with status when prediction has null times but non-null boarding_status](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210826290372849?focus=true)

Adds the formatting in nearby transit called for in [Adam’s mockup](https://mbta.slack.com/archives/C05QMG9GS9M/p1754346288816529?thread_ts=1754073004.733619&cid=C05QMG9GS9M) that was deferred in #1195, plus adds some previews and tests so we can be more confident that this actually works even in the absence of real issues to hit this case.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the previews look correct and the tests pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
