### PR TITLE
fix?(ios.NearbyTransitViewTests): adjust timeout of testNoService

### DIFF
--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -744,7 +744,7 @@ final class NearbyTransitViewTests: XCTestCase {
     @MainActor func testNoService() throws {
         let objects = route52Objects()
         objects.alert { alert in
-            alert.activePeriod(start: EasternTimeInstant.now().minus(seconds: 1), end: nil)
+            alert.activePeriod(start: EasternTimeInstant.now().minus(seconds: 90), end: nil)
             alert.effect = .suspension
             alert.informedEntity(
                 activities: [.board],
@@ -760,12 +760,12 @@ final class NearbyTransitViewTests: XCTestCase {
         let loadPublisher = PassthroughSubject<LoadedStops, Never>()
         let sut = setUpSut(objects, loadPublisher)
 
-        let exp = sut.inspection.inspect(onReceive: loadPublisher, after: 0.5) { view in
+        let exp = sut.inspection.inspect(onReceive: loadPublisher, after: 1) { view in
             XCTAssertNotNil(try view.find(text: "Suspension")
                 .find(RouteCardDepartures.self, relation: .parent).find(text: "Dedham Mall"))
         }
         ViewHosting.host(view: sut.withFixedSettings([:]))
-        wait(for: [exp], timeout: 1)
+        wait(for: [exp], timeout: 2)
     }
 
     @MainActor func testElevatorClosed() throws {


### PR DESCRIPTION
### Summary

No ticket, blocking merge of https://github.com/mbta/mobile_app/pull/1222 and has blocked others. As [discussed in slack](https://mbta.slack.com/archives/C062QNAJZ2M/p1754580575872399).

What is this PR for?

This PR is a low-effort attempt to address a flaky test that has been holding up CI. This view is loading a lot of little data pieces, and therefore requires some complex publisher-based testing. I think a more robust fix to this flakiness would involve one or more of the following:
* Breaking out a lower-level presentation only view and testing that directly
* Making NearbyViewModel mockable and mocking it in tests

Since we have upcoming work to refactor the NearbyViewModel, I don't think it is necessarily worth the time to mock it for this particular test. If these time-based adjustments don't work though, we should consider doing so sooner.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* I ran the test originally for 1000+ repetitions on my physical device. I ran it 100+ repetitions on a simulator and got a mix of different failures, so it was hard to tell if this actually moved the needle or not.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
