### PR TITLE
fix(ios.RoutePill): Scale down text at dynamic size when needed

### DIFF
--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -111,6 +111,7 @@ struct RoutePill: View {
             .font(.custom("Helvetica Neue", size: fontSize).bold())
             .tracking(0.5)
             .modifier(FramePaddingModifier(spec: spec))
+            .minimumScaleFactor(0.4)
             .lineLimit(1)
             .modifier(ColorModifier(pill: self))
             .modifier(ClipShapeModifier(spec: spec))


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Address UI QA - route pill size](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1211025684993054?focus=true)

What is this PR for?
Decreases the route pill size at larger text sizes to prevent cutoff! This ended up being easier than I hoped, thanks to the `minimumScaleFactor` modifier. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Ran locally, confirmed that the longest fixed route pill (62/76) can be read
* Confirmed search route pills can also be read
<img width="1170" height="2532" alt="IMG_0375" src="https://github.com/user-attachments/assets/c324b198-a2a6-467e-a338-bd6a259a9fad" /><img width="1170" height="2532" alt="IMG_0374" src="https://github.com/user-attachments/assets/ea02942c-a88b-4947-aca0-0b8ac0b008bb" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
