### PR TITLE
fix(Android): don’t `rememberSaveable` a `Stop?`

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -273,7 +273,8 @@ fun RouteStopListView(
         }
     }
 
-    var showFavoritesStopConfirmation by rememberSaveable { mutableStateOf<Stop?>(null) }
+    var showFavoritesStopConfirmationId by rememberSaveable { mutableStateOf<String?>(null) }
+    val showFavoritesStopConfirmation = globalData.getStop(showFavoritesStopConfirmationId)
 
     fun stopRowContext(stop: Stop) =
         when (context) {
@@ -282,7 +283,7 @@ fun RouteStopListView(
                 RouteDetailsRowContext.Favorites(
                     isFavorited =
                         isFavorite(RouteStopDirection(lineOrRoute.id, stop.id, selectedDirection)),
-                    onTapStar = { showFavoritesStopConfirmation = stop },
+                    onTapStar = { showFavoritesStopConfirmationId = stop.id },
                 )
         }
 
@@ -304,7 +305,7 @@ fun RouteStopListView(
                 isFavorite = ::isFavorite,
                 updateFavorites = ::confirmFavorites,
             ) {
-                showFavoritesStopConfirmation = null
+                showFavoritesStopConfirmationId = null
             }
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | RouteStopListView showFavoritesStopConfirmation is rememberingSaveable a Stop](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1211001075059985?focus=true)
[Sentry issue](https://mbtace.sentry.io/issues/6675679257/)

Domain objects aren’t saveable with the default saver, and instead of checking this at compile time, this is just a perpetual sword of Damocles at runtime.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
