### PR TITLE
fix(ios.RouteCardDepartures): tapped_departure event correctly records if isFavorite

### DIFF
--- a/iosApp/iosApp/ComponentViews/RouteCard/LoadingRouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/LoadingRouteCard.swift
@@ -17,6 +17,7 @@ struct LoadingRouteCard: View {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         )

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCard.swift
@@ -63,6 +63,7 @@ struct RouteCard: View {
     let now: EasternTimeInstant
     let onPin: (String) -> Void
     let pinned: Bool
+    let isFavorite: (RouteStopDirection) -> Bool
     let pushNavEntry: (SheetNavigationStackEntry) -> Void
     let showStopHeader: Bool
 
@@ -81,7 +82,7 @@ struct RouteCard: View {
                 stopData: stopData,
                 global: global,
                 now: now,
-                pinned: pinned,
+                isFavorite: isFavorite,
                 pushNavEntry: pushNavEntry
             )
         }
@@ -95,6 +96,7 @@ private func cardForPreview(_ card: RouteCardData, _ previewData: RouteCardPrevi
         now: previewData.now,
         onPin: { _ in },
         pinned: false,
+        isFavorite: { _ in false },
         pushNavEntry: { _ in },
         showStopHeader: true
     )

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDepartures.swift
@@ -14,7 +14,7 @@ struct RouteCardDepartures: View {
     let stopData: RouteCardData.RouteStopData
     let global: GlobalResponse?
     let now: EasternTimeInstant
-    let pinned: Bool
+    let isFavorite: (RouteStopDirection) -> Bool
     let pushNavEntry: (SheetNavigationStackEntry) -> Void
 
     var body: some View {
@@ -66,7 +66,9 @@ struct RouteCardDepartures: View {
         analytics.tappedDeparture(
             routeId: stopData.lineOrRoute.id,
             stopId: stopData.stop.id,
-            pinned: pinned,
+            pinned: isFavorite(RouteStopDirection(route: stopData.lineOrRoute.id,
+                                                  stop: stopData.stop.id,
+                                                  direction: leaf.directionId)),
             alert: leaf.alertsHere(tripId: nil).count > 0,
             routeType: stopData.lineOrRoute.type,
             noTrips: noTrips

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardList.swift
@@ -16,6 +16,7 @@ struct RouteCardList<EmptyView: View>: View {
     let now: Date
     let isPinned: (String) -> Bool
     let onPin: (String) -> Void
+    let isFavorite: (RouteStopDirection) -> Bool
     let pushNavEntry: (SheetNavigationStackEntry) -> Void
     let showStopHeader: Bool
 
@@ -30,6 +31,7 @@ struct RouteCardList<EmptyView: View>: View {
                             now: now.toEasternInstant(),
                             onPin: onPin,
                             pinned: isPinned(routeCardData.lineOrRoute.id),
+                            isFavorite: isFavorite,
                             pushNavEntry: pushNavEntry,
                             showStopHeader: showStopHeader
                         )

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -57,6 +57,7 @@ struct FavoritesView: View {
                 now: now,
                 isPinned: { _ in false },
                 onPin: { _ in },
+                isFavorite: { rsd in favoritesVMState.favorites?.contains(where: { rsd == $0 }) ?? false },
                 pushNavEntry: { nearbyVM.pushNavEntry($0) },
                 showStopHeader: true
             )

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
@@ -59,6 +59,9 @@ struct NearbyTransitPage: View {
                 .onReceive(inspection.notice) { inspection.visit(self, $0) }
             }
             .toolbarBackground(.visible, for: .tabBar)
+            .onAppear {
+                nearbyVM.loadFavorites()
+            }
             .onChange(of: viewportProvider.isManuallyCentering) { isManuallyCentering in
                 if isManuallyCentering {
                     // The user is manually moving the map, clear the nearby state and

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -143,6 +143,9 @@ struct NearbyTransitView: View {
                                 now: now.toEasternInstant(),
                                 onPin: { id in toggledPinnedRoute(id) },
                                 pinned: pinnedRoutes.contains(cardData.lineOrRoute.id),
+                                isFavorite: { rsd in
+                                    nearbyVM.favorites.routeStopDirection?.contains(where: { rsd == $0 }) ?? false
+                                },
                                 pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                                 showStopHeader: true
                             )
@@ -170,6 +173,7 @@ struct NearbyTransitView: View {
                         now: now.toEasternInstant(),
                         onPin: { _ in },
                         pinned: false,
+                        isFavorite: { _ in false },
                         pushNavEntry: { _ in },
                         showStopHeader: true
                     )

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -154,6 +154,10 @@ struct StopDetailsUnfilteredView: View {
                                             .Pinned(routeId: routeCardData.lineOrRoute.id),
                                             enhancedFavorites: false
                                         ),
+                                        isFavorite: { rsd in stopDetailsVM.isFavorite(
+                                            .Favorite(routeStopDirection: rsd),
+                                            enhancedFavorites: true
+                                        ) },
                                         pushNavEntry: { entry in nearbyVM.pushNavEntry(entry) },
                                         showStopHeader: false
                                     )
@@ -181,6 +185,7 @@ struct StopDetailsUnfilteredView: View {
                     now: now,
                     onPin: { _ in },
                     pinned: false,
+                    isFavorite: { _ in false },
                     pushNavEntry: { _ in },
                     showStopHeader: false
                 )

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -36,6 +36,7 @@ class NearbyViewModel: ObservableObject {
     }
 
     @Published var alerts: AlertsStreamDataResponse?
+    @Published var favorites: Favorites = .init(routeStopDirection: [])
     @Published var nearbyState = NearbyTransitState()
     @Published var routeCardData: [RouteCardData]?
 
@@ -45,6 +46,7 @@ class NearbyViewModel: ObservableObject {
 
     private let alertsUsecase: AlertsUsecase
     private let errorBannerRepository: IErrorBannerStateRepository
+    private let favoritesRepository: IFavoritesRepository
     private let nearbyRepository: INearbyRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
     private var fetchNearbyTask: Task<Void, Never>?
@@ -55,6 +57,7 @@ class NearbyViewModel: ObservableObject {
         navigationStack: [SheetNavigationStackEntry] = [],
         alertsUsecase: AlertsUsecase = UsecaseDI().alertsUsecase,
         errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner,
+        favoritesRepository: IFavoritesRepository = RepositoryDI().favorites,
         nearbyRepository: INearbyRepository = RepositoryDI().nearby,
         visitHistoryUsecase: VisitHistoryUsecase = UsecaseDI().visitHistoryUsecase,
         analytics: Analytics = AnalyticsProvider.shared
@@ -64,6 +67,7 @@ class NearbyViewModel: ObservableObject {
 
         self.alertsUsecase = alertsUsecase
         self.errorBannerRepository = errorBannerRepository
+        self.favoritesRepository = favoritesRepository
         self.nearbyRepository = nearbyRepository
         self.visitHistoryUsecase = visitHistoryUsecase
         self.analytics = analytics
@@ -201,6 +205,20 @@ class NearbyViewModel: ObservableObject {
             nearbyState.loadedLocation = location
             nearbyState.loading = false
             isTargeting = false
+        }
+    }
+
+    func loadFavorites() {
+        Task {
+            do {
+                let nextFavorites = try await favoritesRepository.getFavorites()
+                Task { @MainActor in self.favorites = nextFavorites }
+            } catch is CancellationError {
+                // do nothing on cancellation
+            } catch {
+                // getFavorites shouldn't actually fail
+                debugPrint(error)
+            }
         }
     }
 

--- a/iosApp/iosAppTests/Views/RouteCardTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardTests.swift
@@ -33,6 +33,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([:])
@@ -63,6 +64,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([:])
@@ -89,6 +91,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([.enhancedFavorites: true])
@@ -124,6 +127,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([:])
@@ -144,6 +148,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: false
         ).withFixedSettings([:])
@@ -183,6 +188,7 @@ final class RouteCardTests: XCTestCase {
             now: EasternTimeInstant.now(),
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([:])
@@ -198,6 +204,7 @@ final class RouteCardTests: XCTestCase {
             now: data.now,
             onPin: { _ in },
             pinned: false,
+            isFavorite: { _ in false },
             pushNavEntry: { _ in },
             showStopHeader: true
         ).withFixedSettings([:])


### PR DESCRIPTION
### Summary

What is this PR for?

No ticket, found while working on [Favorites | Clean up old favorites flows](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210767320164832?focus=true).

On android the [RouteCard uses FavoritesBridge ](https://github.com/mbta/mobile_app/blob/481f807e8acace88556ad003d25d32cf44748f7d/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt#L66)so that tapped_departure can set the value for `pinned` whether a favorite is old or new, but on iOS it only looked for the old version of pinned. Since I'm doing away with FavoritesBridge anyway in my next PR, opting to just use `isFavorite(RouteStopDirection)`. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~ - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added a unit test
* Added logging for tappedDeparture analytics event and confirmed `pinned` was set as expected from nearby, stop details, and favorites tabs. It seemed trickier to test that directly.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
