### PR TITLE
chore: ignore Android Gradle Plugin non-patch updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,6 @@ updates:
       interval: weekly
     open-pull-requests-limit: 100
     rebase-strategy: disabled
+    ignore:
+      - dependency-name: "agp"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
### Summary

_Ticket:_ none

Hopefully, this will stop us from getting spam like #1206. If it doesn’t, we may need to specify `com.android.application` and `com.android.library` as the dependency names instead of `agp` — the [docs](https://docs.github.com/en/enterprise-cloud@latest/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) aren’t very specific.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Not testable.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
