### PR TITLE
fix: resolve and detect translated strings with different placeholders

### DIFF
--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -404,7 +404,7 @@
     <string name="vehicle_cancelled_other">y a las %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s seleccionado</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s seleccionada, parada seleccionada</string>
-    <string name="vehicle_prediction_actual_arrival">llegará a la(s) %2$s</string>
+    <string name="vehicle_prediction_actual_arrival">llegará a la(s) %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s llegando en %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s llegando en %2$d h %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">y en %1$d h %2$d min</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -404,7 +404,7 @@
     <string name="vehicle_cancelled_other">et à %1$s est annulé</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s sélectionné</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s sélectionné, arrêt sélectionné</string>
-    <string name="vehicle_prediction_actual_arrival">arrivant à %2$s</string>
+    <string name="vehicle_prediction_actual_arrival">arrivant à %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s arrive dans %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s arrive dans %2$d h et %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">et dans %1$d h et %2$d min</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -419,7 +419,7 @@
     <string name="vehicle_cancelled_other">epi a %1$s anile</string>
     <string name="vehicle_desc_accessibility_desc">Chwazi %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Chwazi %1$s %2$s %3$s, arè ou chwazi a</string>
-    <string name="vehicle_prediction_actual_arrival">ap rive a %2$s</string>
+    <string name="vehicle_prediction_actual_arrival">ap rive a %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s ap rive nan %2$d èdtan</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s rive nan %2$d è %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">epi nan %1$d è %2$d min</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -404,7 +404,7 @@
     <string name="vehicle_cancelled_other">e às %1$s cancelado</string>
     <string name="vehicle_desc_accessibility_desc">%1$s %2$s %3$s selecionados</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">%1$s %2$s %3$s selecionados, parada selecionada</string>
-    <string name="vehicle_prediction_actual_arrival">chegando às %2$s</string>
+    <string name="vehicle_prediction_actual_arrival">chegando às %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s chegando em %2$d h</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s chegando em %2$d hr %3$d min</string>
     <string name="vehicle_prediction_hours_minutes_other">e em %1$d h %2$d min</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -394,7 +394,7 @@
     <string name="vehicle_cancelled_other">và tại %1$s đã hủy</string>
     <string name="vehicle_desc_accessibility_desc">Đã chọn %1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">Đã chọn %1$s %2$s %3$s, điểm dừng đã chọn</string>
-    <string name="vehicle_prediction_actual_arrival">sẽ đến lúc %2$s</string>
+    <string name="vehicle_prediction_actual_arrival">sẽ đến lúc %1$s</string>
     <string name="vehicle_prediction_hours_first">%1$s sẽ đến trong %2$d giờ</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s sẽ đến trong %2$d giờ %3$d phút</string>
     <string name="vehicle_prediction_hours_minutes_other">và trong %1$d giờ %2$d phút</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -394,7 +394,7 @@
     <string name="vehicle_cancelled_other">于%1$s到站的下一趟车已取消</string>
     <string name="vehicle_desc_accessibility_desc">选定%1$s %2$s %3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">选定%1$s %2$s %3$s，选定站点</string>
-    <string name="vehicle_prediction_actual_arrival">于%2$s到站</string>
+    <string name="vehicle_prediction_actual_arrival">于%1$s到站</string>
     <string name="vehicle_prediction_hours_first">%1$s将于%2$d小时内到站</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s将于%2$d小时%3$d分钟内到站</string>
     <string name="vehicle_prediction_hours_minutes_other">下一趟车将在%1$d小时%2$d分钟内抵达</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -394,7 +394,7 @@
     <string name="vehicle_cancelled_other">於%1$s到站的下一趟車已取消</string>
     <string name="vehicle_desc_accessibility_desc">選定%1$s%2$s%3$s</string>
     <string name="vehicle_desc_accessibility_desc_selected_stop">選定%1$s%2$s%3$s，選定站點</string>
-    <string name="vehicle_prediction_actual_arrival">於%2$s到站</string>
+    <string name="vehicle_prediction_actual_arrival">於%1$s到站</string>
     <string name="vehicle_prediction_hours_first">%1$s將在%2$d小時內到站</string>
     <string name="vehicle_prediction_hours_minutes_first">%1$s將在%2$d小時%3$d分鐘內到站</string>
     <string name="vehicle_prediction_hours_minutes_other">下一趟車將在%1$d小時%2$d分鐘內抵達</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -4889,43 +4889,43 @@
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "llegará a la(s) %2$@"
+            "value" : "llegará a la(s) %1$@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "arrivant à %2$@"
+            "value" : "arrivant à %1$@"
           }
         },
         "ht" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "ap rive a %2$@"
+            "value" : "ap rive a %1$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "chegando às %2$@"
+            "value" : "chegando às %1$@"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "sẽ đến lúc %2$@"
+            "value" : "sẽ đến lúc %1$@"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "于%2$@到站"
+            "value" : "于%1$@到站"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "於%2$@到站"
+            "value" : "於%1$@到站"
           }
         }
       }


### PR DESCRIPTION
### Summary

_Ticket:_ ["arriving at %1$@" placeholder translations reference %2$@ instead](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211001463064536?focus=true)

This popped up in Sentry and wasn’t particularly difficult to fix and catch earlier.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that with mismatched placeholders the conversion step will correctly fail.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
