### PR TITLE
fix: Reset scroll position when search results change

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -132,10 +132,6 @@ fun RoutePickerView(
                 searchInputFocused,
                 {
                     if (!it) {
-                        // Only reset the search result scroll position on clear if there is an
-                        // active search, to prevent autoscrolling an already unfiltered list
-                        if (searchInputState.isNotEmpty())
-                            scope.launch { routeScroll.animateScrollTo(0) }
                         searchInputState = ""
                     }
                     onRouteSearchExpandedChange(it)
@@ -183,6 +179,8 @@ fun RoutePickerView(
                             }
                         }
                     }
+
+                LaunchedEffect(displayedRoutes) { scope.launch { routeScroll.animateScrollTo(0) } }
                 if (displayedRoutes.isNotEmpty())
                     Column(
                         Modifier.padding(bottom = 14.dp)


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Address UI QA - Search](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211025684993052?focus=true)

What is this PR for?
This PR resets the scroll position for route search results when the results change. 

I looked into addressing the AC "don't drop the background when keyboard opens" for a bit, but didn't find a suitable workaround. It looks like this is the default behavior of a `TextField` in a sheet to accommodate the keyboard height. It is not respecting our system-defined max detent of the sheet which is surprising, and also makes it seems not worth too much effort to try and resolve.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally, searched & scrolled repeatedly to ensure scroll position reset

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
