### PR TITLE
chore: use Kotlin explicit API mode in shared

### DIFF
--- a/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/DependencyCodegenTask.kt
+++ b/buildSrc/src/main/kotlin/com/mbta/tid/mbta_app/gradle/DependencyCodegenTask.kt
@@ -69,7 +69,7 @@ abstract class DependencyCodegenTask : DefaultTask() {
             """
 package com.mbta.tid.mbta_app.model
 
-actual fun Dependency.Companion.getAllDependencies(): List<Dependency> =
+public actual fun Dependency.Companion.getAllDependencies(): List<Dependency> =
     listOf(
         ${dependencyLines.joinToString(",\n        ")}
     )

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -10,7 +10,6 @@ struct ContentView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.accessibilityVoiceOverEnabled) var voiceOver
 
-    let platform = Platform_iosKt.getPlatform().name
     @StateObject var searchObserver = TextFieldObserver()
     @EnvironmentObject var locationDataManager: LocationDataManager
     @EnvironmentObject var socketProvider: SocketProvider

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -31,6 +31,7 @@ plugins {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     applyDefaultHierarchyTemplate()
+    explicitApi()
 
     compilerOptions {
         optIn.add("kotlin.time.ExperimentalTime")

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -12,7 +12,7 @@ import org.koin.core.module.Module
 internal fun createDataStore(context: Context): DataStore<Preferences> =
     getDataStore(producePath = { context.filesDir.resolve(dataStoreFileName).absolutePath })
 
-fun initKoin(appVariant: AppVariant, nativeModules: List<Module>, context: Context) {
+public fun initKoin(appVariant: AppVariant, nativeModules: List<Module>, context: Context) {
     startKoin {
         androidContext(context)
         modules(appModule(appVariant) + viewModelModule() + platformModule() + nativeModules)

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/Platform.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/Platform.android.kt
@@ -4,12 +4,12 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import java.util.UUID
 
-class AndroidPlatform : Platform {
+internal class AndroidPlatform : Platform {
     override val name: String = "Android ${android.os.Build.VERSION.SDK_INT}"
     override val httpClientEngine: HttpClientEngine
         get() = OkHttp.create()
 }
 
-actual fun getPlatform(): Platform = AndroidPlatform()
+internal actual fun getPlatform(): Platform = AndroidPlatform()
 
-actual fun uuid(): String = UUID.randomUUID().toString()
+internal actual fun uuid(): String = UUID.randomUUID().toString()

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
@@ -7,7 +7,7 @@ import com.mbta.tid.mbta_app.utils.SystemPaths
 import kotlin.time.Clock
 import org.koin.dsl.module
 
-fun platformModule() = module {
+internal fun platformModule() = module {
     includes(
         module { single { createDataStore(get()) } },
         module { single<SystemPaths> { AndroidSystemPaths(get()) } },

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.android.kt
@@ -1,4 +1,4 @@
 package com.mbta.tid.mbta_app.model
 
-actual val FeaturePromo.addedInVersion: AppVersion
+internal actual val FeaturePromo.addedInVersion: AppVersion
     get() = addedInAndroidVersion

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
@@ -6,7 +6,7 @@ import android.content.Context.CONNECTIVITY_SERVICE
 import android.net.ConnectivityManager
 import android.net.Network
 
-class NetworkConnectivityMonitor(context: Context) : INetworkConnectivityMonitor {
+internal class NetworkConnectivityMonitor(context: Context) : INetworkConnectivityMonitor {
     private var networkCallback: ConnectivityManager.NetworkCallback? = null
     private val connectivityManager =
         context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.android.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Build
 import android.view.accessibility.AccessibilityManager
 
-class AccessibilityStatusRepository(context: Context) : IAccessibilityStatusRepository {
+public class AccessibilityStatusRepository(context: Context) : IAccessibilityStatusRepository {
     private val accessibility =
         context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
 

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.android.kt
@@ -2,8 +2,8 @@ package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.model.AppVersion
 
-class CurrentAppVersionRepository(versionName: String) : ICurrentAppVersionRepository {
+public class CurrentAppVersionRepository(versionName: String) : ICurrentAppVersionRepository {
     private val appVersion = AppVersion.parse(versionName)
 
-    override fun getCurrentAppVersion() = appVersion
+    override fun getCurrentAppVersion(): AppVersion = appVersion
 }

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.android.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import okio.Path
 import okio.Path.Companion.toPath
 
-class AndroidSystemPaths(val context: Context) : SystemPaths {
+internal class AndroidSystemPaths(val context: Context) : SystemPaths {
     override val data: Path
         get() = context.filesDir.absolutePath.toPath()
 

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.android.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
 
-actual abstract class MoleculeScopeViewModel actual constructor() : ViewModel() {
-    actual val scope by lazy {
+public actual abstract class MoleculeScopeViewModel actual constructor() : ViewModel() {
+    internal actual val scope by lazy {
         CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
     }
 }

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -7,7 +8,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-actual fun viewModelModule() = module {
+public actual fun viewModelModule(): Module = module {
     single {
             FavoritesViewModel(get(), get(), get(), get(named("coroutineDispatcherDefault")), get())
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app
 import io.sentry.kotlin.multiplatform.Sentry
 import io.sentry.kotlin.multiplatform.SentryOptions
 
-fun initializeSentry(dsn: String, environment: String) {
+public fun initializeSentry(dsn: String, environment: String) {
     val configuration: (SentryOptions) -> Unit = {
         it.dsn = dsn
         it.environment = environment

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app
 
-enum class AppVariant(
-    val backendHost: String,
-    val lightMapStyle: String,
-    val darkMapStyle: String,
+public enum class AppVariant(
+    internal val backendHost: String,
+    public val lightMapStyle: String,
+    public val darkMapStyle: String,
 ) {
     DevOrange(
         "mobile-app-backend-dev-orange.mbtace.com",
@@ -21,6 +21,6 @@ enum class AppVariant(
         "mapbox://styles/mbtamobileapp/cm02vjs2000e001psbu2v10p9",
     );
 
-    val backendRoot = "https://$backendHost"
-    val socketUrl = "wss://$backendHost/socket"
+    internal val backendRoot = "https://$backendHost"
+    public val socketUrl: String = "wss://$backendHost/socket"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/DataStore.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/DataStore.kt
@@ -9,5 +9,5 @@ import okio.Path.Companion.toPath
 internal const val dataStoreFileName = "mbta.preferences_pb"
 
 @OptIn(InternalCoroutinesApi::class)
-fun getDataStore(producePath: () -> String): DataStore<Preferences> =
+internal fun getDataStore(producePath: () -> String): DataStore<Preferences> =
     PreferenceDataStoreFactory.createWithPath(produceFile = { producePath().toPath() })

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Json.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Json.kt
@@ -4,9 +4,9 @@ import io.github.dellisd.spatialk.geojson.Feature
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-val json = Json {
+public val json: Json = Json {
     ignoreUnknownKeys = true
     coerceInputValues = true
 }
 
-fun Feature.propertiesToString() = json.encodeToString(properties)
+internal fun Feature.propertiesToString() = json.encodeToString(properties)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Platform.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/Platform.kt
@@ -2,12 +2,12 @@ package com.mbta.tid.mbta_app
 
 import io.ktor.client.engine.HttpClientEngine
 
-interface Platform {
+internal interface Platform {
     val name: String
 
     val httpClientEngine: HttpClientEngine
 }
 
-expect fun getPlatform(): Platform
+internal expect fun getPlatform(): Platform
 
-expect fun uuid(): String
+internal expect fun uuid(): String

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
@@ -8,12 +8,12 @@ import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import kotlin.experimental.ExperimentalObjCName
 import kotlin.native.ObjCName
 
-abstract class Analytics {
+public abstract class Analytics {
     protected abstract fun logEvent(name: String, parameters: Map<String, String>)
 
     protected abstract fun setUserProperty(name: String, value: String)
 
-    var lastTrackedScreen: AnalyticsScreen? = null
+    internal var lastTrackedScreen: AnalyticsScreen? = null
         private set
 
     private fun logEvent(name: String, vararg parameters: Pair<String, String>) {
@@ -21,7 +21,7 @@ abstract class Analytics {
         logEvent(name, paramsMap)
     }
 
-    fun favoritesUpdated(
+    public fun favoritesUpdated(
         updatedFavorites: Map<RouteStopDirection, Boolean>,
         context: EditFavoritesContext,
         defaultDirection: Int,
@@ -45,43 +45,43 @@ abstract class Analytics {
             }
     }
 
-    fun performedSearch(query: String) {
+    public fun performedSearch(query: String) {
         logEvent("search", "query" to query)
     }
 
-    fun performedRouteFilter(query: String) {
+    public fun performedRouteFilter(query: String) {
         logEvent("route_filter", "query" to query)
     }
 
-    fun recordSession(colorScheme: AnalyticsColorScheme) {
+    public fun recordSession(colorScheme: AnalyticsColorScheme) {
         setUserProperty("color_scheme", colorScheme.recordedValue)
     }
 
-    fun recordSession(locationAccess: AnalyticsLocationAccess) {
+    public fun recordSession(locationAccess: AnalyticsLocationAccess) {
         setUserProperty("location_access", locationAccess.recordedValue)
     }
 
-    fun recordSession(favoritesCount: Int) {
+    public fun recordSession(favoritesCount: Int) {
         setUserProperty("favorites_count", "$favoritesCount")
     }
 
     @OptIn(ExperimentalObjCName::class)
     @ObjCName(swiftName = "recordSession")
-    fun recordSessionHideMaps(hideMaps: Boolean) {
+    public fun recordSessionHideMaps(hideMaps: Boolean) {
         setUserProperty("hide_maps_on", hideMaps.toString())
     }
 
     @OptIn(ExperimentalObjCName::class)
     @ObjCName(swiftName = "recordSession")
-    fun recordSessionVoiceOver(voiceOver: Boolean) {
+    public fun recordSessionVoiceOver(voiceOver: Boolean) {
         setUserProperty("screen_reader_on", voiceOver.toString())
     }
 
-    fun refetchedNearbyTransit() {
+    public fun refetchedNearbyTransit() {
         logEvent("refetched_nearby_transit")
     }
 
-    fun tappedAffectedStops(routeId: String, stopId: String, alertId: String) {
+    public fun tappedAffectedStops(routeId: String, stopId: String, alertId: String) {
         logEvent(
             "tapped_affected_stops",
             "route_id" to routeId,
@@ -91,7 +91,7 @@ abstract class Analytics {
     }
 
     @DefaultArgumentInterop.Enabled
-    fun tappedAlertDetails(
+    public fun tappedAlertDetails(
         routeId: String,
         stopId: String,
         alertId: String,
@@ -106,7 +106,7 @@ abstract class Analytics {
         )
     }
 
-    fun tappedAlertDetailsLegacy(routeId: String, stopId: String, alertId: String) {
+    public fun tappedAlertDetailsLegacy(routeId: String, stopId: String, alertId: String) {
         logEvent(
             "tapped_alert_details",
             "route_id" to routeId,
@@ -115,7 +115,7 @@ abstract class Analytics {
         )
     }
 
-    fun tappedDeparture(
+    public fun tappedDeparture(
         routeId: String,
         stopId: String,
         pinned: Boolean,
@@ -150,7 +150,7 @@ abstract class Analytics {
         )
     }
 
-    fun tappedDownstreamStop(
+    public fun tappedDownstreamStop(
         routeId: String,
         stopId: String,
         tripId: String,
@@ -165,19 +165,19 @@ abstract class Analytics {
         )
     }
 
-    fun tappedOnStop(stopId: String) {
+    public fun tappedOnStop(stopId: String) {
         logEvent("tapped_on_stop", "stop_id" to stopId)
     }
 
-    fun tappedRouteFilter(routeId: String, stopId: String) {
+    public fun tappedRouteFilter(routeId: String, stopId: String) {
         logEvent("tapped_route_filter", "route_id" to routeId, "stop_id" to stopId)
     }
 
-    fun tappedRouteFilterLegacy(routeId: String, stopId: String) {
+    public fun tappedRouteFilterLegacy(routeId: String, stopId: String) {
         logEvent("tapped_route_filter", "route_id" to routeId, "stop_id" to stopId)
     }
 
-    fun tappedTripPlanner(routeId: String, stopId: String, alertId: String) {
+    public fun tappedTripPlanner(routeId: String, stopId: String, alertId: String) {
         logEvent(
             "tapped_trip_planner",
             "route_id" to routeId,
@@ -186,20 +186,20 @@ abstract class Analytics {
         )
     }
 
-    fun tappedVehicle(routeId: String) {
+    public fun tappedVehicle(routeId: String) {
         logEvent("tapped_vehicle", "route_id" to routeId)
     }
 
-    fun toggledPinnedRoute(pinned: Boolean, routeId: String) {
+    public fun toggledPinnedRoute(pinned: Boolean, routeId: String) {
         logEvent(if (pinned) "pin_route" else "unpin_route", "route_id" to routeId)
     }
 
-    fun track(screen: AnalyticsScreen) {
+    public fun track(screen: AnalyticsScreen) {
         lastTrackedScreen = screen
         logEvent(ANALYTICS_EVENT_SCREEN_VIEW, ANALYTICS_PARAMETER_SCREEN_NAME to screen.pageName)
     }
 
-    companion object {
+    internal companion object {
         const val ANALYTICS_EVENT_SCREEN_VIEW = "screen_view"
         const val ANALYTICS_PARAMETER_SCREEN_NAME = "screen_name"
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsColorScheme.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsColorScheme.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.analytics
 
-enum class AnalyticsColorScheme(val recordedValue: String) {
+public enum class AnalyticsColorScheme(internal val recordedValue: String) {
     Light("light"),
     Dark("dark"),
     /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsLocationAccess.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsLocationAccess.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.analytics
 
-enum class AnalyticsLocationAccess(val recordedValue: String) {
+public enum class AnalyticsLocationAccess(internal val recordedValue: String) {
     Precise("precise"),
     Approximate("approximate"),
     Off("off"),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsScreen.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.analytics
 
-enum class AnalyticsScreen(val pageName: String) {
+public enum class AnalyticsScreen(internal val pageName: String) {
     Favorites("FavoritesPage"),
     NearbyTransit("NearbyTransitPage"),
     RouteDetails("RouteDetailsPage"),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/MockAnalytics.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/MockAnalytics.kt
@@ -2,11 +2,11 @@ package com.mbta.tid.mbta_app.analytics
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 
-class MockAnalytics
+public class MockAnalytics
 @DefaultArgumentInterop.Enabled
 constructor(
-    val onLogEvent: (String, Map<String, String>) -> Unit = { _, _ -> },
-    val onSetUserProperty: (String, String) -> Unit = { _, _ -> },
+    internal val onLogEvent: (String, Map<String, String>) -> Unit = { _, _ -> },
+    internal val onSetUserProperty: (String, String) -> Unit = { _, _ -> },
 ) : Analytics() {
     override fun logEvent(name: String, parameters: Map<String, String>) {
         onLogEvent(name, parameters)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
@@ -23,16 +23,16 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 @Serializable
-data class ResponseMetadata(
+internal data class ResponseMetadata(
     val etag: String?,
     @Serializable(with = TimeMarkSerializer::class)
     var fetchTime: TimeSource.Monotonic.ValueTimeMark,
     val invalidationKey: String? = null,
 )
 
-@Serializable data class Response<T>(val metadata: ResponseMetadata, val body: T)
+@Serializable internal data class Response<T>(val metadata: ResponseMetadata, val body: T)
 
-class ResponseCache<T : Any>(
+internal class ResponseCache<T : Any>(
     private val cacheKey: String,
     val maxAge: Duration,
     private val serializer: KSerializer<T>,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/TimeMarkSerializer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/TimeMarkSerializer.kt
@@ -20,7 +20,7 @@ import kotlinx.serialization.encoding.Encoder
  * This could cause problems if the system clock is set into the past between persisting and loading
  * from disk, since then the data won't become stale for a longer duration than the cache expects.
  */
-object TimeMarkSerializer : KSerializer<TimeSource.Monotonic.ValueTimeMark> {
+internal object TimeMarkSerializer : KSerializer<TimeSource.Monotonic.ValueTimeMark> {
     override val descriptor: SerialDescriptor
         get() =
             PrimitiveSerialDescriptor("TimeSource.Monotonic.ValueTimeMark", PrimitiveKind.STRING)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -44,7 +44,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 /** Define the koin module with the resources to use in dependency injection */
-fun appModule(appVariant: AppVariant) = module {
+internal fun appModule(appVariant: AppVariant) = module {
     includes(
         module { single { MobileBackendClient(appVariant) } },
         module { single { FileSystem.SYSTEM } },
@@ -56,7 +56,7 @@ fun appModule(appVariant: AppVariant) = module {
     )
 }
 
-fun repositoriesModule(repositories: IRepositories): Module {
+public fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IConfigRepository> { repositories.config }
         single<ITabPreferencesRepository> { repositories.tabPreferences }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -87,35 +87,35 @@ import com.mbta.tid.mbta_app.repositories.VisitHistoryRepository
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IRepositories {
-    val accessibilityStatus: IAccessibilityStatusRepository?
-    val alerts: IAlertsRepository?
-    val config: IConfigRepository
-    val tabPreferences: ITabPreferencesRepository
-    val currentAppVersion: ICurrentAppVersionRepository?
-    val errorBanner: IErrorBannerStateRepository
-    val global: IGlobalRepository
-    val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository
-    val nearby: INearbyRepository
-    val onboarding: IOnboardingRepository
-    val pinnedRoutes: IPinnedRoutesRepository
-    val predictions: IPredictionsRepository?
-    val railRouteShapes: IRailRouteShapeRepository
-    val routeStops: IRouteStopsRepository
-    val schedules: ISchedulesRepository
-    val searchResults: ISearchResultRepository
-    val sentry: ISentryRepository
-    val settings: ISettingsRepository
-    val stop: IStopRepository
-    val trip: ITripRepository
-    val tripPredictions: ITripPredictionsRepository?
-    val vehicle: IVehicleRepository?
-    val vehicles: IVehiclesRepository?
-    val visitHistory: IVisitHistoryRepository
-    val favorites: IFavoritesRepository
+public interface IRepositories {
+    public val accessibilityStatus: IAccessibilityStatusRepository?
+    public val alerts: IAlertsRepository?
+    public val config: IConfigRepository
+    public val tabPreferences: ITabPreferencesRepository
+    public val currentAppVersion: ICurrentAppVersionRepository?
+    public val errorBanner: IErrorBannerStateRepository
+    public val global: IGlobalRepository
+    public val lastLaunchedAppVersion: ILastLaunchedAppVersionRepository
+    public val nearby: INearbyRepository
+    public val onboarding: IOnboardingRepository
+    public val pinnedRoutes: IPinnedRoutesRepository
+    public val predictions: IPredictionsRepository?
+    public val railRouteShapes: IRailRouteShapeRepository
+    public val routeStops: IRouteStopsRepository
+    public val schedules: ISchedulesRepository
+    public val searchResults: ISearchResultRepository
+    public val sentry: ISentryRepository
+    public val settings: ISettingsRepository
+    public val stop: IStopRepository
+    public val trip: ITripRepository
+    public val tripPredictions: ITripPredictionsRepository?
+    public val vehicle: IVehicleRepository?
+    public val vehicles: IVehiclesRepository?
+    public val visitHistory: IVisitHistoryRepository
+    public val favorites: IFavoritesRepository
 }
 
-class RepositoryDI : IRepositories, KoinComponent {
+public class RepositoryDI : IRepositories, KoinComponent {
     override val accessibilityStatus: IAccessibilityStatusRepository by inject()
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
@@ -143,7 +143,7 @@ class RepositoryDI : IRepositories, KoinComponent {
     override val favorites: IFavoritesRepository by inject()
 }
 
-class RealRepositories : IRepositories {
+internal class RealRepositories : IRepositories {
     // initialize repositories with platform-specific dependencies as null.
     // instantiate the real repositories in makeNativeModule
 
@@ -174,7 +174,7 @@ class RealRepositories : IRepositories {
     override val favorites = FavoritesRepository()
 }
 
-class MockRepositories : IRepositories {
+public class MockRepositories : IRepositories {
     override var accessibilityStatus: IAccessibilityStatusRepository =
         MockAccessibilityStatusRepository(isScreenReaderEnabled = false)
     override var alerts: IAlertsRepository = MockAlertsRepository()
@@ -204,7 +204,7 @@ class MockRepositories : IRepositories {
     override var visitHistory: IVisitHistoryRepository = VisitHistoryRepository()
     override var favorites: IFavoritesRepository = MockFavoritesRepository()
 
-    fun useObjects(objects: ObjectCollectionBuilder) {
+    public fun useObjects(objects: ObjectCollectionBuilder) {
         alerts = MockAlertsRepository(AlertsStreamDataResponse(objects))
         global = MockGlobalRepository(GlobalResponse(objects))
         nearby = MockNearbyRepository(NearbyResponse(objects))

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/UsecaseDI.kt
@@ -9,11 +9,11 @@ import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-class UsecaseDI : KoinComponent {
-    val alertsUsecase: AlertsUsecase by inject()
-    val configUsecase: ConfigUseCase by inject()
-    val featurePromoUsecase: IFeaturePromoUseCase by inject()
-    val toggledPinnedRouteUsecase: TogglePinnedRouteUsecase by inject()
-    val visitHistoryUsecase: VisitHistoryUsecase by inject()
-    val favoritesUsecases: FavoritesUsecases by inject()
+public class UsecaseDI : KoinComponent {
+    public val alertsUsecase: AlertsUsecase by inject()
+    public val configUsecase: ConfigUseCase by inject()
+    public val featurePromoUsecase: IFeaturePromoUseCase by inject()
+    public val toggledPinnedRouteUsecase: TogglePinnedRouteUsecase by inject()
+    public val visitHistoryUsecase: VisitHistoryUsecase by inject()
+    public val favoritesUsecases: FavoritesUsecases by inject()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
@@ -17,7 +17,7 @@ import com.mbta.tid.mbta_app.repositories.VehiclesRepository
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-fun makeNativeModule(
+public fun makeNativeModule(
     accessibilityStatus: IAccessibilityStatusRepository,
     analytics: Analytics,
     currentAppVersion: ICurrentAppVersionRepository,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -64,7 +64,7 @@ import kotlin.time.Duration.Companion.minutes
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-fun endToEndModule(): Module {
+internal fun endToEndModule(): Module {
     val now = EasternTimeInstant.now()
     val objects = ObjectCollectionBuilder()
     val lineRed = objects.line()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/Visit.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/Visit.kt
@@ -4,8 +4,8 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class Visit {
-    val timestamp: EasternTimeInstant = EasternTimeInstant.now()
+public sealed class Visit {
+    internal val timestamp: EasternTimeInstant = EasternTimeInstant.now()
 
-    @Serializable data class StopVisit(val stopId: String) : Visit()
+    @Serializable public data class StopVisit(internal val stopId: String) : Visit()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/VisitHistory.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/history/VisitHistory.kt
@@ -3,15 +3,15 @@ package com.mbta.tid.mbta_app.history
 import kotlinx.serialization.Serializable
 
 @Serializable
-class VisitHistory {
-    companion object {
+public class VisitHistory {
+    internal companion object {
         const val RETRIEVE_COUNT = 10
         const val SAVE_COUNT = 50
     }
 
     private var visits: MutableList<Visit> = mutableListOf()
 
-    fun add(visit: Visit) {
+    public fun add(visit: Visit) {
         visits.remove(visit)
         visits.add(0, visit)
         if (visits.size > SAVE_COUNT) {
@@ -19,7 +19,7 @@ class VisitHistory {
         }
     }
 
-    fun latest(n: Int = RETRIEVE_COUNT): List<Visit> {
+    internal fun latest(n: Int = RETRIEVE_COUNT): List<Visit> {
         return visits.take(n)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/kdTree/Axis.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/kdTree/Axis.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.kdTree
 
 import io.github.dellisd.spatialk.geojson.Position
 
-enum class Axis {
+internal enum class Axis {
     Longitude,
     Latitude;
 
@@ -13,13 +13,13 @@ enum class Axis {
         }
 }
 
-operator fun Position.get(axis: Axis): Double =
+internal operator fun Position.get(axis: Axis): Double =
     when (axis) {
         Axis.Longitude -> longitude
         Axis.Latitude -> latitude
     }
 
-fun Position.butWith(axis: Axis, value: Double) =
+internal fun Position.butWith(axis: Axis, value: Double) =
     when (axis) {
         Axis.Longitude -> Position(longitude = value, latitude = latitude)
         Axis.Latitude -> Position(longitude = longitude, latitude = value)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/kdTree/KdTree.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/kdTree/KdTree.kt
@@ -9,7 +9,7 @@ import io.github.dellisd.spatialk.geojson.Position
  * Handles the specific condition where many points coincide - this is frequently true for parent
  * and child stations, for example.
  */
-class KdTree(elements: List<Pair<String, Position>>) {
+internal class KdTree(elements: List<Pair<String, Position>>) {
     internal val root: KdTreeNode? = KdTreeNode.build(elements, Axis.Longitude)
 
     /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/AlertIcons.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/AlertIcons.kt
@@ -6,12 +6,12 @@ import com.mbta.tid.mbta_app.map.style.downcastToResolvedImage
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.StopAlertState
 
-object AlertIcons {
-    val alertIconPrefix = "alert-"
-    val alertZoomClosePrefix = "large-"
-    val alertZoomWidePrefix = "small-"
+public object AlertIcons {
+    internal val alertIconPrefix = "alert-"
+    internal val alertZoomClosePrefix = "large-"
+    internal val alertZoomWidePrefix = "small-"
 
-    val all: List<String> =
+    public val all: List<String> =
         listOf(alertZoomClosePrefix, alertZoomWidePrefix).flatMap { zoomPrefix ->
             MapStopRoute.entries.flatMap { routeType ->
                 StopAlertState.entries
@@ -62,7 +62,7 @@ object AlertIcons {
         )
     }
 
-    fun getAlertLayerIcon(index: Int, forBus: Boolean = false): Exp<ResolvedImage> {
+    internal fun getAlertLayerIcon(index: Int, forBus: Boolean = false): Exp<ResolvedImage> {
         return Exp.step(
                 Exp.zoom(),
                 getAlertIconName(alertZoomWidePrefix, index, forBus),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopFeaturesBuilder.kt
@@ -9,7 +9,7 @@ import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.Stop
 import io.github.dellisd.spatialk.geojson.Point
 
-object ChildStopFeaturesBuilder {
+internal object ChildStopFeaturesBuilder {
     val childStopSourceId = "child-stop-source"
 
     val propNameKey = FeatureProperty<String>("name")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopIcons.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopIcons.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.map
 
-object ChildStopIcons {
+internal object ChildStopIcons {
     val entranceIcon = "map-child-stop-entrance"
     val platformIcon = "map-child-stop-platform"
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ChildStopLayerGenerator.kt
@@ -8,7 +8,7 @@ import com.mbta.tid.mbta_app.map.style.downcastToColor
 import com.mbta.tid.mbta_app.map.style.downcastToResolvedImage
 import com.mbta.tid.mbta_app.model.LocationType
 
-object ChildStopLayerGenerator {
+internal object ChildStopLayerGenerator {
     val childStopLayerId = "child-stop-layer"
 
     val annotationTextZoomThreshold = 19.0

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ColorPalette.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/ColorPalette.kt
@@ -3,9 +3,12 @@ package com.mbta.tid.mbta_app.map
 /**
  * A set of colors to use, specific to light or dark mode. Expects colors as `#ABCDEF` hex strings.
  */
-data class ColorPalette(val deemphasized: String, val fill3: String, val text: String) {
-    companion object {
-        val light = ColorPalette(deemphasized = "#8A9199", fill3 = "#FFFFFF", text = "#192026")
-        val dark = ColorPalette(deemphasized = "#8A9199", fill3 = "#000000", text = "#E5E5E3")
+public data class ColorPalette
+internal constructor(val deemphasized: String, val fill3: String, val text: String) {
+    public companion object {
+        public val light: ColorPalette =
+            ColorPalette(deemphasized = "#8A9199", fill3 = "#FFFFFF", text = "#192026")
+        public val dark: ColorPalette =
+            ColorPalette(deemphasized = "#8A9199", fill3 = "#000000", text = "#E5E5E3")
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapDefaults.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapDefaults.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.map
 
-object MapDefaults {
-    val midZoomThreshold = 11.0
-    val closeZoomThreshold = 15.0
-    val defaultZoomThreshold = 16.0
+public object MapDefaults {
+    public val midZoomThreshold: Double = 11.0
+    internal val closeZoomThreshold: Double = 15.0
+    public val defaultZoomThreshold: Double = 16.0
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapExp.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapExp.kt
@@ -8,7 +8,7 @@ import com.mbta.tid.mbta_app.model.MapStopRoute
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 
-object MapExp {
+internal object MapExp {
     // Get the array of MapStopRoute string values from a stop feature
     val routesExp = Exp.get(StopFeaturesBuilder.propMapRoutesKey)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapTestDataHelper.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/MapTestDataHelper.kt
@@ -2,6 +2,8 @@ package com.mbta.tid.mbta_app.map
 
 import com.mbta.tid.mbta_app.model.MapStop
 import com.mbta.tid.mbta_app.model.MapStopRoute
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteSegment
 import com.mbta.tid.mbta_app.model.SegmentedRouteShape
@@ -9,18 +11,18 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.utils.TestData
 
-object MapTestDataHelper {
-    val objects = TestData.clone()
-    val routeRed = objects.getRoute("Red")
-    val routeOrange = objects.getRoute("Orange")
-    val route67 = objects.getRoute("67")
+public object MapTestDataHelper {
+    public val objects: ObjectCollectionBuilder = TestData.clone()
+    internal val routeRed = objects.getRoute("Red")
+    public val routeOrange: Route = objects.getRoute("Orange")
+    internal val route67 = objects.getRoute("67")
 
-    val routesById = mapOf(routeRed.id to routeRed, routeOrange.id to routeOrange)
+    internal val routesById = mapOf(routeRed.id to routeRed, routeOrange.id to routeOrange)
 
-    val stopAlewife = objects.getStop("place-alfcl")
-    val stopAlewifeChild = objects.getStop("70061")
+    internal val stopAlewife = objects.getStop("place-alfcl")
+    internal val stopAlewifeChild = objects.getStop("70061")
 
-    val mapStopAlewife: MapStop =
+    internal val mapStopAlewife: MapStop =
         MapStop(
             stopAlewife,
             mapOf(MapStopRoute.RED to listOf(routeRed), MapStopRoute.BUS to listOf(route67)),
@@ -30,10 +32,10 @@ object MapTestDataHelper {
             null,
         )
 
-    val stopDavis = objects.getStop("place-davis")
-    val stopDavisChild = objects.getStop("70063")
+    internal val stopDavis = objects.getStop("place-davis")
+    internal val stopDavisChild = objects.getStop("70063")
 
-    val mapStopDavis =
+    internal val mapStopDavis =
         MapStop(
             stop = stopDavis,
             routes = mapOf(MapStopRoute.RED to listOf(routeRed)),
@@ -43,9 +45,9 @@ object MapTestDataHelper {
             alerts = null,
         )
 
-    val stopPorter = objects.getStop("place-portr")
+    internal val stopPorter = objects.getStop("place-portr")
 
-    val mapStopPorter =
+    internal val mapStopPorter =
         MapStop(
             stopPorter,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
@@ -55,9 +57,9 @@ object MapTestDataHelper {
             null,
         )
 
-    val stopHarvard = objects.getStop("place-harsq")
+    internal val stopHarvard = objects.getStop("place-harsq")
 
-    val mapStopHarvard =
+    internal val mapStopHarvard =
         MapStop(
             stopHarvard,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
@@ -67,9 +69,9 @@ object MapTestDataHelper {
             null,
         )
 
-    val stopCentral = objects.getStop("place-cntsq")
+    internal val stopCentral = objects.getStop("place-cntsq")
 
-    val mapStopCentral =
+    internal val mapStopCentral =
         MapStop(
             stopCentral,
             mapOf(MapStopRoute.RED to listOf(routeRed)),
@@ -79,11 +81,11 @@ object MapTestDataHelper {
             null,
         )
 
-    val stopAssembly = objects.getStop("place-astao")
+    internal val stopAssembly = objects.getStop("place-astao")
 
-    val stopAssemblyChild = objects.getStop("70279")
+    internal val stopAssemblyChild = objects.getStop("70279")
 
-    val mapStopAssembly =
+    internal val mapStopAssembly =
         MapStop(
             stopAssembly,
             mapOf(MapStopRoute.ORANGE to listOf(routeOrange)),
@@ -93,9 +95,9 @@ object MapTestDataHelper {
             null,
         )
 
-    val stopSullivan = objects.getStop("place-sull")
+    internal val stopSullivan = objects.getStop("place-sull")
 
-    val mapStopSullivan =
+    internal val mapStopSullivan =
         MapStop(
             stopSullivan,
             mapOf(MapStopRoute.ORANGE to listOf(routeOrange)),
@@ -105,58 +107,58 @@ object MapTestDataHelper {
             null,
         )
 
-    val patternRed10 = objects.getRoutePattern("Red-1-0")
-    val patternRed30 = objects.getRoutePattern("Red-3-0")
+    internal val patternRed10 = objects.getRoutePattern("Red-1-0")
+    internal val patternRed30 = objects.getRoutePattern("Red-3-0")
 
-    val patternOrange30 = objects.getRoutePattern("Orange-3-0")
-    val patternOrange70 =
+    public val patternOrange30: RoutePattern = objects.getRoutePattern("Orange-3-0")
+    internal val patternOrange70 =
         objects.routePattern(routeOrange) {
             id = "Orange-7-0"
             typicality = RoutePattern.Typicality.Atypical
             representativeTripId = "61746557"
         }
 
-    val pattern67 = objects.getRoutePattern("67-4-0")
+    internal val pattern67 = objects.getRoutePattern("67-4-0")
 
-    val tripRedC1 = objects.getTrip("canonical-Red-C1-0")
-    val tripRedC2 = objects.getTrip("canonical-Red-C2-0")
-    val tripOrangeC1 = objects.getTrip("canonical-Orange-C1-0")
-    val tripOrangeAtypical =
+    internal val tripRedC1 = objects.getTrip("canonical-Red-C1-0")
+    internal val tripRedC2 = objects.getTrip("canonical-Red-C2-0")
+    internal val tripOrangeC1 = objects.getTrip("canonical-Orange-C1-0")
+    internal val tripOrangeAtypical =
         objects.trip(patternOrange30) {
             id = "61746557"
             shapeId = "40460002"
         }
 
-    val trip67 =
+    internal val trip67 =
         objects.trip(pattern67) {
             id = "61846289"
             stopIds = listOf(stopAlewife.id)
         }
 
-    val shapeRedC1 =
+    internal val shapeRedC1 =
         objects.shape {
             id = "canonical-933_0009"
             polyline =
                 "}nwaG~|eqLGyNIqAAc@S_CAEWu@g@}@u@k@u@Wu@OMGIMISQkAOcAGw@SoDFkCf@sUXcJJuERwHPkENqCJmB^mDn@}D??D[TeANy@\\iAt@qB`AwBl@cAl@m@b@Yn@QrBEtCKxQ_ApMT??R?`m@hD`Np@jAF|@C`B_@hBi@n@s@d@gA`@}@Z_@RMZIl@@fBFlB\\tAP??~@L^?HCLKJWJ_@vC{NDGLQvG}HdCiD`@e@Xc@b@oAjEcPrBeGfAsCvMqVl@sA??jByD`DoGd@cAj@cBJkAHqBNiGXeHVmJr@kR~@q^HsB@U??NgDr@gJTcH`@aMFyCF}AL}DN}GL}CXkILaD@QFmA@[??DaAFiBDu@BkA@UB]Fc@Jo@BGJ_@Lc@\\}@vJ_OrCyDj@iAb@_AvBuF`@gA`@aAv@qBVo@Xu@??bDgI??Tm@~IsQj@cAr@wBp@kBj@kB??HWtDcN`@g@POl@UhASh@Eb@?t@FXHl@Px@b@he@h[pCC??bnAm@h@T??xF|BpBp@^PLBXAz@Yl@]l@e@|B}CT[p@iA|A}BZi@jBeDnAiBz@iAf@k@l@g@dAs@fAe@|@WpCe@l@GTCRE\\G??~@O`@ELA|AGf@A\\CjCGrEKz@AdEAxHY|BD~@JjB^fF~AdDbA|InCxCv@zD|@rWfEXDpB`@tANvAHx@AjBIx@M~@S~@a@fAi@HEnA{@fA{@|HuI|DwEbDqDpLkNhCyClEiFhLaN`@c@f@o@RURUbDsDbAiA`AgAv@_AHKHI~E}FdBoBfAgAfD{DxDoE~DcF|BkClAwALODEJOJK|@gATWvAoA`Au@fAs@hAk@n@QpAa@vDeAhA[x@Yh@Wv@a@b@YfAaAjCgCz@aAtByBz@{@??|FaGtCaDbL{LhI{IzHgJdAuAjC{CVYvAwA??JIl@a@NMNM\\[|AuArF_GlPyQrD_ErAwAd@e@nE{ErDuD\\a@nE_FZYPSRUvL{Mv@}@Z[JILKv@m@z@i@fCkAlBmAl@[t@[??h@WxBeAp@]dAi@p@YXIPEXKDALENEbAQl@Gz@ChADtAL~ARnCZbGx@xB`@TDL@PBzAVjIvA^FVDVB|@NjHlAlPnCnCd@vBXhBNv@JtAPL@|BXrAN??`@FRBj@Bp@FbADz@?dAIp@I|@Mx@Q`AWhAYlBs@pDaBzAs@nBgAZQJGJGhAs@RKVMNKTMf@YdHcEzBmApAw@`GmDLI@AHGlEwClAi@hA_@v@Up@ObB]z@Kr@Ir@EZCpA?dCRf@DpAHvANrE`@bDTr@DfMdA`CJvBRn@DnCLnBPfAFV@"
         }
 
-    val shapeRedC2 =
+    internal val shapeRedC2 =
         objects.shape {
             id = "canonical-931_0009"
             polyline =
                 "}nwaG~|eqLGyNIqAAc@S_CAEWu@g@}@u@k@u@Wu@OMGIMISQkAOcAGw@SoDFkCf@sUXcJJuERwHPkENqCJmB^mDn@}D??D[TeANy@\\iAt@qB`AwBl@cAl@m@b@Yn@QrBEtCKxQ_ApMT??R?`m@hD`Np@jAF|@C`B_@hBi@n@s@d@gA`@}@Z_@RMZIl@@fBFlB\\tAP??~@L^?HCLKJWJ_@vC{NDGLQvG}HdCiD`@e@Xc@b@oAjEcPrBeGfAsCvMqVl@sA??jByD`DoGd@cAj@cBJkAHqBNiGXeHVmJr@kR~@q^HsB@U??NgDr@gJTcH`@aMFyCF}AL}DN}GL}CXkILaD@QFmA@[??DaAFiBDu@BkA@UB]Fc@Jo@BGJ_@Lc@\\}@vJ_OrCyDj@iAb@_AvBuF`@gA`@aAv@qBVo@Xu@??bDgI??Tm@~IsQj@cAr@wBp@kBj@kB??HWtDcN`@g@POl@UhASh@Eb@?t@FXHl@Px@b@he@h[pCC??bnAm@h@T??xF|BpBp@^PLBXAz@Yl@]l@e@|B}CT[p@iA|A}BZi@zDuF\\c@n@s@VObAw@^Sl@Yj@U\\O|@WdAUxAQRCt@E??xAGrBQZAhAGlAEv@Et@E~@AdAAbCGpCA|BEjCMr@?nBDvANlARdBb@nDbA~@XnBp@\\JRH??|Al@`AZbA^jA^lA\\h@P|@TxAZ|@J~@LN?fBXxHhApDt@b@JXFtAVhALx@FbADtAC`B?z@BHBH@|@f@RN^^T\\h@hANb@HZH`@H^LpADlA@dD@jD@x@@b@Bp@HdAFd@Ll@F^??n@rDBRl@vD^pATp@Rb@b@z@\\l@`@j@p@t@j@h@n@h@n@`@hAh@n@\\t@PzANpAApBGtE}@xBa@??xB_@nOmB`OgBb@IrC[p@MbEmARCV@d@LH?tDyAXM"
         }
 
-    val shapeOrangeC1 =
+    internal val shapeOrangeC1 =
         objects.shape {
             id = "canonical-903_0018"
             polyline =
                 "an_bG|_xpLpBPrCZXBTBP@P@~Dd@dANlATjBd@tDhALDNDhA\\pIbClGjBz@ZhA\\xA`@XJpBl@??ZHpBn@HBfHvBfF~AhDbApA\\bAVND`Er@nALvCVfBLfFDb@?dBAjCEfB?pFDrHF~HFfB?vAC~FFpQJpB?|C@P?`B?V?X?h@B??l@DfEFL@f@BpCDxDFfABfA?lCBdB@fABnC@|C@tO@`ECfCI??|@ElESdCGdCAzA@pEEdBCnBItAAdBA^AT@nAAd@@`A?VAbC?fABzAD??nBDR?Z@v@@`DKtFCn@AZC`@Gr@Q\\MHEb@MzA{@zJeIlBaBhBoBzA}BlAoBrB_EVw@r@oBvAiE??DId@cBxCkGpGmK@Cda@o_@PO??tHkGbCuCh@e@b@Y????`@Sr@IlMg@zGB??T?vC?N@VN`ElDvAvBbBrBtA~A????v@t@hAtAhDbDb@f@t@p@VJj@Nh@@n@Bz@F??RBdD`@|B^XJRLz@`AxBvB|@N??xATNP`HrRJd@BZAf@OzCCbAApFCvG@hC?~F@t@@bB@jAFlAJ~AJf@???@Jb@DLRb@T^v@dA|AxBbB~BnHlJ^f@xAlBJHn@x@rBbClDnEt@fA??Zd@b@n@b@l@nDxEjN`RfAtApCrDb@h@RV??tCxDRTjLzNNRfEnFNN~AhBn@n@NJ`@\\????|@t@dE~CnA|@bAn@n@X`@Vd@R|@^\\Rf@Tp@Xn@R|@T~@ZpA`@l@NZHtEpAHBf@LbHrCvAr@??LFRLf@\\PJvA|@lA~@|AhAvCbCfDpCnA|@hCbBv@b@vAt@lAj@VL??JDd@TtBz@hA^RFvD`AdAZhBl@pA\\??~CfAzAh@vDfBxC`BXNb@T??NJdAj@~CdB|@h@h@Zv@h@fDhBHDnFvCdAn@vC`B~BrAvA~@|CjBrA~@hBhALJl@d@NHNJnDvBhAr@"
         }
 
-    val shapeOrangeAtypical = objects.shape { id = "40460002" }
+    internal val shapeOrangeAtypical = objects.shape { id = "40460002" }
 
-    val routeResponse =
+    public val routeResponse: MapFriendlyRouteResponse =
         MapFriendlyRouteResponse(
             listOf(
                 MapFriendlyRouteResponse.RouteWithSegmentedShapes(
@@ -217,5 +219,5 @@ object MapTestDataHelper {
             )
         )
 
-    val global = GlobalResponse(objects)
+    internal val global = GlobalResponse(objects)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/Polyline.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/Polyline.kt
@@ -5,7 +5,7 @@ import kotlin.experimental.and
 import kotlin.math.round
 
 // https://developers.google.com/maps/documentation/utilities/polylinealgorithm
-object Polyline {
+internal object Polyline {
     private sealed interface State {
         data object AwaitingLatitude : State
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-data class RouteLineData(
+internal data class RouteLineData(
     val id: String,
     val sourceRoutePatternId: String,
     val line: LineString,
@@ -37,26 +37,27 @@ data class RouteLineData(
     val alertState: SegmentAlertState,
 )
 
-data class RouteSourceData(
+public data class RouteSourceData
+internal constructor(
     val routeId: String,
-    val lines: List<RouteLineData>,
+    internal val lines: List<RouteLineData>,
     val features: FeatureCollection,
 )
 
-object RouteFeaturesBuilder {
-    val routeSourceId = "route-source"
+public object RouteFeaturesBuilder {
+    internal val routeSourceId = "route-source"
 
-    fun getRouteSourceId(routeId: String) = "$routeSourceId-$routeId"
+    public fun getRouteSourceId(routeId: String): String = "$routeSourceId-$routeId"
 
-    val propAlertStateKey = FeatureProperty<String>("alertState")
+    internal val propAlertStateKey = FeatureProperty<String>("alertState")
 
     @DefaultArgumentInterop.Enabled
-    suspend fun generateRouteSources(
+    public suspend fun generateRouteSources(
         routeData: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         globalData: GlobalResponse,
         globalMapData: GlobalMapData?,
         coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    ) =
+    ): List<RouteSourceData> =
         generateRouteSources(
             routeData,
             globalData.stops,
@@ -65,7 +66,7 @@ object RouteFeaturesBuilder {
         )
 
     @DefaultArgumentInterop.Enabled
-    suspend fun generateRouteSources(
+    internal suspend fun generateRouteSources(
         routeData: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         stopsById: Map<String, Stop>,
         alertsByStop: Map<String, AlertAssociatedStop>,
@@ -101,7 +102,7 @@ object RouteFeaturesBuilder {
         return RouteSourceData(routeId, routeLines, featureCollection)
     }
 
-    fun shapesWithStopsToMapFriendly(
+    internal fun shapesWithStopsToMapFriendly(
         shapesWithStops: List<ShapeWithStops>,
         stopsById: Map<String, Stop>?,
     ): List<MapFriendlyRouteResponse.RouteWithSegmentedShapes> =
@@ -109,7 +110,7 @@ object RouteFeaturesBuilder {
             shapeWithStopsToMapFriendly(shapeWithStops, stopsById)
         }
 
-    fun shapeWithStopsToMapFriendly(
+    internal fun shapeWithStopsToMapFriendly(
         shapeWithStops: ShapeWithStops,
         stopsById: Map<String, Stop>?,
     ): MapFriendlyRouteResponse.RouteWithSegmentedShapes? {
@@ -194,11 +195,12 @@ object RouteFeaturesBuilder {
         )
     }
 
-    fun forRailAtStop(
+    public fun forRailAtStop(
         stopShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         railShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         globalData: GlobalResponse?,
-    ) = forRailAtStop(stopShapes, railShapes, globalData?.routes)
+    ): List<MapFriendlyRouteResponse.RouteWithSegmentedShapes> =
+        forRailAtStop(stopShapes, railShapes, globalData?.routes)
 
     private fun forRailAtStop(
         stopShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
@@ -219,7 +221,7 @@ object RouteFeaturesBuilder {
         return railShapes.filter { stopRailRouteIds.contains(it.routeId) }
     }
 
-    fun filteredRouteShapesForStop(
+    public fun filteredRouteShapesForStop(
         stopMapData: StopMapResponse,
         filter: StopDetailsFilter,
         routeCardData: List<RouteCardData>?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteLayerGenerator.kt
@@ -12,13 +12,13 @@ import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-object RouteLayerGenerator {
-    val routeLayerId = "route-layer"
+public object RouteLayerGenerator {
+    public val routeLayerId: String = "route-layer"
     private val closeZoomCutoff = MapDefaults.closeZoomThreshold
 
-    fun getRouteLayerId(routeId: String) = "$routeLayerId-$routeId"
+    internal fun getRouteLayerId(routeId: String) = "$routeLayerId-$routeId"
 
-    suspend fun createAllRouteLayers(
+    public suspend fun createAllRouteLayers(
         routesWithShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         globalResponse: GlobalResponse,
         colorPalette: ColorPalette,
@@ -47,7 +47,7 @@ object RouteLayerGenerator {
                 }
         }
 
-    fun createRouteLayer(route: Route): LineLayer {
+    internal fun createRouteLayer(route: Route): LineLayer {
         val layer = baseRouteLayer(getRouteLayerId(route.id), route)
         layer.lineWidth = Exp.step(Exp.zoom(), Exp(3), Exp(closeZoomCutoff) to Exp(4))
         return layer
@@ -59,7 +59,10 @@ object RouteLayerGenerator {
      * Creates separate layers for shuttle and suspension segments because `LineLayer.lineDasharray`
      * [doesn't support data-driven styling](https://docs.mapbox.com/style-spec/reference/layers/#paint-line-line-dasharray)
      */
-    fun createAlertingRouteLayers(route: Route, colorPalette: ColorPalette): List<LineLayer> {
+    internal fun createAlertingRouteLayers(
+        route: Route,
+        colorPalette: ColorPalette,
+    ): List<LineLayer> {
         val shuttledLayer = baseRouteLayer(getRouteLayerId("${route.id}-shuttled"), route)
         shuttledLayer.filter =
             Exp.eq(
@@ -92,7 +95,7 @@ object RouteLayerGenerator {
         return listOf(alertBackgroundLayer, shuttledLayer, suspendedLayer)
     }
 
-    fun baseRouteLayer(layerId: String, route: Route): LineLayer {
+    internal fun baseRouteLayer(layerId: String, route: Route): LineLayer {
         val layer =
             LineLayer(id = layerId, source = RouteFeaturesBuilder.getRouteSourceId(route.id))
         layer.lineColor = Exp("#${route.color}")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilder.kt
@@ -16,30 +16,31 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-data class StopFeatureData(val stop: MapStop, val feature: Feature)
+internal data class StopFeatureData(val stop: MapStop, val feature: Feature)
 
-object StopFeaturesBuilder {
-    val stopSourceId = "stop-source"
+public object StopFeaturesBuilder {
+    public val stopSourceId: String = "stop-source"
 
-    val propIdKey = FeatureProperty<String>("id")
-    val propIsTerminalKey = FeatureProperty<Boolean>("isTerminal")
+    public val propIdKey: FeatureProperty<String> = FeatureProperty("id")
+    internal val propIsTerminalKey = FeatureProperty<Boolean>("isTerminal")
     // Map routes is an array of MapStopRoute enum names
-    val propMapRoutesKey = FeatureProperty<List<String>>("mapRoutes")
-    val propNameKey = FeatureProperty<String>("name")
+    internal val propMapRoutesKey = FeatureProperty<List<String>>("mapRoutes")
+    internal val propNameKey = FeatureProperty<String>("name")
     // Route IDs are in a map keyed by MapStopRoute enum names, each with a list of IDs
-    val propRouteIdsKey = FeatureProperty<Map<String, List<String>>>("routeIds")
-    val propServiceStatusKey = FeatureProperty<Map<String, String>>("serviceStatus")
-    val propSortOrderKey = FeatureProperty<Number>("sortOrder")
+    internal val propRouteIdsKey = FeatureProperty<Map<String, List<String>>>("routeIds")
+    internal val propServiceStatusKey = FeatureProperty<Map<String, String>>("serviceStatus")
+    internal val propSortOrderKey = FeatureProperty<Number>("sortOrder")
 
     /** Routes and directions are stored as "<route id>/<direction id>". */
-    val propAllRouteDirectionsKey = FeatureProperty<List<String>>("allRouteDirections")
+    internal val propAllRouteDirectionsKey = FeatureProperty<List<String>>("allRouteDirections")
 
     @DefaultArgumentInterop.Enabled
-    suspend fun buildCollection(
+    public suspend fun buildCollection(
         globalMapData: GlobalMapData?,
         routeSourceDetails: List<RouteSourceData>,
         coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    ) = buildCollection(globalMapData?.mapStops.orEmpty(), routeSourceDetails, coroutineDispatcher)
+    ): FeatureCollection =
+        buildCollection(globalMapData?.mapStops.orEmpty(), routeSourceDetails, coroutineDispatcher)
 
     @DefaultArgumentInterop.Enabled
     internal suspend fun buildCollection(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopIcons.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopIcons.kt
@@ -5,26 +5,26 @@ import com.mbta.tid.mbta_app.map.style.ResolvedImage
 import com.mbta.tid.mbta_app.map.style.downcastToResolvedImage
 import com.mbta.tid.mbta_app.model.MapStopRoute
 
-object StopIcons {
-    val stopIconPrefix = "map-stop-"
-    val stopZoomClosePrefix = "close-"
-    val stopZoomWidePrefix = "wide-"
+public object StopIcons {
+    internal val stopIconPrefix = "map-stop-"
+    internal val stopZoomClosePrefix = "close-"
+    internal val stopZoomWidePrefix = "wide-"
 
-    val stopContainerPrefix = "${stopIconPrefix}container-"
-    val stopTransferSuffix = "-transfer"
-    val stopTerminalSuffix = "-terminal"
+    internal val stopContainerPrefix = "${stopIconPrefix}container-"
+    internal val stopTransferSuffix = "-transfer"
+    internal val stopTerminalSuffix = "-terminal"
 
     // This is a single transparent pixel, used to create a layer just for tap target padding
-    val stopDummyIcon = "${stopIconPrefix}dummy-tap-pixel"
+    internal val stopDummyIcon = "${stopIconPrefix}dummy-tap-pixel"
 
-    val stopPinIcon = "${stopIconPrefix}pin"
+    internal val stopPinIcon = "${stopIconPrefix}pin"
 
-    val basicStopIcons =
+    internal val basicStopIcons =
         MapStopRoute.entries.flatMap { routeType -> atZooms(stopIconPrefix, routeType.name) }
-    val stopContainerIcons =
+    internal val stopContainerIcons =
         listOf("2", "3").flatMap { memberCount -> atZooms(stopContainerPrefix, memberCount) }
 
-    val terminalIcons: List<String> =
+    internal val terminalIcons: List<String> =
         MapStopRoute.entries
             .filter { !it.hasBranchingTerminals }
             .map { routeType ->
@@ -41,7 +41,7 @@ object StopIcons {
                 "${stopIconPrefix}${stopZoomWidePrefix}${MapStopRoute.SILVER.name}${stopTerminalSuffix}"
             )
 
-    val branchIcons: List<String> =
+    internal val branchIcons: List<String> =
         MapStopRoute.entries
             .filter { it.hasBranchingTerminals }
             .flatMap { routeType ->
@@ -50,12 +50,12 @@ object StopIcons {
                 }
             }
 
-    val specialCaseStopIcons =
+    internal val specialCaseStopIcons =
         terminalIcons +
             branchIcons +
             atZooms(stopIconPrefix, MapStopRoute.BUS.name + stopTransferSuffix)
 
-    val all: List<String> =
+    public val all: List<String> =
         basicStopIcons +
             specialCaseStopIcons +
             stopContainerIcons +
@@ -75,7 +75,7 @@ object StopIcons {
             Exp(""),
         )
 
-    fun atZooms(pre: String, post: String): List<String> {
+    internal fun atZooms(pre: String, post: String): List<String> {
         return listOf(stopZoomClosePrefix, stopZoomWidePrefix).map { zoom ->
             "${pre}${zoom}${post}"
         }
@@ -104,7 +104,7 @@ object StopIcons {
     // If the stop serves a single type of route, display a regular stop icon,
     // if it serves 2 or 3, display a container icon, and the stop icons in it
     // will be displayed by the transfer layers.
-    fun getStopIconName(zoomPrefix: String, forBus: Boolean): Exp<ResolvedImage> {
+    internal fun getStopIconName(zoomPrefix: String, forBus: Boolean): Exp<ResolvedImage> {
         return MapExp.busSwitchExp(
                 forBus = forBus,
                 Exp.step(
@@ -117,7 +117,7 @@ object StopIcons {
             .downcastToResolvedImage()
     }
 
-    fun getStopLayerIcon(forBus: Boolean = false): Exp<ResolvedImage> {
+    internal fun getStopLayerIcon(forBus: Boolean = false): Exp<ResolvedImage> {
         return Exp.step(
             Exp.zoom(),
             getStopIconName(stopZoomWidePrefix, forBus = forBus),
@@ -126,7 +126,7 @@ object StopIcons {
         )
     }
 
-    fun getTransferIconName(zoomPrefix: String, index: Int): Exp<ResolvedImage> {
+    internal fun getTransferIconName(zoomPrefix: String, index: Int): Exp<ResolvedImage> {
         return Exp.step(
                 Exp.length(MapExp.routesExp),
                 Exp(""),
@@ -146,7 +146,7 @@ object StopIcons {
             .downcastToResolvedImage()
     }
 
-    fun getTransferLayerIcon(index: Int): Exp<ResolvedImage> {
+    internal fun getTransferLayerIcon(index: Int): Exp<ResolvedImage> {
         return Exp.step(
             Exp.zoom(),
             getTransferIconName(stopZoomWidePrefix, index),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/StopLayerGenerator.kt
@@ -11,27 +11,30 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-object StopLayerGenerator {
-    val maxTransferLayers = 3
-    val stopZoomThreshold = 11.0
-    val busStopZoomThreshold = 12.0
+public object StopLayerGenerator {
+    internal val maxTransferLayers = 3
+    public val stopZoomThreshold: Double = 11.0
+    internal val busStopZoomThreshold = 12.0
 
-    val stopLayerId = "stop-layer"
-    val stopTouchTargetLayerId = "${stopLayerId}-touch-target"
-    val stopLayerSelectedPinId = "${stopLayerId}-selected-pin"
+    public val stopLayerId: String = "stop-layer"
+    public val stopTouchTargetLayerId: String = "${stopLayerId}-touch-target"
+    internal val stopLayerSelectedPinId = "${stopLayerId}-selected-pin"
 
-    val busLayerId = "${stopLayerId}-bus"
-    val busAlertLayerId = "${stopLayerId}-bus-alert"
+    public val busLayerId: String = "${stopLayerId}-bus"
+    internal val busAlertLayerId = "${stopLayerId}-bus-alert"
 
-    fun getAlertLayerId(index: Int) = "${stopLayerId}-alert-${index}"
+    internal fun getAlertLayerId(index: Int) = "${stopLayerId}-alert-${index}"
 
-    fun getTransferLayerId(index: Int) = "${stopLayerId}-transfer-${index}"
+    internal fun getTransferLayerId(index: Int) = "${stopLayerId}-transfer-${index}"
 
-    data class State
+    public data class State
     @DefaultArgumentInterop.Enabled
     constructor(val selectedStopId: String? = null, val stopFilter: StopDetailsFilter? = null)
 
-    suspend fun createStopLayers(colorPalette: ColorPalette, state: State): List<SymbolLayer> {
+    public suspend fun createStopLayers(
+        colorPalette: ColorPalette,
+        state: State,
+    ): List<SymbolLayer> {
         return withContext(Dispatchers.Default) {
             val sourceId = StopFeaturesBuilder.stopSourceId
 
@@ -90,7 +93,7 @@ object StopLayerGenerator {
         }
     }
 
-    fun createAlertLayer(
+    internal fun createAlertLayer(
         id: String,
         index: Int = 0,
         forBus: Boolean = false,
@@ -105,7 +108,7 @@ object StopLayerGenerator {
         return alertLayer
     }
 
-    fun createStopLayer(
+    internal fun createStopLayer(
         id: String,
         forBus: Boolean = false,
         colorPalette: ColorPalette,
@@ -121,7 +124,7 @@ object StopLayerGenerator {
         return stopLayer
     }
 
-    fun includedDefaultTextProps(layer: SymbolLayer, colorPalette: ColorPalette) {
+    internal fun includedDefaultTextProps(layer: SymbolLayer, colorPalette: ColorPalette) {
         layer.textColor = Exp(colorPalette.text).downcastToColor()
         layer.textFont = listOf("Inter Regular")
         layer.textHaloColor = Exp(colorPalette.fill3).downcastToColor()
@@ -135,7 +138,7 @@ object StopLayerGenerator {
         layer.textOffset = MapExp.labelOffsetExp
     }
 
-    fun includeSharedProps(layer: SymbolLayer, forBus: Boolean, state: State) {
+    internal fun includeSharedProps(layer: SymbolLayer, forBus: Boolean, state: State) {
         layer.iconSize = MapExp.selectedSizeExp(state)
 
         layer.iconAllowOverlap = true
@@ -169,7 +172,7 @@ object StopLayerGenerator {
             Exp.ge(Exp.zoom(), if (forBus) Exp(busStopZoomThreshold) else Exp(stopZoomThreshold)),
         )
 
-    fun offsetAlertValue(index: Int): Exp<List<Number>> {
+    internal fun offsetAlertValue(index: Int): Exp<List<Number>> {
         return Exp.step(
             Exp.zoom(),
             MapExp.offsetAlertExp(closeZoom = false, index),
@@ -177,7 +180,7 @@ object StopLayerGenerator {
         )
     }
 
-    fun offsetTransferValue(index: Int): Exp<List<Number>> {
+    internal fun offsetTransferValue(index: Int): Exp<List<Number>> {
         return Exp.step(
             Exp.zoom(),
             MapExp.offsetTransferExp(closeZoom = false, index),
@@ -185,7 +188,7 @@ object StopLayerGenerator {
         )
     }
 
-    fun offsetPinValue(): Exp<List<Number>> {
+    internal fun offsetPinValue(): Exp<List<Number>> {
         return Exp.step(
             Exp.zoom(),
             MapExp.offsetPinExp(closeZoom = false),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/ArrayType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/ArrayType.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonPrimitive
 
-sealed interface ArrayType<T> : MapboxStyleObject {
+internal sealed interface ArrayType<T> : MapboxStyleObject {
     data object String : ArrayType<kotlin.String>
 
     data object Number : ArrayType<kotlin.Number>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Color.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Color.kt
@@ -1,3 +1,3 @@
 package com.mbta.tid.mbta_app.map.style
 
-typealias Color = String
+internal typealias Color = String

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Exp.kt
@@ -18,11 +18,11 @@ import kotlinx.serialization.json.buildJsonArray
  * making [Exp] an interface avoids that restriction. This also makes it much more explicit in the
  * code when a bare [JsonElement] is being inserted directly.
  */
-sealed interface Exp<T> : MapboxStyleObject {
-    data class Bare<T>(val body: JsonElement) : Exp<T> {
-        override fun asJson() = body
+public sealed interface Exp<T> : MapboxStyleObject {
+    public data class Bare<T> internal constructor(internal val body: JsonElement) : Exp<T> {
+        override fun asJson(): JsonElement = body
 
-        companion object {
+        internal companion object {
             fun arrayOf(vararg elements: String) =
                 Bare<List<String>>(
                     buildJsonArray {
@@ -34,7 +34,7 @@ sealed interface Exp<T> : MapboxStyleObject {
         }
     }
 
-    companion object {
+    public companion object {
         private fun <T> op(operator: String, block: JsonArrayBuilder.() -> Unit) =
             Bare<T>(
                 buildJsonArray {
@@ -46,7 +46,7 @@ sealed interface Exp<T> : MapboxStyleObject {
         private fun <T> op(operator: String, vararg operands: Exp<*>): Exp<T> =
             op(operator) { for (operand in operands) add(operand) }
 
-        fun <T> array(
+        internal fun <T> array(
             type: ArrayType<T>? = null,
             size: Number? = null,
             value: Exp<List<T>>,
@@ -59,65 +59,70 @@ sealed interface Exp<T> : MapboxStyleObject {
             }
         }
 
-        fun boolean(value: Exp<Boolean>): Exp<Boolean> = op("boolean", value)
+        internal fun boolean(value: Exp<Boolean>): Exp<Boolean> = op("boolean", value)
 
-        fun image(value: Exp<String>): Exp<ResolvedImage> = op("image", value)
+        internal fun image(value: Exp<String>): Exp<ResolvedImage> = op("image", value)
 
-        fun <T> literal(value: JsonArray): Exp<List<T>> = op("literal") { add(value) }
+        internal fun <T> literal(value: JsonArray): Exp<List<T>> = op("literal") { add(value) }
 
-        fun number(value: Exp<Number>): Exp<Number> = op("number", value)
+        internal fun number(value: Exp<Number>): Exp<Number> = op("number", value)
 
-        fun string(value: Exp<String>): Exp<String> = op("string", value)
+        internal fun string(value: Exp<String>): Exp<String> = op("string", value)
 
-        fun <T> at(index: Exp<Number>, array: Exp<List<T>>): Exp<T> = op("at", index, array)
+        internal fun <T> at(index: Exp<Number>, array: Exp<List<T>>): Exp<T> =
+            op("at", index, array)
 
-        fun <T> get(property: FeatureProperty<T>): Exp<T> = op("get") { add(property.key) }
+        internal fun <T> get(property: FeatureProperty<T>): Exp<T> = op("get") { add(property.key) }
 
-        fun <K, V> get(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<V> =
+        internal fun <K, V> get(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<V> =
             op("get") {
                 add(property)
                 add(inObject)
             }
 
-        fun has(property: FeatureProperty<*>): Exp<Boolean> = op("has") { add(property.key) }
+        internal fun has(property: FeatureProperty<*>): Exp<Boolean> =
+            op("has") { add(property.key) }
 
-        fun <K, V> has(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<Boolean> =
+        internal fun <K, V> has(property: Exp<K>, inObject: Exp<Map<K, V>>): Exp<Boolean> =
             op("has") {
                 add(property)
                 add(inObject)
             }
 
         @JvmName("inArray")
-        fun <T> `in`(keyword: Exp<T>, input: Exp<List<T>>): Exp<Boolean> = op("in", keyword, input)
+        internal fun <T> `in`(keyword: Exp<T>, input: Exp<List<T>>): Exp<Boolean> =
+            op("in", keyword, input)
 
         @JvmName("inString")
-        fun `in`(keyword: Exp<String>, input: Exp<String>): Exp<Boolean> = op("in", keyword, input)
+        internal fun `in`(keyword: Exp<String>, input: Exp<String>): Exp<Boolean> =
+            op("in", keyword, input)
 
         @JvmName("lengthArray")
-        fun <T> length(value: Exp<List<T>>): Exp<Number> = op("length", value)
+        internal fun <T> length(value: Exp<List<T>>): Exp<Number> = op("length", value)
 
-        @JvmName("lengthString") fun length(value: Exp<String>): Exp<Number> = op("length", value)
+        @JvmName("lengthString")
+        internal fun length(value: Exp<String>): Exp<Number> = op("length", value)
 
-        fun not(value: Exp<Boolean>): Exp<Boolean> = op("!", value)
+        internal fun not(value: Exp<Boolean>): Exp<Boolean> = op("!", value)
 
-        fun <T> notEq(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("!=", lhs, rhs)
+        internal fun <T> notEq(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("!=", lhs, rhs)
 
-        fun <T> lt(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("<", lhs, rhs)
+        internal fun <T> lt(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("<", lhs, rhs)
 
-        fun <T> le(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("<=", lhs, rhs)
+        internal fun <T> le(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("<=", lhs, rhs)
 
-        fun <T> eq(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("==", lhs, rhs)
+        internal fun <T> eq(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op("==", lhs, rhs)
 
-        fun <T> gt(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op(">", lhs, rhs)
+        internal fun <T> gt(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op(">", lhs, rhs)
 
-        fun <T> ge(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op(">=", lhs, rhs)
+        internal fun <T> ge(lhs: Exp<T>, rhs: Exp<T>): Exp<Boolean> = op(">=", lhs, rhs)
 
-        fun all(vararg operands: Exp<Boolean>): Exp<Boolean> = op("all", *operands)
+        internal fun all(vararg operands: Exp<Boolean>): Exp<Boolean> = op("all", *operands)
 
-        fun any(vararg operands: Exp<Boolean>): Exp<Boolean> = op("any", *operands)
+        internal fun any(vararg operands: Exp<Boolean>): Exp<Boolean> = op("any", *operands)
 
         // vararg is greedy so fallback must be passed as a named parameter
-        fun <T> case(vararg cases: Pair<Exp<Boolean>, Exp<T>>, fallback: Exp<T>): Exp<T> =
+        internal fun <T> case(vararg cases: Pair<Exp<Boolean>, Exp<T>>, fallback: Exp<T>): Exp<T> =
             op("case") {
                 for (case in cases) {
                     add(case.first)
@@ -127,11 +132,11 @@ sealed interface Exp<T> : MapboxStyleObject {
             }
 
         // convenience overload for single case to avoid naming fallback
-        fun <T> case(case: Pair<Exp<Boolean>, Exp<T>>, fallback: Exp<T>): Exp<T> =
+        internal fun <T> case(case: Pair<Exp<Boolean>, Exp<T>>, fallback: Exp<T>): Exp<T> =
             op("case", case.first, case.second, fallback)
 
         // case labels can be either Exp<I> or Exp<List<I>>, but that can't be checked without pain
-        fun <I, O> match(
+        internal fun <I, O> match(
             input: Exp<I>,
             vararg cases: Pair<Exp<*>, Exp<O>>,
             fallback: Exp<O>,
@@ -145,7 +150,7 @@ sealed interface Exp<T> : MapboxStyleObject {
                 add(fallback)
             }
 
-        fun <T> interpolate(
+        internal fun <T> interpolate(
             interpolation: Interpolation,
             input: Exp<Number>,
             vararg stops: Pair<Exp<Number>, Exp<T>>,
@@ -159,7 +164,7 @@ sealed interface Exp<T> : MapboxStyleObject {
                 }
             }
 
-        fun <T> step(
+        internal fun <T> step(
             input: Exp<Number>,
             outputBelow: Exp<T>,
             vararg stops: Pair<Exp<Number>, Exp<T>>,
@@ -173,7 +178,7 @@ sealed interface Exp<T> : MapboxStyleObject {
                 }
             }
 
-        fun <T> let(vararg bindings: LetVariable.Binding<*>, body: Exp<T>): Exp<T> =
+        internal fun <T> let(vararg bindings: LetVariable.Binding<*>, body: Exp<T>): Exp<T> =
             op("let") {
                 for (binding in bindings) {
                     add(binding.variable.name)
@@ -182,24 +187,24 @@ sealed interface Exp<T> : MapboxStyleObject {
                 add(body)
             }
 
-        fun <T> `var`(variable: LetVariable<T>): Exp<T> = op("var", Exp(variable.name))
+        internal fun <T> `var`(variable: LetVariable<T>): Exp<T> = op("var", Exp(variable.name))
 
-        fun concat(vararg values: Exp<String>): Exp<String> = op("concat", *values)
+        internal fun concat(vararg values: Exp<String>): Exp<String> = op("concat", *values)
 
-        fun downcase(value: Exp<String>): Exp<String> = op("downcase", value)
+        internal fun downcase(value: Exp<String>): Exp<String> = op("downcase", value)
 
-        fun product(vararg values: Exp<Number>): Exp<Number> = op("*", *values)
+        internal fun product(vararg values: Exp<Number>): Exp<Number> = op("*", *values)
 
-        fun zoom(): Exp<Number> = op("zoom")
+        internal fun zoom(): Exp<Number> = op("zoom")
     }
 }
 
-fun Exp(value: Boolean): Exp<Boolean> = Exp.Bare(JsonPrimitive(value))
+internal fun Exp(value: Boolean): Exp<Boolean> = Exp.Bare(JsonPrimitive(value))
 
-fun Exp(value: Number): Exp<Number> = Exp.Bare(JsonPrimitive(value))
+internal fun Exp(value: Number): Exp<Number> = Exp.Bare(JsonPrimitive(value))
 
-fun Exp(value: String): Exp<String> = Exp.Bare(JsonPrimitive(value))
+internal fun Exp(value: String): Exp<String> = Exp.Bare(JsonPrimitive(value))
 
-fun Exp<String>.downcastToColor(): Exp<Color> = Exp.Bare(this.asJson())
+internal fun Exp<String>.downcastToColor(): Exp<Color> = Exp.Bare(this.asJson())
 
-fun Exp<String>.downcastToResolvedImage(): Exp<ResolvedImage> = Exp.Bare(this.asJson())
+internal fun Exp<String>.downcastToResolvedImage(): Exp<ResolvedImage> = Exp.Bare(this.asJson())

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Feature.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Feature.kt
@@ -2,7 +2,8 @@ package com.mbta.tid.mbta_app.map.style
 
 import io.github.dellisd.spatialk.geojson.Geometry
 
-data class Feature(
+public data class Feature
+internal constructor(
     val id: String? = null,
     val geometry: Geometry,
     val properties: FeatureProperties,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureCollection.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureCollection.kt
@@ -1,3 +1,3 @@
 package com.mbta.tid.mbta_app.map.style
 
-data class FeatureCollection(val features: List<Feature>)
+public data class FeatureCollection internal constructor(val features: List<Feature>)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperties.kt
@@ -9,73 +9,79 @@ import kotlin.jvm.JvmName
  * bit of a nuisance to work with in a more type-safe language like Kotlin. Mapbox for iOS defines
  * an enum like this.
  */
-sealed interface JSONValue {
-    data class Array(val data: JSONArray) : JSONValue
+public sealed interface JSONValue {
+    public data class Array internal constructor(val data: JSONArray) : JSONValue
 
-    data class Boolean(val data: kotlin.Boolean) : JSONValue
+    public data class Boolean internal constructor(val data: kotlin.Boolean) : JSONValue
 
-    data class Number(val data: Double) : JSONValue
+    public data class Number internal constructor(val data: Double) : JSONValue
 
-    data class Object(val data: JSONObject) : JSONValue
+    public data class Object internal constructor(val data: JSONObject) : JSONValue
 
-    data class String(val data: kotlin.String) : JSONValue
+    public data class String internal constructor(val data: kotlin.String) : JSONValue
 }
 
-val JSONValue.array: JSONArray
+internal val JSONValue.array: JSONArray
     get() {
         check(this is JSONValue.Array)
         return this.data
     }
 
-val JSONValue.boolean: Boolean
+internal val JSONValue.boolean: Boolean
     get() {
         check(this is JSONValue.Boolean)
         return this.data
     }
 
-val JSONValue.number: Number
+internal val JSONValue.number: Number
     get() {
         check(this is JSONValue.Number)
         return this.data
     }
 
-val JSONValue.`object`: JSONObject
+internal val JSONValue.`object`: JSONObject
     get() {
         check(this is JSONValue.Object)
         return this.data
     }
-val JSONValue.string: String
+internal val JSONValue.string: String
     get() {
         check(this is JSONValue.String)
         return this.data
     }
 
-typealias JSONArray = List<JSONValue>
+public typealias JSONArray = List<JSONValue>
 
-typealias JSONObject = Map<String, JSONValue>
+public typealias JSONObject = Map<String, JSONValue>
 
-data class FeatureProperties(val data: JSONObject) {
-    operator fun get(property: FeatureProperty<Boolean>): Boolean? = data[property.key]?.boolean
+public data class FeatureProperties internal constructor(val data: JSONObject) {
+    internal operator fun get(property: FeatureProperty<Boolean>): Boolean? =
+        data[property.key]?.boolean
 
-    operator fun get(property: FeatureProperty<Number>): Number? = data[property.key]?.number
+    internal operator fun get(property: FeatureProperty<Number>): Number? =
+        data[property.key]?.number
 
-    operator fun get(property: FeatureProperty<String>): String? = data[property.key]?.string
+    internal operator fun get(property: FeatureProperty<String>): String? =
+        data[property.key]?.string
 
-    operator fun get(property: FeatureProperty<List<String>>): List<String>? =
+    internal operator fun get(property: FeatureProperty<List<String>>): List<String>? =
         data[property.key]?.array?.map { it.string }
 
     @JvmName("getMapStringString")
-    operator fun get(property: FeatureProperty<Map<String, String>>): Map<String, String>? =
-        data[property.key]?.`object`?.mapValues { it.value.string }
+    internal operator fun get(
+        property: FeatureProperty<Map<String, String>>
+    ): Map<String, String>? = data[property.key]?.`object`?.mapValues { it.value.string }
 
     @JvmName("getMapStringListString")
-    operator fun get(
+    internal operator fun get(
         property: FeatureProperty<Map<String, List<String>>>
     ): Map<String, List<String>>? =
         data[property.key]?.`object`?.mapValues { it.value.array.map { it.string } }
 }
 
-class FeaturePropertiesBuilder(private val data: MutableMap<String, JSONValue> = mutableMapOf()) {
+internal class FeaturePropertiesBuilder(
+    private val data: MutableMap<String, JSONValue> = mutableMapOf()
+) {
     fun put(property: FeatureProperty<Boolean>, value: Boolean) {
         data[property.key] = JSONValue.Boolean(value)
     }
@@ -115,7 +121,9 @@ class FeaturePropertiesBuilder(private val data: MutableMap<String, JSONValue> =
     fun built() = FeatureProperties(data)
 }
 
-inline fun buildFeatureProperties(block: FeaturePropertiesBuilder.() -> Unit): FeatureProperties {
+internal inline fun buildFeatureProperties(
+    block: FeaturePropertiesBuilder.() -> Unit
+): FeatureProperties {
     val builder = FeaturePropertiesBuilder()
     builder.block()
     return builder.built()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperty.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/FeatureProperty.kt
@@ -1,3 +1,3 @@
 package com.mbta.tid.mbta_app.map.style
 
-data class FeatureProperty<T>(val key: String)
+public data class FeatureProperty<T>(val key: String)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Interpolation.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Interpolation.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.map.style
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 
-sealed interface Interpolation : MapboxStyleObject {
+internal sealed interface Interpolation : MapboxStyleObject {
     data object Linear : Interpolation {
         override fun asJson() = buildJsonArray { add("linear") }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Layer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/Layer.kt
@@ -1,18 +1,19 @@
 package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-sealed class Layer : MapboxStyleObject {
-    abstract val id: String
-    abstract val type: LayerType
-    abstract val filter: Exp<Boolean>?
-    abstract val source: String?
+public sealed class Layer : MapboxStyleObject {
+    public abstract val id: String
+    public abstract val type: LayerType
+    public abstract val filter: Exp<Boolean>?
+    public abstract val source: String?
 
-    var minZoom: Double? = null
+    public var minZoom: Double? = null
 
-    final override fun asJson() = buildJsonObject {
+    final override fun asJson(): JsonObject = buildJsonObject {
         put("id", id)
         put("type", type)
 
@@ -25,7 +26,7 @@ sealed class Layer : MapboxStyleObject {
         put("source", source)
     }
 
-    abstract fun layoutAsJson(): JsonElement
+    internal abstract fun layoutAsJson(): JsonElement
 
-    abstract fun paintAsJson(): JsonElement
+    internal abstract fun paintAsJson(): JsonElement
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LayerType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LayerType.kt
@@ -2,11 +2,11 @@ package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonPrimitive
 
-enum class LayerType : MapboxStyleObject {
+public enum class LayerType : MapboxStyleObject {
     Line,
     Symbol;
 
-    override fun asJson() =
+    override fun asJson(): JsonPrimitive =
         when (this) {
             Line -> JsonPrimitive("line")
             Symbol -> JsonPrimitive("symbol")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LetVariable.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LetVariable.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.map.style
 
-data class LetVariable<T>(val name: String) {
+internal data class LetVariable<T>(val name: String) {
     infix fun boundTo(value: Exp<T>) = Binding(this, value)
 
     data class Binding<T>(val variable: LetVariable<T>, val value: Exp<T>)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineJoin.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineJoin.kt
@@ -2,13 +2,13 @@ package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonPrimitive
 
-enum class LineJoin : MapboxStyleObject {
+public enum class LineJoin : MapboxStyleObject {
     Bevel,
     Round,
     Miter,
     None;
 
-    override fun asJson() =
+    override fun asJson(): JsonPrimitive =
         when (this) {
             Bevel -> JsonPrimitive("bevel")
             Round -> JsonPrimitive("round")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineLayer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/LineLayer.kt
@@ -4,8 +4,9 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 
-data class LineLayer(override val id: String, override val source: String) : Layer() {
-    override val type = LayerType.Line
+public data class LineLayer
+internal constructor(override val id: String, override val source: String) : Layer() {
+    override val type: LayerType = LayerType.Line
     override var filter: Exp<Boolean>? = null
 
     var lineColor: Exp<Color>? = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/MapboxStyleObject.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/MapboxStyleObject.kt
@@ -6,12 +6,12 @@ import kotlinx.serialization.json.JsonArrayBuilder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObjectBuilder
 
-interface MapboxStyleObject {
-    fun asJson(): JsonElement
+public interface MapboxStyleObject {
+    public fun asJson(): JsonElement
 
-    fun toJsonString() = json.encodeToString(asJson())
+    public fun toJsonString(): String = json.encodeToString(asJson())
 }
 
-fun JsonArrayBuilder.add(`object`: MapboxStyleObject) = add(`object`.asJson())
+internal fun JsonArrayBuilder.add(`object`: MapboxStyleObject) = add(`object`.asJson())
 
-fun JsonObjectBuilder.put(key: String, value: MapboxStyleObject) = put(key, value.asJson())
+internal fun JsonObjectBuilder.put(key: String, value: MapboxStyleObject) = put(key, value.asJson())

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/ResolvedImage.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/ResolvedImage.kt
@@ -1,4 +1,4 @@
 package com.mbta.tid.mbta_app.map.style
 
 /** Represents an image in the [Exp] type checking system. Does not contain a value. */
-typealias ResolvedImage = Nothing
+internal typealias ResolvedImage = Nothing

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/SymbolLayer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/SymbolLayer.kt
@@ -5,8 +5,9 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-data class SymbolLayer(override val id: String, override val source: String) : Layer() {
-    override val type = LayerType.Symbol
+public data class SymbolLayer
+internal constructor(override val id: String, override val source: String) : Layer() {
+    override val type: LayerType = LayerType.Symbol
     override var filter: Exp<Boolean>? = null
 
     var iconAllowOverlap: Boolean? = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/TextAnchor.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/TextAnchor.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonPrimitive
 
-enum class TextAnchor : MapboxStyleObject {
+public enum class TextAnchor : MapboxStyleObject {
     CENTER,
     LEFT,
     RIGHT,
@@ -13,7 +13,7 @@ enum class TextAnchor : MapboxStyleObject {
     BOTTOM_LEFT,
     BOTTOM_RIGHT;
 
-    override fun asJson() =
+    override fun asJson(): JsonPrimitive =
         when (this) {
             CENTER -> JsonPrimitive("center")
             LEFT -> JsonPrimitive("left")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/TextJustify.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/style/TextJustify.kt
@@ -2,13 +2,13 @@ package com.mbta.tid.mbta_app.map.style
 
 import kotlinx.serialization.json.JsonPrimitive
 
-enum class TextJustify : MapboxStyleObject {
+public enum class TextJustify : MapboxStyleObject {
     AUTO,
     LEFT,
     CENTER,
     RIGHT;
 
-    override fun asJson() =
+    override fun asJson(): JsonPrimitive =
         when (this) {
             AUTO -> JsonPrimitive("auto")
             LEFT -> JsonPrimitive("left")

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
@@ -3,13 +3,13 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlinx.serialization.Serializable
 
-class AlertAssociatedStop(val stop: Stop) {
-    var relevantAlerts: List<Alert> = mutableListOf()
-    var serviceAlerts: List<Alert> = mutableListOf()
-    var childAlerts: Map<String, AlertAssociatedStop> = mutableMapOf()
-    var stateByRoute: Map<MapStopRoute, StopAlertState> = mutableMapOf()
+public class AlertAssociatedStop internal constructor(internal val stop: Stop) {
+    internal var relevantAlerts: List<Alert> = mutableListOf()
+    internal var serviceAlerts: List<Alert> = mutableListOf()
+    internal var childAlerts: Map<String, AlertAssociatedStop> = mutableMapOf()
+    internal var stateByRoute: Map<MapStopRoute, StopAlertState> = mutableMapOf()
 
-    constructor(
+    internal constructor(
         stop: Stop,
         alertsByStop: Map<String, Set<Alert>>,
         nullStopAlerts: Set<Alert>,
@@ -47,7 +47,7 @@ class AlertAssociatedStop(val stop: Stop) {
         }
     }
 
-    constructor(
+    internal constructor(
         stop: Stop,
         relevantAlerts: List<Alert>,
         stateByRoute: Map<MapStopRoute, StopAlertState>,
@@ -58,7 +58,7 @@ class AlertAssociatedStop(val stop: Stop) {
         this.stateByRoute = stateByRoute
     }
 
-    constructor(
+    internal constructor(
         stop: Stop,
         relevantAlerts: List<Alert>,
         childAlerts: Map<String, AlertAssociatedStop>,
@@ -72,7 +72,7 @@ class AlertAssociatedStop(val stop: Stop) {
 }
 
 @Serializable
-enum class StopAlertState {
+public enum class StopAlertState {
     Elevator,
     Issue,
     Normal,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSignificance.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSignificance.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
-enum class AlertSignificance : Comparable<AlertSignificance> {
+public enum class AlertSignificance : Comparable<AlertSignificance> {
     // defined in ascending order so that Major > Secondary > Minor > None
     /** Hidden everywhere. */
     None,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -10,35 +10,37 @@ import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 
-data class AlertSummary(
-    val effect: Alert.Effect,
+public data class AlertSummary(
+    internal val effect: Alert.Effect,
     val location: Location? = null,
     val timeframe: Timeframe? = null,
 ) {
-    sealed class Location {
-        data class DirectionToStop(val direction: Direction, val endStopName: String) : Location()
-
-        data class SingleStop(val stopName: String) : Location()
-
-        data class StopToDirection(val startStopName: String, val direction: Direction) :
+    public sealed class Location {
+        public data class DirectionToStop(val direction: Direction, val endStopName: String) :
             Location()
 
-        data class SuccessiveStops(val startStopName: String, val endStopName: String) : Location()
+        public data class SingleStop(val stopName: String) : Location()
+
+        public data class StopToDirection(val startStopName: String, val direction: Direction) :
+            Location()
+
+        public data class SuccessiveStops(val startStopName: String, val endStopName: String) :
+            Location()
     }
 
-    sealed class Timeframe {
-        data object EndOfService : Timeframe()
+    public sealed class Timeframe {
+        public data object EndOfService : Timeframe()
 
-        data object Tomorrow : Timeframe()
+        public data object Tomorrow : Timeframe()
 
-        data class LaterDate(val time: EasternTimeInstant) : Timeframe()
+        public data class LaterDate(val time: EasternTimeInstant) : Timeframe()
 
-        data class ThisWeek(val time: EasternTimeInstant) : Timeframe()
+        public data class ThisWeek(val time: EasternTimeInstant) : Timeframe()
 
-        data class Time(val time: EasternTimeInstant) : Timeframe()
+        public data class Time(val time: EasternTimeInstant) : Timeframe()
     }
 
-    companion object {
+    internal companion object {
         suspend fun summarizing(
             alert: Alert,
             stopId: String,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AppVersion.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AppVersion.kt
@@ -1,16 +1,16 @@
 package com.mbta.tid.mbta_app.model
 
-data class AppVersion(val major: UInt, val minor: UInt, val patch: UInt) {
-    operator fun compareTo(otherVersion: AppVersion): Int {
+public data class AppVersion(val major: UInt, val minor: UInt, val patch: UInt) {
+    public operator fun compareTo(otherVersion: AppVersion): Int {
         return major.compareTo(otherVersion.major).takeUnless { it == 0 }
             ?: minor.compareTo(otherVersion.minor).takeUnless { it == 0 }
             ?: patch.compareTo(otherVersion.patch)
     }
 
-    override fun toString() = "$major.$minor.$patch"
+    override fun toString(): String = "$major.$minor.$patch"
 
-    companion object {
-        fun parse(version: String): AppVersion {
+    public companion object {
+        public fun parse(version: String): AppVersion {
             val numbers = version.split('.', limit = 3).map(String::toUInt)
             return AppVersion(numbers[0], numbers[1], numbers[2])
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/BackendObject.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/BackendObject.kt
@@ -5,6 +5,6 @@ package com.mbta.tid.mbta_app.model
  *
  * Useful in the [ObjectCollectionBuilder] for maintaining maps from IDs to objects.
  */
-interface BackendObject {
-    val id: String
+public interface BackendObject {
+    public val id: String
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Dependency.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Dependency.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
-data class Dependency(val id: String, val name: String, val licenseText: String) {
-    companion object
+public data class Dependency(val id: String, val name: String, val licenseText: String) {
+    public companion object
 }
 
-expect fun Dependency.Companion.getAllDependencies(): List<Dependency>
+public expect fun Dependency.Companion.getAllDependencies(): List<Dependency>

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Direction.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 
-data class Direction(var name: String?, var destination: String?, var id: Int) {
+public data class Direction(var name: String?, var destination: String?, var id: Int) {
     /**
      * This constructor is used to provide additional context to a Direction to allow for overriding
      * the destination label in cases where a route or line has branching. We want to display a
@@ -17,7 +17,7 @@ data class Direction(var name: String?, var destination: String?, var id: Int) {
      * that the direction label will just display the direction name.
      */
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         directionId: Int,
         route: Route,
         stop: Stop? = null,
@@ -32,7 +32,7 @@ data class Direction(var name: String?, var destination: String?, var id: Int) {
         directionId,
     )
 
-    companion object {
+    internal companion object {
         // This is split into a separate variable for a hardcoded check
         private val northStationDestination = "North Station & North"
         /*

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
@@ -2,19 +2,19 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-sealed class ErrorBannerState {
+public sealed class ErrorBannerState {
     /** What to do when the button in the error banner is pressed */
-    abstract val action: (() -> Unit)?
+    public abstract val action: (() -> Unit)?
 
-    data class StalePredictions(
-        val lastUpdated: EasternTimeInstant,
+    public data class StalePredictions(
+        internal val lastUpdated: EasternTimeInstant,
         override val action: () -> Unit,
     ) : ErrorBannerState() {
-        fun minutesAgo() = (EasternTimeInstant.now() - lastUpdated).inWholeMinutes
+        public fun minutesAgo(): Long = (EasternTimeInstant.now() - lastUpdated).inWholeMinutes
     }
 
-    data class DataError(val messages: Set<String>, override val action: () -> Unit) :
+    public data class DataError(val messages: Set<String>, override val action: () -> Unit) :
         ErrorBannerState()
 
-    data class NetworkError(override val action: (() -> Unit)?) : ErrorBannerState()
+    public data class NetworkError(override val action: (() -> Unit)?) : ErrorBannerState()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Facility.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Facility.kt
@@ -4,14 +4,15 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Facility(
+public data class Facility
+internal constructor(
     override val id: String,
-    @SerialName("long_name") val longName: String? = null,
+    @SerialName("long_name") internal val longName: String? = null,
     @SerialName("short_name") val shortName: String? = null,
     val type: Type = Type.Other,
 ) : BackendObject {
     @Serializable
-    enum class Type {
+    public enum class Type {
         @SerialName("bike_storage") BikeStorage,
         @SerialName("bridge_plate") BridgePlate,
         @SerialName("electric_car_chargers") ElectricCarChargers,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
@@ -2,24 +2,24 @@ package com.mbta.tid.mbta_app.model
 
 import kotlinx.serialization.Serializable
 
-@Serializable data class Favorites(val routeStopDirection: Set<RouteStopDirection>? = null)
+@Serializable public data class Favorites(val routeStopDirection: Set<RouteStopDirection>? = null)
 
 @Serializable
-data class RouteStopDirection(val route: String, val stop: String, val direction: Int)
+public data class RouteStopDirection(val route: String, val stop: String, val direction: Int)
 
 /** Temporary class while we are supporting old pinned routes & enhanced favorites */
-sealed class FavoriteBridge {
-    data class Favorite(val routeStopDirection: RouteStopDirection) : FavoriteBridge()
+public sealed class FavoriteBridge {
+    public data class Favorite(val routeStopDirection: RouteStopDirection) : FavoriteBridge()
 
-    data class Pinned(val routeId: String) : FavoriteBridge()
+    public data class Pinned(val routeId: String) : FavoriteBridge()
 }
 
 /** Temporary class while we are supporting old pinned routes & enhanced favorites */
-sealed class FavoriteUpdateBridge {
-    data class Favorites(
+public sealed class FavoriteUpdateBridge {
+    public data class Favorites(
         val updatedValues: Map<RouteStopDirection, Boolean>,
         val defaultDirection: Int,
     ) : FavoriteUpdateBridge()
 
-    data class Pinned(val routeId: String) : FavoriteUpdateBridge()
+    public data class Pinned(val routeId: String) : FavoriteUpdateBridge()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.kt
@@ -1,13 +1,16 @@
 package com.mbta.tid.mbta_app.model
 
-enum class FeaturePromo(val addedInAndroidVersion: AppVersion, val addedInIosVersion: AppVersion) {
+public enum class FeaturePromo(
+    internal val addedInAndroidVersion: AppVersion,
+    internal val addedInIosVersion: AppVersion,
+) {
 
     CombinedStopAndTrip(AppVersion(0u, 0u, 0u), AppVersion(1u, 2u, 0u)),
     EnhancedFavorites(AppVersion(2u, 0u, 0u), AppVersion(2u, 0u, 0u));
 
     constructor(addedInVersion: AppVersion) : this(addedInVersion, addedInVersion)
 
-    companion object {
+    internal companion object {
         fun featuresBetween(
             lastLaunchedVersion: AppVersion,
             currentVersion: AppVersion,
@@ -19,4 +22,4 @@ enum class FeaturePromo(val addedInAndroidVersion: AppVersion, val addedInIosVer
     }
 }
 
-expect val FeaturePromo.addedInVersion: AppVersion
+internal expect val FeaturePromo.addedInVersion: AppVersion

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
@@ -4,7 +4,7 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-data class MapStop(
+public data class MapStop(
     val stop: Stop,
     val routes: Map<MapStopRoute, List<Route>>,
     val routeTypes: List<MapStopRoute>,
@@ -13,11 +13,11 @@ data class MapStop(
     val alerts: Map<MapStopRoute, StopAlertState>?,
 )
 
-data class GlobalMapData(
+public data class GlobalMapData(
     internal val mapStops: Map<String, MapStop>,
     internal val alertsByStop: Map<String, AlertAssociatedStop>?,
 ) {
-    companion object {
+    internal companion object {
         /*
         Only stops without a parent stop (stations and isolated stops) are returned in the result.
         Each AlertAssociatedStop will have entries in childAlerts if there are any active alerts on
@@ -80,13 +80,13 @@ data class GlobalMapData(
         }
     }
 
-    constructor(
+    public constructor(
         globalData: GlobalResponse,
         alerts: AlertsStreamDataResponse?,
         filterAtTime: EasternTimeInstant,
     ) : this(globalData, getAlertsByStop(globalData, alerts, filterAtTime))
 
-    constructor(
+    internal constructor(
         globalData: GlobalResponse,
         alertsByStop: Map<String, AlertAssociatedStop>?,
     ) : this(
@@ -173,5 +173,5 @@ data class GlobalMapData(
         alertsByStop,
     )
 
-    override fun toString() = "[GlobalMapData]"
+    override fun toString(): String = "[GlobalMapData]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
@@ -5,12 +5,12 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 /** Represents a [RouteCardData.Leaf] ready to be displayed. */
-sealed class LeafFormat {
-    abstract fun tileData(directionDestination: String?): List<TileData>
+public sealed class LeafFormat {
+    public abstract fun tileData(directionDestination: String?): List<TileData>
 
-    abstract fun noPredictionsStatus(): UpcomingFormat.NoTripsFormat?
+    public abstract fun noPredictionsStatus(): UpcomingFormat.NoTripsFormat?
 
-    val isAllServiceDisrupted: Boolean
+    public val isAllServiceDisrupted: Boolean
         get() {
             return when (this) {
                 is Single -> this.format is UpcomingFormat.Disruption
@@ -19,7 +19,8 @@ sealed class LeafFormat {
         }
 
     /** A [RouteCardData.Leaf] which only has one destination within its direction. */
-    data class Single(
+    public data class Single
+    internal constructor(
         /**
          * The route to display next to [headsign] and [format]. Only set if the
          * [RouteCardData.Leaf] comes from a grouped line, and therefore always worth showing if
@@ -45,7 +46,8 @@ sealed class LeafFormat {
             }
         }
 
-        override fun noPredictionsStatus() = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
+        override fun noPredictionsStatus(): UpcomingFormat.NoTripsFormat? =
+            (format as? UpcomingFormat.NoTrips)?.noTripsFormat
     }
 
     /**
@@ -60,11 +62,13 @@ sealed class LeafFormat {
      *   once for the entire direction. This may be a secondary alert at this stop, or a major alert
      *   affecting a stop downstream of this one on any of the route patterns it serves.
      */
-    data class Branched(
+    public data class Branched
+    internal constructor(
         val branchRows: List<BranchRow>,
         val secondaryAlert: UpcomingFormat.SecondaryAlert? = null,
     ) : LeafFormat() {
-        data class BranchRow(
+        public data class BranchRow
+        internal constructor(
             /**
              * The route to display next to [headsign] and [format]. Only set if the
              * [RouteCardData.Leaf] comes from a grouped line, and therefore always worth showing if
@@ -78,7 +82,8 @@ sealed class LeafFormat {
              * SwiftUI needs to be able to distinguish rows with the same headsign, but that
              * shouldn’t be included in equality checks or computed eagerly.
              */
-            @OptIn(ExperimentalUuidApi::class) val id by lazy { "$headsign-${Uuid.random()}" }
+            @OptIn(ExperimentalUuidApi::class)
+            internal val id by lazy { "$headsign-${Uuid.random()}" }
         }
 
         override fun tileData(directionDestination: String?): List<TileData> {
@@ -112,7 +117,7 @@ sealed class LeafFormat {
         }
     }
 
-    class BranchedBuilder {
+    internal class BranchedBuilder {
         private val branchRows = mutableListOf<Branched.BranchRow>()
         var secondaryAlert: UpcomingFormat.SecondaryAlert? = null
 
@@ -125,7 +130,7 @@ sealed class LeafFormat {
         internal fun built() = Branched(branchRows, secondaryAlert)
     }
 
-    companion object {
+    internal companion object {
         fun branched(block: BranchedBuilder.() -> Unit) = BranchedBuilder().apply(block).built()
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Line.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Line.kt
@@ -4,18 +4,18 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Line(
+public data class Line(
     override val id: String,
     val color: String,
     @SerialName("long_name") val longName: String,
-    @SerialName("short_name") val shortName: String,
-    @SerialName("sort_order") val sortOrder: Int,
+    @SerialName("short_name") internal val shortName: String,
+    @SerialName("sort_order") internal val sortOrder: Int,
     @SerialName("text_color") val textColor: String,
 ) : BackendObject {
     /** Grouped lines are displayed as though they are different branches of a single route. */
-    val isGrouped = this.id in groupedIds
+    internal val isGrouped = this.id in groupedIds
 
-    companion object {
+    internal companion object {
         val groupedIds = setOf("line-Green")
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -6,11 +6,11 @@ import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
-object LoadingPlaceholders {
-    fun nearbyRoute() =
+public object LoadingPlaceholders {
+    public fun nearbyRoute(): RouteCardData =
         routeCardData(context = RouteCardData.Context.NearbyTransit, now = EasternTimeInstant.now())
 
-    fun routeCardData(
+    public fun routeCardData(
         routeId: String? = null,
         trips: Int = 2,
         context: RouteCardData.Context,
@@ -98,7 +98,7 @@ object LoadingPlaceholders {
         return routeData
     }
 
-    fun routeDetailsStops(
+    public fun routeDetailsStops(
         lineOrRoute: RouteCardData.LineOrRoute,
         directionId: Int,
     ): RouteDetailsStopList {
@@ -136,7 +136,7 @@ object LoadingPlaceholders {
         )
     }
 
-    fun stopDetailsRouteCards() =
+    public fun stopDetailsRouteCards(): List<RouteCardData> =
         (1..5).map {
             routeCardData(
                 context = RouteCardData.Context.StopDetailsUnfiltered,
@@ -144,7 +144,7 @@ object LoadingPlaceholders {
             )
         }
 
-    fun stopResults(): List<SearchViewModel.StopResult> {
+    public fun stopResults(): List<SearchViewModel.StopResult> {
         val otherRoutePill =
             RoutePillSpec(
                 textColor = "8A9199",
@@ -164,7 +164,8 @@ object LoadingPlaceholders {
         }
     }
 
-    data class TripDetailsInfo(
+    public data class TripDetailsInfo
+    internal constructor(
         val stops: TripDetailsStopList,
         val trip: Trip,
         val vehicle: Vehicle,
@@ -172,7 +173,7 @@ object LoadingPlaceholders {
         val route: Route,
     )
 
-    fun tripDetailsInfo(): TripDetailsInfo {
+    public fun tripDetailsInfo(): TripDetailsInfo {
         val objects = ObjectCollectionBuilder()
         val route =
             objects.route {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LocationType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LocationType.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class LocationType {
+public enum class LocationType {
     @SerialName("stop") STOP,
     @SerialName("station") STATION,
     @SerialName("entrance_exit") ENTRANCE_EXIT,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/MapStopRoute.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/MapStopRoute.kt
@@ -2,13 +2,13 @@ package com.mbta.tid.mbta_app.model
 
 import kotlinx.serialization.Serializable
 
-val silverRoutes = setOf("741", "742", "743", "751", "749", "746")
-val greenRoutes = setOf("Green-B", "Green-C", "Green-D", "Green-E")
+public val silverRoutes: Set<String> = setOf("741", "742", "743", "751", "749", "746")
+internal val greenRoutes = setOf("Green-B", "Green-C", "Green-D", "Green-E")
 
 @Serializable
-enum class MapStopRoute(
-    val hasBranchingTerminals: Boolean = false,
-    val branchingRoutes: Set<String> = setOf(),
+public enum class MapStopRoute(
+    internal val hasBranchingTerminals: Boolean = false,
+    internal val branchingRoutes: Set<String> = setOf(),
 ) {
     RED {
         override fun matches(route: Route): Boolean {
@@ -56,11 +56,11 @@ enum class MapStopRoute(
         }
     };
 
-    abstract fun matches(route: Route): Boolean
+    internal abstract fun matches(route: Route): Boolean
 
-    companion object {
+    internal companion object {
         fun matching(route: Route): MapStopRoute? {
-            return MapStopRoute.entries.firstOrNull { it.matches(route) }
+            return entries.firstOrNull { it.matches(route) }
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -20,21 +20,21 @@ import kotlin.time.Instant
  * - Objects which need to be referenced directly but descend inherently from a parent (e.g. route
  *   patterns from routes) are built with a required parent argument
  */
-class ObjectCollectionBuilder
+public class ObjectCollectionBuilder
 private constructor(
-    val alerts: MutableMap<String, Alert>,
-    val facilities: MutableMap<String, Facility>,
-    val lines: MutableMap<String, Line>,
-    val predictions: MutableMap<String, Prediction>,
-    val routes: MutableMap<String, Route>,
-    val routePatterns: MutableMap<String, RoutePattern>,
-    val schedules: MutableMap<String, Schedule>,
-    val stops: MutableMap<String, Stop>,
-    val trips: MutableMap<String, Trip>,
-    val shapes: MutableMap<String, Shape>,
-    val vehicles: MutableMap<String, Vehicle>,
+    public val alerts: MutableMap<String, Alert>,
+    public val facilities: MutableMap<String, Facility>,
+    public val lines: MutableMap<String, Line>,
+    public val predictions: MutableMap<String, Prediction>,
+    public val routes: MutableMap<String, Route>,
+    public val routePatterns: MutableMap<String, RoutePattern>,
+    public val schedules: MutableMap<String, Schedule>,
+    public val stops: MutableMap<String, Stop>,
+    public val trips: MutableMap<String, Trip>,
+    public val shapes: MutableMap<String, Shape>,
+    public val vehicles: MutableMap<String, Vehicle>,
 ) {
-    constructor() :
+    public constructor() :
         this(
             alerts = mutableMapOf(),
             facilities = mutableMapOf(),
@@ -49,7 +49,7 @@ private constructor(
             vehicles = mutableMapOf(),
         )
 
-    fun clone() =
+    public fun clone(): ObjectCollectionBuilder =
         ObjectCollectionBuilder(
             alerts = alerts.toMutableMap(),
             facilities = facilities.toMutableMap(),
@@ -64,11 +64,11 @@ private constructor(
             vehicles = vehicles.toMutableMap(),
         )
 
-    interface ObjectBuilder<Built : BackendObject> {
+    internal interface ObjectBuilder<Built : BackendObject> {
         fun built(): Built
     }
 
-    fun put(`object`: BackendObject) {
+    public fun put(`object`: BackendObject) {
         when (`object`) {
             is Alert -> alerts[`object`.id] = `object`
             is Facility -> facilities[`object`.id] = `object`
@@ -85,27 +85,28 @@ private constructor(
         }
     }
 
-    class AlertBuilder : ObjectBuilder<Alert> {
-        var id = uuid()
-        var activePeriod = mutableListOf<Alert.ActivePeriod>()
-        var cause = Alert.Cause.UnknownCause
-        var description: String? = null
-        var durationCertainty = Alert.DurationCertainty.Unknown
-        var effect = Alert.Effect.UnknownEffect
-        var effectName: String? = null
-        var informedEntity = mutableListOf<Alert.InformedEntity>()
-        var header: String? = null
-        var lifecycle = Alert.Lifecycle.New
-        var severity = 0
-        var updatedAt = EasternTimeInstant(Instant.fromEpochMilliseconds(0))
-        var facilities: Map<String, Facility>? = null
+    public class AlertBuilder : ObjectBuilder<Alert> {
+        public var id: String = uuid()
+        public var activePeriod: MutableList<Alert.ActivePeriod> = mutableListOf()
+        public var cause: Alert.Cause = Alert.Cause.UnknownCause
+        public var description: String? = null
+        public var durationCertainty: Alert.DurationCertainty = Alert.DurationCertainty.Unknown
+        public var effect: Alert.Effect = Alert.Effect.UnknownEffect
+        public var effectName: String? = null
+        public var informedEntity: MutableList<Alert.InformedEntity> = mutableListOf()
+        public var header: String? = null
+        public var lifecycle: Alert.Lifecycle = Alert.Lifecycle.New
+        public var severity: Int = 0
+        public var updatedAt: EasternTimeInstant =
+            EasternTimeInstant(Instant.fromEpochMilliseconds(0))
+        public var facilities: Map<String, Facility>? = null
 
-        fun activePeriod(start: EasternTimeInstant, end: EasternTimeInstant?) {
+        public fun activePeriod(start: EasternTimeInstant, end: EasternTimeInstant?) {
             activePeriod.add(Alert.ActivePeriod(start, end))
         }
 
         @DefaultArgumentInterop.Enabled
-        fun informedEntity(
+        public fun informedEntity(
             activities: List<Alert.InformedEntity.Activity>,
             directionId: Int? = null,
             facility: String? = null,
@@ -127,7 +128,7 @@ private constructor(
             )
         }
 
-        override fun built() =
+        override fun built(): Alert =
             Alert(
                 id,
                 activePeriod,
@@ -145,55 +146,57 @@ private constructor(
             )
     }
 
-    fun alert(block: AlertBuilder.() -> Unit) = build(AlertBuilder(), block)
+    public fun alert(block: AlertBuilder.() -> Unit): Alert = build(AlertBuilder(), block)
 
-    fun getAlert(id: String) = alerts.getValue(id)
+    public fun getAlert(id: String): Alert = alerts.getValue(id)
 
-    class FacilityBuilder : ObjectBuilder<Facility> {
-        var id = uuid()
-        var longName: String? = null
-        var shortName: String? = null
-        var type: Facility.Type = Facility.Type.Other
+    public class FacilityBuilder : ObjectBuilder<Facility> {
+        public var id: String = uuid()
+        public var longName: String? = null
+        public var shortName: String? = null
+        public var type: Facility.Type = Facility.Type.Other
 
-        override fun built() = Facility(id, longName, shortName, type)
+        override fun built(): Facility = Facility(id, longName, shortName, type)
     }
 
     @DefaultArgumentInterop.Enabled
-    fun facility(block: FacilityBuilder.() -> Unit = {}) = build(FacilityBuilder(), block)
+    public fun facility(block: FacilityBuilder.() -> Unit = {}): Facility =
+        build(FacilityBuilder(), block)
 
-    fun getFacility(id: String) = facilities.getValue(id)
+    public fun getFacility(id: String): Facility = facilities.getValue(id)
 
-    class LineBuilder : ObjectBuilder<Line> {
-        var id = uuid()
-        var color = "FFFFFF"
-        var longName = ""
-        var shortName = ""
-        var sortOrder = 0
-        var textColor = "000000"
+    public class LineBuilder : ObjectBuilder<Line> {
+        public var id: String = uuid()
+        public var color: String = "FFFFFF"
+        public var longName: String = ""
+        public var shortName: String = ""
+        public var sortOrder: Int = 0
+        public var textColor: String = "000000"
 
-        override fun built() = Line(id, color, longName, shortName, sortOrder, textColor)
+        override fun built(): Line = Line(id, color, longName, shortName, sortOrder, textColor)
     }
 
     @DefaultArgumentInterop.Enabled
-    fun line(block: LineBuilder.() -> Unit = {}) = build(LineBuilder(), block)
+    public fun line(block: LineBuilder.() -> Unit = {}): Line = build(LineBuilder(), block)
 
-    fun getLine(id: String) = lines.getValue(id)
+    public fun getLine(id: String): Line = lines.getValue(id)
 
-    inner class PredictionBuilder : ObjectBuilder<Prediction> {
-        var id = uuid()
-        var arrivalTime: EasternTimeInstant? = null
-        var departureTime: EasternTimeInstant? = null
-        var directionId = 0
-        var revenue = true
-        var scheduleRelationship = Prediction.ScheduleRelationship.Scheduled
-        var status: String? = null
-        var stopSequence = 0
-        var routeId = ""
-        var stopId = ""
-        var tripId = ""
-        var vehicleId: String? = null
+    public inner class PredictionBuilder : ObjectBuilder<Prediction> {
+        public var id: String = uuid()
+        public var arrivalTime: EasternTimeInstant? = null
+        public var departureTime: EasternTimeInstant? = null
+        public var directionId: Int = 0
+        public var revenue: Boolean = true
+        public var scheduleRelationship: Prediction.ScheduleRelationship =
+            Prediction.ScheduleRelationship.Scheduled
+        public var status: String? = null
+        public var stopSequence: Int = 0
+        public var routeId: String = ""
+        public var stopId: String = ""
+        public var tripId: String = ""
+        public var vehicleId: String? = null
 
-        var trip: Trip
+        public var trip: Trip
             get() = checkNotNull(trips[tripId])
             set(trip) {
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it }
@@ -201,7 +204,7 @@ private constructor(
                 directionId = trip.directionId
             }
 
-        override fun built() =
+        override fun built(): Prediction =
             Prediction(
                 id,
                 arrivalTime,
@@ -219,9 +222,13 @@ private constructor(
     }
 
     @DefaultArgumentInterop.Enabled
-    fun prediction(block: PredictionBuilder.() -> Unit = {}) = build(PredictionBuilder(), block)
+    public fun prediction(block: PredictionBuilder.() -> Unit = {}): Prediction =
+        build(PredictionBuilder(), block)
 
-    fun prediction(schedule: Schedule, block: PredictionBuilder.() -> Unit = {}) =
+    public fun prediction(
+        schedule: Schedule,
+        block: PredictionBuilder.() -> Unit = {},
+    ): Prediction =
         build(
             PredictionBuilder().apply {
                 routeId = schedule.routeId
@@ -232,23 +239,23 @@ private constructor(
             block,
         )
 
-    fun getPrediction(id: String) = predictions.getValue(id)
+    public fun getPrediction(id: String): Prediction = predictions.getValue(id)
 
-    class RouteBuilder : ObjectBuilder<Route> {
-        var id = uuid()
-        var type = RouteType.LIGHT_RAIL
-        var color = "FFFFFF"
-        var directionNames = listOf("", "")
-        var directionDestinations = listOf("", "")
-        var isListedRoute = true
-        var longName = ""
-        var shortName = ""
-        var sortOrder = 0
-        var textColor = "000000"
-        var lineId: String? = null
-        var routePatternIds = mutableListOf<String>()
+    public class RouteBuilder : ObjectBuilder<Route> {
+        public var id: String = uuid()
+        public var type: RouteType = RouteType.LIGHT_RAIL
+        public var color: String = "FFFFFF"
+        public var directionNames: List<String> = listOf("", "")
+        public var directionDestinations: List<String> = listOf("", "")
+        public var isListedRoute: Boolean = true
+        public var longName: String = ""
+        public var shortName: String = ""
+        public var sortOrder: Int = 0
+        public var textColor: String = "000000"
+        public var lineId: String? = null
+        public var routePatternIds: MutableList<String> = mutableListOf()
 
-        override fun built() =
+        override fun built(): Route =
             Route(
                 id,
                 type,
@@ -266,20 +273,20 @@ private constructor(
     }
 
     @DefaultArgumentInterop.Enabled
-    fun route(block: RouteBuilder.() -> Unit = {}) = build(RouteBuilder(), block)
+    public fun route(block: RouteBuilder.() -> Unit = {}): Route = build(RouteBuilder(), block)
 
-    fun getRoute(id: String) = routes.getValue(id)
+    public fun getRoute(id: String): Route = routes.getValue(id)
 
-    inner class RoutePatternBuilder : ObjectBuilder<RoutePattern> {
-        var id: String = uuid()
-        var directionId: Int = 0
-        var name: String = ""
-        var sortOrder: Int = 0
-        var typicality: RoutePattern.Typicality? = RoutePattern.Typicality.Atypical
-        var representativeTripId: String = ""
-        var routeId: String = ""
+    public inner class RoutePatternBuilder : ObjectBuilder<RoutePattern> {
+        public var id: String = uuid()
+        public var directionId: Int = 0
+        public var name: String = ""
+        public var sortOrder: Int = 0
+        public var typicality: RoutePattern.Typicality? = RoutePattern.Typicality.Atypical
+        public var representativeTripId: String = ""
+        public var routeId: String = ""
 
-        fun representativeTrip(block: TripBuilder.() -> Unit = {}) =
+        public fun representativeTrip(block: TripBuilder.() -> Unit = {}): Trip =
             this@ObjectCollectionBuilder.trip {
                     routeId = this@RoutePatternBuilder.routeId
                     routePatternId = this@RoutePatternBuilder.id
@@ -288,7 +295,7 @@ private constructor(
                 }
                 .also { this.representativeTripId = it.id }
 
-        override fun built() =
+        override fun built(): RoutePattern =
             RoutePattern(
                 id,
                 directionId,
@@ -300,29 +307,31 @@ private constructor(
             )
     }
 
-    fun routePattern(route: Route, block: RoutePatternBuilder.() -> Unit = {}) =
-        build(RoutePatternBuilder().apply { routeId = route.id }, block)
+    public fun routePattern(
+        route: Route,
+        block: RoutePatternBuilder.() -> Unit = {},
+    ): RoutePattern = build(RoutePatternBuilder().apply { routeId = route.id }, block)
 
-    fun getRoutePattern(id: String) = routePatterns.getValue(id)
+    public fun getRoutePattern(id: String): RoutePattern = routePatterns.getValue(id)
 
-    inner class ScheduleBuilder : ObjectBuilder<Schedule> {
-        var id = uuid()
-        var arrivalTime: EasternTimeInstant? = null
-        var departureTime: EasternTimeInstant? = null
-        var stopHeadsign: String? = null
-        var stopSequence = 0
-        var routeId = ""
-        var stopId = ""
-        var tripId = ""
+    public inner class ScheduleBuilder : ObjectBuilder<Schedule> {
+        public var id: String = uuid()
+        public var arrivalTime: EasternTimeInstant? = null
+        public var departureTime: EasternTimeInstant? = null
+        public var stopHeadsign: String? = null
+        public var stopSequence: Int = 0
+        public var routeId: String = ""
+        public var stopId: String = ""
+        public var tripId: String = ""
 
-        var trip: Trip
+        public var trip: Trip
             get() = checkNotNull(trips[tripId])
             set(trip) {
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it }
                 tripId = trip.id
             }
 
-        override fun built() =
+        override fun built(): Schedule =
             Schedule(
                 id,
                 arrivalTime,
@@ -343,27 +352,28 @@ private constructor(
             )
     }
 
-    fun schedule(block: ScheduleBuilder.() -> Unit = {}) = build(ScheduleBuilder(), block)
+    public fun schedule(block: ScheduleBuilder.() -> Unit = {}): Schedule =
+        build(ScheduleBuilder(), block)
 
-    fun getSchedule(id: String) = schedules.getValue(id)
+    public fun getSchedule(id: String): Schedule = schedules.getValue(id)
 
-    class TripBuilder : ObjectBuilder<Trip> {
-        var id = uuid()
-        var directionId = 0
-        var headsign = ""
-        var routeId = ""
-        var routePatternId: String? = null
-        var shapeId: String? = null
-        var stopIds: List<String>? = null
+    public class TripBuilder : ObjectBuilder<Trip> {
+        public var id: String = uuid()
+        public var directionId: Int = 0
+        public var headsign: String = ""
+        public var routeId: String = ""
+        public var routePatternId: String? = null
+        public var shapeId: String? = null
+        public var stopIds: List<String>? = null
 
-        override fun built() =
+        override fun built(): Trip =
             Trip(id, directionId, headsign, routeId, routePatternId, shapeId, stopIds)
     }
 
-    fun trip(block: TripBuilder.() -> Unit = {}) = build(TripBuilder(), block)
+    public fun trip(block: TripBuilder.() -> Unit = {}): Trip = build(TripBuilder(), block)
 
     @DefaultArgumentInterop.Enabled
-    fun trip(routePattern: RoutePattern, block: TripBuilder.() -> Unit = {}) =
+    public fun trip(routePattern: RoutePattern, block: TripBuilder.() -> Unit = {}): Trip =
         build(
             TripBuilder().apply {
                 directionId = routePattern.directionId
@@ -379,49 +389,49 @@ private constructor(
             block,
         )
 
-    fun getTrip(id: String) = trips.getValue(id)
+    public fun getTrip(id: String): Trip = trips.getValue(id)
 
-    class ShapeBuilder : ObjectBuilder<Shape> {
-        var id = uuid()
-        var polyline = ""
+    public class ShapeBuilder : ObjectBuilder<Shape> {
+        public var id: String = uuid()
+        public var polyline: String = ""
 
-        override fun built() = Shape(id, polyline)
+        override fun built(): Shape = Shape(id, polyline)
     }
 
-    fun shape(block: ShapeBuilder.() -> Unit = {}) = build(ShapeBuilder(), block)
+    public fun shape(block: ShapeBuilder.() -> Unit = {}): Shape = build(ShapeBuilder(), block)
 
-    fun getShape(id: String) = shapes.getValue(id)
+    public fun getShape(id: String): Shape = shapes.getValue(id)
 
-    inner class StopBuilder : ObjectBuilder<Stop> {
-        var id = uuid()
-        var latitude = 1.2
-        var longitude = 3.4
-        var name = ""
-        var locationType = LocationType.STOP
-        var description: String? = null
-        var platformCode: String? = null
-        var platformName: String? = null
-        var vehicleType: RouteType? = null
-        var childStopIds: List<String> = emptyList()
-        var connectingStopIds: List<String> = emptyList()
-        var parentStationId: String? = null
-        var wheelchairBoarding: WheelchairBoardingStatus? = null
+    public inner class StopBuilder : ObjectBuilder<Stop> {
+        public var id: String = uuid()
+        public var latitude: Double = 1.2
+        public var longitude: Double = 3.4
+        public var name: String = ""
+        public var locationType: LocationType = LocationType.STOP
+        public var description: String? = null
+        public var platformCode: String? = null
+        public var platformName: String? = null
+        public var vehicleType: RouteType? = null
+        public var childStopIds: List<String> = emptyList()
+        public var connectingStopIds: List<String> = emptyList()
+        public var parentStationId: String? = null
+        public var wheelchairBoarding: WheelchairBoardingStatus? = null
 
-        var position: Position
+        public var position: Position
             get() = Position(latitude = latitude, longitude = longitude)
             set(value) {
                 latitude = value.latitude
                 longitude = value.longitude
             }
 
-        fun childStop(block: StopBuilder.() -> Unit = {}) =
+        public fun childStop(block: StopBuilder.() -> Unit = {}): Stop =
             this@ObjectCollectionBuilder.stop {
                     parentStationId = this@StopBuilder.id
                     block()
                 }
                 .also { childStopIds += listOf(it.id) }
 
-        override fun built() =
+        override fun built(): Stop =
             Stop(
                 id,
                 latitude,
@@ -439,24 +449,24 @@ private constructor(
             )
     }
 
-    fun stop(block: StopBuilder.() -> Unit = {}) = build(StopBuilder(), block)
+    public fun stop(block: StopBuilder.() -> Unit = {}): Stop = build(StopBuilder(), block)
 
-    fun getStop(id: String) = stops.getValue(id)
+    public fun getStop(id: String): Stop = stops.getValue(id)
 
-    class VehicleBuilder : ObjectBuilder<Vehicle> {
-        var id: String = uuid()
-        var bearing = 0.0
-        lateinit var currentStatus: Vehicle.CurrentStatus
-        var currentStopSequence: Int? = null
-        var directionId = 0
-        var latitude = 1.2
-        var longitude = 3.4
-        var updatedAt = EasternTimeInstant.now() - 10.seconds
-        var routeId: String? = null
-        var stopId: String? = null
-        var tripId = ""
+    public class VehicleBuilder : ObjectBuilder<Vehicle> {
+        public var id: String = uuid()
+        public var bearing: Double = 0.0
+        public lateinit var currentStatus: Vehicle.CurrentStatus
+        public var currentStopSequence: Int? = null
+        public var directionId: Int = 0
+        public var latitude: Double = 1.2
+        public var longitude: Double = 3.4
+        public var updatedAt: EasternTimeInstant = EasternTimeInstant.now() - 10.seconds
+        public var routeId: String? = null
+        public var stopId: String? = null
+        public var tripId: String = ""
 
-        override fun built() =
+        override fun built(): Vehicle =
             Vehicle(
                 id,
                 bearing,
@@ -472,12 +482,13 @@ private constructor(
             )
     }
 
-    fun vehicle(block: VehicleBuilder.() -> Unit = {}) = build(VehicleBuilder(), block)
+    public fun vehicle(block: VehicleBuilder.() -> Unit = {}): Vehicle =
+        build(VehicleBuilder(), block)
 
-    fun getVehicle(id: String) = vehicles.getValue(id)
+    public fun getVehicle(id: String): Vehicle = vehicles.getValue(id)
 
     @DefaultArgumentInterop.Enabled
-    fun upcomingTrip(
+    public fun upcomingTrip(
         schedule: Schedule? = null,
         prediction: Prediction? = null,
         predictionStop: Stop? = null,
@@ -498,7 +509,7 @@ private constructor(
         )
     }
 
-    fun upcomingTrip(prediction: Prediction, predictionStop: Stop? = null): UpcomingTrip =
+    public fun upcomingTrip(prediction: Prediction, predictionStop: Stop? = null): UpcomingTrip =
         upcomingTrip(null, prediction, predictionStop, null)
 
     private fun <Built : BackendObject, Builder : ObjectBuilder<Built>> build(
@@ -510,32 +521,40 @@ private constructor(
         return result.also(this::put)
     }
 
-    object Single {
-        fun alert(block: AlertBuilder.() -> Unit = {}) = ObjectCollectionBuilder().alert(block)
+    public object Single {
+        public fun alert(block: AlertBuilder.() -> Unit = {}): Alert =
+            ObjectCollectionBuilder().alert(block)
 
-        fun facility(block: FacilityBuilder.() -> Unit = {}) =
+        public fun facility(block: FacilityBuilder.() -> Unit = {}): Facility =
             ObjectCollectionBuilder().facility(block)
 
-        fun line(block: LineBuilder.() -> Unit = {}) = ObjectCollectionBuilder().line(block)
+        public fun line(block: LineBuilder.() -> Unit = {}): Line =
+            ObjectCollectionBuilder().line(block)
 
-        fun prediction(block: PredictionBuilder.() -> Unit = {}) =
+        public fun prediction(block: PredictionBuilder.() -> Unit = {}): Prediction =
             ObjectCollectionBuilder().prediction(block)
 
-        fun route(block: RouteBuilder.() -> Unit = {}) = ObjectCollectionBuilder().route(block)
+        public fun route(block: RouteBuilder.() -> Unit = {}): Route =
+            ObjectCollectionBuilder().route(block)
 
-        fun routePattern(route: Route, block: RoutePatternBuilder.() -> Unit = {}) =
-            ObjectCollectionBuilder().routePattern(route, block)
+        public fun routePattern(
+            route: Route,
+            block: RoutePatternBuilder.() -> Unit = {},
+        ): RoutePattern = ObjectCollectionBuilder().routePattern(route, block)
 
-        fun trip(block: TripBuilder.() -> Unit = {}) = ObjectCollectionBuilder().trip(block)
+        public fun trip(block: TripBuilder.() -> Unit = {}): Trip =
+            ObjectCollectionBuilder().trip(block)
 
-        fun shape(block: ShapeBuilder.() -> Unit = {}) = ObjectCollectionBuilder().shape(block)
+        public fun shape(block: ShapeBuilder.() -> Unit = {}): Shape =
+            ObjectCollectionBuilder().shape(block)
 
-        fun schedule(block: ScheduleBuilder.() -> Unit = {}) =
+        public fun schedule(block: ScheduleBuilder.() -> Unit = {}): Schedule =
             ObjectCollectionBuilder().schedule(block)
 
-        fun stop(block: StopBuilder.() -> Unit = {}) = ObjectCollectionBuilder().stop(block)
+        public fun stop(block: StopBuilder.() -> Unit = {}): Stop =
+            ObjectCollectionBuilder().stop(block)
 
-        fun vehicle(block: VehicleBuilder.() -> Unit = {}) =
+        public fun vehicle(block: VehicleBuilder.() -> Unit = {}): Vehicle =
             ObjectCollectionBuilder().vehicle(block)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/OnboardingScreen.kt
@@ -2,13 +2,13 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 
-enum class OnboardingScreen {
+public enum class OnboardingScreen {
     Location,
     StationAccessibility,
     HideMaps,
     Feedback;
 
-    fun applies(accessibilityStatus: IAccessibilityStatusRepository): Boolean =
+    internal fun applies(accessibilityStatus: IAccessibilityStatusRepository): Boolean =
         when (this) {
             Location -> true
             StationAccessibility -> true

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import io.github.dellisd.spatialk.geojson.Position
 
-object PatternSorting {
+internal object PatternSorting {
     private fun patternServiceBucket(leafData: RouteCardData.Leaf) =
         when {
             // showing either a trip or an alert

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Prediction.kt
@@ -6,28 +6,29 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-val ARRIVAL_CUTOFF = 30.seconds
-val APPROACH_CUTOFF = 60.seconds
-val BOARDING_CUTOFF = 90.seconds
-val SCHEDULE_CLOCK_CUTOFF = 60.minutes
+internal val ARRIVAL_CUTOFF = 30.seconds
+internal val APPROACH_CUTOFF = 60.seconds
+internal val BOARDING_CUTOFF = 90.seconds
+internal val SCHEDULE_CLOCK_CUTOFF = 60.minutes
 
 @Serializable
-data class Prediction(
+public data class Prediction
+internal constructor(
     override val id: String,
     @SerialName("arrival_time") override val arrivalTime: EasternTimeInstant?,
     @SerialName("departure_time") override val departureTime: EasternTimeInstant?,
-    @SerialName("direction_id") val directionId: Int,
-    val revenue: Boolean,
-    @SerialName("schedule_relationship") val scheduleRelationship: ScheduleRelationship,
-    val status: String?,
-    @SerialName("stop_sequence") val stopSequence: Int,
-    @SerialName("route_id") val routeId: String,
-    @SerialName("stop_id") val stopId: String,
+    @SerialName("direction_id") internal val directionId: Int,
+    internal val revenue: Boolean,
+    @SerialName("schedule_relationship") internal val scheduleRelationship: ScheduleRelationship,
+    internal val status: String?,
+    @SerialName("stop_sequence") internal val stopSequence: Int,
+    @SerialName("route_id") internal val routeId: String,
+    @SerialName("stop_id") internal val stopId: String,
     @SerialName("trip_id") val tripId: String,
     @SerialName("vehicle_id") val vehicleId: String?,
 ) : BackendObject, TripStopTime {
     @Serializable
-    enum class ScheduleRelationship {
+    public enum class ScheduleRelationship {
         @SerialName("added") Added,
         @SerialName("cancelled") Cancelled,
         @SerialName("no_data") NoData,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Route.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Route.kt
@@ -4,21 +4,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Route(
+public data class Route(
     override val id: String,
     val type: RouteType,
     val color: String,
     @SerialName("direction_names") val directionNames: List<String?>,
     @SerialName("direction_destinations") val directionDestinations: List<String?>,
-    @SerialName("listed_route") val isListedRoute: Boolean = true,
+    @SerialName("listed_route") internal val isListedRoute: Boolean = true,
     @SerialName("long_name") val longName: String,
     @SerialName("short_name") val shortName: String,
     @SerialName("sort_order") val sortOrder: Int,
     @SerialName("text_color") val textColor: String,
     @SerialName("line_id") val lineId: String? = null,
-    @SerialName("route_pattern_ids") val routePatternIds: List<String>? = null,
+    @SerialName("route_pattern_ids") internal val routePatternIds: List<String>? = null,
 ) : Comparable<Route>, BackendObject {
-    override fun compareTo(other: Route) = sortOrder.compareTo(other.sortOrder)
+    override fun compareTo(other: Route): Int = sortOrder.compareTo(other.sortOrder)
 
     val label: String =
         when (type) {
@@ -27,5 +27,5 @@ data class Route(
             else -> longName
         }
 
-    val isShuttle: Boolean = id.startsWith("Shuttle")
+    internal val isShuttle: Boolean = id.startsWith("Shuttle")
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteBranchSegment.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteBranchSegment.kt
@@ -5,36 +5,41 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RouteBranchSegment(
-    val stops: List<BranchStop>,
-    val name: String?,
-    @SerialName("typical?") val isTypical: Boolean,
+public data class RouteBranchSegment(
+    internal val stops: List<BranchStop>,
+    internal val name: String?,
+    @SerialName("typical?") internal val isTypical: Boolean,
 ) {
     @Serializable
-    enum class Lane {
+    public enum class Lane {
         @SerialName("left") Left,
         @SerialName("center") Center,
         @SerialName("right") Right,
     }
 
     @Serializable
-    data class BranchStop(
-        @SerialName("stop_id") val stopId: String,
-        @SerialName("stop_lane") val stopLane: Lane,
-        val connections: List<StickConnection>,
+    public data class BranchStop(
+        @SerialName("stop_id") internal val stopId: String,
+        @SerialName("stop_lane") internal val stopLane: Lane,
+        internal val connections: List<StickConnection>,
     )
 
     @Serializable
-    data class StickConnection(
+    public data class StickConnection(
         @SerialName("from_stop") val fromStop: String,
         @SerialName("to_stop") val toStop: String,
-        @SerialName("from_lane") val fromLane: Lane,
-        @SerialName("to_lane") val toLane: Lane,
+        @SerialName("from_lane") internal val fromLane: Lane,
+        @SerialName("to_lane") internal val toLane: Lane,
         @SerialName("from_vpos") val fromVPos: VPos,
         @SerialName("to_vpos") val toVPos: VPos,
     ) {
-        companion object {
-            fun forward(stopBefore: String?, stop: String?, stopAfter: String?, lane: Lane) =
+        public companion object {
+            public fun forward(
+                stopBefore: String?,
+                stop: String?,
+                stopAfter: String?,
+                lane: Lane,
+            ): List<StickConnection> =
                 listOfNotNull(
                     if (stopBefore != null && stop != null)
                         StickConnection(
@@ -70,20 +75,20 @@ data class RouteBranchSegment(
         }
     }
 
-    enum class VPos {
+    public enum class VPos {
         @SerialName("top") Top,
         @SerialName("center") Center,
         @SerialName("bottom") Bottom,
     }
 
-    companion object {
+    public companion object {
         @DefaultArgumentInterop.Enabled
-        fun of(
+        public fun of(
             stopIds: List<String>,
             name: String? = null,
             isTypical: Boolean = true,
             lane: Lane = Lane.Center,
-        ) =
+        ): RouteBranchSegment =
             RouteBranchSegment(
                 stopIds.mapIndexed { index, stopId ->
                     BranchStop(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
@@ -5,16 +5,16 @@ import com.mbta.tid.mbta_app.repositories.RouteStopsResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-data class RouteDetailsStopList(val directionId: Int, val segments: List<Segment>) {
+public data class RouteDetailsStopList(val directionId: Int, val segments: List<Segment>) {
 
     /** A subset of consecutive stops that are all typical or all non-typical. */
-    data class Segment(val stops: List<Entry>, val isTypical: Boolean) {
+    public data class Segment(val stops: List<Entry>, val isTypical: Boolean) {
         /**
          * Assuming that this segment will be collapsed, returns the connections that should be
          * drawn in the toggle, and whether or not they should be twisted because they contain
          * stops.
          */
-        fun twistedConnections(): List<Pair<RouteBranchSegment.StickConnection, Boolean>> {
+        public fun twistedConnections(): List<Pair<RouteBranchSegment.StickConnection, Boolean>> {
             val lanesWithStops = stops.map { it.stopLane }.toSet()
             val connectionsBefore =
                 stops.first().stickConnections.filter { it.fromVPos == RouteBranchSegment.VPos.Top }
@@ -58,18 +58,18 @@ data class RouteDetailsStopList(val directionId: Int, val segments: List<Segment
         }
     }
 
-    data class Entry(
+    public data class Entry(
         val stop: Stop,
         val stopLane: RouteBranchSegment.Lane,
         val stickConnections: List<RouteBranchSegment.StickConnection>,
         val connectingRoutes: List<Route>,
     )
 
-    data class RouteParameters(
+    public data class RouteParameters(
         val availableDirections: List<Int>,
         val directions: List<Direction>,
     ) {
-        constructor(
+        public constructor(
             lineOrRoute: RouteCardData.LineOrRoute,
             globalData: GlobalResponse,
         ) : this(
@@ -96,9 +96,9 @@ data class RouteDetailsStopList(val directionId: Int, val segments: List<Segment
         )
     }
 
-    companion object {
+    public companion object {
 
-        suspend fun fromPieces(
+        public suspend fun fromPieces(
             routeId: String,
             directionId: Int,
             routeStops: RouteStopsResult?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -6,7 +6,8 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RoutePattern(
+public data class RoutePattern
+internal constructor(
     override val id: String,
     @SerialName("direction_id") val directionId: Int,
     val name: String,
@@ -16,7 +17,7 @@ data class RoutePattern(
     @SerialName("route_id") val routeId: String,
 ) : Comparable<RoutePattern>, BackendObject {
     @Serializable
-    enum class Typicality {
+    public enum class Typicality {
         @SerialName("typical") Typical,
         @SerialName("deviation") Deviation,
         @SerialName("atypical") Atypical,
@@ -29,16 +30,16 @@ data class RoutePattern(
      *
      * If any typicality is unknown, the route should be shown, and so this will return true.
      */
-    fun isTypical() = typicality == null || typicality == Typicality.Typical
+    public fun isTypical(): Boolean = typicality == null || typicality == Typicality.Typical
 
-    override fun compareTo(other: RoutePattern) = sortOrder.compareTo(other.sortOrder)
+    override fun compareTo(other: RoutePattern): Int = sortOrder.compareTo(other.sortOrder)
 
-    data class PatternsForStop(
+    internal data class PatternsForStop(
         val allPatterns: List<RoutePattern>,
         val patternsNotSeenAtEarlierStops: Set<String>,
     )
 
-    companion object {
+    internal companion object {
 
         /**
          * Return the map of LineOrRoute => Stop => Patterns that are served by the given [stopIds].

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 
-data class RoutePillSpec(
+public data class RoutePillSpec(
     val textColor: String,
     val routeColor: String,
     val content: Content,
@@ -10,21 +10,21 @@ data class RoutePillSpec(
     val shape: Shape,
     val contentDescription: ContentDescription? = null,
 ) {
-    enum class Type {
+    public enum class Type {
         Fixed,
         Flex,
         FlexCompact,
     }
 
-    sealed interface Content {
-        data object Empty : Content
+    public sealed interface Content {
+        public data object Empty : Content
 
-        data class Text(val text: String) : Content
+        public data class Text(val text: String) : Content
 
-        data class ModeImage(val mode: RouteType) : Content
+        public data class ModeImage internal constructor(val mode: RouteType) : Content
     }
 
-    enum class Size {
+    public enum class Size {
         FixedPill,
         Circle,
         CircleSmall,
@@ -32,18 +32,18 @@ data class RoutePillSpec(
         FlexPillSmall,
     }
 
-    enum class Shape {
+    public enum class Shape {
         Capsule,
         Rectangle,
     }
 
-    enum class Context {
+    public enum class Context {
         SearchStation,
         Default,
     }
 
-    sealed class ContentDescription {
-        data class StopSearchResultRoute(
+    public sealed class ContentDescription {
+        public data class StopSearchResultRoute(
             val routeName: String?,
             val routeType: RouteType,
             val isOnly: Boolean,
@@ -51,7 +51,7 @@ data class RoutePillSpec(
     }
 
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         route: Route?,
         line: Line?,
         type: Type,
@@ -86,7 +86,7 @@ data class RoutePillSpec(
         contentDescription = contentDescription,
     )
 
-    companion object {
+    internal companion object {
 
         private fun linePillContent(line: Line): Content =
             if (line.longName == "Green Line") {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteResult.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteResult.kt
@@ -4,15 +4,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class RouteResult(
+public data class RouteResult
+internal constructor(
     val id: String,
-    val rank: Int,
-    @SerialName("long_name") val longName: String,
-    @SerialName("name") val shortName: String,
-    @SerialName("route_type") val routeType: RouteType,
+    internal val rank: Int,
+    @SerialName("long_name") internal val longName: String,
+    @SerialName("name") internal val shortName: String,
+    @SerialName("route_type") internal val routeType: RouteType,
 ) {
     /** Convenience constructor for testing */
-    constructor(
+    public constructor(
         route: Route,
         rank: Int = 1,
     ) : this(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-interface IRouteSegment {
+internal interface IRouteSegment {
     val sourceRoutePatternId: String
     val sourceRouteId: String
     val stopIds: List<String>
@@ -11,7 +11,7 @@ interface IRouteSegment {
 }
 
 @Serializable
-data class RoutePatternKey(
+public data class RoutePatternKey(
     @SerialName("route_id") val routeId: String,
     @SerialName("route_pattern_id") val routePatternId: String,
 )
@@ -21,7 +21,7 @@ data class RoutePatternKey(
  * A sequential chunk of stops on a route pattern. A segment may only intersect with other segments
  * at the first and last stop.
  */
-data class RouteSegment(
+public data class RouteSegment(
     val id: String,
     @SerialName("source_route_pattern_id") override val sourceRoutePatternId: String,
     @SerialName("source_route_id") override val sourceRouteId: String,
@@ -34,7 +34,7 @@ data class RouteSegment(
      * Split this route segment into one or more `AlertAwareRouteSegments` based on the alerts for
      * the stops within this segment.
      */
-    fun splitAlertingSegments(
+    internal fun splitAlertingSegments(
         alertsByStop: Map<String, AlertAssociatedStop>
     ): List<AlertAwareRouteSegment> {
         val stopsAlertState = alertStateByStopId(alertsByStop)
@@ -110,7 +110,7 @@ data class RouteSegment(
      * Split the list of stops into segments based on whether or not they are alerting. Stops on
      * boundaries are included in both segments.
      */
-    companion object {
+    internal companion object {
         internal fun alertingSegments(
             stopIds: List<String>,
             stopsAlertState: Map<String, StopAlertState>,
@@ -173,7 +173,7 @@ data class RouteSegment(
  * segments that are adjacent to an alerting segment will include the consecutive stops up to and
  * including the adjacent alerting stop.
  */
-data class AlertAwareRouteSegment(
+internal data class AlertAwareRouteSegment(
     val id: String,
     override val sourceRoutePatternId: String,
     override val sourceRouteId: String,
@@ -182,7 +182,7 @@ data class AlertAwareRouteSegment(
     val alertState: SegmentAlertState,
 ) : IRouteSegment
 
-enum class SegmentAlertState {
+public enum class SegmentAlertState {
     Suspension,
     Shuttle,
     Normal,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteType.kt
@@ -4,12 +4,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class RouteType {
+public enum class RouteType {
     @SerialName("light_rail") LIGHT_RAIL,
     @SerialName("heavy_rail") HEAVY_RAIL,
     @SerialName("commuter_rail") COMMUTER_RAIL,
     @SerialName("bus") BUS,
     @SerialName("ferry") FERRY;
 
-    fun isSubway(): Boolean = this === HEAVY_RAIL || this === LIGHT_RAIL
+    internal fun isSubway(): Boolean = this === HEAVY_RAIL || this === LIGHT_RAIL
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Schedule.kt
@@ -5,20 +5,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Schedule(
+public data class Schedule
+internal constructor(
     override val id: String,
     @SerialName("arrival_time") override val arrivalTime: EasternTimeInstant?,
     @SerialName("departure_time") override val departureTime: EasternTimeInstant?,
-    @SerialName("drop_off_type") val dropOffType: StopEdgeType,
-    @SerialName("pick_up_type") val pickUpType: StopEdgeType,
+    @SerialName("drop_off_type") internal val dropOffType: StopEdgeType,
+    @SerialName("pick_up_type") internal val pickUpType: StopEdgeType,
     @SerialName("stop_headsign") val stopHeadsign: String?,
-    @SerialName("stop_sequence") val stopSequence: Int,
-    @SerialName("route_id") val routeId: String,
-    @SerialName("stop_id") val stopId: String,
-    @SerialName("trip_id") val tripId: String,
+    @SerialName("stop_sequence") internal val stopSequence: Int,
+    @SerialName("route_id") internal val routeId: String,
+    @SerialName("stop_id") internal val stopId: String,
+    @SerialName("trip_id") internal val tripId: String,
 ) : BackendObject, TripStopTime {
     @Serializable
-    enum class StopEdgeType {
+    internal enum class StopEdgeType {
         /** Regularly scheduled drop off / pickup */
         @SerialName("regular") Regular,
         /** No drop off / pickup available */

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SearchResults.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SearchResults.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SearchResults(
-    val routes: List<RouteResult> = emptyList(),
-    val stops: List<StopResult> = emptyList(),
+public data class SearchResults(
+    internal val routes: List<RouteResult> = emptyList(),
+    internal val stops: List<StopResult> = emptyList(),
 )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SegmentedRouteShape.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SegmentedRouteShape.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @param routeSegments segments of stops that stopped at on the route pattern.
  */
 @Serializable
-data class SegmentedRouteShape(
+public data class SegmentedRouteShape(
     @SerialName("source_route_pattern_id") val sourceRoutePatternId: String,
     @SerialName("source_route_id") val sourceRouteId: String,
     @SerialName("direction_id") val directionId: Int,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Shape.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Shape.kt
@@ -3,4 +3,6 @@ package com.mbta.tid.mbta_app.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Shape(override val id: String, val polyline: String? = null) : BackendObject
+public data class Shape
+internal constructor(override val id: String, internal val polyline: String? = null) :
+    BackendObject

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SheetRoutes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SheetRoutes.kt
@@ -5,31 +5,32 @@ import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class SheetRoutes {
+public sealed class SheetRoutes {
 
-    @Serializable sealed interface Entrypoint
+    @Serializable public sealed interface Entrypoint
 
-    @Serializable data object Favorites : SheetRoutes(), Entrypoint
+    @Serializable public data object Favorites : SheetRoutes(), Entrypoint
 
-    @Serializable data object NearbyTransit : SheetRoutes(), Entrypoint
+    @Serializable public data object NearbyTransit : SheetRoutes(), Entrypoint
 
     @Serializable
-    data class StopDetails(
+    public data class StopDetails(
         val stopId: String,
         val stopFilter: StopDetailsFilter?,
         val tripFilter: TripDetailsFilter?,
     ) : SheetRoutes()
 
     @Serializable
-    data class RoutePicker(val path: RoutePickerPath, val context: RouteDetailsContext) :
+    public data class RoutePicker(val path: RoutePickerPath, val context: RouteDetailsContext) :
         SheetRoutes()
 
     @Serializable
-    data class RouteDetails(val routeId: String, val context: RouteDetailsContext) : SheetRoutes()
+    public data class RouteDetails(val routeId: String, val context: RouteDetailsContext) :
+        SheetRoutes()
 
-    @Serializable data object EditFavorites : SheetRoutes()
+    @Serializable public data object EditFavorites : SheetRoutes()
 
-    val showSearchBar: Boolean
+    public val showSearchBar: Boolean
         get() =
             when (this) {
                 is Favorites,
@@ -37,7 +38,7 @@ sealed class SheetRoutes {
                 else -> false
             }
 
-    val allowTargeting: Boolean
+    public val allowTargeting: Boolean
         get() =
             when (this) {
                 is Favorites,
@@ -45,9 +46,9 @@ sealed class SheetRoutes {
                 else -> false
             }
 
-    companion object {
+    public companion object {
 
-        fun shouldResetSheetHeight(first: SheetRoutes?, second: SheetRoutes?): Boolean {
+        public fun shouldResetSheetHeight(first: SheetRoutes?, second: SheetRoutes?): Boolean {
             return !retainSheetSize(first, second) && pageChanged(first, second)
         }
 
@@ -55,7 +56,7 @@ sealed class SheetRoutes {
          * Whether the page within the nearby transit tab changed. Moving from StopDetails to
          * StopDetails is only considered a page change if the stopId changed.
          */
-        fun pageChanged(first: SheetRoutes?, second: SheetRoutes?): Boolean {
+        internal fun pageChanged(first: SheetRoutes?, second: SheetRoutes?): Boolean {
             return if (first is StopDetails && second is StopDetails) {
                 first.stopId != second.stopId
             } else {
@@ -66,7 +67,7 @@ sealed class SheetRoutes {
         /**
          * We want to retain sheet size unless moving into or out of stop details, or between tabs
          */
-        fun retainSheetSize(first: SheetRoutes?, second: SheetRoutes?): Boolean {
+        internal fun retainSheetSize(first: SheetRoutes?, second: SheetRoutes?): Boolean {
             val transitionSet = setOf(first?.let { it::class }, second?.let { it::class })
             return !transitionSet.contains(StopDetails::class) &&
                 transitionSet != setOf(NearbyTransit::class, Favorites::class) &&

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SocketError.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SocketError.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
-object SocketError {
+internal object SocketError {
     const val FAILURE = "channel failure"
     const val RECEIVED_ERROR = "channel received error"
     const val FAILED_TO_PARSE = "channel failed to parse"

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Stop.kt
@@ -8,46 +8,48 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Stop(
+public data class Stop
+internal constructor(
     override val id: String,
     val latitude: Double,
     val longitude: Double,
     val name: String,
-    @SerialName("location_type") val locationType: LocationType,
-    val description: String? = null,
-    @SerialName("platform_code") val platformCode: String? = null,
-    @SerialName("platform_name") val platformName: String? = null,
-    @SerialName("vehicle_type") val vehicleType: RouteType? = null,
+    @SerialName("location_type") internal val locationType: LocationType,
+    internal val description: String? = null,
+    @SerialName("platform_code") internal val platformCode: String? = null,
+    @SerialName("platform_name") internal val platformName: String? = null,
+    @SerialName("vehicle_type") internal val vehicleType: RouteType? = null,
     @SerialName("child_stop_ids") val childStopIds: List<String> = emptyList(),
-    @SerialName("connecting_stop_ids") val connectingStopIds: List<String> = emptyList(),
-    @SerialName("parent_station_id") val parentStationId: String? = null,
-    @SerialName("wheelchair_boarding") val wheelchairBoarding: WheelchairBoardingStatus? = null,
+    @SerialName("connecting_stop_ids") internal val connectingStopIds: List<String> = emptyList(),
+    @SerialName("parent_station_id") internal val parentStationId: String? = null,
+    @SerialName("wheelchair_boarding")
+    internal val wheelchairBoarding: WheelchairBoardingStatus? = null,
 ) : BackendObject {
-    val position = Position(latitude = latitude, longitude = longitude)
+    val position: Position = Position(latitude = latitude, longitude = longitude)
 
     /**
      * Commuter Rail core stations have realtime track numbers displayed and track change alerts
      * hidden.
      */
-    val isCRCore = this.id in crCoreStations || this.parentStationId in crCoreStations
+    internal val isCRCore = this.id in crCoreStations || this.parentStationId in crCoreStations
 
-    val shouldShowTrackNumber: Boolean =
+    internal val shouldShowTrackNumber: Boolean =
         this.vehicleType == RouteType.COMMUTER_RAIL && this.isCRCore
 
     val isWheelchairAccessible: Boolean =
         wheelchairBoarding == WheelchairBoardingStatus.ACCESSIBLE ||
             this.vehicleType == RouteType.BUS
 
-    fun resolveParent(stops: Map<String, Stop>): Stop {
+    internal fun resolveParent(stops: Map<String, Stop>): Stop {
         if (this.parentStationId == null) return this
         val parentStation = stops[parentStationId] ?: return this
         return parentStation.resolveParent(stops)
     }
 
-    fun resolveParent(global: GlobalResponse) = resolveParent(global.stops)
+    public fun resolveParent(global: GlobalResponse): Stop = resolveParent(global.stops)
 
     @OptIn(ExperimentalTurfApi::class)
-    fun distanceFrom(position: Position): Double = distance(position, this.position)
+    internal fun distanceFrom(position: Position): Double = distance(position, this.position)
 
     /**
      * Is this stop the last stop for all patterns in which it appears? True if for each patterns in
@@ -55,7 +57,7 @@ data class Stop(
      * - this stop (or its parent) only appears as the last stop
      * - this stop does not appear at all
      */
-    fun isLastStopForAllPatterns(
+    public fun isLastStopForAllPatterns(
         directionId: Int,
         patterns: List<RoutePattern>,
         global: GlobalResponse,
@@ -75,7 +77,7 @@ data class Stop(
             }
     }
 
-    companion object {
+    internal companion object {
         /**
          * Checks if the given stop IDs (as resolved in [stops]) refer to stops which are the same,
          * have the same parent, or are a parent and child.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsFilters.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsFilters.kt
@@ -3,27 +3,27 @@ package com.mbta.tid.mbta_app.model
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import kotlinx.serialization.Serializable
 
-interface RouteDirection {
-    val routeId: String
-    val directionId: Int
+public interface RouteDirection {
+    public val routeId: String
+    public val directionId: Int
 }
 
 @Serializable
-data class StopDetailsFilter
+public data class StopDetailsFilter
 @DefaultArgumentInterop.Enabled
 constructor(
     override val routeId: String,
     override val directionId: Int,
     val autoFilter: Boolean = false,
 ) : RouteDirection {
-    companion object {
+    public companion object {
         /**
          * When the stop filter changes, we want a new entry to be added (i.e. no pop) only when
          * you're on the unfiltered (lastFilter == nil) page, but if there is already a filter, or
          * the new entry is an auto filter, the entry with the old filter should be popped and
          * replaced with the new value.
          */
-        fun shouldPopLastStopEntry(
+        public fun shouldPopLastStopEntry(
             lastFilter: StopDetailsFilter?,
             newFilter: StopDetailsFilter?,
         ): Boolean {
@@ -33,7 +33,7 @@ constructor(
 }
 
 @Serializable
-data class TripDetailsFilter(
+public data class TripDetailsFilter(
     val tripId: String,
     val vehicleId: String?,
     val stopSequence: Int?,
@@ -43,7 +43,7 @@ data class TripDetailsFilter(
 )
 
 @Serializable
-data class StopDetailsPageFilters(
+public data class StopDetailsPageFilters(
     val stopId: String,
     val stopFilter: StopDetailsFilter?,
     val tripFilter: TripDetailsFilter?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsStatusRowData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsStatusRowData.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
-data class StopDetailsStatusRowData(
+internal data class StopDetailsStatusRowData(
     val route: Route,
     val headsign: String,
     val formatted: UpcomingFormat,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
@@ -4,12 +4,12 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-object StopDetailsUtils {
+public object StopDetailsUtils {
     /**
      * If the stop serves only 1 route in a single direction, returns a new filter for that route
      * and direction.
      */
-    fun autoStopFilter(routeCardData: List<RouteCardData>?): StopDetailsFilter? {
+    public fun autoStopFilter(routeCardData: List<RouteCardData>?): StopDetailsFilter? {
         val route = routeCardData?.singleOrNull() ?: return null
         val directions = route.stopData.flatMap { it.data }.map { it.directionId }.toSet()
         if (directions.size != 1) {
@@ -19,7 +19,7 @@ object StopDetailsUtils {
         return StopDetailsFilter(route.lineOrRoute.id, direction, autoFilter = true)
     }
 
-    fun autoTripFilter(
+    public fun autoTripFilter(
         routeCardData: List<RouteCardData>?,
         stopFilter: StopDetailsFilter?,
         currentTripFilter: TripDetailsFilter?,
@@ -70,13 +70,13 @@ object StopDetailsUtils {
         )
     }
 
-    class ScreenReaderContext(
-        val routeType: RouteType,
-        val destination: String?,
-        val stopName: String,
+    public class ScreenReaderContext(
+        public val routeType: RouteType,
+        public val destination: String?,
+        public val stopName: String,
     )
 
-    fun getScreenReaderTripDepartureContext(
+    public fun getScreenReaderTripDepartureContext(
         routeCardData: List<RouteCardData>?,
         previousFilters: StopDetailsPageFilters,
     ): ScreenReaderContext? {
@@ -98,7 +98,7 @@ object StopDetailsUtils {
         )
     }
 
-    fun filterVehiclesByUpcoming(
+    public fun filterVehiclesByUpcoming(
         routeCardData: List<RouteCardData>,
         vehicles: VehiclesStreamDataResponse,
     ): Map<String, Vehicle> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopResult.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopResult.kt
@@ -4,13 +4,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StopResult(
+public data class StopResult(
     val id: String,
     val rank: Int,
     val name: String,
     val zone: String?,
     @SerialName("station?") val isStation: Boolean,
-    val routes: List<StopResultRoute>,
+    internal val routes: List<StopResultRoute>,
 )
 
-@Serializable data class StopResultRoute(val type: RouteType, val icon: String)
+@Serializable
+public data class StopResultRoute(internal val type: RouteType, internal val icon: String)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Trip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Trip.kt
@@ -4,12 +4,13 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Trip(
+public data class Trip
+internal constructor(
     override val id: String,
     @SerialName("direction_id") val directionId: Int,
     val headsign: String,
     @SerialName("route_id") val routeId: String,
-    @SerialName("route_pattern_id") val routePatternId: String? = null,
-    @SerialName("shape_id") val shapeId: String? = null,
+    @SerialName("route_pattern_id") internal val routePatternId: String? = null,
+    @SerialName("shape_id") internal val shapeId: String? = null,
     @SerialName("stop_ids") val stopIds: List<String>? = null,
 ) : BackendObject

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -9,31 +9,31 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-data class TripDetailsStopList
+public data class TripDetailsStopList
 @DefaultArgumentInterop.Enabled
 constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entry? = null) {
 
-    data class Entry
+    public data class Entry
     @DefaultArgumentInterop.Enabled
     constructor(
         val stop: Stop,
         val stopSequence: Int,
         val disruption: UpcomingFormat.Disruption?,
-        val schedule: Schedule?,
+        internal val schedule: Schedule?,
         val prediction: Prediction?,
         // The prediction stop can be the same as `stop`, but it can also be a child stop which
         // contains more specific boarding information for a prediction, like the track number
-        val predictionStop: Stop? = stop.takeIf { prediction != null },
-        val vehicle: Vehicle?,
+        internal val predictionStop: Stop? = stop.takeIf { prediction != null },
+        internal val vehicle: Vehicle?,
         val routes: List<Route>,
-        val elevatorAlerts: List<Alert> = emptyList(),
+        internal val elevatorAlerts: List<Alert> = emptyList(),
     ) {
         val trackNumber: String? =
             if (predictionStop?.shouldShowTrackNumber == true) predictionStop.platformCode else null
 
-        val isTruncating = disruption?.alert?.hasNoThroughService == true
+        internal val isTruncating = disruption?.alert?.hasNoThroughService == true
 
-        fun activeElevatorAlerts(now: EasternTimeInstant) =
+        public fun activeElevatorAlerts(now: EasternTimeInstant): List<Alert> =
             elevatorAlerts.filter { it.isActive(now) }
 
         /**
@@ -41,7 +41,11 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
          *
          * @return [disruption], an [UpcomingFormat.Some] with a single entry, or null
          */
-        fun format(trip: Trip, now: EasternTimeInstant, routeType: RouteType): UpcomingFormat? {
+        public fun format(
+            trip: Trip,
+            now: EasternTimeInstant,
+            routeType: RouteType,
+        ): UpcomingFormat? {
             if (disruption != null) {
                 // ignore activities on platforms since they may be wrong or they may be correct in
                 // a way that doesn’t match how service is being run
@@ -71,7 +75,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
      * ID, picking the last copy if there are duplicates. Returns all entries in
      * [TargetSplit.followingStops] if no match at all can be found.
      */
-    fun splitForTarget(
+    public fun splitForTarget(
         targetStopId: String,
         targetStopSequence: Int?,
         globalData: GlobalResponse?,
@@ -126,7 +130,8 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
         )
     }
 
-    data class TargetSplit(
+    public data class TargetSplit
+    internal constructor(
         val firstStop: Entry? = null,
         val collapsedStops: List<Entry>?,
         val targetStop: Entry?,
@@ -143,9 +148,9 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
         val vehicle: Vehicle? = null,
     )
 
-    override fun toString() = "[TripDetailsStopList]"
+    override fun toString(): String = "[TripDetailsStopList]"
 
-    companion object {
+    public companion object {
 
         // TODO: Remove hardcoded IDs once the `listed_route` field is exposed by the API.
         // https://mbta.slack.com/archives/C03K6NLKKD1/p1716220182028299
@@ -196,7 +201,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             }
         }
 
-        suspend fun fromPieces(
+        public suspend fun fromPieces(
             trip: Trip,
             tripSchedules: TripSchedulesResponse?,
             tripPredictions: PredictionsStreamDataResponse?,
@@ -345,7 +350,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             )
         }
 
-        fun getTransferRoutes(
+        internal fun getTransferRoutes(
             stopId: String,
             currentRouteId: String?,
             globalData: GlobalResponse,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -9,67 +9,70 @@ import kotlin.time.DurationUnit
  *
  * Can be localized in the frontend layer, except for `Overridden` which is always English.
  */
-sealed class TripInstantDisplay {
-    data class Overridden(val text: String) : TripInstantDisplay()
+public sealed class TripInstantDisplay {
+    public data class Overridden(val text: String) : TripInstantDisplay()
 
-    data object Hidden : TripInstantDisplay()
+    public data object Hidden : TripInstantDisplay()
 
-    data object Boarding : TripInstantDisplay()
+    public data object Boarding : TripInstantDisplay()
 
-    data object Arriving : TripInstantDisplay()
+    public data object Arriving : TripInstantDisplay()
 
-    data object Approaching : TripInstantDisplay()
+    public data object Approaching : TripInstantDisplay()
 
-    data object Now : TripInstantDisplay()
+    public data object Now : TripInstantDisplay()
 
-    data class Time(val predictionTime: EasternTimeInstant, val headline: Boolean = false) :
+    public data class Time(val predictionTime: EasternTimeInstant, val headline: Boolean = false) :
         TripInstantDisplay()
 
-    data class TimeWithStatus(
+    public data class TimeWithStatus(
         val predictionTime: EasternTimeInstant,
         val status: String,
         val headline: Boolean = false,
     ) : TripInstantDisplay()
 
-    data class TimeWithSchedule(
+    public data class TimeWithSchedule(
         val predictionTime: EasternTimeInstant,
         val scheduledTime: EasternTimeInstant,
         val headline: Boolean = false,
     ) : TripInstantDisplay()
 
-    data class Minutes(val minutes: Int) : TripInstantDisplay()
+    public data class Minutes(val minutes: Int) : TripInstantDisplay()
 
-    data class ScheduleTime(val scheduledTime: EasternTimeInstant, val headline: Boolean = false) :
-        TripInstantDisplay()
+    public data class ScheduleTime(
+        val scheduledTime: EasternTimeInstant,
+        val headline: Boolean = false,
+    ) : TripInstantDisplay()
 
-    data class ScheduleTimeWithStatusColumn(
+    public data class ScheduleTimeWithStatusColumn(
         val scheduledTime: EasternTimeInstant,
         val status: String,
         val headline: Boolean = false,
     ) : TripInstantDisplay()
 
-    data class ScheduleTimeWithStatusRow(
+    public data class ScheduleTimeWithStatusRow(
         val scheduledTime: EasternTimeInstant,
         val status: String,
     ) : TripInstantDisplay()
 
-    data class ScheduleMinutes(val minutes: Int) : TripInstantDisplay()
+    public data class ScheduleMinutes(val minutes: Int) : TripInstantDisplay()
 
-    data class Skipped(val scheduledTime: EasternTimeInstant?) : TripInstantDisplay()
+    public data class Skipped(internal val scheduledTime: EasternTimeInstant?) :
+        TripInstantDisplay()
 
-    data class Cancelled(val scheduledTime: EasternTimeInstant) : TripInstantDisplay()
+    public data class Cancelled(val scheduledTime: EasternTimeInstant) : TripInstantDisplay()
 
-    enum class Context {
+    public enum class Context {
         NearbyTransit,
         StopDetailsUnfiltered,
         StopDetailsFiltered,
         TripDetails,
     }
 
-    companion object {
-        val delayStatuses = setOf("Delay", "Delayed", "Late")
+    public companion object {
+        public val delayStatuses: Set<String> = setOf("Delay", "Delayed", "Late")
 
-        fun from(
+        internal fun from(
             prediction: Prediction?,
             schedule: Schedule?,
             vehicle: Vehicle?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShape.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShape.kt
@@ -5,4 +5,5 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TripShape(@SerialName("shape_with_stops") val shapeWithStops: ShapeWithStops)
+public data class TripShape
+internal constructor(@SerialName("shape_with_stops") internal val shapeWithStops: ShapeWithStops)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-interface TripStopTime : Comparable<TripStopTime> {
+internal interface TripStopTime : Comparable<TripStopTime> {
     val arrivalTime: EasternTimeInstant?
     val departureTime: EasternTimeInstant?
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -3,15 +3,15 @@ package com.mbta.tid.mbta_app.model
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-sealed class UpcomingFormat {
-    sealed class NoTripsFormat {
-        data object NoSchedulesToday : NoTripsFormat()
+public sealed class UpcomingFormat {
+    public sealed class NoTripsFormat {
+        public data object NoSchedulesToday : NoTripsFormat()
 
-        data object ServiceEndedToday : NoTripsFormat()
+        public data object ServiceEndedToday : NoTripsFormat()
 
-        data object PredictionsUnavailable : NoTripsFormat()
+        public data object PredictionsUnavailable : NoTripsFormat()
 
-        companion object {
+        internal companion object {
             /**
              * Determine the appropriate NoTripsFormat to show. Only for use in situations where it
              * is already determined that there are no trips to show and we only need to determine
@@ -41,67 +41,69 @@ sealed class UpcomingFormat {
         }
     }
 
-    abstract val secondaryAlert: SecondaryAlert?
+    public abstract val secondaryAlert: SecondaryAlert?
 
-    data class SecondaryAlert(val iconName: String) {
-        constructor(
+    public data class SecondaryAlert(val iconName: String) {
+        internal constructor(
             alert: Alert,
             mapStopRoute: MapStopRoute?,
         ) : this(alert.alertState, mapStopRoute)
 
-        constructor(
+        internal constructor(
             alertState: StopAlertState,
             mapStopRoute: MapStopRoute?,
         ) : this(iconName(alertState, mapStopRoute))
     }
 
-    data object Loading : UpcomingFormat() {
-        override val secondaryAlert = null
+    public data object Loading : UpcomingFormat() {
+        override val secondaryAlert: SecondaryAlert? = null
     }
 
-    data class Some(val trips: List<FormattedTrip>, override val secondaryAlert: SecondaryAlert?) :
-        UpcomingFormat() {
-        data class FormattedTrip(
-            val trip: UpcomingTrip,
+    public data class Some(
+        val trips: List<FormattedTrip>,
+        override val secondaryAlert: SecondaryAlert?,
+    ) : UpcomingFormat() {
+        public data class FormattedTrip(
+            internal val trip: UpcomingTrip,
             val routeType: RouteType,
             val format: TripInstantDisplay,
         ) {
             val id: String
                 get() = trip.id
 
-            constructor(
+            public constructor(
                 trip: UpcomingTrip,
                 routeType: RouteType,
                 now: EasternTimeInstant,
                 context: TripInstantDisplay.Context,
             ) : this(trip, routeType, trip.display(now, routeType, context))
 
-            override fun toString() = format.toString()
+            override fun toString(): String = format.toString()
         }
 
-        constructor(
+        public constructor(
             trip: FormattedTrip,
             secondaryAlert: SecondaryAlert?,
         ) : this(listOf(trip), secondaryAlert)
     }
 
-    data class NoTrips
+    public data class NoTrips
     @DefaultArgumentInterop.Enabled
     constructor(
         val noTripsFormat: NoTripsFormat,
         override val secondaryAlert: SecondaryAlert? = null,
     ) : UpcomingFormat()
 
-    data class Disruption(val alert: Alert, val iconName: String) : UpcomingFormat() {
-        override val secondaryAlert = null
+    public data class Disruption(val alert: Alert, val iconName: String) : UpcomingFormat() {
+        override val secondaryAlert: SecondaryAlert? = null
 
-        constructor(
+        public constructor(
             alert: Alert,
             mapStopRoute: MapStopRoute?,
         ) : this(alert, iconName(alert.alertState, mapStopRoute))
     }
 
-    companion object {
+    internal companion object {
         private fun iconName(alertState: StopAlertState, mapStopRoute: MapStopRoute?) =
             "alert-${mapStopRoute?.let { "large-${it.name.lowercase()}" } ?: "borderless"}-${alertState.name.lowercase()}"
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Vehicle(
+public data class Vehicle(
     override val id: String,
     val bearing: Double?,
     @SerialName("current_status") val currentStatus: CurrentStatus,
@@ -19,14 +19,14 @@ data class Vehicle(
     @SerialName("stop_id") val stopId: String?,
     @SerialName("trip_id") val tripId: String?,
 ) : BackendObject {
-    val position = Position(latitude = latitude, longitude = longitude)
+    val position: Position = Position(latitude = latitude, longitude = longitude)
 
     @Serializable
-    enum class CurrentStatus {
+    public enum class CurrentStatus {
         @SerialName("incoming_at") IncomingAt,
         @SerialName("stopped_at") StoppedAt,
         @SerialName("in_transit_to") InTransitTo,
     }
 
-    override fun toString() = "Vehicle(id=$id)"
+    override fun toString(): String = "Vehicle(id=$id)"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/WheelchairBoardingStatus.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/WheelchairBoardingStatus.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class WheelchairBoardingStatus {
+public enum class WheelchairBoardingStatus {
     @SerialName("accessible") ACCESSIBLE,
     @SerialName("inaccessible") INACCESSIBLE,
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreItem.kt
@@ -2,20 +2,25 @@ package com.mbta.tid.mbta_app.model.morePage
 
 import com.mbta.tid.mbta_app.repositories.Settings
 
-sealed class MoreItem {
+public sealed class MoreItem {
 
-    data class Action(val label: String, val action: () -> Unit) : MoreItem()
-
-    data class Link(val label: String, val url: String, val note: String? = null) : MoreItem()
-
-    data class NavLink(val label: String, val callback: () -> Unit, val note: String? = null) :
+    public data class Action internal constructor(val label: String, val action: () -> Unit) :
         MoreItem()
 
-    data class Phone(val label: String, val phoneNumber: String) : MoreItem()
+    public data class Link(val label: String, val url: String, val note: String? = null) :
+        MoreItem()
 
-    data class Toggle(val label: String, val settings: Settings) : MoreItem()
+    public data class NavLink(
+        val label: String,
+        val callback: () -> Unit,
+        val note: String? = null,
+    ) : MoreItem()
 
-    fun id() {
+    public data class Phone(val label: String, val phoneNumber: String) : MoreItem()
+
+    public data class Toggle(val label: String, val settings: Settings) : MoreItem()
+
+    internal fun id() {
         when (this) {
             is Action -> label
             is Link -> url

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/MoreSection.kt
@@ -1,13 +1,13 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-class MoreSection(
-    var id: Category,
-    var items: List<MoreItem>,
-    var noteAbove: String? = null,
-    var noteBelow: String? = null,
+public class MoreSection(
+    public var id: Category,
+    public var items: List<MoreItem>,
+    public var noteAbove: String? = null,
+    public var noteBelow: String? = null,
 ) {
 
-    enum class Category {
+    public enum class Category {
         Feedback,
         FeatureFlags,
         Settings,
@@ -16,7 +16,7 @@ class MoreSection(
         Support,
     }
 
-    val hiddenOnProd: Boolean =
+    public val hiddenOnProd: Boolean =
         when (this.id) {
             Category.FeatureFlags -> true
             else -> false

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.model.morePage
 
-fun localizedFeedbackFormUrl(
+public fun localizedFeedbackFormUrl(
     baseUrl: String,
     translation: String,
     separateHTForm: Boolean = false,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -5,14 +5,14 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
-    constructor(objects: ObjectCollectionBuilder) : this(objects.alerts)
+public data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
+    public constructor(objects: ObjectCollectionBuilder) : this(objects.alerts)
 
-    fun getAlert(alertId: String) = alerts[alertId]
+    public fun getAlert(alertId: String): Alert? = alerts[alertId]
 
-    fun isEmpty() = alerts.isEmpty()
+    public fun isEmpty(): Boolean = alerts.isEmpty()
 
-    fun injectFacilities(globalResponse: GlobalResponse?): AlertsStreamDataResponse =
+    internal fun injectFacilities(globalResponse: GlobalResponse?): AlertsStreamDataResponse =
         globalResponse?.let { global ->
             AlertsStreamDataResponse(
                 alerts.mapValues { (_, alert) ->
@@ -25,7 +25,7 @@ data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
             )
         } ?: this
 
-    override fun toString() = "[AlertsStreamDataResponse]"
+    override fun toString(): String = "[AlertsStreamDataResponse]"
 }
 
-fun AlertsStreamDataResponse?.isNullOrEmpty() = this == null || this.isEmpty()
+public fun AlertsStreamDataResponse?.isNullOrEmpty(): Boolean = this == null || this.isEmpty()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
@@ -2,18 +2,19 @@ package com.mbta.tid.mbta_app.model.response
 
 import io.ktor.client.plugins.ResponseException
 
-sealed class ApiResult<out T : Any> {
-    data class Ok<T : Any>(val data: T) : ApiResult<T>()
+public sealed class ApiResult<out T : Any> {
+    public data class Ok<T : Any>(val data: T) : ApiResult<T>()
 
-    data class Error<T : Any>(val code: Int? = null, val message: String) : ApiResult<T>()
+    public data class Error<T : Any>(internal val code: Int? = null, val message: String) :
+        ApiResult<T>()
 
     @Throws(IllegalStateException::class)
-    fun dataOrThrow(): T {
+    internal fun dataOrThrow(): T {
         check(this is Ok) { this }
         return this.data
     }
 
-    companion object {
+    internal companion object {
         inline fun <T : Any> runCatching(block: () -> T): ApiResult<T> {
             return try {
                 Ok(block())

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ConfigResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ConfigResponse.kt
@@ -4,4 +4,4 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ConfigResponse(@SerialName("mapbox_public_token") val mapboxPublicToken: String)
+public data class ConfigResponse(@SerialName("mapbox_public_token") val mapboxPublicToken: String)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -20,7 +20,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
 @Serializable
-data class GlobalResponse(
+public data class GlobalResponse
+internal constructor(
     internal val facilities: Map<String, Facility>,
     internal val lines: Map<String, Line>,
     @SerialName("pattern_ids_by_stop") internal val patternIdsByStop: Map<String, List<String>>,
@@ -29,7 +30,7 @@ data class GlobalResponse(
     internal val stops: Map<String, Stop>,
     internal val trips: Map<String, Trip>,
 ) {
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder
     ) : this(
         objects.facilities,
@@ -47,7 +48,7 @@ data class GlobalResponse(
         objects.trips,
     )
 
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder,
         patternIdsByStop: Map<String, List<String>>,
     ) : this(
@@ -76,11 +77,11 @@ data class GlobalResponse(
     internal val routesByLineId: Map<String, List<Route>> =
         routes.values.filter { it.lineId != null && !it.isShuttle }.groupBy { it.lineId!! }
 
-    fun getFacility(facilityId: String?) = facilities[facilityId]
+    internal fun getFacility(facilityId: String?) = facilities[facilityId]
 
-    fun getRoute(routeId: String?) = routes[routeId]
+    public fun getRoute(routeId: String?): Route? = routes[routeId]
 
-    fun getRoutesForPicker(path: RoutePickerPath) =
+    public fun getRoutesForPicker(path: RoutePickerPath): List<RouteCardData.LineOrRoute> =
         routes.values
             .filter {
                 it.isListedRoute &&
@@ -117,16 +118,16 @@ data class GlobalResponse(
             }
             .distinct()
 
-    fun getStop(stopId: String?) = stops[stopId]
+    public fun getStop(stopId: String?): Stop? = stops[stopId]
 
-    fun getLine(lineId: String?) =
+    public fun getLine(lineId: String?): Line? =
         if (lineId != null) {
             lines[lineId]
         } else {
             null
         }
 
-    fun getLineOrRoute(lineOrRouteId: String): RouteCardData.LineOrRoute? {
+    public fun getLineOrRoute(lineOrRouteId: String): RouteCardData.LineOrRoute? {
         val route = this.getRoute(lineOrRouteId)
         val line = this.getLine(lineOrRouteId) ?: this.getLine(route?.lineId)
         return when {
@@ -138,14 +139,17 @@ data class GlobalResponse(
         }
     }
 
-    fun getPatternsFor(stopId: String): List<RoutePattern> {
+    internal fun getPatternsFor(stopId: String): List<RoutePattern> {
         val stop = stops[stopId] ?: return emptyList()
         val stopIds = stop.childStopIds + listOf(stopId)
         val patternIds = stopIds.flatMap { patternIdsByStop[it] ?: emptyList() }
         return patternIds.mapNotNull { routePatterns[it] }
     }
 
-    fun getPatternsFor(stopId: String, lineOrRoute: RouteCardData.LineOrRoute): List<RoutePattern> {
+    public fun getPatternsFor(
+        stopId: String,
+        lineOrRoute: RouteCardData.LineOrRoute,
+    ): List<RoutePattern> {
         val stop = stops[stopId] ?: return emptyList()
         val stopIds = stop.childStopIds + listOf(stopId)
         val patternIds = stopIds.flatMap { patternIdsByStop[it] ?: emptyList() }
@@ -154,11 +158,11 @@ data class GlobalResponse(
             .filter { lineOrRoute.containsRoute(it.routeId) }
     }
 
-    fun getPatternsFor(stopId: String, routeId: String): List<RoutePattern> {
+    internal fun getPatternsFor(stopId: String, routeId: String): List<RoutePattern> {
         return getPatternsFor(stopId).filter { it.routeId == routeId }
     }
 
-    fun getTypicalRoutesFor(stopId: String): List<Route> {
+    internal fun getTypicalRoutesFor(stopId: String): List<Route> {
         return getPatternsFor(stopId)
             .mapNotNull { routePattern ->
                 if (routePattern.typicality != RoutePattern.Typicality.Typical) {
@@ -169,7 +173,7 @@ data class GlobalResponse(
             .distinct()
     }
 
-    fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
+    public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
         if (alert == null || routes == null) return null
         val routeEntities =
             routes.flatMap { route ->
@@ -180,5 +184,5 @@ data class GlobalResponse(
         return parentStops.distinct()
     }
 
-    override fun toString() = "[GlobalResponse]"
+    override fun toString(): String = "[GlobalResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/MapFriendlyRouteResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/MapFriendlyRouteResponse.kt
@@ -5,16 +5,16 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class MapFriendlyRouteResponse(
+public data class MapFriendlyRouteResponse(
     @SerialName("map_friendly_route_shapes")
     val routesWithSegmentedShapes: List<RouteWithSegmentedShapes>
 ) {
 
     @Serializable
-    data class RouteWithSegmentedShapes(
+    public data class RouteWithSegmentedShapes(
         @SerialName("route_id") val routeId: String,
         @SerialName("route_shapes") val segmentedShapes: List<SegmentedRouteShape>,
     )
 
-    override fun toString() = "[MapFriendlyRouteResponse]"
+    override fun toString(): String = "[MapFriendlyRouteResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NearbyResponse(@SerialName("stop_ids") val stopIds: List<String>) {
-    constructor(objects: ObjectCollectionBuilder) : this(objects.stops.keys.toList())
+public data class NearbyResponse(@SerialName("stop_ids") val stopIds: List<String>) {
+    public constructor(objects: ObjectCollectionBuilder) : this(objects.stops.keys.toList())
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -8,14 +8,14 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PredictionsByStopJoinResponse(
+public data class PredictionsByStopJoinResponse(
     @SerialName("predictions_by_stop")
     internal val predictionsByStop: Map<String, Map<String, Prediction>>,
     internal val trips: Map<String, Trip>,
     internal val vehicles: Map<String, Vehicle>,
 ) {
 
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder
     ) : this(
         objects.predictions.values
@@ -25,7 +25,7 @@ data class PredictionsByStopJoinResponse(
         objects.vehicles,
     )
 
-    constructor(
+    public constructor(
         partialResponse: PredictionsByStopMessageResponse
     ) : this(
         mapOf(partialResponse.stopId to partialResponse.predictions),
@@ -37,7 +37,7 @@ data class PredictionsByStopJoinResponse(
      * Merge the latest predictions for a single stop into the predictions for all stops. Removes
      * vehicles & trips that are no longer referenced in any predictions
      */
-    fun mergePredictions(
+    public fun mergePredictions(
         updatedPredictions: PredictionsByStopMessageResponse
     ): PredictionsByStopJoinResponse {
 
@@ -67,7 +67,7 @@ data class PredictionsByStopJoinResponse(
     }
 
     /** Flattens the `predictionsByStop` field into a single map of predictions by id */
-    fun toPredictionsStreamDataResponse(): PredictionsStreamDataResponse {
+    public fun toPredictionsStreamDataResponse(): PredictionsStreamDataResponse {
         val predictionsById = predictionsByStop.flatMap { it.value.values }.associateBy { it.id }
         return PredictionsStreamDataResponse(
             predictions = predictionsById,
@@ -76,13 +76,14 @@ data class PredictionsByStopJoinResponse(
         )
     }
 
-    fun predictionQuantity() = predictionsByStop.map { it.value.size }.sum()
+    public fun predictionQuantity(): Int = predictionsByStop.map { it.value.size }.sum()
 
-    override fun toString() = "[PredictionsByStopJoinResponse]"
+    override fun toString(): String = "[PredictionsByStopJoinResponse]"
 
-    companion object {
-        val empty = PredictionsByStopJoinResponse(emptyMap(), emptyMap(), emptyMap())
+    public companion object {
+        public val empty: PredictionsByStopJoinResponse =
+            PredictionsByStopJoinResponse(emptyMap(), emptyMap(), emptyMap())
     }
 }
 
-fun PredictionsByStopJoinResponse?.orEmpty() = this ?: PredictionsByStopJoinResponse.empty
+internal fun PredictionsByStopJoinResponse?.orEmpty() = this ?: PredictionsByStopJoinResponse.empty

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
@@ -9,17 +9,18 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PredictionsByStopMessageResponse(
+public data class PredictionsByStopMessageResponse
+internal constructor(
     @SerialName("stop_id") val stopId: String,
     internal val predictions: Map<String, Prediction>,
     internal val trips: Map<String, Trip>,
     internal val vehicles: Map<String, Vehicle>,
 ) {
     @DefaultArgumentInterop.Enabled
-    constructor(
+    internal constructor(
         objects: ObjectCollectionBuilder,
         stopId: String = objects.stops.keys.single(),
     ) : this(stopId, objects.predictions, objects.trips, objects.vehicles)
 
-    override fun toString() = "[PredictionsByStopMessageResponse]"
+    override fun toString(): String = "[PredictionsByStopMessageResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
@@ -7,16 +7,16 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class PredictionsStreamDataResponse(
+public data class PredictionsStreamDataResponse(
     internal val predictions: Map<String, Prediction>,
     internal val trips: Map<String, Trip>,
     internal val vehicles: Map<String, Vehicle>,
 ) {
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder
     ) : this(objects.predictions, objects.trips, objects.vehicles)
 
-    fun predictionQuantity() = predictions.size
+    public fun predictionQuantity(): Int = predictions.size
 
-    override fun toString() = "[PredictionsStreamDataResponse]"
+    override fun toString(): String = "[PredictionsStreamDataResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/RouteStopsResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/RouteStopsResponse.kt
@@ -3,4 +3,5 @@ package com.mbta.tid.mbta_app.model.response
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable data class RouteStopsResponse(@SerialName("stop_ids") val stopIds: List<String>)
+@Serializable
+internal data class RouteStopsResponse(@SerialName("stop_ids") val stopIds: List<String>)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
@@ -6,15 +6,15 @@ import com.mbta.tid.mbta_app.model.Trip
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ScheduleResponse(
+public data class ScheduleResponse(
     internal val schedules: List<Schedule>,
     internal val trips: Map<String, Trip>,
 ) {
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder
     ) : this(objects.schedules.values.toList(), objects.trips)
 
-    fun getSchedulesTodayByPattern(): Map<String, Boolean> {
+    internal fun getSchedulesTodayByPattern(): Map<String, Boolean> {
         val scheduledTrips = this.trips
         val hasSchedules: MutableMap<String, Boolean> = mutableMapOf()
         for (schedule in this.schedules) {
@@ -25,5 +25,5 @@ data class ScheduleResponse(
         return hasSchedules
     }
 
-    override fun toString() = "[ScheduleResponse]"
+    override fun toString(): String = "[ScheduleResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/SearchResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/SearchResponse.kt
@@ -4,6 +4,6 @@ import com.mbta.tid.mbta_app.model.SearchResults
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class SearchResponse(val data: SearchResults) {
+internal data class SearchResponse(val data: SearchResults) {
     override fun toString() = "[SearchResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ShapeWithStops.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ShapeWithStops.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ShapeWithStops(
+internal data class ShapeWithStops(
     @SerialName("direction_id") val directionId: Int,
     @SerialName("route_id") val routeId: String,
     @SerialName("route_pattern_id") val routePatternId: String,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/StopMapResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/StopMapResponse.kt
@@ -5,10 +5,10 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StopMapResponse(
+public data class StopMapResponse(
     @SerialName("map_friendly_route_shapes")
     val routeShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
-    @SerialName("child_stops") val childStops: Map<String, Stop>,
+    @SerialName("child_stops") internal val childStops: Map<String, Stop>,
 ) {
-    override fun toString() = "[StopMapResponse]"
+    override fun toString(): String = "[StopMapResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripResponse.kt
@@ -3,4 +3,4 @@ package com.mbta.tid.mbta_app.model.response
 import com.mbta.tid.mbta_app.model.Trip
 import kotlinx.serialization.Serializable
 
-@Serializable data class TripResponse(val trip: Trip)
+@Serializable public data class TripResponse(val trip: Trip)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/TripSchedulesResponse.kt
@@ -6,21 +6,21 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class TripSchedulesResponse {
+public sealed class TripSchedulesResponse {
     @Serializable
     @SerialName("schedules")
-    data class Schedules(val schedules: List<Schedule>) : TripSchedulesResponse() {
+    public data class Schedules(internal val schedules: List<Schedule>) : TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
             schedules.mapNotNull { globalData.stops[it.stopId] }
 
         override fun routeId(): String? = schedules.map { it.routeId }.distinct().singleOrNull()
 
-        override fun toString() = "[TripSchedulesResponse.Schedules]"
+        override fun toString(): String = "[TripSchedulesResponse.Schedules]"
     }
 
     @Serializable
     @SerialName("stop_ids")
-    data class StopIds(@SerialName("stop_ids") val stopIds: List<String>) :
+    public data class StopIds(@SerialName("stop_ids") internal val stopIds: List<String>) :
         TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop> =
             stopIds.mapNotNull { globalData.stops[it] }
@@ -30,13 +30,13 @@ sealed class TripSchedulesResponse {
 
     @Serializable
     @SerialName("unknown")
-    data object Unknown : TripSchedulesResponse() {
+    public data object Unknown : TripSchedulesResponse() {
         override fun stops(globalData: GlobalResponse): List<Stop>? = null
 
         override fun routeId() = null
     }
 
-    abstract fun stops(globalData: GlobalResponse): List<Stop>?
+    internal abstract fun stops(globalData: GlobalResponse): List<Stop>?
 
-    abstract fun routeId(): String?
+    internal abstract fun routeId(): String?
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehicleStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehicleStreamDataResponse.kt
@@ -3,4 +3,4 @@ package com.mbta.tid.mbta_app.model.response
 import com.mbta.tid.mbta_app.model.Vehicle
 import kotlinx.serialization.Serializable
 
-@Serializable data class VehicleStreamDataResponse(val vehicle: Vehicle?)
+@Serializable public data class VehicleStreamDataResponse(val vehicle: Vehicle?)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehiclesStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/VehiclesStreamDataResponse.kt
@@ -4,6 +4,6 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class VehiclesStreamDataResponse(val vehicles: Map<String, Vehicle>) {
-    override fun toString() = "[VehiclesStreamDataResponse]"
+public data class VehiclesStreamDataResponse(val vehicles: Map<String, Vehicle>) {
+    override fun toString(): String = "[VehiclesStreamDataResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/routeDetailsPage/RouteDetailsContext.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/routeDetailsPage/RouteDetailsContext.kt
@@ -3,8 +3,8 @@ package com.mbta.tid.mbta_app.model.routeDetailsPage
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class RouteDetailsContext {
-    @Serializable data object Favorites : RouteDetailsContext()
+public sealed class RouteDetailsContext {
+    @Serializable public data object Favorites : RouteDetailsContext()
 
-    @Serializable data object Details : RouteDetailsContext()
+    @Serializable public data object Details : RouteDetailsContext()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/routeDetailsPage/RoutePickerPath.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/routeDetailsPage/RoutePickerPath.kt
@@ -4,18 +4,18 @@ import com.mbta.tid.mbta_app.model.RouteType
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class RoutePickerPath {
-    @Serializable data object Root : RoutePickerPath()
+public sealed class RoutePickerPath {
+    @Serializable public data object Root : RoutePickerPath()
 
-    @Serializable data object Bus : RoutePickerPath()
+    @Serializable public data object Bus : RoutePickerPath()
 
-    @Serializable data object Silver : RoutePickerPath()
+    @Serializable public data object Silver : RoutePickerPath()
 
-    @Serializable data object CommuterRail : RoutePickerPath()
+    @Serializable public data object CommuterRail : RoutePickerPath()
 
-    @Serializable data object Ferry : RoutePickerPath()
+    @Serializable public data object Ferry : RoutePickerPath()
 
-    val RoutePickerPath.routeType
+    public val RoutePickerPath.routeType: RouteType
         get() =
             when (this) {
                 is Root -> RouteType.HEAVY_RAIL

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/ExplainerType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/ExplainerType.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.model.stopDetailsPage
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class ExplainerType {
+public enum class ExplainerType {
     NoPrediction,
     FinishingAnotherTrip,
     NoVehicle,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/StopData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/StopData.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StopData(
+public data class StopData(
     val stopId: String,
     val schedules: ScheduleResponse?,
     val predictionsByStop: PredictionsByStopJoinResponse?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -7,7 +7,7 @@ import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-data class TileData(
+public data class TileData(
     val route: Route?,
     val headsign: String?,
     val formatted: UpcomingFormat,
@@ -15,13 +15,13 @@ data class TileData(
 ) {
     val id: String = upcoming.id
 
-    fun isSelected(tripFilter: TripDetailsFilter?): Boolean =
+    public fun isSelected(tripFilter: TripDetailsFilter?): Boolean =
         upcoming.trip.id == tripFilter?.tripId &&
             tripFilter.stopSequence?.let { filterSequence ->
                 upcoming.stopSequence?.let { it == filterSequence }
             } ?: true
 
-    companion object {
+    internal companion object {
         fun fromUpcoming(upcoming: UpcomingTrip, route: Route, now: EasternTimeInstant): TileData? {
             val formattedUpcomingTrip =
                 upcoming.format(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
@@ -8,7 +8,7 @@ import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class TripData(
+public data class TripData(
     val tripFilter: TripDetailsFilter,
     val trip: Trip,
     val tripSchedules: TripSchedulesResponse?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripHeaderSpec.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripHeaderSpec.kt
@@ -4,22 +4,23 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.Vehicle
 
-sealed class TripHeaderSpec {
-    data object FinishingAnotherTrip : TripHeaderSpec()
+public sealed class TripHeaderSpec {
+    public data object FinishingAnotherTrip : TripHeaderSpec()
 
-    data object NoVehicle : TripHeaderSpec()
+    public data object NoVehicle : TripHeaderSpec()
 
-    data class Scheduled(val stop: Stop, val entry: TripDetailsStopList.Entry) : TripHeaderSpec()
+    public data class Scheduled(val stop: Stop, val entry: TripDetailsStopList.Entry) :
+        TripHeaderSpec()
 
-    data class VehicleOnTrip(
+    public data class VehicleOnTrip(
         val vehicle: Vehicle,
         val stop: Stop,
         val entry: TripDetailsStopList.Entry?,
         val atTerminal: Boolean,
     ) : TripHeaderSpec()
 
-    companion object {
-        fun getSpec(
+    public companion object {
+        public fun getSpec(
             tripId: String,
             stops: TripDetailsStopList,
             terminalStop: Stop?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobileBackendClient.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobileBackendClient.kt
@@ -22,7 +22,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.serialization.kotlinx.KotlinxWebsocketSerializationConverter
 import io.ktor.serialization.kotlinx.json.json
 
-class MobileBackendClient(engine: HttpClientEngine, val appVariant: AppVariant) {
+internal class MobileBackendClient(engine: HttpClientEngine, val appVariant: AppVariant) {
     constructor(appVariant: AppVariant) : this(getPlatform().httpClientEngine, appVariant)
 
     private val httpClient =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobilePhoenixInterfaces.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobilePhoenixInterfaces.kt
@@ -2,50 +2,52 @@ package com.mbta.tid.mbta_app.network
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 
-enum class PhoenixPushStatus(val value: String) {
+public enum class PhoenixPushStatus(public val value: String) {
     Ok("ok"),
     Error("error"),
     Timeout("timeout"),
 }
 
-interface PhoenixMessage {
-    val subject: String
-    val body: Map<String, Any?>
-    val jsonBody: String?
+public interface PhoenixMessage {
+    public val subject: String
+    public val body: Map<String, Any?>
+    public val jsonBody: String?
 }
 
-interface PhoenixPush {
-    fun receive(status: PhoenixPushStatus, callback: ((PhoenixMessage) -> Unit)): PhoenixPush
+public interface PhoenixPush {
+    public fun receive(status: PhoenixPushStatus, callback: ((PhoenixMessage) -> Unit)): PhoenixPush
 }
 
-interface PhoenixChannel {
-    fun onEvent(event: String, callback: ((PhoenixMessage) -> Unit))
+public interface PhoenixChannel {
+    public fun onEvent(event: String, callback: ((PhoenixMessage) -> Unit))
 
-    fun onFailure(callback: ((message: PhoenixMessage) -> Unit))
+    public fun onFailure(callback: ((message: PhoenixMessage) -> Unit))
 
-    fun onDetach(callback: ((PhoenixMessage) -> Unit))
+    public fun onDetach(callback: ((PhoenixMessage) -> Unit))
 
-    fun attach(): PhoenixPush
+    public fun attach(): PhoenixPush
 
-    fun detach(): PhoenixPush
+    public fun detach(): PhoenixPush
 }
 
-interface PhoenixSocket {
-    fun onAttach(callback: () -> Unit): String
+public interface PhoenixSocket {
+    public fun onAttach(callback: () -> Unit): String
 
-    fun onDetach(callback: () -> Unit): String
+    public fun onDetach(callback: () -> Unit): String
 
-    fun attach()
+    public fun attach()
 
-    fun getChannel(topic: String, params: Map<String, Any>): PhoenixChannel
+    public fun getChannel(topic: String, params: Map<String, Any>): PhoenixChannel
 
-    fun detach()
+    public fun detach()
 }
 
-class MockPhoenixSocket
+public class MockPhoenixSocket
 @DefaultArgumentInterop.Enabled
-constructor(val onAttachCallback: () -> Unit = {}, val onDetatchCallback: () -> Unit = {}) :
-    PhoenixSocket {
+constructor(
+    private val onAttachCallback: () -> Unit = {},
+    private val onDetatchCallback: () -> Unit = {},
+) : PhoenixSocket {
     override fun onAttach(callback: () -> Unit): String {
         return "attached"
     }
@@ -67,7 +69,7 @@ constructor(val onAttachCallback: () -> Unit = {}, val onDetatchCallback: () -> 
     }
 }
 
-class MockPhoenixChannel : PhoenixChannel {
+internal class MockPhoenixChannel : PhoenixChannel {
     override fun onEvent(event: String, callback: (PhoenixMessage) -> Unit) {}
 
     override fun onFailure(callback: (message: PhoenixMessage) -> Unit) {}
@@ -83,7 +85,7 @@ class MockPhoenixChannel : PhoenixChannel {
     }
 }
 
-class MockPush : PhoenixPush {
+internal class MockPush : PhoenixPush {
     override fun receive(
         status: PhoenixPushStatus,
         callback: (PhoenixMessage) -> Unit,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
@@ -1,6 +1,6 @@
 package com.mbta.tid.mbta_app.network
 
 /** Observe changes in the device's network connectivity. */
-interface INetworkConnectivityMonitor {
+internal interface INetworkConnectivityMonitor {
     fun registerListener(onNetworkAvailable: () -> Unit, onNetworkLost: () -> Unit)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannel.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.phoenix
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 
-class AlertsChannel {
+internal class AlertsChannel {
     companion object {
         val topic = "alerts:v2"
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/PredictionsForStopsChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/PredictionsForStopsChannel.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 
-class PredictionsForStopsChannel {
+internal class PredictionsForStopsChannel {
     companion object {
         val topic = "predictions:stops"
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/VehicleChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/VehicleChannel.kt
@@ -1,7 +1,7 @@
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 
-class VehicleChannel {
+internal class VehicleChannel {
     companion object {
         fun topic(vehicleId: String): String = "vehicle:id:${vehicleId}"
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/VehiclesOnRouteChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/VehiclesOnRouteChannel.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.phoenix
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 
-object VehiclesOnRouteChannel {
+internal object VehiclesOnRouteChannel {
     val topic = "vehicles:route"
 
     val newDataEvent = "stream_data"

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.repositories
 
-interface IAccessibilityStatusRepository {
-    fun isScreenReaderEnabled(): Boolean
+public interface IAccessibilityStatusRepository {
+    public fun isScreenReaderEnabled(): Boolean
 }
 
-class MockAccessibilityStatusRepository(private val isScreenReaderEnabled: Boolean) :
+internal class MockAccessibilityStatusRepository(private val isScreenReaderEnabled: Boolean) :
     IAccessibilityStatusRepository {
     override fun isScreenReaderEnabled() = isScreenReaderEnabled
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -11,13 +11,14 @@ import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.AlertsChannel
 import org.koin.core.component.KoinComponent
 
-interface IAlertsRepository {
-    fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit)
+public interface IAlertsRepository {
+    public fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit)
 
-    fun disconnect()
+    public fun disconnect()
 }
 
-class AlertsRepository(private val socket: PhoenixSocket) : IAlertsRepository, KoinComponent {
+internal class AlertsRepository(private val socket: PhoenixSocket) :
+    IAlertsRepository, KoinComponent {
 
     var channel: PhoenixChannel? = null
 
@@ -69,15 +70,15 @@ class AlertsRepository(private val socket: PhoenixSocket) : IAlertsRepository, K
     }
 }
 
-class MockAlertsRepository
+public class MockAlertsRepository
 @DefaultArgumentInterop.Enabled
-constructor(
+internal constructor(
     private val result: ApiResult<AlertsStreamDataResponse>,
     private val onConnect: () -> Unit = {},
     private val onDisconnect: () -> Unit = {},
 ) : IAlertsRepository {
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         response: AlertsStreamDataResponse = AlertsStreamDataResponse(emptyMap()),
         onConnect: () -> Unit = {},
         onDisconnect: () -> Unit = {},
@@ -95,7 +96,7 @@ constructor(
         onDisconnect()
     }
 
-    fun receiveResult(result: ApiResult<AlertsStreamDataResponse>) {
+    internal fun receiveResult(result: ApiResult<AlertsStreamDataResponse>) {
         receiveCallback?.let { it(result) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ConfigRepository.kt
@@ -9,12 +9,12 @@ import io.ktor.http.path
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IConfigRepository {
+public interface IConfigRepository {
 
-    suspend fun getConfig(): ApiResult<ConfigResponse>
+    public suspend fun getConfig(): ApiResult<ConfigResponse>
 }
 
-class ConfigRepository : IConfigRepository, KoinComponent {
+internal class ConfigRepository : IConfigRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     override suspend fun getConfig(): ApiResult<ConfigResponse> =
@@ -25,8 +25,8 @@ class ConfigRepository : IConfigRepository, KoinComponent {
         }
 }
 
-class MockConfigRepository(
-    var response: ApiResult<ConfigResponse> =
+public class MockConfigRepository(
+    private var response: ApiResult<ConfigResponse> =
         ApiResult.Ok(ConfigResponse(mapboxPublicToken = "fake_mapbox_token"))
 ) : IConfigRepository, KoinComponent {
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/CurrentAppVersionRepository.kt
@@ -6,11 +6,11 @@ import com.mbta.tid.mbta_app.model.AppVersion
  * The app version is defined at compile time in Android, but the shared library can't see it there,
  * so a simple `expect`/`actual` won't cut it.
  */
-fun interface ICurrentAppVersionRepository {
-    fun getCurrentAppVersion(): AppVersion?
+public fun interface ICurrentAppVersionRepository {
+    public fun getCurrentAppVersion(): AppVersion?
 }
 
-class MockCurrentAppVersionRepository(private val currentAppVersion: AppVersion?) :
+public class MockCurrentAppVersionRepository(private val currentAppVersion: AppVersion?) :
     ICurrentAppVersionRepository {
-    override fun getCurrentAppVersion() = currentAppVersion
+    override fun getCurrentAppVersion(): AppVersion? = currentAppVersion
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepository.kt
@@ -12,13 +12,13 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IFavoritesRepository {
-    suspend fun getFavorites(): Favorites
+public interface IFavoritesRepository {
+    public suspend fun getFavorites(): Favorites
 
-    suspend fun setFavorites(favorites: Favorites)
+    public suspend fun setFavorites(favorites: Favorites)
 }
 
-class FavoritesRepository : IFavoritesRepository, KoinComponent {
+internal class FavoritesRepository : IFavoritesRepository, KoinComponent {
 
     private val dataStore: DataStore<Preferences> by inject()
 
@@ -41,10 +41,10 @@ class FavoritesRepository : IFavoritesRepository, KoinComponent {
     }
 }
 
-class MockFavoritesRepository
+public class MockFavoritesRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    var favorites: Favorites = Favorites(),
+    private var favorites: Favorites = Favorites(),
     private val onGet: (() -> Unit)? = null,
     private val onSet: ((Favorites) -> Unit)? = null,
 ) : IFavoritesRepository {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepository.kt
@@ -16,13 +16,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IGlobalRepository {
-    val state: StateFlow<GlobalResponse?>
+public interface IGlobalRepository {
+    public val state: StateFlow<GlobalResponse?>
 
-    suspend fun getGlobalData(): ApiResult<GlobalResponse>
+    public suspend fun getGlobalData(): ApiResult<GlobalResponse>
 }
 
-class GlobalRepository(
+internal class GlobalRepository(
     val cache: ResponseCache<GlobalResponse> =
         ResponseCache.create(cacheKey = "global", invalidationKey = "2025-03-19")
 ) : IGlobalRepository, KoinComponent {
@@ -39,12 +39,13 @@ class GlobalRepository(
         }
 }
 
-class MockGlobalRepository
+public class MockGlobalRepository
 @DefaultArgumentInterop.Enabled
-constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) : IGlobalRepository {
+constructor(private val result: ApiResult<GlobalResponse>, private val onGet: () -> Unit = {}) :
+    IGlobalRepository {
 
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         response: GlobalResponse =
             GlobalResponse(
                 emptyMap(),
@@ -58,7 +59,7 @@ constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) :
         onGet: () -> Unit = {},
     ) : this(ApiResult.Ok(response), onGet)
 
-    override val state =
+    override val state: MutableStateFlow<GlobalResponse?> =
         MutableStateFlow(
             when (result) {
                 is ApiResult.Error -> null
@@ -71,13 +72,13 @@ constructor(val result: ApiResult<GlobalResponse>, val onGet: () -> Unit = {}) :
         return result
     }
 
-    fun updateGlobalData(newGlobal: GlobalResponse?) {
+    internal fun updateGlobalData(newGlobal: GlobalResponse?) {
         state.update { newGlobal }
     }
 }
 
-class IdleGlobalRepository : IGlobalRepository {
-    override val state = MutableStateFlow(null)
+public class IdleGlobalRepository : IGlobalRepository {
+    override val state: MutableStateFlow<GlobalResponse?> = MutableStateFlow(null)
 
     override suspend fun getGlobalData(): ApiResult<GlobalResponse> {
         return suspendCancellableCoroutine {}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/LastLaunchedAppVersionRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/LastLaunchedAppVersionRepository.kt
@@ -11,13 +11,13 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface ILastLaunchedAppVersionRepository {
-    suspend fun getLastLaunchedAppVersion(): AppVersion?
+public interface ILastLaunchedAppVersionRepository {
+    public suspend fun getLastLaunchedAppVersion(): AppVersion?
 
-    suspend fun setLastLaunchedAppVersion(version: AppVersion)
+    public suspend fun setLastLaunchedAppVersion(version: AppVersion)
 }
 
-class LastLaunchedAppVersionRepository : ILastLaunchedAppVersionRepository, KoinComponent {
+internal class LastLaunchedAppVersionRepository : ILastLaunchedAppVersionRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     private val lastLaunchedAppVersionKey = stringPreferencesKey("last_launched_app_version")
@@ -34,13 +34,13 @@ class LastLaunchedAppVersionRepository : ILastLaunchedAppVersionRepository, Koin
     }
 }
 
-class MockLastLaunchedAppVersionRepository
+public class MockLastLaunchedAppVersionRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     private var lastLaunchedAppVersion: AppVersion?,
     private var onSet: (AppVersion) -> Unit = {},
 ) : ILastLaunchedAppVersionRepository {
-    override suspend fun getLastLaunchedAppVersion() = lastLaunchedAppVersion
+    override suspend fun getLastLaunchedAppVersion(): AppVersion? = lastLaunchedAppVersion
 
     override suspend fun setLastLaunchedAppVersion(version: AppVersion) {
         onSet(version)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
@@ -9,16 +9,16 @@ import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import io.github.dellisd.spatialk.geojson.Position
 import org.koin.core.component.KoinComponent
 
-interface INearbyRepository {
+public interface INearbyRepository {
     /**
      * Gets the list of stops within 0.5 miles (or 1 mile for CR). Includes only stops with
      * [LocationType.STOP]. Omits stops that serves route pattern that are all served by closer
      * stops.
      */
-    fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String>
+    public fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String>
 }
 
-class NearbyRepository : KoinComponent, INearbyRepository {
+public class NearbyRepository : KoinComponent, INearbyRepository {
     override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> {
         val searchPosition = Position(latitude = location.latitude, longitude = location.longitude)
 
@@ -90,15 +90,15 @@ class NearbyRepository : KoinComponent, INearbyRepository {
     }
 }
 
-class MockNearbyRepository(
-    val response: NearbyResponse,
-    val stopIds: List<String> = response.stopIds,
+public class MockNearbyRepository(
+    private val response: NearbyResponse,
+    private val stopIds: List<String> = response.stopIds,
 ) : INearbyRepository {
     override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> =
         stopIds
 }
 
-class IdleNearbyRepository : INearbyRepository {
+internal class IdleNearbyRepository : INearbyRepository {
     override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> =
         emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/OnboardingRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/OnboardingRepository.kt
@@ -11,13 +11,13 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IOnboardingRepository {
-    suspend fun getPendingOnboarding(): List<OnboardingScreen>
+public interface IOnboardingRepository {
+    public suspend fun getPendingOnboarding(): List<OnboardingScreen>
 
-    suspend fun markOnboardingCompleted(screen: OnboardingScreen)
+    public suspend fun markOnboardingCompleted(screen: OnboardingScreen)
 }
 
-class OnboardingRepository : IOnboardingRepository, KoinComponent {
+internal class OnboardingRepository : IOnboardingRepository, KoinComponent {
     private val accessibilityStatus: IAccessibilityStatusRepository by inject()
     private val dataStore: DataStore<Preferences> by inject()
 
@@ -44,7 +44,7 @@ class OnboardingRepository : IOnboardingRepository, KoinComponent {
     }
 }
 
-class MockOnboardingRepository
+public class MockOnboardingRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     private val pendingOnboarding: List<OnboardingScreen> = emptyList(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PinnedRoutesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PinnedRoutesRepository.kt
@@ -10,13 +10,13 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IPinnedRoutesRepository {
-    suspend fun getPinnedRoutes(): Set<String>
+public interface IPinnedRoutesRepository {
+    public suspend fun getPinnedRoutes(): Set<String>
 
-    suspend fun setPinnedRoutes(routes: Set<String>)
+    public suspend fun setPinnedRoutes(routes: Set<String>)
 }
 
-class PinnedRoutesRepository : IPinnedRoutesRepository, KoinComponent {
+internal class PinnedRoutesRepository : IPinnedRoutesRepository, KoinComponent {
 
     private val dataStore: DataStore<Preferences> by inject()
 
@@ -31,14 +31,14 @@ class PinnedRoutesRepository : IPinnedRoutesRepository, KoinComponent {
     }
 }
 
-class MockPinnedRoutesRepository
+public class MockPinnedRoutesRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     initialPinnedRoutes: Set<String> = emptySet(),
     private val onGet: (() -> Unit)? = null,
     private val onSet: ((Set<String>) -> Unit)? = null,
 ) : IPinnedRoutesRepository, KoinComponent {
-    var pinnedRoutes: Set<String> = initialPinnedRoutes
+    public var pinnedRoutes: Set<String> = initialPinnedRoutes
 
     override suspend fun getPinnedRoutes(): Set<String> {
         onGet?.invoke()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -16,26 +16,26 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import org.koin.core.component.KoinComponent
 
-interface IPredictionsRepository {
-    fun connect(
+public interface IPredictionsRepository {
+    public fun connect(
         stopIds: List<String>,
         onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
     )
 
-    fun connectV2(
+    public fun connectV2(
         stopIds: List<String>,
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     )
 
-    var lastUpdated: EasternTimeInstant?
+    public var lastUpdated: EasternTimeInstant?
 
-    fun shouldForgetPredictions(predictionCount: Int): Boolean
+    public fun shouldForgetPredictions(predictionCount: Int): Boolean
 
-    fun disconnect()
+    public fun disconnect()
 }
 
-class PredictionsRepository(private val socket: PhoenixSocket) :
+internal class PredictionsRepository(private val socket: PhoenixSocket) :
     IPredictionsRepository, KoinComponent {
 
     var channel: PhoenixChannel? = null
@@ -176,18 +176,18 @@ class PredictionsRepository(private val socket: PhoenixSocket) :
     }
 }
 
-class MockPredictionsRepository
+public class MockPredictionsRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    val onConnect: () -> Unit = {},
-    val onConnectV2: (List<String>) -> Unit = {},
-    val onDisconnect: () -> Unit = {},
+    internal val onConnect: () -> Unit = {},
+    internal val onConnectV2: (List<String>) -> Unit = {},
+    internal val onDisconnect: () -> Unit = {},
     private val connectOutcome: ApiResult<PredictionsStreamDataResponse>? = null,
     private val connectV2Outcome: ApiResult<PredictionsByStopJoinResponse>? = null,
 ) : IPredictionsRepository {
 
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         onConnect: () -> Unit = {},
         onConnectV2: (List<String>) -> Unit = {},
         onDisconnect: () -> Unit = {},
@@ -229,15 +229,15 @@ constructor(
         this.onMessage = onMessage
     }
 
-    var onMessage: ((ApiResult<PredictionsByStopMessageResponse>) -> Unit)? = null
+    internal var onMessage: ((ApiResult<PredictionsByStopMessageResponse>) -> Unit)? = null
 
-    fun sendMessage(message: PredictionsByStopMessageResponse) {
+    internal fun sendMessage(message: PredictionsByStopMessageResponse) {
         onMessage?.invoke(ApiResult.Ok(message))
     }
 
     override var lastUpdated: EasternTimeInstant? = null
 
-    override fun shouldForgetPredictions(predictionCount: Int) = false
+    override fun shouldForgetPredictions(predictionCount: Int): Boolean = false
 
     override fun disconnect() {
         onDisconnect()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepository.kt
@@ -19,13 +19,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IRailRouteShapeRepository {
-    val state: StateFlow<MapFriendlyRouteResponse?>
+public interface IRailRouteShapeRepository {
+    public val state: StateFlow<MapFriendlyRouteResponse?>
 
-    suspend fun getRailRouteShapes(): ApiResult<MapFriendlyRouteResponse>
+    public suspend fun getRailRouteShapes(): ApiResult<MapFriendlyRouteResponse>
 }
 
-class RailRouteShapeRepository(
+internal class RailRouteShapeRepository(
     val cache: ResponseCache<MapFriendlyRouteResponse> =
         ResponseCache.create(cacheKey = "rail-route-shapes", invalidationKey = "2025-03-19")
 ) : IRailRouteShapeRepository, KoinComponent {
@@ -42,14 +42,14 @@ class RailRouteShapeRepository(
         }
 }
 
-class MockRailRouteShapeRepository
+public class MockRailRouteShapeRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    val response: MapFriendlyRouteResponse = MapFriendlyRouteResponse(emptyList()),
-    val onGet: () -> Unit = {},
+    private val response: MapFriendlyRouteResponse = MapFriendlyRouteResponse(emptyList()),
+    private val onGet: () -> Unit = {},
 ) : IRailRouteShapeRepository {
 
-    constructor(
+    public constructor(
         objects: ObjectCollectionBuilder
     ) : this(
         response =
@@ -102,7 +102,7 @@ constructor(
             )
     )
 
-    override val state = MutableStateFlow(response)
+    override val state: MutableStateFlow<MapFriendlyRouteResponse> = MutableStateFlow(response)
 
     override suspend fun getRailRouteShapes(): ApiResult<MapFriendlyRouteResponse> {
         onGet()
@@ -110,7 +110,7 @@ constructor(
     }
 }
 
-class IdleRailRouteShapeRepository : IRailRouteShapeRepository {
+internal class IdleRailRouteShapeRepository : IRailRouteShapeRepository {
     override val state = MutableStateFlow(null)
 
     override suspend fun getRailRouteShapes(): ApiResult<MapFriendlyRouteResponse> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/RouteStopsRepository.kt
@@ -13,17 +13,20 @@ import org.koin.core.component.inject
 // The response doesn't include the route ID and direction ID, which we need in the UI to ensure
 // that we're using the correct stop list for the selected route and direction.
 @Serializable
-data class RouteStopsResult(
-    val routeId: String,
-    val directionId: Int,
-    val segments: List<RouteBranchSegment>,
+public data class RouteStopsResult(
+    internal val routeId: String,
+    internal val directionId: Int,
+    internal val segments: List<RouteBranchSegment>,
 )
 
-interface IRouteStopsRepository {
-    suspend fun getRouteSegments(routeId: String, directionId: Int): ApiResult<RouteStopsResult>
+public interface IRouteStopsRepository {
+    public suspend fun getRouteSegments(
+        routeId: String,
+        directionId: Int,
+    ): ApiResult<RouteStopsResult>
 }
 
-class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
+internal class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     override suspend fun getRouteSegments(
@@ -45,12 +48,12 @@ class RouteStopsRepository : IRouteStopsRepository, KoinComponent {
         }
 }
 
-class MockRouteStopsRepository(
+public class MockRouteStopsRepository(
     private val result: ApiResult<RouteStopsResult>,
     private val onGet: (String, Int) -> Unit = { _, _ -> },
 ) : IRouteStopsRepository {
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         segments: List<RouteBranchSegment>,
         routeId: String = "",
         directionId: Int = 0,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
@@ -11,16 +11,16 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface ISchedulesRepository {
-    suspend fun getSchedule(
+public interface ISchedulesRepository {
+    public suspend fun getSchedule(
         stopIds: List<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse>
 
-    suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse>
+    public suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse>
 }
 
-class SchedulesRepository : ISchedulesRepository, KoinComponent {
+internal class SchedulesRepository : ISchedulesRepository, KoinComponent {
 
     private val mobileBackendClient: MobileBackendClient by inject()
 
@@ -45,18 +45,18 @@ class SchedulesRepository : ISchedulesRepository, KoinComponent {
     }
 }
 
-class MockScheduleRepository(
+public class MockScheduleRepository(
     private val response: ApiResult<ScheduleResponse>,
     private val callback: (stopIds: List<String>) -> Unit = {},
 ) : ISchedulesRepository {
 
     @DefaultArgumentInterop.Enabled
-    constructor(
+    public constructor(
         scheduleResponse: ScheduleResponse = ScheduleResponse(listOf(), mapOf()),
         callback: (stopIds: List<String>) -> Unit = {},
     ) : this(ApiResult.Ok(scheduleResponse), callback)
 
-    constructor() :
+    public constructor() :
         this(
             scheduleResponse = ScheduleResponse(schedules = listOf(), trips = mapOf()),
             callback = {},
@@ -76,7 +76,7 @@ class MockScheduleRepository(
     }
 }
 
-class IdleScheduleRepository : ISchedulesRepository {
+public class IdleScheduleRepository : ISchedulesRepository {
     override suspend fun getSchedule(
         stopIds: List<String>,
         now: EasternTimeInstant,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
@@ -13,13 +13,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface ISearchResultRepository {
-    suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>?
+public interface ISearchResultRepository {
+    public suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>?
 
-    suspend fun getSearchResults(query: String): ApiResult<SearchResults>?
+    public suspend fun getSearchResults(query: String): ApiResult<SearchResults>?
 }
 
-class SearchResultRepository : KoinComponent, ISearchResultRepository {
+internal class SearchResultRepository : KoinComponent, ISearchResultRepository {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     private suspend fun searchRequest(endpoint: String, query: String): ApiResult<SearchResults>? {
@@ -44,7 +44,7 @@ class SearchResultRepository : KoinComponent, ISearchResultRepository {
         searchRequest("api/search/query", query)
 }
 
-class MockSearchResultRepository
+public class MockSearchResultRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     private val routeResults: List<RouteResult> = emptyList(),
@@ -63,7 +63,7 @@ constructor(
     }
 }
 
-class IdleSearchResultRepository : ISearchResultRepository {
+internal class IdleSearchResultRepository : ISearchResultRepository {
     override suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>? {
         return suspendCancellableCoroutine {}
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SentryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SentryRepository.kt
@@ -2,14 +2,14 @@ package com.mbta.tid.mbta_app.repositories
 
 import io.sentry.kotlin.multiplatform.Sentry
 
-interface ISentryRepository {
+public interface ISentryRepository {
 
-    fun captureMessage(msg: String)
+    public fun captureMessage(msg: String)
 
-    fun captureException(throwable: Throwable)
+    public fun captureException(throwable: Throwable)
 }
 
-class SentryRepository : ISentryRepository {
+internal class SentryRepository : ISentryRepository {
     override fun captureMessage(msg: String) {
         Sentry.captureMessage(msg)
     }
@@ -19,7 +19,7 @@ class SentryRepository : ISentryRepository {
     }
 }
 
-class MockSentryRepository : ISentryRepository {
+public class MockSentryRepository : ISentryRepository {
     override fun captureMessage(msg: String) {
         TODO("Not yet implemented")
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -10,14 +10,14 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface ISettingsRepository {
+public interface ISettingsRepository {
 
-    suspend fun getSettings(): Map<Settings, Boolean>
+    public suspend fun getSettings(): Map<Settings, Boolean>
 
-    suspend fun setSettings(settings: Map<Settings, Boolean>)
+    public suspend fun setSettings(settings: Map<Settings, Boolean>)
 }
 
-class SettingsRepository : ISettingsRepository, KoinComponent {
+internal class SettingsRepository : ISettingsRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     override suspend fun getSettings(): Map<Settings, Boolean> {
@@ -35,7 +35,10 @@ class SettingsRepository : ISettingsRepository, KoinComponent {
     }
 }
 
-enum class Settings(val dataStoreKey: Preferences.Key<Boolean>, val override: Boolean? = null) {
+public enum class Settings(
+    internal val dataStoreKey: Preferences.Key<Boolean>,
+    public val override: Boolean? = null,
+) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     EnhancedFavorites(booleanPreferencesKey("enhanced_favorites_feature_flag"), true),
     HideMaps(booleanPreferencesKey("hide_maps")),
@@ -43,7 +46,7 @@ enum class Settings(val dataStoreKey: Preferences.Key<Boolean>, val override: Bo
     StationAccessibility(booleanPreferencesKey("elevator_accessibility")),
 }
 
-class MockSettingsRepository
+public class MockSettingsRepository
 @DefaultArgumentInterop.Enabled
 constructor(
     private var settings: Map<Settings, Boolean> = emptyMap(),
@@ -55,5 +58,6 @@ constructor(
         return settings
     }
 
-    override suspend fun setSettings(settings: Map<Settings, Boolean>) = onSaveSettings(settings)
+    override suspend fun setSettings(settings: Map<Settings, Boolean>): Unit =
+        onSaveSettings(settings)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/StopRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/StopRepository.kt
@@ -14,11 +14,11 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IStopRepository {
-    suspend fun getStopMapData(stopId: String): ApiResult<StopMapResponse>
+public interface IStopRepository {
+    public suspend fun getStopMapData(stopId: String): ApiResult<StopMapResponse>
 }
 
-class StopRepository : IStopRepository, KoinComponent {
+internal class StopRepository : IStopRepository, KoinComponent {
 
     private val mobileBackendClient: MobileBackendClient by inject()
 
@@ -35,7 +35,8 @@ class StopRepository : IStopRepository, KoinComponent {
         }
 }
 
-class MockStopRepository(val objects: ObjectCollectionBuilder? = null) : IStopRepository {
+public class MockStopRepository(private val objects: ObjectCollectionBuilder? = null) :
+    IStopRepository {
     override suspend fun getStopMapData(stopId: String): ApiResult<StopMapResponse> {
 
         if (objects == null) {
@@ -69,7 +70,7 @@ class MockStopRepository(val objects: ObjectCollectionBuilder? = null) : IStopRe
     }
 }
 
-class IdleStopRepository : IStopRepository {
+internal class IdleStopRepository : IStopRepository {
     override suspend fun getStopMapData(stopId: String): ApiResult<StopMapResponse> {
         return suspendCancellableCoroutine {}
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -10,19 +10,19 @@ import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-enum class DefaultTab(val entrypoint: SheetRoutes.Entrypoint) {
+public enum class DefaultTab(public val entrypoint: SheetRoutes.Entrypoint) {
     Favorites(SheetRoutes.Favorites),
     Nearby(SheetRoutes.NearbyTransit),
 }
 
-interface ITabPreferencesRepository {
+public interface ITabPreferencesRepository {
 
-    suspend fun getDefaultTab(): DefaultTab
+    public suspend fun getDefaultTab(): DefaultTab
 
-    suspend fun setDefaultTab(defaultTab: DefaultTab)
+    public suspend fun setDefaultTab(defaultTab: DefaultTab)
 }
 
-class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
+internal class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
 
     private val defaultTabKey = stringPreferencesKey("default_tab")
@@ -37,7 +37,7 @@ class TabPreferencesRepository : ITabPreferencesRepository, KoinComponent {
     }
 }
 
-class MockTabPreferencesRepository : ITabPreferencesRepository {
+public class MockTabPreferencesRepository : ITabPreferencesRepository {
     override suspend fun getDefaultTab(): DefaultTab {
         return DefaultTab.Nearby
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
@@ -14,17 +14,20 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import org.koin.core.component.KoinComponent
 
-interface ITripPredictionsRepository {
-    fun connect(tripId: String, onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit)
+public interface ITripPredictionsRepository {
+    public fun connect(
+        tripId: String,
+        onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
+    )
 
-    var lastUpdated: EasternTimeInstant?
+    public var lastUpdated: EasternTimeInstant?
 
-    fun shouldForgetPredictions(predictionCount: Int): Boolean
+    public fun shouldForgetPredictions(predictionCount: Int): Boolean
 
-    fun disconnect()
+    public fun disconnect()
 }
 
-class TripPredictionsRepository(private val socket: PhoenixSocket) :
+internal class TripPredictionsRepository(private val socket: PhoenixSocket) :
     ITripPredictionsRepository, KoinComponent {
 
     var channel: PhoenixChannel? = null
@@ -87,12 +90,12 @@ class TripPredictionsRepository(private val socket: PhoenixSocket) :
     }
 }
 
-class MockTripPredictionsRepository
+public class MockTripPredictionsRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    var onConnect: () -> Unit = {},
-    var onDisconnect: () -> Unit = {},
-    var response: PredictionsStreamDataResponse =
+    internal var onConnect: () -> Unit = {},
+    internal var onDisconnect: () -> Unit = {},
+    internal var response: PredictionsStreamDataResponse =
         PredictionsStreamDataResponse(emptyMap(), emptyMap(), emptyMap()),
 ) : ITripPredictionsRepository {
 
@@ -106,7 +109,7 @@ constructor(
 
     override var lastUpdated: EasternTimeInstant? = null
 
-    override fun shouldForgetPredictions(predictionCount: Int) = false
+    override fun shouldForgetPredictions(predictionCount: Int): Boolean = false
 
     override fun disconnect() {
         onDisconnect()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripRepository.kt
@@ -16,15 +16,15 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface ITripRepository {
-    suspend fun getTripSchedules(tripId: String): ApiResult<TripSchedulesResponse>
+public interface ITripRepository {
+    public suspend fun getTripSchedules(tripId: String): ApiResult<TripSchedulesResponse>
 
-    suspend fun getTrip(tripId: String): ApiResult<TripResponse>
+    public suspend fun getTrip(tripId: String): ApiResult<TripResponse>
 
-    suspend fun getTripShape(tripId: String): ApiResult<TripShape>
+    public suspend fun getTripShape(tripId: String): ApiResult<TripShape>
 }
 
-class TripRepository : ITripRepository, KoinComponent {
+internal class TripRepository : ITripRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     override suspend fun getTripSchedules(tripId: String): ApiResult<TripSchedulesResponse> =
@@ -66,7 +66,7 @@ class TripRepository : ITripRepository, KoinComponent {
         }
 }
 
-open class IdleTripRepository : ITripRepository {
+internal open class IdleTripRepository : ITripRepository {
     override suspend fun getTripSchedules(tripId: String): ApiResult<TripSchedulesResponse> {
         return suspendCancellableCoroutine {}
     }
@@ -80,12 +80,12 @@ open class IdleTripRepository : ITripRepository {
     }
 }
 
-class MockTripRepository
+public class MockTripRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    var tripSchedulesResponse: TripSchedulesResponse = TripSchedulesResponse.Unknown,
-    var tripResponse: TripResponse = TripResponse(ObjectCollectionBuilder().trip {}),
-    var tripShape: TripShape = TripShape(ShapeWithStops(0, "", "", null, emptyList())),
+    internal var tripSchedulesResponse: TripSchedulesResponse = TripSchedulesResponse.Unknown,
+    internal var tripResponse: TripResponse = TripResponse(ObjectCollectionBuilder().trip {}),
+    internal var tripShape: TripShape = TripShape(ShapeWithStops(0, "", "", null, emptyList())),
 ) : ITripRepository {
     override suspend fun getTripSchedules(tripId: String): ApiResult<TripSchedulesResponse> {
         return ApiResult.Ok(tripSchedulesResponse)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
@@ -11,13 +11,14 @@ import com.mbta.tid.mbta_app.network.PhoenixPushStatus
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import org.koin.core.component.KoinComponent
 
-interface IVehicleRepository {
-    fun connect(vehicleId: String, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit)
+public interface IVehicleRepository {
+    public fun connect(vehicleId: String, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit)
 
-    fun disconnect()
+    public fun disconnect()
 }
 
-class VehicleRepository(private val socket: PhoenixSocket) : IVehicleRepository, KoinComponent {
+internal class VehicleRepository(private val socket: PhoenixSocket) :
+    IVehicleRepository, KoinComponent {
     var channel: PhoenixChannel? = null
 
     override fun connect(
@@ -71,11 +72,11 @@ class VehicleRepository(private val socket: PhoenixSocket) : IVehicleRepository,
     }
 }
 
-class MockVehicleRepository
+public class MockVehicleRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    var onConnect: () -> Unit = {},
-    var onDisconnect: () -> Unit = {},
+    internal var onConnect: () -> Unit = {},
+    internal var onDisconnect: () -> Unit = {},
     private val outcome: ApiResult<VehicleStreamDataResponse>? = null,
 ) : IVehicleRepository {
     override fun connect(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
@@ -14,17 +14,18 @@ import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.VehiclesOnRouteChannel
 import org.koin.core.component.KoinComponent
 
-interface IVehiclesRepository {
-    fun connect(
+public interface IVehiclesRepository {
+    public fun connect(
         routeId: String,
         directionId: Int,
         onReceive: (ApiResult<VehiclesStreamDataResponse>) -> Unit,
     )
 
-    fun disconnect()
+    public fun disconnect()
 }
 
-class VehiclesRepository(private val socket: PhoenixSocket) : IVehiclesRepository, KoinComponent {
+internal class VehiclesRepository(private val socket: PhoenixSocket) :
+    IVehiclesRepository, KoinComponent {
     var channel: PhoenixChannel? = null
 
     override fun connect(
@@ -88,18 +89,18 @@ class VehiclesRepository(private val socket: PhoenixSocket) : IVehiclesRepositor
     }
 }
 
-class MockVehiclesRepository
+public class MockVehiclesRepository
 @DefaultArgumentInterop.Enabled
 constructor(
-    val response: VehiclesStreamDataResponse,
-    val onConnect: (routeId: String, directionId: Int) -> Unit = { _: String, _: Int -> },
-    val onDisconnect: () -> Unit = {},
+    internal val response: VehiclesStreamDataResponse,
+    internal val onConnect: (routeId: String, directionId: Int) -> Unit = { _: String, _: Int -> },
+    internal val onDisconnect: () -> Unit = {},
 ) : IVehiclesRepository {
-    constructor(
+    public constructor(
         vehicles: List<Vehicle> = emptyList()
     ) : this(response = VehiclesStreamDataResponse(vehicles.associateBy { it.id }))
 
-    constructor(
+    internal constructor(
         objects: ObjectCollectionBuilder
     ) : this(response = VehiclesStreamDataResponse(objects.vehicles))
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VisitHistoryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VisitHistoryRepository.kt
@@ -13,13 +13,13 @@ import kotlinx.coroutines.sync.Mutex
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-interface IVisitHistoryRepository {
-    suspend fun getVisitHistory(): VisitHistory
+public interface IVisitHistoryRepository {
+    public suspend fun getVisitHistory(): VisitHistory
 
-    suspend fun setVisitHistory(visits: VisitHistory)
+    public suspend fun setVisitHistory(visits: VisitHistory)
 }
 
-class VisitHistoryRepository : IVisitHistoryRepository, KoinComponent {
+internal class VisitHistoryRepository : IVisitHistoryRepository, KoinComponent {
     private val dataStore: DataStore<Preferences> by inject()
     private val mutex = Mutex()
 
@@ -42,7 +42,7 @@ class VisitHistoryRepository : IVisitHistoryRepository, KoinComponent {
     }
 }
 
-class MockVisitHistoryRepository
+public class MockVisitHistoryRepository
 @DefaultArgumentInterop.Enabled
 constructor(private var history: VisitHistory = VisitHistory()) : IVisitHistoryRepository {
     override suspend fun getVisitHistory(): VisitHistory {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/CrossPlatformPathTypes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/CrossPlatformPathTypes.kt
@@ -1,11 +1,16 @@
 package com.mbta.tid.mbta_app.shape
 
-object Path {
-    data class Point(val x: Float, val y: Float)
+public object Path {
+    public data class Point(val x: Float, val y: Float)
 
-    data class Rect(val minX: Float, val maxX: Float, val minY: Float, val maxY: Float) {
-        val width = maxX - minX
-        val height = maxY - minY
+    public data class Rect(
+        internal val minX: Float,
+        internal val maxX: Float,
+        internal val minY: Float,
+        internal val maxY: Float,
+    ) {
+        internal val width: Float = maxX - minX
+        internal val height: Float = maxY - minY
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/FavoriteStarShape.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/FavoriteStarShape.kt
@@ -4,7 +4,7 @@ import kotlin.math.cos
 import kotlin.math.min
 import kotlin.math.sin
 
-class FavoriteStarShape(rect: Path.Rect, scale: Float = 1f) {
+public class FavoriteStarShape(rect: Path.Rect, scale: Float = 1f) {
     private val starPoints = 5
     private val phaseShift = 0.25f
     private val diameter = min(rect.width, rect.height) * scale
@@ -29,7 +29,7 @@ class FavoriteStarShape(rect: Path.Rect, scale: Float = 1f) {
         )
     }
 
-    data class Arm(
+    public data class Arm(
         val `in`: Path.Point,
         val outStart: Path.Point,
         val outStartControl: Path.Point,
@@ -40,7 +40,7 @@ class FavoriteStarShape(rect: Path.Rect, scale: Float = 1f) {
         val outEnd: Path.Point,
     )
 
-    val arms =
+    public val arms: List<Arm> =
         (1..5).map {
             val i = it.toFloat()
             val midI = i + 0.5f
@@ -80,7 +80,7 @@ class FavoriteStarShape(rect: Path.Rect, scale: Float = 1f) {
             )
         }
 
-    companion object {
+    internal companion object {
         private const val PI = kotlin.math.PI.toFloat()
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/shape/StickDiagramShapes.kt
@@ -5,8 +5,9 @@ import kotlin.math.abs
 import kotlin.math.cos
 import kotlin.math.sin
 
-object StickDiagramShapes {
-    data class Connection(
+public object StickDiagramShapes {
+    public data class Connection
+    internal constructor(
         val start: Path.Point,
         val startControl: Path.Point,
         val endControl: Path.Point,
@@ -23,22 +24,25 @@ object StickDiagramShapes {
         val centerY = (topY + bottomY) / 2
     }
 
-    data class NonTwisted(
+    public data class NonTwisted
+    internal constructor(
         val start: Path.Point,
         val startControl: Path.Point,
         val endControl: Path.Point,
         val end: Path.Point,
     )
 
-    data class Twisted(
+    public data class Twisted
+    internal constructor(
         val shadow: Shadow,
         val curves: Curves,
         val ends: Ends,
         val opensToNothing: Boolean,
     ) {
-        data class Shadow(val start: Path.Point, val end: Path.Point)
+        public data class Shadow internal constructor(val start: Path.Point, val end: Path.Point)
 
-        data class Curves(
+        public data class Curves
+        internal constructor(
             val bottom: Path.Point?,
             val bottomCurveStart: Path.Point,
             val bottomCurveControl: Path.Point,
@@ -49,7 +53,8 @@ object StickDiagramShapes {
             val top: Path.Point?,
         )
 
-        data class Ends(
+        public data class Ends
+        internal constructor(
             val bottom: Path.Point?,
             val bottomCurveStart: Path.Point,
             val topCurveStart: Path.Point,
@@ -73,7 +78,10 @@ object StickDiagramShapes {
 
     private const val PI = kotlin.math.PI.toFloat()
 
-    fun connection(connection: RouteBranchSegment.StickConnection, rect: Path.Rect): Connection {
+    public fun connection(
+        connection: RouteBranchSegment.StickConnection,
+        rect: Path.Rect,
+    ): Connection {
         val fromX = x(connection.fromLane, rect)
         val toX = x(connection.toLane, rect)
         val fromY = y(connection.fromVPos, rect)
@@ -117,7 +125,7 @@ object StickDiagramShapes {
         )
     }
 
-    fun nonTwisted(
+    public fun nonTwisted(
         connection: RouteBranchSegment.StickConnection,
         rect: Path.Rect,
         proportionClosed: Float,
@@ -131,7 +139,7 @@ object StickDiagramShapes {
         )
     }
 
-    fun twisted(
+    public fun twisted(
         connection: RouteBranchSegment.StickConnection,
         rect: Path.Rect,
         proportionClosed: Float,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 
-class AlertsUsecase
+public class AlertsUsecase
 @DefaultArgumentInterop.Enabled
 constructor(
     private val alertsRepository: IAlertsRepository,
@@ -25,7 +25,7 @@ constructor(
     private var globalState = globalRepository.state
     private var globalUpdateJob: Job? = null
 
-    fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
+    public fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
         fun injectAndReceive(result: ApiResult<AlertsStreamDataResponse>) {
             val injectedResult =
                 if (result is ApiResult.Ok) {
@@ -47,7 +47,7 @@ constructor(
             }
     }
 
-    fun disconnect() {
+    public fun disconnect() {
         alertsRepository.disconnect()
         globalUpdateJob?.cancel()
         globalUpdateJob = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/ConfigUseCase.kt
@@ -6,12 +6,12 @@ import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import org.koin.core.component.KoinComponent
 
-class ConfigUseCase(
+public class ConfigUseCase(
     private val configRepo: IConfigRepository,
     private val sentryRepo: ISentryRepository,
 ) : KoinComponent {
 
-    suspend fun getConfig(): ApiResult<ConfigResponse> =
+    public suspend fun getConfig(): ApiResult<ConfigResponse> =
         try {
             configRepo.getConfig()
         } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
@@ -5,17 +5,17 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import org.koin.core.component.KoinComponent
 
-class FavoritesUsecases(
+public class FavoritesUsecases(
     private val repository: IFavoritesRepository,
     private val analytics: Analytics,
 ) : KoinComponent {
 
-    suspend fun getRouteStopDirectionFavorites(): Set<RouteStopDirection> {
+    public suspend fun getRouteStopDirectionFavorites(): Set<RouteStopDirection> {
         val storedFavorites = repository.getFavorites()
         return storedFavorites.routeStopDirection ?: emptySet()
     }
 
-    suspend fun updateRouteStopDirections(
+    public suspend fun updateRouteStopDirections(
         newValues: Map<RouteStopDirection, Boolean>,
         context: EditFavoritesContext,
         defaultDirection: Int,
@@ -42,7 +42,7 @@ class FavoritesUsecases(
     }
 }
 
-enum class EditFavoritesContext {
+public enum class EditFavoritesContext {
     Favorites,
     StopDetails,
     RouteDetails,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FeaturePromoUseCase.kt
@@ -5,11 +5,11 @@ import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
 import com.mbta.tid.mbta_app.repositories.ILastLaunchedAppVersionRepository
 import org.koin.core.component.KoinComponent
 
-interface IFeaturePromoUseCase {
-    suspend fun getFeaturePromos(): List<FeaturePromo>
+public interface IFeaturePromoUseCase {
+    public suspend fun getFeaturePromos(): List<FeaturePromo>
 }
 
-class FeaturePromoUseCase(
+public class FeaturePromoUseCase(
     private val currentAppVersionRepository: ICurrentAppVersionRepository,
     private val lastLaunchedAppVersionRepository: ILastLaunchedAppVersionRepository,
 ) : IFeaturePromoUseCase, KoinComponent {
@@ -25,7 +25,7 @@ class FeaturePromoUseCase(
         return newFeatures
     }
 
-    companion object {
+    internal companion object {
         // https://www.xkcd.com/2615/
         const val MAX_PROMOS = 2
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/TogglePinnedRouteUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/TogglePinnedRouteUsecase.kt
@@ -3,10 +3,11 @@ package com.mbta.tid.mbta_app.usecases
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import org.koin.core.component.KoinComponent
 
-class TogglePinnedRouteUsecase(private val repository: IPinnedRoutesRepository) : KoinComponent {
+public class TogglePinnedRouteUsecase(private val repository: IPinnedRoutesRepository) :
+    KoinComponent {
 
     // Boolean return value indicates pinned or unpinned state
-    suspend fun execute(route: String): Boolean {
+    public suspend fun execute(route: String): Boolean {
         val currentRoutes = repository.getPinnedRoutes().toMutableSet()
         val containsRoute = currentRoutes.contains(route)
         if (containsRoute) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/VisitHistoryUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/VisitHistoryUsecase.kt
@@ -7,12 +7,12 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
 
-class VisitHistoryUsecase(private val repository: IVisitHistoryRepository) : KoinComponent {
+public class VisitHistoryUsecase(private val repository: IVisitHistoryRepository) : KoinComponent {
     private val mutex = Mutex()
 
     private val visitHistoryKey = stringPreferencesKey("visit_history")
 
-    suspend fun addVisit(visit: Visit) {
+    public suspend fun addVisit(visit: Visit) {
         mutex.withLock {
             val history = repository.getVisitHistory()
             history.add(visit)
@@ -20,7 +20,7 @@ class VisitHistoryUsecase(private val repository: IVisitHistoryRepository) : Koi
         }
     }
 
-    suspend fun getLatestVisits(): List<Visit> {
+    internal suspend fun getLatestVisits(): List<Visit> {
         mutex.withLock {
             return repository.getVisitHistory().latest()
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
@@ -22,14 +22,14 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = EasternTimeInstant.Serializer::class)
-class EasternTimeInstant
-private constructor(private val instant: Instant, val local: LocalDateTime) :
+public class EasternTimeInstant
+private constructor(private val instant: Instant, public val local: LocalDateTime) :
     Comparable<EasternTimeInstant> {
-    constructor(instant: Instant) : this(instant, instant.toLocalDateTime(timeZone))
+    public constructor(instant: Instant) : this(instant, instant.toLocalDateTime(timeZone))
 
-    constructor(local: LocalDateTime) : this(local.toInstant(timeZone), local)
+    internal constructor(local: LocalDateTime) : this(local.toInstant(timeZone), local)
 
-    constructor(
+    public constructor(
         year: Int,
         month: Month,
         day: Int,
@@ -39,19 +39,19 @@ private constructor(private val instant: Instant, val local: LocalDateTime) :
     ) : this(LocalDateTime(year, month, day, hour, minute, second))
 
     /** The time component becomes irrelevant after this coercion and should be ignored */
-    fun coerceInServiceDay(): EasternTimeInstant {
+    public fun coerceInServiceDay(): EasternTimeInstant {
         if (local.date == serviceDate) return this
         val instant = this.instant - 24.hours
         return EasternTimeInstant(instant)
     }
 
-    val serviceDate: LocalDate
+    internal val serviceDate: LocalDate
         get() = if (local.hour >= 3) local.date else local.date.minus(DatePeriod(days = 1))
 
     // Service end times will be set to 3:00 in Alerts UI, which means that a LocalDateTime
     // representing the end of service on one date will think that it belongs to the next service
     // day, this allows you to specify if you want to round forward or backward in that case.
-    fun serviceDate(rounding: ServiceDateRounding): LocalDate {
+    internal fun serviceDate(rounding: ServiceDateRounding): LocalDate {
         return if (
             rounding == ServiceDateRounding.BACKWARDS && local.hour == 3 && local.minute == 0
         )
@@ -59,15 +59,17 @@ private constructor(private val instant: Instant, val local: LocalDateTime) :
         else serviceDate
     }
 
-    fun secondsHasDivisor(divisor: Long) = this.instant.epochSeconds % divisor == 0L
+    public fun secondsHasDivisor(divisor: Long): Boolean = this.instant.epochSeconds % divisor == 0L
 
-    fun toEpochFracSeconds() = this.instant.toEpochMilliseconds() / 1000.0
+    internal fun toEpochFracSeconds() = this.instant.toEpochMilliseconds() / 1000.0
 
-    operator fun plus(duration: Duration) = EasternTimeInstant(instant + duration)
+    public operator fun plus(duration: Duration): EasternTimeInstant =
+        EasternTimeInstant(instant + duration)
 
-    operator fun minus(duration: Duration) = EasternTimeInstant(instant - duration)
+    public operator fun minus(duration: Duration): EasternTimeInstant =
+        EasternTimeInstant(instant - duration)
 
-    operator fun minus(other: EasternTimeInstant) = instant - other.instant
+    public operator fun minus(other: EasternTimeInstant): Duration = instant - other.instant
 
     override fun compareTo(other: EasternTimeInstant): Int {
         return this.instant.compareTo(other.instant)
@@ -81,14 +83,14 @@ private constructor(private val instant: Instant, val local: LocalDateTime) :
         return instant.hashCode()
     }
 
-    override fun toString() = local.toString() + timeZone.offsetAt(instant).toString()
+    override fun toString(): String = local.toString() + timeZone.offsetAt(instant).toString()
 
-    enum class ServiceDateRounding {
+    internal enum class ServiceDateRounding {
         FORWARDS,
         BACKWARDS,
     }
 
-    object Serializer : KSerializer<EasternTimeInstant> {
+    internal object Serializer : KSerializer<EasternTimeInstant> {
         private val delegateSerializer = Instant.serializer()
 
         override val descriptor =
@@ -108,10 +110,11 @@ private constructor(private val instant: Instant, val local: LocalDateTime) :
         }
     }
 
-    companion object {
-        val timeZone by lazy { TimeZone.Companion.of("America/New_York") }
+    public companion object {
+        internal val timeZone by lazy { TimeZone.Companion.of("America/New_York") }
 
         @DefaultArgumentInterop.Enabled
-        fun now(clock: Clock = Clock.System) = EasternTimeInstant(clock.now())
+        public fun now(clock: Clock = Clock.System): EasternTimeInstant =
+            EasternTimeInstant(clock.now())
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/GreenLineHelper.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/GreenLineHelper.kt
@@ -1,74 +1,79 @@
 package com.mbta.tid.mbta_app.utils
 
+import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteSegment
 import com.mbta.tid.mbta_app.model.SegmentedRouteShape
+import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
 
-typealias RouteWithSegmentedShapes = MapFriendlyRouteResponse.RouteWithSegmentedShapes
+internal typealias RouteWithSegmentedShapes = MapFriendlyRouteResponse.RouteWithSegmentedShapes
 
-class GreenLineTestHelper {
-    companion object {
-        val objects = TestData.clone()
-        val line = objects.getLine("line-Green")
-        val routeB = objects.getRoute("Green-B")
-        val routeC = objects.getRoute("Green-C")
-        val routeE = objects.getRoute("Green-E")
+public class GreenLineTestHelper {
+    public companion object {
+        public val objects: ObjectCollectionBuilder = TestData.clone()
+        public val line: Line = objects.getLine("line-Green")
+        public val routeB: Route = objects.getRoute("Green-B")
+        public val routeC: Route = objects.getRoute("Green-C")
+        public val routeE: Route = objects.getRoute("Green-E")
 
-        val stopArlington = objects.getStop("place-armnl")
-        val stopEastbound = objects.getStop("70156")
-        val stopWestbound = objects.getStop("70157")
+        internal val stopArlington = objects.getStop("place-armnl")
+        public val stopEastbound: Stop = objects.getStop("70156")
+        public val stopWestbound: Stop = objects.getStop("70157")
 
-        val rpB0 = objects.getRoutePattern("Green-B-812-0")
-        val rpB1 = objects.getRoutePattern("Green-B-812-1")
-        val rpC0 = objects.getRoutePattern("Green-C-832-0")
-        val rpC1 = objects.getRoutePattern("Green-C-832-1")
-        val rpE0 = objects.getRoutePattern("Green-E-886-0")
-        val rpE1 = objects.getRoutePattern("Green-E-886-1")
+        public val rpB0: RoutePattern = objects.getRoutePattern("Green-B-812-0")
+        public val rpB1: RoutePattern = objects.getRoutePattern("Green-B-812-1")
+        public val rpC0: RoutePattern = objects.getRoutePattern("Green-C-832-0")
+        public val rpC1: RoutePattern = objects.getRoutePattern("Green-C-832-1")
+        public val rpE0: RoutePattern = objects.getRoutePattern("Green-E-886-0")
+        public val rpE1: RoutePattern = objects.getRoutePattern("Green-E-886-1")
 
-        val shapeB0 =
+        internal val shapeB0 =
             objects.shape {
                 id = "canonical-8000012"
                 polyline =
                     "oplaGpwjqLJq@B_@@W@}@KmBGmBAyAAqDJ}K@eEDaBHoAJ{AVcCJw@RkABQ??Z}AZwAVw@`@mAd@kAdAsCn@kBLg@Lk@DYLaBCUESKWA???AASYMQEEm@g@YQg@Sg@Uc@So@_@c@Wc@_@a@_@[_@w@gAaA_BO[??[s@a@kA[sAQ}@Go@G_ACcB@k@BiB?}@E}AEi@C]??Eo@Im@Mo@S_A]eA[y@Wk@u@oA_@e@]a@]]o@g@w@i@eAm@??ECuAy@{@m@uCeBm@[QI[U_B{@yAk@q@Sc@IiCUg@Mu@W??[KUKIGQYUe@Kc@Ii@Ew@?g@@]B]Ha@d@_CBE??t@aDNo@Jo@Dc@@a@?_@Ag@Gi@Gk@Om@_@cAOa@??O_@uA{DcAiCs@qB_@_A}@eCGM??q@iBOk@Gc@Eg@Ai@?m@FyALyB@k@?gAAe@Eq@QsAKe@Om@Uo@c@eAe@_AYi@q@kAg@o@QY??W_@IQAO?Yh@sIX{E`@wGBg@??PiCHmABo@J_C\\mFRiD^cG??\\oFLkC\\yFBW@[Fw@Da@?EHgA\\uFj@uIRiD??JkBn@qKFkA??`@uGT_ERgDJyA??B]JsBVyEViF@aBEqGMqF?G???A?oC@S@MFQt@aAzAkBHOL_@FWBQ@QQuR?kABm@??D{@Bm@b@aJ?SAOGa@{Igg@YcB_@aCMs@??cJog@Ga@??wAqIe@cDScCKcBXaLC_@CMEKEE??CEyA]]Ma@Ui@SOQQGa@QSIgBw@q@UYO]Co@]i@c@W[_@c@[_@{@eAU]??q@{@UYWQa@c@o@u@uB_Cu@q@eEmC[Ua@]"
             }
 
-        val shapeB1 =
+        internal val shapeB1 =
             objects.shape {
                 id = "canonical-8000013"
                 polyline =
                     "{hpaGdxupLXVZTdElCt@p@tB~Bn@t@`@b@VPTXp@z@??T\\z@dAZ^^b@VZh@b@n@\\\\BXNp@TfBv@RH`@PPFNPh@R`@T\\LB@??tAZHJDJBLB^Y`LJbBRbCd@bDvArI??F^bJng@??Lr@^`CXbBzIfg@F`@@N?Rc@`JCl@Ez@??Cl@?jAPtRAPCPGVM^IN{AjBu@`AGPALAR?nC?D???BLpFDpGA`BWhFWxEKrBEj@??IjASfDU~Da@`H??G~@o@pKM~B??QtCk@tI]tFIfA?DE`@Gv@AZCV]xFMjC_@`G??]pFShD]lFK~BCn@IlASvC??AXa@vGYzEi@rI?X@NHPX`@??NVf@n@p@jAXh@d@~@b@dATn@Nl@Jd@PrADp@@d@?fAAj@MxBGxA?l@@h@Df@Fb@Nj@r@jB??DJ|@dC^~@r@pBbAhCtAzD^`A@@??\\`ANl@Fj@Fh@@f@?^A`@Eb@Kn@On@y@fD????e@~BI`@C\\A\\?f@Dv@Hh@Jb@Td@PXHFTJVJ??x@Vf@LhCTb@Hp@RxAj@~Az@ZTPHl@ZtCdBz@l@tAx@D@??dAn@v@h@n@f@\\\\\\`@^d@t@nAVj@Zx@\\dAR~@Ln@Hl@Dp@??BZDh@D|A?|@ChBAj@BbBF~@Fn@P|@ZrA`@jAj@nABD??|@xAv@fAZ^`@^b@^b@Vn@^b@Rf@Tf@RXPl@f@DDLPRX????B@JVDRBTM`BEXMj@Mf@o@jBeArCe@jAa@lAWv@[vAYvA??EVSjAKv@WbCKzAInAE`BAdEK|K@pD@xAFlBJlBA|@AVC^??"
             }
 
-        val shapeC0 =
+        internal val shapeC0 =
             objects.shape {
                 id = "canonical-8000005"
                 polyline =
                     "}wkaGligqL_@uCQcAEYg@kDcAaIGc@??E]Kw@SiB_@wCc@qDQuAEa@Q{A??QwAk@yDg@gD]eC@PGa@??i@iDgAmHUuAIe@EMUu@Mc@AG??Ie@EYGi@KeBEaAAy@@_C?oDA{AAO???YIgBIeBM_BMmA??EY[oBQiAUiAe@sBOi@_@mAI]KWIYa@gBCO]gB??G_@g@_DKw@g@cEcAiGS_AEUCW??Gc@AYEe@[oBSiAc@wBcBaJ]uB??Ki@OaAs@mDo@uDUmAKm@??s@}Da@wBg@oCUmAAK??_AeFYuAUyAMy@{@sEKc@Om@??GQOq@]aBs@cEkFqXgF{ZAS??COAiECuACkB?EQ}B?G???A?oC@S@MFQt@aAzAkBHOL_@FWBQ@QQuR?kABm@??D{@Bm@b@aJ?SAOGa@{Igg@YcB_@aCMs@??cJog@Ga@??wAqIe@cDScCKcBXaLC_@CMEKEE??CEyA]]Ma@Ui@SOQQGa@QSIgBw@q@UYO]Co@]i@c@W[_@c@[_@{@eAU]??q@{@UYWQa@c@o@u@uB_Cu@q@eEmC[Ua@]"
             }
 
-        val shapeC1 =
+        internal val shapeC1 =
             objects.shape {
                 id = "canonical-8000006"
                 polyline =
                     "{hpaGdxupLXVZTdElCt@p@tB~Bn@t@`@b@VPTXp@z@??T\\z@dAZ^^b@VZh@b@n@\\\\BXNp@TfBv@RH`@PPFNPh@R`@T\\LB@??tAZHJDJBLB^Y`LJbBRbCd@bDvArI??F^bJng@??Lr@^`CXbBzIfg@F`@@N?Rc@`JCl@Ez@??Cl@?jAPtRAPCPGVM^IN{AjBu@`AGPALAR?nC?D???BP|B?DBjBBtA@hEBN??@RfFzZjFpXr@bE\\`BNp@DP??Pl@Jb@z@rELx@TxAXtA~@dF??@JTlAf@nC`@vB~@jFDR??Nx@n@tDr@lDN`ATlA??RpAbB`Jb@vBRhAZnBDd@@XFd@??BTDTR~@bAhGf@bEJv@f@~CX~A??Jf@BN`@fBHXJVH\\^lANh@d@rBThAPhAPbA??Hj@RfBL~AHdBDv@??Bn@@h@@zA?nDA~B@x@D`AJdBFh@DXJl@FR??DNTt@DLHd@TtAfAlHh@hD??F`@AQ\\dCf@fDj@xDVxB??Jx@D`@PtAb@pD^vCRhBJv@L`AFZ??z@dHf@jDDXPbA^tC"
             }
 
-        val shapeE0 =
+        internal val shapeE0 =
             objects.shape {
                 id = "canonical-8000015"
                 polyline =
                     "cgjaGbu_qLCCCAOBGDKLIJW`@QX_@d@e@TgA`@aBn@WF??_Cp@wDbA??SH[FEAEEQYQ[Q]Ua@[i@o@oAM]O_@Yu@Ia@GYAGCW??CUAm@?w@Aw@?w@C_AAuC?qA?[Ee@Mq@Oi@]}@OYKS??Yq@a@eAOi@Ss@??EMQi@k@oBEO}AuFSw@m@mCMk@k@mB]eAOi@IU??m@kBm@}B}B}HcB_Gg@iB??WeA_BaFYaAgAyDUaA_@oAq@}Bq@cCIW{AcFg@_BQi@??s@yBYcA]kAQm@Oe@e@aAWe@gA{A_D}Da@g@k@u@??{MiQSY??_@i@yE{GW]_@Yw@[iHiAOCmBf@QGISYaAYcB_@aCMs@??cJog@Ga@??wAqIe@cDScCKcBXaLC_@CMEKEE??CEyA]]Ma@Ui@SOQQGa@QSIgBw@q@UYO]Co@]i@c@W[_@c@[_@{@eAU]??q@{@UYWQa@c@o@u@uB_Cu@q@eEmC[Ua@]??KIQQq@o@uE}DUOUAg@@aGRa@H[BSDKD??_@RMHi@b@MPyAbBmIjH??ONuCrCGPCN?RBh@BVJZbB~Ef@|ALl@D`@Bb@ANCN]~@_@`CKr@KbAUtASt@Sp@Un@Uh@Qd@e@jAELwAfDw@~B??ELo@zAeBlEkBnEqA~Cw@jBsBfFO^s@nBuAjBo@`@A@??]VWPONUZ[h@Qj@WjAUfAmEjLo@~As@v@y@v@YRe@Ra@FQD_A^YRW\\]h@e@`A[z@IZO^MX_@f@{@~@cAdA_A~@wKdKs@z@aArAe@n@wBvB??_DzC{H|HsDfDiAz@iBnAkApAk@p@u@p@qAvAs@~@k@v@eApBcAvBo@dBaBzEw@|Be@rA??IT{@xBk@xAY|@k@vAaA~Ce@rAiCrHyAvDOd@a@`A[l@m@dAo@dA[h@KPs@~@m@l@{@|@s@t@UPq@f@q@`@ED??UL{@l@cAr@{@j@q@d@a@Vg@\\e@Zg@\\KFQNy@h@i@\\a@XMJgBlAs@d@s@h@cAp@m@`@c@Zw@f@m@b@y@h@_@V_An@w@h@o@b@??IDe@Zk@b@o@b@cAn@_Aj@]VSLa@Xg@\\c@Ze@Xg@\\UNg@\\g@^cAr@{@j@_@T{AfAOJsA|@iD`CqCjBkCdBm@`@OLMJSN"
             }
 
-        val shapeE1 =
+        internal val shapeE1 =
             objects.shape {
                 id = "canonical-8000018"
                 polyline =
                     "awyaG|~`qLZSLKNMl@a@jCeBpCkBhDaCrA}@NKzAgA^Uz@k@bAs@f@_@f@]TOf@]d@Yb@[f@]`@YRM\\W~@k@bAo@n@c@j@c@d@[JG??l@a@v@i@~@o@^Wx@i@l@c@v@g@b@[l@a@bAq@r@i@r@e@fBmALK`@Yh@]x@i@POJGf@]d@[f@]`@Wp@e@z@k@bAs@z@m@TM??DEp@a@p@g@TQr@u@z@}@l@m@r@_AJQZi@n@eAl@eAZm@`@aANe@xAwDhCsHd@sA`A_Dj@wAX}@j@yAz@yBDO??h@yAv@}B`B{En@eBbAwBdAqBj@w@r@_ApAwAt@q@j@q@jAqAhBoAhA{@rDgDzH}HzCyC??zByBd@o@`AsAr@{@vKeK~@_AbAeAz@_A^g@LYN_@H[Z{@d@aA\\i@V]XS~@_@PE`@Gd@SXSx@w@r@w@n@_BlEkLTgAVkAPk@Zi@T[NOVQ\\Y??@?n@a@tAkBr@oBN_@rBgFv@kBpA_DjBoEdBmEn@{A@C??z@iCvAgDDMd@kAPe@Ti@To@Rq@Ru@TuAJcAJs@^aC\\_ABO@OCc@Ea@Mm@g@}AcB_FK[CWCi@?SBOFQtCsCNO??lIkHxAcBLQh@c@LIZQ??NGREZC`@I`GSf@AT@TNtE|Dp@n@PPRN??XVZTdElCt@p@tB~Bn@t@`@b@VPTXp@z@??T\\z@dAZ^^b@VZh@b@n@\\\\BXNp@TfBv@RH`@PPFNPh@R`@T\\LB@??tAZHJDJBLB^Y`LJbBRbCd@bDvArI??F^bJng@??Lr@^`CXbBX`AHRPFlBg@NBhHhAv@Z^XV\\xEzG^h@??RXxMfQ??l@v@`@f@~C|DfAzAVd@d@`ANd@Pl@\\jAXbAr@xB??Ph@f@~AzAbFHVp@bCp@|B^nAT`AfAxDX`A~A`FXhA??d@dBbB~F|B|Hl@|Bj@dB??JZNh@\\dAj@lBLj@l@lCRv@|AtFDNj@nBPh@DL??Rr@Nh@`@dAZr@??HPNX\\|@Nh@Lp@Dd@?Z?pA@tCB~@?v@@v@?v@@l@D^??@L@FFXH`@Xt@N^L\\n@nAZh@T`@P\\PZPXDDD@ZGTI??tDcA~Bq@??VG`Bo@fAa@d@Uf@Bd@CT?b@MBa@CYG]"
             }
 
-        val stopMapResponse =
+        internal val stopMapResponse =
             StopMapResponse(
                 listOf(
                     RouteWithSegmentedShapes(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MapLayerManager.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MapLayerManager.kt
@@ -7,24 +7,24 @@ import com.mbta.tid.mbta_app.map.style.FeatureCollection
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 
-interface IMapLayerManager {
-    suspend fun addLayers(
+public interface IMapLayerManager {
+    public suspend fun addLayers(
         mapFriendlyRouteResponse: MapFriendlyRouteResponse,
         state: StopLayerGenerator.State,
         globalResponse: GlobalResponse,
         colorPalette: ColorPalette,
     )
 
-    suspend fun addLayers(
+    public suspend fun addLayers(
         routes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         state: StopLayerGenerator.State,
         globalResponse: GlobalResponse,
         colorPalette: ColorPalette,
     )
 
-    fun resetPuckPosition()
+    public fun resetPuckPosition()
 
-    suspend fun updateRouteSourceData(routeData: List<RouteSourceData>)
+    public suspend fun updateRouteSourceData(routeData: List<RouteSourceData>)
 
-    suspend fun updateStopSourceData(stopData: FeatureCollection)
+    public suspend fun updateStopSourceData(stopData: FeatureCollection)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MinutesFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/MinutesFormat.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.utils
 
-sealed class MinutesFormat {
-    companion object {
-        fun from(minutes: Int): MinutesFormat {
+public sealed class MinutesFormat {
+    public companion object {
+        public fun from(minutes: Int): MinutesFormat {
             val hours = minutes.floorDiv(60)
             val remainingMinutes = minutes - (hours * 60)
             return if (hours >= 1)
@@ -11,9 +11,10 @@ sealed class MinutesFormat {
         }
     }
 
-    data class Hour(val hours: Int) : MinutesFormat()
+    public data class Hour internal constructor(val hours: Int) : MinutesFormat()
 
-    data class HourMinute(val hours: Int, val minutes: Int) : MinutesFormat()
+    public data class HourMinute internal constructor(val hours: Int, val minutes: Int) :
+        MinutesFormat()
 
-    data class Minute(val minutes: Int) : MinutesFormat()
+    public data class Minute internal constructor(val minutes: Int) : MinutesFormat()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -14,7 +14,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.atTime
 
-open class RouteCardPreviewData {
+public open class RouteCardPreviewData {
     private val today: LocalDate = EasternTimeInstant.now().local.date
     private val objects = TestData.clone()
     private val greenLine = objects.getLine("line-Green")
@@ -64,8 +64,8 @@ open class RouteCardPreviewData {
     private val suspensionAlert = objects.alert { effect = Alert.Effect.Suspension }
     private val context = RouteCardData.Context.NearbyTransit
 
-    val now = EasternTimeInstant(today.atTime(11, 30))
-    val global = GlobalResponse(objects)
+    public val now: EasternTimeInstant = EasternTimeInstant(today.atTime(11, 30))
+    public val global: GlobalResponse = GlobalResponse(objects)
 
     private fun cardStop(
         lineOrRoute: RouteCardData.LineOrRoute,
@@ -162,7 +162,7 @@ open class RouteCardPreviewData {
     }
 
     // "Downstream disruption" group = "1. Orange Line disruption"
-    fun OL1() =
+    public fun OL1(): RouteCardData =
         card(
             orangeLine,
             ruggles,
@@ -196,7 +196,7 @@ open class RouteCardPreviewData {
         )
 
     // "Disrupted stop" group = "1. Orange Line disruption"
-    fun OL2() =
+    public fun OL2(): RouteCardData =
         card(
             orangeLine,
             objects.stop {
@@ -208,7 +208,7 @@ open class RouteCardPreviewData {
         )
 
     // "Show up to the next three trips in the branching direction" group = "2. Red Line branching"
-    fun RL1() =
+    public fun RL1(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -247,7 +247,7 @@ open class RouteCardPreviewData {
         )
 
     // "Next three trips go to the same destination" group = "2. Red Line branching"
-    fun RL2() =
+    public fun RL2(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -292,7 +292,7 @@ open class RouteCardPreviewData {
         )
 
     // "Predictions unavailable for a branch" group = "2. Red Line branching"
-    fun RL3() =
+    public fun RL3(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -331,7 +331,7 @@ open class RouteCardPreviewData {
         )
 
     // "Service not running on a branch downstream", group = "2. Red Line branching"
-    fun RL4() =
+    public fun RL4(): RouteCardData =
         card(
             redLine,
             objects.stop {
@@ -374,7 +374,7 @@ open class RouteCardPreviewData {
         )
 
     // "Service disrupted on a branch downstream", group = "2. Red Line branching"
-    fun RL5() =
+    public fun RL5(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -414,7 +414,7 @@ open class RouteCardPreviewData {
         )
 
     // "Branching in both directions" group = "3. Green Line branching")
-    fun GL1() =
+    public fun GL1(): RouteCardData =
         card(
             greenLine,
             boylston,
@@ -459,7 +459,7 @@ open class RouteCardPreviewData {
         )
 
     // "Downstream disruption", group = "3. Green Line branching"
-    fun GL2() =
+    public fun GL2(): RouteCardData =
         card(
             greenLine,
             boylston,
@@ -505,7 +505,7 @@ open class RouteCardPreviewData {
         )
 
     // "Branching in one direction", group = "4. Silver Line branching"
-    fun SL1() =
+    public fun SL1(): RouteCardData =
         card(
             slWaterfront,
             objects.stop {
@@ -582,7 +582,7 @@ open class RouteCardPreviewData {
         )
 
     // "Branching in one direction", group = "5. CR branching"
-    fun CR1() =
+    public fun CR1(): RouteCardData =
         card(
             providenceLine,
             ruggles,
@@ -656,7 +656,7 @@ open class RouteCardPreviewData {
         )
 
     // "Next two trips go to the same destination" group = "6. Bus route single direction"
-    fun Bus1(): RouteCardData {
+    public fun Bus1(): RouteCardData {
         val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
         return RouteCardData(
             lineOrRoute,
@@ -715,7 +715,7 @@ open class RouteCardPreviewData {
     }
 
     // "Next two trips go to different destinations" group = "6. Bus route single direction"
-    fun Bus2(): RouteCardData {
+    public fun Bus2(): RouteCardData {
         val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
         return RouteCardData(
             lineOrRoute,
@@ -768,7 +768,7 @@ open class RouteCardPreviewData {
     }
 
     // "Next two trips go to different destinations" group = "7. Bus route both directions"
-    fun Bus3() =
+    public fun Bus3(): RouteCardData =
         card(
             bus15,
             objects.stop {
@@ -828,7 +828,7 @@ open class RouteCardPreviewData {
         )
 
     // "Service ended on a branch", group = "8. Service ended")
-    fun RL6() =
+    public fun RL6(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -861,7 +861,7 @@ open class RouteCardPreviewData {
         )
 
     // "Service ended on all branches" group = "8. Service ended"
-    fun RL7() =
+    public fun RL7(): RouteCardData =
         card(
             redLine,
             jfkUmass,
@@ -882,7 +882,7 @@ open class RouteCardPreviewData {
         )
 
     // "Predictions unavailable on a branch", group = "9. Predictions unavailable"
-    fun GL3() =
+    public fun GL3(): RouteCardData =
         card(
             greenLine,
             boylston,
@@ -933,7 +933,7 @@ open class RouteCardPreviewData {
         )
 
     // "Predictions unavailable on all branches", group = "9. Predictions unavailable"
-    fun GL4() =
+    public fun GL4(): RouteCardData =
         card(
             greenLine,
             boylston,
@@ -978,7 +978,7 @@ open class RouteCardPreviewData {
         )
 
     // "Disruption on a branch" group = "A. Disruption"
-    fun GL5(): RouteCardData {
+    public fun GL5(): RouteCardData {
         val kenmoreShuttleToRiverside =
             objects.alert {
                 effect = Alert.Effect.Shuttle
@@ -1029,7 +1029,7 @@ open class RouteCardPreviewData {
     }
 
     // "Disruption on a branch, predictions unavailable for other branches" group = "A. Disruption"
-    fun GL6(): RouteCardData {
+    public fun GL6(): RouteCardData {
         val boylstonShuttleToRiverside =
             objects.alert {
                 effect = Alert.Effect.Shuttle
@@ -1079,7 +1079,7 @@ open class RouteCardPreviewData {
     }
 
     // "Disruption on all branches" group = "A. Disruption"
-    fun GL7(): RouteCardData {
+    public fun GL7(): RouteCardData {
 
         val shuttleAllBranches =
             objects.alert {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.kt
@@ -3,11 +3,11 @@ package com.mbta.tid.mbta_app.utils
 import okio.Path
 import okio.Path.Companion.toPath
 
-interface SystemPaths {
+internal interface SystemPaths {
     val data: Path
     val cache: Path
 }
 
-class MockSystemPaths(override val data: Path, override val cache: Path) : SystemPaths {
+internal class MockSystemPaths(override val data: Path, override val cache: Path) : SystemPaths {
     constructor(data: String, cache: String) : this(data.toPath(), cache.toPath())
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/Timer.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/Timer.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
-class ClockTickHandler {
+internal class ClockTickHandler {
     companion object {
         private val _clockFlow = MutableSharedFlow<EasternTimeInstant>(replay = 0)
         var job: Job? = null
@@ -39,7 +39,7 @@ class ClockTickHandler {
 }
 
 @Composable
-fun timer(
+internal fun timer(
     updateInterval: Duration = 5.seconds,
     clock: Clock = koinInject(),
 ): State<EasternTimeInstant> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/ViewportManager.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/ViewportManager.kt
@@ -3,16 +3,16 @@ package com.mbta.tid.mbta_app.utils
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.Vehicle
 
-interface ViewportManager {
-    suspend fun saveNearbyTransitViewport()
+public interface ViewportManager {
+    public suspend fun saveNearbyTransitViewport()
 
-    suspend fun restoreNearbyTransitViewport()
+    public suspend fun restoreNearbyTransitViewport()
 
-    suspend fun stopCenter(stop: Stop)
+    public suspend fun stopCenter(stop: Stop)
 
-    suspend fun vehicleOverview(vehicle: Vehicle, stop: Stop?, density: Float)
+    public suspend fun vehicleOverview(vehicle: Vehicle, stop: Stop?, density: Float)
 
-    suspend fun follow(transitionAnimationDuration: Long?)
+    public suspend fun follow(transitionAnimationDuration: Long?)
 
-    suspend fun isDefault(): Boolean
+    public suspend fun isDefault(): Boolean
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/resolveParentId.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/resolveParentId.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.utils
 
 import com.mbta.tid.mbta_app.model.Stop
 
-fun Map<String, Stop>.resolveParentId(stopId: String): String {
+internal fun Map<String, Stop>.resolveParentId(stopId: String): String {
     val stop = this[stopId] ?: return stopId
     val parentStopId = stop.parentStationId ?: return stopId
     return resolveParentId(parentStopId)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -26,31 +26,31 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-interface IFavoritesViewModel {
-    val models: StateFlow<FavoritesViewModel.State>
+public interface IFavoritesViewModel {
+    public val models: StateFlow<FavoritesViewModel.State>
 
-    fun reloadFavorites()
+    public fun reloadFavorites()
 
-    fun setActive(active: Boolean, wasSentToBackground: Boolean = false)
+    public fun setActive(active: Boolean, wasSentToBackground: Boolean = false)
 
-    fun setAlerts(alerts: AlertsStreamDataResponse?)
+    public fun setAlerts(alerts: AlertsStreamDataResponse?)
 
-    fun setContext(context: FavoritesViewModel.Context)
+    public fun setContext(context: FavoritesViewModel.Context)
 
-    fun setLocation(location: Position?)
+    public fun setLocation(location: Position?)
 
-    fun setNow(now: EasternTimeInstant)
+    public fun setNow(now: EasternTimeInstant)
 
-    fun setIsFirstExposureToNewFavorites(isFirst: Boolean)
+    public fun setIsFirstExposureToNewFavorites(isFirst: Boolean)
 
-    fun updateFavorites(
+    public fun updateFavorites(
         updatedFavorites: Map<RouteStopDirection, Boolean>,
         context: EditFavoritesContext,
         defaultDirection: Int,
     )
 }
 
-class FavoritesViewModel(
+public class FavoritesViewModel(
     private val favoritesUsecases: FavoritesUsecases,
     private val pinnedRoutesRepository: IPinnedRoutesRepository,
     private val tabPreferencesRepository: ITabPreferencesRepository,
@@ -58,35 +58,36 @@ class FavoritesViewModel(
     private val analytics: Analytics,
 ) : MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
 
-    sealed class Context {
-        data object Favorites : Context()
+    public sealed class Context {
+        public data object Favorites : Context()
 
-        data object Edit : Context()
+        public data object Edit : Context()
     }
 
-    sealed interface Event {
-        data object ReloadFavorites : Event
+    public sealed interface Event {
+        public data object ReloadFavorites : Event
 
-        data class SetActive(val active: Boolean, val wasSentToBackground: Boolean) : Event
+        public data class SetActive(val active: Boolean, val wasSentToBackground: Boolean) : Event
 
-        data class SetAlerts(val alerts: AlertsStreamDataResponse?) : Event
+        public data class SetAlerts(val alerts: AlertsStreamDataResponse?) : Event
 
-        data class SetContext(val context: Context) : Event
+        public data class SetContext(val context: Context) : Event
 
-        data class SetLocation(val location: Position?) : Event
+        public data class SetLocation(val location: Position?) : Event
 
-        data class SetNow(val now: EasternTimeInstant) : Event
+        public data class SetNow(val now: EasternTimeInstant) : Event
 
-        data class SetFirstExposureToNewFavorites(val isFirstExposure: Boolean = true) : Event
+        public data class SetFirstExposureToNewFavorites(val isFirstExposure: Boolean = true) :
+            Event
 
-        data class UpdateFavorites(
+        public data class UpdateFavorites(
             val updatedFavorites: Map<RouteStopDirection, Boolean>,
             val context: EditFavoritesContext,
             val defaultDirection: Int,
         ) : Event
     }
 
-    data class State(
+    public data class State(
         val awaitingPredictionsAfterBackground: Boolean,
         val favorites: Set<RouteStopDirection>?,
         val shouldShowFirstTimeToast: Boolean = false,
@@ -94,7 +95,7 @@ class FavoritesViewModel(
         val staticRouteCardData: List<RouteCardData>?,
         val loadedLocation: Position?,
     ) {
-        constructor() : this(false, null, false, null, null, null)
+        public constructor() : this(false, null, false, null, null, null)
     }
 
     @Composable
@@ -240,21 +241,22 @@ class FavoritesViewModel(
         )
     }
 
-    override val models
+    override val models: StateFlow<State>
         get() = internalModels
 
-    override fun reloadFavorites() = fireEvent(Event.ReloadFavorites)
+    override fun reloadFavorites(): Unit = fireEvent(Event.ReloadFavorites)
 
-    override fun setActive(active: Boolean, wasSentToBackground: Boolean) =
+    override fun setActive(active: Boolean, wasSentToBackground: Boolean): Unit =
         fireEvent(Event.SetActive(active, wasSentToBackground))
 
-    override fun setAlerts(alerts: AlertsStreamDataResponse?) = fireEvent(Event.SetAlerts(alerts))
+    override fun setAlerts(alerts: AlertsStreamDataResponse?): Unit =
+        fireEvent(Event.SetAlerts(alerts))
 
-    override fun setContext(context: Context) = fireEvent(Event.SetContext(context))
+    override fun setContext(context: Context): Unit = fireEvent(Event.SetContext(context))
 
-    override fun setLocation(location: Position?) = fireEvent(Event.SetLocation(location))
+    override fun setLocation(location: Position?): Unit = fireEvent(Event.SetLocation(location))
 
-    override fun setNow(now: EasternTimeInstant) = fireEvent(Event.SetNow(now))
+    override fun setNow(now: EasternTimeInstant): Unit = fireEvent(Event.SetNow(now))
 
     override fun setIsFirstExposureToNewFavorites(isFirstExposure: Boolean) {
         fireEvent(Event.SetFirstExposureToNewFavorites(isFirstExposure))
@@ -269,20 +271,20 @@ class FavoritesViewModel(
     }
 }
 
-class MockFavoritesViewModel
+public class MockFavoritesViewModel
 @DefaultArgumentInterop.Enabled
 constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State()) :
     IFavoritesViewModel {
-    var onReloadFavorites = {}
-    var onSetActive = { _: Boolean, _: Boolean -> }
-    var onSetAlerts = { _: AlertsStreamDataResponse? -> }
-    var onSetContext = { _: FavoritesViewModel.Context -> }
-    var onSetLocation = { _: Position? -> }
-    var onSetNow = { _: EasternTimeInstant -> }
-    var onSetIsFirstExposureToNewFavorites = { _: Boolean -> }
-    var onUpdateFavorites = { _: Map<RouteStopDirection, Boolean> -> }
+    public var onReloadFavorites: () -> Unit = {}
+    public var onSetActive: (Boolean, Boolean) -> Unit = { _, _ -> }
+    public var onSetAlerts: (AlertsStreamDataResponse?) -> Unit = {}
+    private var onSetContext = { _: FavoritesViewModel.Context -> }
+    public var onSetLocation: (Position?) -> Unit = {}
+    public var onSetNow: (EasternTimeInstant) -> Unit = { _ -> }
+    public var onSetIsFirstExposureToNewFavorites: (Boolean) -> Unit = { _ -> }
+    public var onUpdateFavorites: (Map<RouteStopDirection, Boolean>) -> Unit = { _ -> }
 
-    override val models = MutableStateFlow(initialState)
+    override val models: MutableStateFlow<FavoritesViewModel.State> = MutableStateFlow(initialState)
 
     override fun reloadFavorites() {
         onReloadFavorites()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -41,41 +41,41 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
 
-interface IMapViewModel {
+public interface IMapViewModel {
 
-    val models: StateFlow<MapViewModel.State>
+    public val models: StateFlow<MapViewModel.State>
 
-    fun selectedStop(stop: Stop, stopFilter: StopDetailsFilter?)
+    public fun selectedStop(stop: Stop, stopFilter: StopDetailsFilter?)
 
-    fun selectedTrip(
+    public fun selectedTrip(
         stopFilter: StopDetailsFilter?,
         stop: Stop?,
         tripFilter: TripDetailsFilter,
         vehicle: Vehicle?,
     )
 
-    fun navChanged(currentNavEntry: SheetRoutes?)
+    public fun navChanged(currentNavEntry: SheetRoutes?)
 
-    fun recenter(type: RecenterType = RecenterType.CurrentLocation)
+    public fun recenter(type: RecenterType = RecenterType.CurrentLocation)
 
-    fun alertsChanged(alerts: AlertsStreamDataResponse?)
+    public fun alertsChanged(alerts: AlertsStreamDataResponse?)
 
-    fun routeCardDataChanged(routeCardData: List<RouteCardData>?)
+    public fun routeCardDataChanged(routeCardData: List<RouteCardData>?)
 
-    fun colorPaletteChanged(isDarkMode: Boolean)
+    public fun colorPaletteChanged(isDarkMode: Boolean)
 
-    fun densityChanged(density: Float)
+    public fun densityChanged(density: Float)
 
-    fun mapStyleLoaded()
+    public fun mapStyleLoaded()
 
-    fun layerManagerInitialized(layerManager: IMapLayerManager)
+    public fun layerManagerInitialized(layerManager: IMapLayerManager)
 
-    fun locationPermissionsChanged(hasPermission: Boolean)
+    public fun locationPermissionsChanged(hasPermission: Boolean)
 
-    fun setViewportManager(viewportManager: ViewportManager)
+    public fun setViewportManager(viewportManager: ViewportManager)
 }
 
-class MapViewModel(
+public class MapViewModel(
     private val globalRepository: IGlobalRepository,
     private val railRouteShapeRepository: IRailRouteShapeRepository,
     private val stopRepository: IStopRepository,
@@ -86,58 +86,64 @@ class MapViewModel(
     private lateinit var viewportManager: ViewportManager
     private val routeCardDataUpdates = MutableStateFlow<List<RouteCardData>?>(null)
 
-    sealed interface Event {
+    public sealed interface Event {
 
-        enum class RecenterType {
+        public enum class RecenterType {
             CurrentLocation,
             Trip,
         }
 
-        data class SelectedStop(val stop: Stop, val stopFilter: StopDetailsFilter?) : Event
+        public data class SelectedStop
+        internal constructor(internal val stop: Stop, internal val stopFilter: StopDetailsFilter?) :
+            Event
 
-        data class SelectedTrip(
-            val stop: Stop?,
-            val stopFilter: StopDetailsFilter?,
-            val tripFilter: TripDetailsFilter,
-            val vehicle: Vehicle?,
+        public data class SelectedTrip
+        internal constructor(
+            internal val stop: Stop?,
+            internal val stopFilter: StopDetailsFilter?,
+            internal val tripFilter: TripDetailsFilter,
+            internal val vehicle: Vehicle?,
         ) : Event
 
-        data class NavChanged(val currentNavEntry: SheetRoutes?) : Event
+        public data class NavChanged
+        internal constructor(internal val currentNavEntry: SheetRoutes?) : Event
 
-        data class Recenter(val type: RecenterType) : Event
+        public data class Recenter(val type: RecenterType) : Event
 
-        data class AlertsChanged(val alerts: AlertsStreamDataResponse?) : Event
+        public data class AlertsChanged(val alerts: AlertsStreamDataResponse?) : Event
 
-        data class ColorPaletteChanged(val isDarkMode: Boolean) : Event
+        public data class ColorPaletteChanged(val isDarkMode: Boolean) : Event
 
-        data class DensityChanged(val density: Float) : Event
+        public data class DensityChanged(val density: Float) : Event
 
-        data object MapStyleLoaded : Event
+        public data object MapStyleLoaded : Event
 
-        data class LayerManagerInitialized(val layerManager: IMapLayerManager) : Event
+        public data class LayerManagerInitialized
+        internal constructor(internal val layerManager: IMapLayerManager) : Event
 
-        data class LocationPermissionsChanged(val hasPermission: Boolean) : Event
+        public data class LocationPermissionsChanged(val hasPermission: Boolean) : Event
     }
 
-    sealed class State {
+    public sealed class State {
 
-        abstract val stop: Stop?
-        abstract val stopFilter: StopDetailsFilter?
+        internal abstract val stop: Stop?
+        internal abstract val stopFilter: StopDetailsFilter?
 
-        data object Overview : State() {
+        public data object Overview : State() {
             override val stop: Stop? = null
             override val stopFilter: StopDetailsFilter? = null
         }
 
-        data class StopSelected(
+        public data class StopSelected(
             override val stop: Stop,
             override val stopFilter: StopDetailsFilter?,
         ) : State()
 
-        data class TripSelected(
+        public data class TripSelected
+        internal constructor(
             override val stop: Stop?,
             override val stopFilter: StopDetailsFilter?,
-            val tripFilter: TripDetailsFilter,
+            internal val tripFilter: TripDetailsFilter,
             val vehicle: Vehicle?,
         ) : State()
     }
@@ -309,10 +315,10 @@ class MapViewModel(
         return state
     }
 
-    override val models
+    override val models: StateFlow<State>
         get() = internalModels
 
-    override fun selectedStop(stop: Stop, stopFilter: StopDetailsFilter?) =
+    override fun selectedStop(stop: Stop, stopFilter: StopDetailsFilter?): Unit =
         fireEvent(Event.SelectedStop(stop, stopFilter))
 
     override fun selectedTrip(
@@ -320,14 +326,14 @@ class MapViewModel(
         stop: Stop?,
         tripFilter: TripDetailsFilter,
         vehicle: Vehicle?,
-    ) = fireEvent(Event.SelectedTrip(stop, stopFilter, tripFilter, vehicle))
+    ): Unit = fireEvent(Event.SelectedTrip(stop, stopFilter, tripFilter, vehicle))
 
-    override fun navChanged(currentNavEntry: SheetRoutes?) =
+    override fun navChanged(currentNavEntry: SheetRoutes?): Unit =
         fireEvent(Event.NavChanged(currentNavEntry))
 
-    override fun recenter(type: RecenterType) = fireEvent(Event.Recenter(type))
+    override fun recenter(type: RecenterType): Unit = fireEvent(Event.Recenter(type))
 
-    override fun alertsChanged(alerts: AlertsStreamDataResponse?) =
+    override fun alertsChanged(alerts: AlertsStreamDataResponse?): Unit =
         fireEvent(Event.AlertsChanged(alerts))
 
     // Route card data is sent through a separate StateFlow rather than the event flow because
@@ -336,17 +342,17 @@ class MapViewModel(
         routeCardDataUpdates.tryEmit(routeCardData)
     }
 
-    override fun colorPaletteChanged(isDarkMode: Boolean) =
+    override fun colorPaletteChanged(isDarkMode: Boolean): Unit =
         fireEvent(Event.ColorPaletteChanged(isDarkMode))
 
-    override fun densityChanged(density: Float) = fireEvent(Event.DensityChanged(density))
+    override fun densityChanged(density: Float): Unit = fireEvent(Event.DensityChanged(density))
 
-    override fun mapStyleLoaded() = fireEvent(Event.MapStyleLoaded)
+    override fun mapStyleLoaded(): Unit = fireEvent(Event.MapStyleLoaded)
 
-    override fun layerManagerInitialized(layerManager: IMapLayerManager) =
+    override fun layerManagerInitialized(layerManager: IMapLayerManager): Unit =
         fireEvent(Event.LayerManagerInitialized(layerManager))
 
-    override fun locationPermissionsChanged(hasPermission: Boolean) =
+    override fun locationPermissionsChanged(hasPermission: Boolean): Unit =
         fireEvent(Event.LocationPermissionsChanged(hasPermission))
 
     override fun setViewportManager(viewportManager: ViewportManager) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
-expect abstract class MoleculeScopeViewModel() {
-    val scope: CoroutineScope
+public expect abstract class MoleculeScopeViewModel() {
+    internal val scope: CoroutineScope
 }
 
 /**
@@ -21,7 +21,7 @@ expect abstract class MoleculeScopeViewModel() {
  * Implementers should reexpose `val models get() = internalModels` and provide wrappers for
  * `fireEvent` for the types of event that they offer.
  */
-abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel() {
+public abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel() {
     private val events =
         MutableSharedFlow<Event>(
             replay = 20,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
@@ -19,32 +19,33 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
 
-interface ISearchRoutesViewModel {
+public interface ISearchRoutesViewModel {
 
-    val models: StateFlow<SearchRoutesViewModel.State>
+    public val models: StateFlow<SearchRoutesViewModel.State>
 
-    fun setQuery(query: String)
+    public fun setQuery(query: String)
 }
 
-class SearchRoutesViewModel(
+public class SearchRoutesViewModel
+internal constructor(
     private val analytics: Analytics,
     private val globalRepository: IGlobalRepository,
     private val searchResultRepository: ISearchResultRepository,
 ) :
     MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>(),
     ISearchRoutesViewModel {
-    sealed interface Event {
-        data class SetQuery(val query: String) : Event
+    public sealed interface Event {
+        public data class SetQuery internal constructor(internal val query: String) : Event
     }
 
-    sealed class State {
-        data object Unfiltered : State()
+    public sealed class State {
+        public data object Unfiltered : State()
 
-        data class Results(val routeIds: List<String>) : State()
+        public data class Results(val routeIds: List<String>) : State()
 
-        data object Error : State()
+        public data object Error : State()
 
-        val isEmpty: Boolean
+        public val isEmpty: Boolean
             get() =
                 when (this) {
                     Unfiltered -> false
@@ -96,17 +97,18 @@ class SearchRoutesViewModel(
         return state
     }
 
-    override val models
+    override val models: StateFlow<State>
         get() = internalModels
 
-    override fun setQuery(query: String) = fireEvent(Event.SetQuery(query))
+    override fun setQuery(query: String): Unit = fireEvent(Event.SetQuery(query))
 }
 
-class MockSearchRoutesViewModel
+public class MockSearchRoutesViewModel
 @DefaultArgumentInterop.Enabled
 constructor(initialState: SearchRoutesViewModel.State) : ISearchRoutesViewModel {
-    var onSetQuery = { _: String -> }
-    override val models = MutableStateFlow(initialState)
+    internal var onSetQuery = { _: String -> }
+    override val models: MutableStateFlow<SearchRoutesViewModel.State> =
+        MutableStateFlow(initialState)
 
     override fun setQuery(query: String) {
         onSetQuery(query)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
@@ -62,37 +62,38 @@ private fun stopRouteContentDescription(
     }
 }
 
-interface ISearchViewModel {
+public interface ISearchViewModel {
 
-    val models: StateFlow<SearchViewModel.State>
+    public val models: StateFlow<SearchViewModel.State>
 
-    fun setQuery(query: String)
+    public fun setQuery(query: String)
 
-    fun refreshHistory()
+    public fun refreshHistory()
 }
 
-class SearchViewModel(
+public class SearchViewModel(
     private val analytics: Analytics,
     private val globalRepository: IGlobalRepository,
     private val searchResultRepository: ISearchResultRepository,
     private val visitHistoryUsecase: VisitHistoryUsecase,
 ) : MoleculeViewModel<SearchViewModel.Event, SearchViewModel.State>(), ISearchViewModel {
-    sealed interface Event {
-        data class SetQuery(val query: String) : Event
+    public sealed interface Event {
+        public data class SetQuery internal constructor(internal val query: String) : Event
 
-        data object RefreshHistory : Event
+        public data object RefreshHistory : Event
     }
 
-    sealed class State {
-        data object Loading : State()
+    public sealed class State {
+        public data object Loading : State()
 
-        data class RecentStops(val stops: List<StopResult>) : State()
+        public data class RecentStops(val stops: List<StopResult>) : State()
 
-        data class Results(val stops: List<StopResult>, val routes: List<RouteResult>) : State()
+        public data class Results(val stops: List<StopResult>, val routes: List<RouteResult>) :
+            State()
 
-        data object Error : State()
+        public data object Error : State()
 
-        fun isEmpty(includeRoutes: Boolean): Boolean =
+        public fun isEmpty(includeRoutes: Boolean): Boolean =
             when (this) {
                 Loading -> false
                 is RecentStops -> false
@@ -101,13 +102,13 @@ class SearchViewModel(
             }
     }
 
-    data class StopResult(
+    public data class StopResult(
         val id: String,
         val isStation: Boolean,
         val name: String,
         val routePills: List<RoutePillSpec>,
     ) {
-        companion object {
+        internal companion object {
             fun forStop(stopId: String, globalData: GlobalResponse?): StopResult? {
                 val stop = globalData?.getStop(stopId) ?: return null
                 val isStation = stop.locationType == LocationType.STATION
@@ -137,9 +138,9 @@ class SearchViewModel(
         }
     }
 
-    data class RouteResult(val id: String, val name: String, val routePill: RoutePillSpec) {
-        companion object {
-            fun forLineOrRoute(objectId: String, globalData: GlobalResponse?): RouteResult? {
+    public data class RouteResult(val id: String, val name: String, val routePill: RoutePillSpec) {
+        public companion object {
+            public fun forLineOrRoute(objectId: String, globalData: GlobalResponse?): RouteResult? {
                 val route = globalData?.getRoute(objectId)
                 val line = globalData?.getLine(objectId)
 
@@ -223,21 +224,21 @@ class SearchViewModel(
         return state
     }
 
-    override val models
+    override val models: StateFlow<State>
         get() = internalModels
 
-    override fun setQuery(query: String) = fireEvent(Event.SetQuery(query))
+    override fun setQuery(query: String): Unit = fireEvent(Event.SetQuery(query))
 
-    override fun refreshHistory() = fireEvent(Event.RefreshHistory)
+    override fun refreshHistory(): Unit = fireEvent(Event.RefreshHistory)
 }
 
-class MockSearchViewModel
+public class MockSearchViewModel
 @DefaultArgumentInterop.Enabled
 constructor(initialState: SearchViewModel.State = SearchViewModel.State.Loading) :
     ISearchViewModel {
-    var onSetQuery = { _: String -> }
-    var onRefreshHistory = {}
-    override val models = MutableStateFlow(initialState)
+    public var onSetQuery: (String) -> Unit = {}
+    internal var onRefreshHistory = {}
+    override val models: MutableStateFlow<SearchViewModel.State> = MutableStateFlow(initialState)
 
     override fun setQuery(query: String) {
         onSetQuery(query)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
@@ -10,52 +10,54 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.Serializable
 
-interface IToastViewModel {
-    val models: StateFlow<ToastViewModel.State>
+public interface IToastViewModel {
+    public val models: StateFlow<ToastViewModel.State>
 
-    fun hideToast()
+    public fun hideToast()
 
-    fun showToast(toast: Toast)
+    public fun showToast(toast: Toast)
 }
 
-class ToastViewModel : IToastViewModel, MoleculeViewModel<Event, ToastViewModel.State>() {
+public class ToastViewModel internal constructor() :
+    IToastViewModel, MoleculeViewModel<Event, ToastViewModel.State>() {
 
     /**
      * These are parallel to [androidx.compose.material3.SnackbarDuration], because the Jetpack
      * Compose Material 3 snackbar does not allow you to set a specific time, and no toast/snackbar
      * implementation exists in SwiftUI, so we might as well make the behavior match.
      */
-    enum class Duration {
+    public enum class Duration {
         Short,
         Long,
         Indefinite,
     }
 
     @Serializable
-    sealed class ToastAction {
-        @Serializable data class Close(val onClose: (() -> Unit)) : ToastAction()
+    public sealed class ToastAction {
+        @Serializable public data class Close(val onClose: (() -> Unit)) : ToastAction()
 
         @Serializable
-        data class Custom(val actionLabel: String, val onAction: (() -> Unit)) : ToastAction()
+        public data class Custom(val actionLabel: String, val onAction: (() -> Unit)) :
+            ToastAction()
     }
 
     @Serializable
-    data class Toast(
+    public data class Toast(
         val message: String,
         val duration: Duration = Duration.Indefinite,
         val action: ToastAction? = null,
     )
 
-    sealed interface Event {
-        data object Hide : Event
+    public sealed interface Event {
+        public data object Hide : Event
 
-        data class ShowToast(val toast: Toast) : Event
+        public data class ShowToast internal constructor(internal val toast: Toast) : Event
     }
 
-    sealed class State {
-        data object Hidden : State()
+    public sealed class State {
+        public data object Hidden : State()
 
-        data class Visible(val toast: Toast) : State()
+        public data class Visible(val toast: Toast) : State()
     }
 
     @Composable
@@ -72,23 +74,23 @@ class ToastViewModel : IToastViewModel, MoleculeViewModel<Event, ToastViewModel.
             .value
     }
 
-    override val models
+    override val models: StateFlow<State>
         get() = internalModels
 
-    override fun hideToast() = fireEvent(Event.Hide)
+    override fun hideToast(): Unit = fireEvent(Event.Hide)
 
-    override fun showToast(toast: Toast) = fireEvent(Event.ShowToast(toast))
+    override fun showToast(toast: Toast): Unit = fireEvent(Event.ShowToast(toast))
 }
 
-class MockToastViewModel
+public class MockToastViewModel
 @DefaultArgumentInterop.Enabled
 constructor(initialState: ToastViewModel.State = ToastViewModel.State.Hidden) : IToastViewModel {
-    override val models = MutableStateFlow(initialState)
+    override val models: MutableStateFlow<ToastViewModel.State> = MutableStateFlow(initialState)
 
-    var onHideToast = {}
-    var onShowToast = { _: Toast -> }
+    public var onHideToast: () -> Unit = {}
+    public var onShowToast: (Toast) -> Unit = { _: Toast -> }
 
-    override fun hideToast() = onHideToast()
+    override fun hideToast(): Unit = onHideToast()
 
-    override fun showToast(toast: Toast) = onShowToast(toast)
+    override fun showToast(toast: Toast): Unit = onShowToast(toast)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
@@ -8,7 +8,7 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
  * `errorBannerRepo` and calls `onSuccess`. If `getData` returns an `ApiResultError` or throws, sets
  * an error in `errorKey` in `errorBannerRepo` with the given `onRefreshAfterError`.
  */
-suspend fun <T : Any> fetchApi(
+internal suspend fun <T : Any> fetchApi(
     errorBannerRepo: IErrorBannerStateRepository,
     errorKey: String,
     getData: suspend () -> ApiResult<T>,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
@@ -35,7 +35,7 @@ private fun fetchGlobalData(
 }
 
 @Composable
-fun getGlobalData(
+internal fun getGlobalData(
     errorKey: String,
     globalRepository: IGlobalRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -43,7 +43,7 @@ private fun fetchSchedules(
 }
 
 @Composable
-fun getSchedules(
+internal fun getSchedules(
     stopIds: List<String>?,
     errorKey: String,
     schedulesRepository: ISchedulesRepository = koinInject(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -17,7 +17,7 @@ import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import org.koin.compose.koinInject
 
 @Composable
-fun subscribeToPredictions(
+internal fun subscribeToPredictions(
     stopIds: List<String>?,
     active: Boolean,
     onAnyMessageReceived: () -> Unit = {},

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
@@ -2,4 +2,4 @@ package com.mbta.tid.mbta_app.viewModel
 
 import org.koin.core.module.Module
 
-expect fun viewModelModule(): Module
+public expect fun viewModelModule(): Module

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/style/ExpEval.kt
@@ -337,19 +337,22 @@ private data class EvaluationContext(
 }
 
 @JvmName("evaluateBoolean")
-fun Exp<Boolean>.evaluate(featureProperties: FeatureProperties, zoom: Double): Boolean {
+internal fun Exp<Boolean>.evaluate(featureProperties: FeatureProperties, zoom: Double): Boolean {
     val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
     return result.jsonPrimitive.boolean
 }
 
 @JvmName("evaluateResolvedImage")
-fun Exp<ResolvedImage>.evaluate(featureProperties: FeatureProperties, zoom: Double): String {
+internal fun Exp<ResolvedImage>.evaluate(
+    featureProperties: FeatureProperties,
+    zoom: Double,
+): String {
     val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
     return result.jsonPrimitive.content
 }
 
 @JvmName("evaluateString")
-fun Exp<String>.evaluate(featureProperties: FeatureProperties, zoom: Double): String {
+internal fun Exp<String>.evaluate(featureProperties: FeatureProperties, zoom: Double): String {
     val result = EvaluationContext(featureProperties, zoom).evaluate(this.asJson())
     return result.jsonPrimitive.content
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalMapDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalMapDataTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class GlobalMapDataTest {
+internal class GlobalMapDataTest {
 
     fun createData(): Pair<ObjectCollectionBuilder, GlobalResponse> {
         val objects = ObjectCollectionBuilder()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
@@ -6,7 +6,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class RoutePatternTest {
+internal class RoutePatternTest {
 
     val objects = ObjectCollectionBuilder()
     val stop1 = objects.stop {}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 
-class NearbyRepositoryTest {
+internal class NearbyRepositoryTest {
     val searchPoint = Position(latitude = 42.3513706803105, longitude = -71.06649626809957)
 
     @OptIn(ExperimentalTurfApi::class)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -15,7 +15,7 @@ import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 
-class SettingsRepositoryTest : KoinTest {
+internal class SettingsRepositoryTest : KoinTest {
     val defaultSettings = Settings.entries.associateWith { false }
 
     @AfterTest

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -48,7 +48,7 @@ import org.koin.dsl.module
 import org.koin.test.KoinTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FavoritesViewModelTest : KoinTest {
+internal class FavoritesViewModelTest : KoinTest {
     val objects = ObjectCollectionBuilder()
     val stop1 =
         objects.stop {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FlowUtils.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FlowUtils.kt
@@ -13,8 +13,9 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 /** Gets a state flow from a [MoleculeViewModel] in the context of a [TestScope] from `runTest`. */
-fun <Event, Model> TestScope.testViewModelFlow(viewModel: MoleculeViewModel<Event, Model>) =
-    viewModel.modelsForUnitTests(this, TestFrameClock(this.testScheduler))
+internal fun <Event, Model> TestScope.testViewModelFlow(
+    viewModel: MoleculeViewModel<Event, Model>
+) = viewModel.modelsForUnitTests(this, TestFrameClock(this.testScheduler))
 
 private class TestFrameClock(private val scheduler: TestCoroutineScheduler) : MonotonicFrameClock {
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -40,7 +40,7 @@ import org.koin.dsl.module
 import org.koin.test.KoinTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MapViewModelTests : KoinTest {
+internal class MapViewModelTests : KoinTest {
 
     class MockViewportManager(
         private val saveNearbyTransitViewportCalled: () -> Unit = {},

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -51,7 +51,7 @@ internal fun createDataStore(): DataStore<Preferences> =
         }
     )
 
-fun initKoin(appVariant: AppVariant, nativeModule: Module) {
+public fun initKoin(appVariant: AppVariant, nativeModule: Module) {
     startKoin {
         modules(appModule(appVariant) + viewModelModule() + platformModule() + nativeModule)
     }
@@ -60,14 +60,14 @@ fun initKoin(appVariant: AppVariant, nativeModule: Module) {
 /*
 Load the Koin mock repositories and use cases, overriding their existing definitions
  */
-fun loadKoinMocks(repositories: IRepositories) {
+public fun loadKoinMocks(repositories: IRepositories) {
     loadKoinModules(listOf(repositoriesModule(repositories)))
 }
 
 /*
 Load the default Koin mock repositories and use cases, overriding their existing definitions
  */
-fun loadDefaultRepoModules() {
+public fun loadDefaultRepoModules() {
     loadKoinModules(repositoriesModule(MockRepositories()))
 }
 
@@ -76,7 +76,7 @@ Start koin with default mocks for all dependencies.
 Useful for IOS testing where we want to start koin once and
 subsequently load in specific modules to override these base definitions.
  */
-fun startKoinIOSTestApp() {
+public fun startKoinIOSTestApp() {
     startKoin {
         modules(
             platformModule() +
@@ -93,7 +93,7 @@ fun startKoinIOSTestApp() {
     loadDefaultRepoModules()
 }
 
-fun startKoinE2E() {
+public fun startKoinE2E() {
     startKoin {
         modules(
             endToEndModule() + viewModelModule() + module { single<Analytics> { MockAnalytics() } }
@@ -102,20 +102,29 @@ fun startKoinE2E() {
 }
 
 /** Converts an [NSDate] into an [EasternTimeInstant]. */
-fun NSDate.toEasternInstant(): EasternTimeInstant = EasternTimeInstant(this.toKotlinInstant())
+public fun NSDate.toEasternInstant(): EasternTimeInstant =
+    EasternTimeInstant(this.toKotlinInstant())
 
 /** Converts an [EasternTimeInstant] into an [NSDate]. Loses time zone information. */
-fun EasternTimeInstant.toNSDateLosingTimeZone(): NSDate =
+public fun EasternTimeInstant.toNSDateLosingTimeZone(): NSDate =
     NSDate.dateWithTimeIntervalSince1970(this.toEpochFracSeconds())
 
-@ObjCName("plus") fun EasternTimeInstant.plusSeconds(seconds: Int) = this + seconds.seconds
+@ObjCName("plus")
+public fun EasternTimeInstant.plusSeconds(seconds: Int): EasternTimeInstant = this + seconds.seconds
 
-@ObjCName("minus") fun EasternTimeInstant.minusSeconds(seconds: Int) = this - seconds.seconds
+@ObjCName("minus")
+public fun EasternTimeInstant.minusSeconds(seconds: Int): EasternTimeInstant =
+    this - seconds.seconds
 
-@ObjCName("plus") fun EasternTimeInstant.plusMinutes(minutes: Int) = this + minutes.minutes
+@ObjCName("plus")
+public fun EasternTimeInstant.plusMinutes(minutes: Int): EasternTimeInstant = this + minutes.minutes
 
-@ObjCName("minus") fun EasternTimeInstant.minusMinutes(minutes: Int) = this - minutes.minutes
+@ObjCName("minus")
+public fun EasternTimeInstant.minusMinutes(minutes: Int): EasternTimeInstant =
+    this - minutes.minutes
 
-@ObjCName("plus") fun EasternTimeInstant.plusHours(hours: Int) = this + hours.hours
+@ObjCName("plus")
+public fun EasternTimeInstant.plusHours(hours: Int): EasternTimeInstant = this + hours.hours
 
-@ObjCName("minus") fun EasternTimeInstant.minusHours(hours: Int) = this - hours.hours
+@ObjCName("minus")
+public fun EasternTimeInstant.minusHours(hours: Int): EasternTimeInstant = this - hours.hours

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Platform.ios.kt
@@ -5,13 +5,13 @@ import io.ktor.client.engine.darwin.Darwin
 import platform.Foundation.NSUUID
 import platform.UIKit.UIDevice
 
-class IOSPlatform : Platform {
+internal class IOSPlatform : Platform {
     override val name: String =
         UIDevice.currentDevice.systemName() + " " + UIDevice.currentDevice.systemVersion
     override val httpClientEngine: HttpClientEngine
         get() = Darwin.create()
 }
 
-actual fun getPlatform(): Platform = IOSPlatform()
+internal actual fun getPlatform(): Platform = IOSPlatform()
 
-actual fun uuid(): String = NSUUID().UUIDString()
+internal actual fun uuid(): String = NSUUID().UUIDString()

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
@@ -6,7 +6,7 @@ import com.mbta.tid.mbta_app.utils.IOSSystemPaths
 import com.mbta.tid.mbta_app.utils.SystemPaths
 import org.koin.dsl.module
 
-fun platformModule() = module {
+internal fun platformModule() = module {
     includes(
         module { single { createDataStore() } },
         module { single<SystemPaths> { IOSSystemPaths() } },

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/model/FeaturePromo.ios.kt
@@ -1,4 +1,4 @@
 package com.mbta.tid.mbta_app.model
 
-actual val FeaturePromo.addedInVersion
+internal actual val FeaturePromo.addedInVersion
     get() = addedInIosVersion

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/network/NetworkConnectivityMonitor.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.network
 import platform.Network.*
 import platform.darwin.dispatch_get_main_queue
 
-class NetworkConnectivityMonitor : INetworkConnectivityMonitor {
+internal class NetworkConnectivityMonitor : INetworkConnectivityMonitor {
     private val monitor = nw_path_monitor_create()
 
     override fun registerListener(onNetworkAvailable: () -> Unit, onNetworkLost: () -> Unit) {

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/repositories/AccessibilityStatusRepository.ios.kt
@@ -3,6 +3,6 @@ package com.mbta.tid.mbta_app.repositories
 import org.koin.core.component.KoinComponent
 import platform.UIKit.UIAccessibilityIsVoiceOverRunning
 
-class AccessibilityStatusRepository : IAccessibilityStatusRepository, KoinComponent {
-    override fun isScreenReaderEnabled() = UIAccessibilityIsVoiceOverRunning()
+public class AccessibilityStatusRepository : IAccessibilityStatusRepository, KoinComponent {
+    override fun isScreenReaderEnabled(): Boolean = UIAccessibilityIsVoiceOverRunning()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.ios.kt
@@ -11,7 +11,7 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
 
 @OptIn(ExperimentalForeignApi::class)
-class IOSSystemPaths() : SystemPaths {
+internal class IOSSystemPaths() : SystemPaths {
     override val data: Path
         get() =
             getURL(NSApplicationSupportDirectory)?.path()?.toPath()

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.ios.kt
@@ -4,6 +4,6 @@ import app.cash.molecule.DisplayLinkClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 
-actual abstract class MoleculeScopeViewModel actual constructor() {
-    actual val scope = CoroutineScope(MainScope().coroutineContext + DisplayLinkClock)
+public actual abstract class MoleculeScopeViewModel actual constructor() {
+    internal actual val scope = CoroutineScope(MainScope().coroutineContext + DisplayLinkClock)
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -4,10 +4,10 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 @Suppress("unused")
-class ViewModelDI : KoinComponent {
-    val favorites: FavoritesViewModel by inject()
-    val map: MapViewModel by inject()
-    val search: SearchViewModel by inject()
-    val searchRoutes: SearchRoutesViewModel by inject()
-    val toast: ToastViewModel by inject()
+public class ViewModelDI : KoinComponent {
+    public val favorites: FavoritesViewModel by inject()
+    public val map: MapViewModel by inject()
+    public val search: SearchViewModel by inject()
+    public val searchRoutes: SearchRoutesViewModel by inject()
+    public val toast: ToastViewModel by inject()
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -1,10 +1,11 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
-actual fun viewModelModule() = module {
+public actual fun viewModelModule(): Module = module {
     single {
         FavoritesViewModel(get(), get(), get(), get(named("coroutineDispatcherDefault")), get())
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Consider Kotlin explicit API mode to speed up shared build](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210966218618200?focus=true)

I still haven’t decided if this is a good idea, but starting to work on this at 4pm at the end of my week and then not wanting to sign off until I finished it was definitely not a good idea.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all the tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
