### PR TITLE
fix(ios.CollapsableStopList): Less common stop font color

### DIFF
--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -48,7 +48,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                 stopListContext: .routeDetails,
                 connectingRoutes: stop.connectingRoutes,
                 stopPlacement: .init(isFirst: isFirstSegment, isLast: isLastSegment),
-                descriptor: { Text("Less common stop").font(Typography.footnote) },
+                descriptor: { Text("Less common stop").font(Typography.footnote).foregroundStyle(Color.text) },
                 rightSideContent: { rightSideContent(stop) }
             ).background(Color.fill1)
                 .onReceive(inspection.notice) { inspection.visit(self, $0) }


### PR DESCRIPTION
### Summary

No ticket, found while looking at different routes for https://github.com/mbta/mobile_app_backend/pull/359

What is this PR for?
Updates the "Less common stop" font color to match designs

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
Ran locally & confirmed text is no longer blue
<img width="1170" height="2532" alt="IMG_0386" src="https://github.com/user-attachments/assets/14d62689-d73d-4008-8877-b0362379511a" />

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
