### PR TITLE
feat(Android): Set Sentry release version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'cocoapods'
 gem 'cyclonedx-cocoapods'
 gem 'fastlane'
 gem 'fastlane-plugin-sentry'
+gem 'fastlane-plugin-versioning_android'
 gem 'rubocop', require: false
 gem 'xcodeproj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-plugin-sentry (1.32.0)
       os (~> 1.1, >= 1.1.4)
+    fastlane-plugin-versioning_android (0.1.1)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     ffi (1.17.1)
@@ -342,6 +343,7 @@ DEPENDENCIES
   cyclonedx-cocoapods
   fastlane
   fastlane-plugin-sentry
+  fastlane-plugin-versioning_android
   rubocop
   xcodeproj
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,6 +61,20 @@ platform :android do
           'android.injected.version.code' => next_version_code
         }
       end
+    if options[:build_type] != 'Prod'
+      UI.message 'Skipped creating Android Sentry release because build is not prod'
+    elsif ENV['SENTRY_AUTH_TOKEN'].nil?
+      UI.important 'Skipped creating Android Sentry release because SENTRY_AUTH_TOKEN not set'
+    else
+      version_name = android_get_version_name(gradle_file: 'androidApp/build.gradle.kts')
+      sentry_create_release(
+        org_slug: 'mbtace',
+        project_slug: 'mobile_app_android',
+        version: "#{version_name}+#{next_version_code}",
+        app_identifier: 'com.mbta.tid.mbta_app',
+        finalize: false
+      )
+    end
     gradle(
       task: 'assemble',
       flavor: options[:flavor],


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Set up sentry releases](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210889278584728?focus=true)

Set sentry release version with Fastlane.

### Testing

Ran pipeline to build for dev orange without the check to skip creating versions on prod, and version was created successfully in Sentry with the proper version code.