### PR TITLE
feat: Add line and route type filtering to route search

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
@@ -25,6 +25,7 @@ import com.mbta.tid.mbta_app.repositories.IdleGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
+import com.mbta.tid.mbta_app.viewModel.MockSearchRoutesViewModel
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
@@ -506,6 +507,39 @@ class RoutePickerViewTest {
         )
         composeTestRule.onNodeWithText(route1.longName).assertIsDisplayed()
         composeTestRule.onNodeWithText(route71.longName).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun testSetPathInVM() {
+        val objects = ObjectCollectionBuilder()
+
+        var setPath: RoutePickerPath? = null
+        val searchVM = MockSearchRoutesViewModel()
+        searchVM.onSetPath = { setPath = it }
+
+        val koin =
+            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+
+        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
+
+        composeTestRule.setContent {
+            KoinContext(koin.koin) {
+                RoutePickerView(
+                    path = RoutePickerPath.Bus,
+                    context = RouteDetailsContext.Favorites,
+                    onOpenPickerPath = { _, _ -> },
+                    onOpenRouteDetails = { _, _ -> },
+                    onRouteSearchExpandedChange = {},
+                    onBack = {},
+                    onClose = {},
+                    errorBannerViewModel = errorBannerVM,
+                    searchRoutesViewModel = searchVM,
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { setPath == RoutePickerPath.Bus }
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -44,6 +44,7 @@ import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath.Bus.routeType
+import com.mbta.tid.mbta_app.viewModel.ISearchRoutesViewModel
 import com.mbta.tid.mbta_app.viewModel.SearchRoutesViewModel
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
@@ -58,7 +59,7 @@ fun RoutePickerView(
     onBack: () -> Unit,
     onClose: () -> Unit,
     errorBannerViewModel: ErrorBannerViewModel,
-    searchRoutesViewModel: SearchRoutesViewModel = koinViewModel(),
+    searchRoutesViewModel: ISearchRoutesViewModel = koinViewModel(),
 ) {
     val globalData = getGlobalData("RoutePickerView.globalData")
     var searchInputState by rememberSaveable { mutableStateOf("") }
@@ -69,6 +70,7 @@ fun RoutePickerView(
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(searchInputState) { searchRoutesViewModel.setQuery(searchInputState) }
+    LaunchedEffect(path) { searchRoutesViewModel.setPath(path) }
 
     if (globalData == null) {
         CircularProgressIndicator(Modifier.semantics { contentDescription = "Loading" })

--- a/iosApp/iosApp/ComponentViews/SheetHeader.swift
+++ b/iosApp/iosApp/ComponentViews/SheetHeader.swift
@@ -43,6 +43,7 @@ struct SheetHeader<Content: View>: View {
         HStack(alignment: .center, spacing: 16) {
             if let onBack {
                 ActionButton(kind: .back, circleColor: buttonColor, iconColor: buttonTextColor, action: { onBack() })
+                    .simultaneousGesture(TapGesture())
             }
             if let title {
                 Text(title)
@@ -64,7 +65,7 @@ struct SheetHeader<Content: View>: View {
                         circleColor: buttonColor,
                         iconColor: buttonTextColor,
                         action: { onClose() }
-                    )
+                    ).simultaneousGesture(TapGesture())
                 }
             }
         }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -411,6 +411,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
                 .accessibilitySortPriority(selected ? 1 : 0)
                 .frame(minHeight: 44)
                 .background(rowColor)
+                .simultaneousGesture(TapGesture())
                 .withRoundedBorder(color: selected ? .halo : Color.clear)
             }
         }

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerRootRow.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerRootRow.swift
@@ -82,7 +82,7 @@ struct RoutePickerRootRow: View {
                 .background(routeColor)
                 .withRoundedBorder(width: 2)
             }
-        )
+        ).simultaneousGesture(TapGesture())
     }
 }
 

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
@@ -36,6 +36,6 @@ struct RoutePickerRow: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 12)
             }
-        )
+        ).simultaneousGesture(TapGesture())
     }
 }

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -107,7 +107,10 @@ struct RoutePickerView: View {
                 }
             }
         }
-        .onAppear { getGlobal() }
+        .onAppear {
+            getGlobal()
+            searchRoutesViewModel.setPath(path: path)
+        }
         .onChange(of: globalData) { globalData in
             routes = globalData?.getRoutesForPicker(path: path) ?? []
         }
@@ -115,6 +118,7 @@ struct RoutePickerView: View {
             withAnimation {
                 routes = globalData?.getRoutesForPicker(path: newPath) ?? []
             }
+            searchRoutesViewModel.setPath(path: newPath)
         }
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .task {
@@ -131,6 +135,8 @@ struct RoutePickerView: View {
         SheetHeader(
             title: headerTitle,
             titleColor: path.textColor,
+            buttonColor: Color.text.opacity(0.6),
+            buttonTextColor: Color.fill3,
             onBack: !(path is RoutePickerPath.Root) ? onBack : nil,
             rightActionContents: {
                 NavTextButton(

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -63,7 +63,11 @@ final class SearchResultViewTests: XCTestCase {
                 self.getSearchResultsExpectation = getSearchResultsExpectation
             }
 
-            func __getRouteFilterResults(query _: String) async throws -> ApiResult<SearchResults>? {
+            func __getRouteFilterResults(
+                query _: String,
+                lineIds _: [String]?,
+                routeTypes _: [RouteType]?
+            ) async throws -> ApiResult<SearchResults>? {
                 XCTFail("Route filter should not be queried")
                 return nil
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteType.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteType.kt
@@ -12,4 +12,7 @@ enum class RouteType {
     @SerialName("ferry") FERRY;
 
     fun isSubway(): Boolean = this === HEAVY_RAIL || this === LIGHT_RAIL
+
+    val serialName: String
+        get() = RouteType.serializer().descriptor.getElementName(this.ordinal)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SearchResultRepository.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.repositories
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.RouteResult
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.SearchResults
 import com.mbta.tid.mbta_app.model.StopResult
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -14,7 +15,11 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 interface ISearchResultRepository {
-    suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>?
+    suspend fun getRouteFilterResults(
+        query: String,
+        lineIds: List<String>? = null,
+        routeTypes: List<RouteType>? = null,
+    ): ApiResult<SearchResults>?
 
     suspend fun getSearchResults(query: String): ApiResult<SearchResults>?
 }
@@ -22,14 +27,16 @@ interface ISearchResultRepository {
 class SearchResultRepository : KoinComponent, ISearchResultRepository {
     private val mobileBackendClient: MobileBackendClient by inject()
 
-    private suspend fun searchRequest(endpoint: String, query: String): ApiResult<SearchResults>? {
-        if (query == "") return null
+    private suspend fun searchRequest(
+        endpoint: String,
+        params: Map<String, String>,
+    ): ApiResult<SearchResults>? {
         return ApiResult.runCatching {
             mobileBackendClient
                 .get {
                     url {
                         path(endpoint)
-                        parameters.append("query", query)
+                        params.forEach { (name, value) -> parameters.append(name, value) }
                     }
                 }
                 .body<SearchResponse>()
@@ -37,8 +44,22 @@ class SearchResultRepository : KoinComponent, ISearchResultRepository {
         }
     }
 
-    override suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>? =
-        searchRequest("api/search/routes", query)
+    private suspend fun searchRequest(endpoint: String, query: String): ApiResult<SearchResults>? {
+        if (query == "") return null
+        return searchRequest(endpoint, mapOf("query" to query))
+    }
+
+    override suspend fun getRouteFilterResults(
+        query: String,
+        lineIds: List<String>?,
+        routeTypes: List<RouteType>?,
+    ): ApiResult<SearchResults>? {
+        if (query == "") return null
+        val params = mutableMapOf("query" to query)
+        lineIds?.let { params.put("line_id", it.joinToString(",")) }
+        routeTypes?.let { params.put("type", it.joinToString(",") { type -> type.serialName }) }
+        return searchRequest("api/search/routes", params)
+    }
 
     override suspend fun getSearchResults(query: String): ApiResult<SearchResults>? =
         searchRequest("api/search/query", query)
@@ -52,7 +73,11 @@ constructor(
     private val onGetRouteFilterResults: () -> Unit = {},
     private val onGetSearchResults: () -> Unit = {},
 ) : ISearchResultRepository {
-    override suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults> {
+    override suspend fun getRouteFilterResults(
+        query: String,
+        lineIds: List<String>?,
+        routeTypes: List<RouteType>?,
+    ): ApiResult<SearchResults> {
         onGetRouteFilterResults()
         return ApiResult.Ok(SearchResults(routeResults, emptyList()))
     }
@@ -64,7 +89,11 @@ constructor(
 }
 
 class IdleSearchResultRepository : ISearchResultRepository {
-    override suspend fun getRouteFilterResults(query: String): ApiResult<SearchResults>? {
+    override suspend fun getRouteFilterResults(
+        query: String,
+        lineIds: List<String>?,
+        routeTypes: List<RouteType>?,
+    ): ApiResult<SearchResults>? {
         return suspendCancellableCoroutine {}
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
@@ -8,7 +8,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
+import com.mbta.tid.mbta_app.model.silverRoutes
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +26,8 @@ interface ISearchRoutesViewModel {
 
     val models: StateFlow<SearchRoutesViewModel.State>
 
+    fun setPath(path: RoutePickerPath)
+
     fun setQuery(query: String)
 }
 
@@ -34,6 +39,8 @@ class SearchRoutesViewModel(
     MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>(),
     ISearchRoutesViewModel {
     sealed interface Event {
+        data class SetPath(val path: RoutePickerPath) : Event
+
         data class SetQuery(val query: String) : Event
     }
 
@@ -55,30 +62,55 @@ class SearchRoutesViewModel(
 
     @Composable
     override fun runLogic(events: Flow<Event>): State {
+        var path: RoutePickerPath? by remember { mutableStateOf(null) }
         var query by remember { mutableStateOf("") }
+
         var state by remember { mutableStateOf<State>(State.Unfiltered) }
 
         LaunchedEffect(null) { globalRepository.getGlobalData() }
 
         LaunchedEffect(null) {
-            events.collect { event -> if (event is Event.SetQuery) query = event.query }
+            events.collect { event ->
+                when (event) {
+                    is Event.SetPath -> path = event.path
+                    is Event.SetQuery -> query = event.query
+                }
+            }
         }
+
+        LaunchedEffect(path) { setQuery("") }
 
         LaunchedEffect(query) {
             analytics.performedRouteFilter(query)
             if (query.isNotEmpty()) {
                 withContext(Dispatchers.IO) {
                     delay(500)
-                    when (val data = searchResultRepository.getRouteFilterResults(query)) {
+                    val params = getParamsForPath(path)
+                    when (
+                        val data =
+                            searchResultRepository.getRouteFilterResults(
+                                query,
+                                params.lineIds,
+                                params.routeTypes,
+                            )
+                    ) {
                         is ApiResult.Ok ->
                             state =
                                 State.Results(
-                                    data.data.routes.map {
-                                        when {
-                                            it.id == "Green" -> "line-Green"
-                                            else -> it.id
+                                    data.data.routes
+                                        .map {
+                                            when {
+                                                it.id == "Green" -> "line-Green"
+                                                else -> it.id
+                                            }
                                         }
-                                    }
+                                        .sortedBy {
+                                            when (path) {
+                                                is RoutePickerPath.Bus ->
+                                                    if (it in silverRoutes) 1 else 0
+                                                else -> 0
+                                            }
+                                        }
                                 )
                         is ApiResult.Error -> {
                             // Only set to error if there's a backend error code, otherwise this
@@ -99,16 +131,39 @@ class SearchRoutesViewModel(
     override val models
         get() = internalModels
 
+    override fun setPath(path: RoutePickerPath) = fireEvent(Event.SetPath(path))
+
     override fun setQuery(query: String) = fireEvent(Event.SetQuery(query))
+
+    companion object {
+        data class FilterParams(val lineIds: List<String>?, val routeTypes: List<RouteType>?)
+
+        fun getParamsForPath(path: RoutePickerPath?) =
+            when (path) {
+                RoutePickerPath.Bus -> FilterParams(null, listOf(RouteType.BUS))
+                RoutePickerPath.CommuterRail -> FilterParams(null, listOf(RouteType.COMMUTER_RAIL))
+                RoutePickerPath.Ferry -> FilterParams(null, listOf(RouteType.FERRY))
+                RoutePickerPath.Root,
+                null -> FilterParams(null, null)
+                RoutePickerPath.Silver ->
+                    FilterParams(
+                        listOf("line-SLWaterfront", "line-SLWashington"),
+                        listOf(RouteType.BUS),
+                    )
+            }
+    }
 }
 
 class MockSearchRoutesViewModel
 @DefaultArgumentInterop.Enabled
-constructor(initialState: SearchRoutesViewModel.State) : ISearchRoutesViewModel {
+constructor(initialState: SearchRoutesViewModel.State = SearchRoutesViewModel.State.Unfiltered) :
+    ISearchRoutesViewModel {
+    var onSetPath = { _: RoutePickerPath -> }
     var onSetQuery = { _: String -> }
+
     override val models = MutableStateFlow(initialState)
 
-    override fun setQuery(query: String) {
-        onSetQuery(query)
-    }
+    override fun setPath(path: RoutePickerPath) = onSetPath(path)
+
+    override fun setQuery(query: String) = onSetQuery(query)
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModelTest.kt
@@ -4,9 +4,11 @@ import app.cash.turbine.test
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteResult
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.SearchResults
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import kotlin.test.Test
@@ -30,7 +32,9 @@ class SearchRoutesViewModelTest {
                 MockGlobalRepository(GlobalResponse(objects)),
                 object : ISearchResultRepository {
                     override suspend fun getRouteFilterResults(
-                        query: String
+                        query: String,
+                        lineIds: List<String>?,
+                        routeTypes: List<RouteType>?,
                     ): ApiResult<SearchResults>? {
                         delay(10.milliseconds)
                         return ApiResult.Ok(searchResults)
@@ -51,6 +55,44 @@ class SearchRoutesViewModelTest {
     }
 
     @Test
+    fun testPathPassesFilterParams() = runTest {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { longName = "searchedRoute" }
+
+        val searchResults = SearchResults(routes = listOf(RouteResult(route)), stops = emptyList())
+        val expectedParams = SearchRoutesViewModel.getParamsForPath(RoutePickerPath.Silver)
+
+        val searchVM =
+            SearchRoutesViewModel(
+                MockAnalytics(),
+                MockGlobalRepository(GlobalResponse(objects)),
+                object : ISearchResultRepository {
+                    override suspend fun getRouteFilterResults(
+                        query: String,
+                        lineIds: List<String>?,
+                        routeTypes: List<RouteType>?,
+                    ): ApiResult<SearchResults>? {
+                        delay(10.milliseconds)
+                        assertEquals(expectedParams.lineIds, lineIds)
+                        assertEquals(expectedParams.routeTypes, routeTypes)
+                        return ApiResult.Ok(searchResults)
+                    }
+
+                    override suspend fun getSearchResults(query: String): ApiResult<SearchResults> {
+                        fail("Standard search should not be called here")
+                    }
+                },
+            )
+
+        testViewModelFlow(searchVM).test {
+            assertEquals(SearchRoutesViewModel.State.Unfiltered, awaitItem())
+            searchVM.setPath(RoutePickerPath.Silver)
+            searchVM.setQuery("query")
+            assertEquals(SearchRoutesViewModel.State.Results(listOf(route.id)), awaitItem())
+        }
+    }
+
+    @Test
     fun testError() = runTest {
         val objects = ObjectCollectionBuilder()
 
@@ -60,7 +102,9 @@ class SearchRoutesViewModelTest {
                 MockGlobalRepository(GlobalResponse(objects)),
                 object : ISearchResultRepository {
                     override suspend fun getRouteFilterResults(
-                        query: String
+                        query: String,
+                        lineIds: List<String>?,
+                        routeTypes: List<RouteType>?,
                     ): ApiResult<SearchResults>? {
                         delay(10.milliseconds)
                         return ApiResult.Error(code = 500, "Oops")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
@@ -73,7 +73,9 @@ class SearchViewModelTest {
                 MockGlobalRepository(GlobalResponse(objects)),
                 object : ISearchResultRepository {
                     override suspend fun getRouteFilterResults(
-                        query: String
+                        query: String,
+                        lineIds: List<String>?,
+                        routeTypes: List<RouteType>?,
                     ): ApiResult<SearchResults>? {
                         fail("Route search should not be called here")
                     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Favorites | Use algolia route facets](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210967667899893?focus=true)

Update the search filters in the route picker to specify line IDs and route types when making backend requests, so that they can be better filtered within Algolia, resulting in smaller payload sizes.

Also fixes a few scroll tap issues with the iOS route picker, and sorts SL results to the bottom of the filtered search results for bus (it was only sorted to the bottom in the unsorted list before this).

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for updated behavior, in shared and platform code