### PR TITLE
feat: Fix a11y QA issues

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SheetHeader.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextLayoutResult
@@ -41,6 +42,7 @@ fun Float.toDp(context: Context): Dp = (this / context.resources.displayMetrics.
 fun SheetHeader(
     modifier: Modifier = Modifier,
     title: String? = null,
+    titleContentDescription: String? = null,
     titleColor: Color = colorResource(R.color.text),
     closeText: String? = null,
     onBack: (() -> Unit)? = null,
@@ -92,7 +94,10 @@ fun SheetHeader(
                 title,
                 color = titleColor,
                 modifier =
-                    Modifier.semantics { heading() }
+                    Modifier.semantics {
+                            heading()
+                            contentDescription = titleContentDescription ?: title
+                        }
                         .padding(top = textPadding)
                         .padding(start = if (onBack == null) 8.dp else 0.dp)
                         .weight(1f)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -103,9 +103,9 @@ fun StopListRow(
             }
             Row(
                 Modifier.fillMaxHeight()
-                    .padding(start = 8.dp)
                     .semantics(mergeDescendants = true) {}
-                    .clickable(onClickLabel = onClickLabel) { onClick() },
+                    .clickable(onClickLabel = onClickLabel) { onClick() }
+                    .padding(start = 8.dp),
                 horizontalArrangement = Arrangement.spacedBy(0.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingPieces.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingPieces.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
@@ -45,10 +46,17 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 
 object OnboardingPieces {
+    sealed class Context {
+        data object Onboarding : Context()
+
+        data object Promo : Context()
+    }
+
     @Composable
     fun PageDescription(
         @StringRes headerId: Int,
         @StringRes bodyId: Int,
+        context: Context,
         modifier: Modifier = Modifier,
     ) {
         val pane = stringResource(headerId)
@@ -59,9 +67,20 @@ object OnboardingPieces {
             modifier.semantics { paneTitle = pane },
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
+            val headerDescription =
+                if (context == Context.Promo)
+                    stringResource(
+                        R.string.new_feature_screen_reader_header_prefix,
+                        stringResource(headerId),
+                    )
+                else stringResource(headerId)
             Text(
                 stringResource(headerId),
-                modifier = Modifier.semantics { heading() },
+                modifier =
+                    Modifier.semantics {
+                        contentDescription = headerDescription
+                        heading()
+                    },
                 style = Typography.title1Bold,
             )
             Text(AnnotatedString.fromHtml(stringResource(bodyId)), style = Typography.title3)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -116,6 +116,7 @@ fun OnboardingScreenView(
                     OnboardingPieces.PageDescription(
                         R.string.onboarding_feedback_header,
                         R.string.onboarding_feedback_body,
+                        OnboardingPieces.Context.Onboarding,
                     )
                     Spacer(modifier = Modifier.height(16.dp))
                     OnboardingPieces.KeyButton(
@@ -131,6 +132,7 @@ fun OnboardingScreenView(
                 OnboardingPieces.PageDescription(
                     R.string.onboarding_map_display_header,
                     R.string.onboarding_map_display_body,
+                    OnboardingPieces.Context.Onboarding,
                     Modifier.align(Alignment.Center)
                         .padding(horizontal = 32.dp)
                         .background(colorResource(R.color.fill2), shape = RoundedCornerShape(32.dp))
@@ -166,6 +168,7 @@ fun OnboardingScreenView(
                     OnboardingPieces.PageDescription(
                         R.string.onboarding_location_header,
                         R.string.onboarding_location_body,
+                        OnboardingPieces.Context.Onboarding,
                     )
                     OnboardingPieces.KeyButton(
                         R.string.onboarding_continue,
@@ -193,6 +196,7 @@ fun OnboardingScreenView(
                     OnboardingPieces.PageDescription(
                         R.string.onboarding_station_accessibility_header,
                         R.string.onboarding_station_accessibility_body,
+                        OnboardingPieces.Context.Onboarding,
                     )
 
                     val stationAccessibility = settingsCache.get(Settings.StationAccessibility)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/promo/PromoScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/promo/PromoScreenView.kt
@@ -44,6 +44,7 @@ fun EnhancedFavorites(textScale: Float, onAdvance: () -> Unit) {
             OnboardingPieces.PageDescription(
                 R.string.promo_favorites_header,
                 R.string.promo_favorites_body,
+                OnboardingPieces.Context.Promo,
             )
             Spacer(modifier = Modifier.height(16.dp))
             OnboardingPieces.KeyButton(R.string.got_it, onClick = onAdvance)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,6 +56,7 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.android.util.label
 import com.mbta.tid.mbta_app.android.util.manageFavorites
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
@@ -318,6 +320,7 @@ fun RouteStopListView(
     Column {
         SheetHeader(
             title = lineOrRoute.name,
+            titleContentDescription = lineOrRoute.label(LocalContext.current),
             titleColor = Color.fromHex(lineOrRoute.textColor),
             closeText =
                 if (context is RouteDetailsContext.Favorites) stringResource(R.string.done)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -56,7 +56,7 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.fromHex
-import com.mbta.tid.mbta_app.android.util.label
+import com.mbta.tid.mbta_app.android.util.labelWithModeIfBus
 import com.mbta.tid.mbta_app.android.util.manageFavorites
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
@@ -320,7 +320,7 @@ fun RouteStopListView(
     Column {
         SheetHeader(
             title = lineOrRoute.name,
-            titleContentDescription = lineOrRoute.label(LocalContext.current),
+            titleContentDescription = lineOrRoute.labelWithModeIfBus(LocalContext.current),
             titleColor = Color.fromHex(lineOrRoute.textColor),
             closeText =
                 if (context is RouteDetailsContext.Favorites) stringResource(R.string.done)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRow.kt
@@ -14,11 +14,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
 
 @Composable
 fun RoutePickerRow(route: RouteCardData.LineOrRoute, onTap: () -> Unit) {
@@ -32,7 +34,10 @@ fun RoutePickerRow(route: RouteCardData.LineOrRoute, onTap: () -> Unit) {
             Arrangement.spacedBy(8.dp),
             Alignment.CenterVertically,
         ) {
-            RoutePill(route.sortRoute, type = RoutePillType.Fixed)
+            // Route pill TalkBack text is redundant except for bus
+            Row(if (route.type != RouteType.BUS) Modifier.clearAndSetSemantics {} else Modifier) {
+                RoutePill(route.sortRoute, type = RoutePillType.Fixed)
+            }
             Text(route.sortRoute.longName)
         }
         Image(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
@@ -5,5 +5,5 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 
-fun RouteCardData.LineOrRoute.label(context: Context): String =
+fun RouteCardData.LineOrRoute.labelWithModeIfBus(context: Context): String =
     if (this.type == RouteType.BUS) context.getString(R.string.bus_label, this.name) else this.name

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.android.util
+
+import android.content.Context
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
+
+fun RouteCardData.LineOrRoute.label(context: Context): String =
+    if (this.type == RouteType.BUS) context.getString(R.string.bus_label, this.name) else this.name

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/RouteStopDirectionExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/RouteStopDirectionExtension.kt
@@ -1,11 +1,9 @@
 package com.mbta.tid.mbta_app.android.util
 
 import android.content.Context
-import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.directionNameFormatted
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.RouteStopDirection
-import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 
 data class RouteStopDirectionLabels(val route: String, val stop: String, val direction: String)
@@ -19,10 +17,7 @@ fun RouteStopDirection.getLabels(
 
     if (lineOrRoute == null || stop == null) return null
 
-    val routeLabel =
-        if (lineOrRoute.type == RouteType.BUS)
-            context.getString(R.string.bus_label, lineOrRoute.name)
-        else lineOrRoute.name
+    val routeLabel = lineOrRoute.label(context)
 
     val directionLabel =
         context.getString(directionNameFormatted(Direction(this.direction, lineOrRoute.sortRoute)))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/RouteStopDirectionExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/RouteStopDirectionExtension.kt
@@ -17,7 +17,7 @@ fun RouteStopDirection.getLabels(
 
     if (lineOrRoute == null || stop == null) return null
 
-    val routeLabel = lineOrRoute.label(context)
+    val routeLabel = lineOrRoute.labelWithModeIfBus(context)
 
     val directionLabel =
         context.getString(directionNameFormatted(Direction(this.direction, lineOrRoute.sortRoute)))

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -218,6 +218,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Tránsito cercano</string>
     <string name="nearby_transit_link">Cerca</string>
+    <string name="new_feature_screen_reader_header_prefix">Nueva función. %1$s</string>
     <string name="next_stop">Próxima parada</string>
     <string name="no_matching_routes">No hay rutas %1$s coincidentes</string>
     <string name="no_predictions">Las predicciones no están disponibles</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -218,6 +218,7 @@
     <string name="more_title">MTBA Go</string>
     <string name="nearby_transit">Transports à proximité</string>
     <string name="nearby_transit_link">Proche</string>
+    <string name="new_feature_screen_reader_header_prefix">Nouvelle fonctionnalité. %1$s</string>
     <string name="next_stop">Prochain arrêt</string>
     <string name="no_matching_routes">Aucune correspondance de routes de %1$s</string>
     <string name="no_predictions">Les prévisions ne sont pas encore disponibles</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -227,6 +227,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Transpò piblik ki toupre</string>
     <string name="nearby_transit_link">Toupre</string>
+    <string name="new_feature_screen_reader_header_prefix">Nouvo karakteristik. %1$s</string>
     <string name="next_stop">Pwochen arè</string>
     <string name="no_matching_routes">Pa gen wout %1$ski matche</string>
     <string name="no_predictions">Pa gen prediksyon disponib</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -218,6 +218,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Trânsito próximo</string>
     <string name="nearby_transit_link">Próximo</string>
+    <string name="new_feature_screen_reader_header_prefix">Novo recurso. %1$s</string>
     <string name="next_stop">Próxima parada</string>
     <string name="no_matching_routes">Não há correspondência %1$s nas rotas</string>
     <string name="no_predictions">Previsões indisponíveis</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -212,6 +212,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Phương tiện công cộng ở gần</string>
     <string name="nearby_transit_link">Ở gần</string>
+    <string name="new_feature_screen_reader_header_prefix">Tính năng mới. %1$s</string>
     <string name="next_stop">Điểm dừng tiếp theo</string>
     <string name="no_matching_routes">Không có tuyến đường %1$s nào phù hợp</string>
     <string name="no_predictions">Dự đoán không có sẵn</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -212,6 +212,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
+    <string name="new_feature_screen_reader_header_prefix">新功能。%1$s</string>
     <string name="next_stop">下一站</string>
     <string name="no_matching_routes">没有匹配的%1$s路线</string>
     <string name="no_predictions">预测不可用</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -212,6 +212,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
+    <string name="new_feature_screen_reader_header_prefix">新功能。 %1$s</string>
     <string name="next_stop">下一站</string>
     <string name="no_matching_routes">沒有匹配的%1$s路線</string>
     <string name="no_predictions">預測不可用</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -217,6 +217,7 @@
     <string name="more_title">MBTA Go</string>
     <string name="nearby_transit">Nearby Transit</string>
     <string name="nearby_transit_link">Nearby</string>
+    <string name="new_feature_screen_reader_header_prefix">New feature. %1$s</string>
     <string name="next_stop">Next stop</string>
     <string name="no_matching_routes">No matching %1$s routes</string>
     <string name="no_predictions">Predictions unavailable</string>

--- a/iosApp/iosApp/ComponentViews/SheetHeader.swift
+++ b/iosApp/iosApp/ComponentViews/SheetHeader.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct SheetHeader<Content: View>: View {
     let title: String?
+    let titleAccessibilityLabel: String?
     let titleColor: Color
     let buttonColor: Color
     let buttonTextColor: Color
@@ -21,6 +22,7 @@ struct SheetHeader<Content: View>: View {
 
     init(
         title: String?,
+        titleAccessibilityLabel: String? = nil,
         titleColor: Color = Color.text,
         buttonColor: Color = Color.contrast,
         buttonTextColor: Color = Color.fill2,
@@ -30,6 +32,7 @@ struct SheetHeader<Content: View>: View {
         @ViewBuilder rightActionContents: @escaping () -> Content = { EmptyView() }
     ) {
         self.title = title
+        self.titleAccessibilityLabel = titleAccessibilityLabel
         self.titleColor = titleColor
         self.buttonColor = buttonColor
         self.buttonTextColor = buttonTextColor
@@ -46,8 +49,14 @@ struct SheetHeader<Content: View>: View {
                     .preventScrollTaps()
             }
             if let title {
+                let accessibilityLabel = if let titleAccessibilityLabel {
+                    titleAccessibilityLabel
+                } else {
+                    title
+                }
                 Text(title)
                     .font(Typography.title2Bold)
+                    .accessibilityLabel(accessibilityLabel)
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h1)
                     .foregroundColor(titleColor)

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -120,16 +120,16 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
 
     @ViewBuilder
     var stopRow: some View {
-        ZStack(alignment: .bottom) {
-            if !stopPlacement.isLast, !targeted, disruption == nil {
-                HaloSeparator()
-            }
-            HStack(alignment: .center, spacing: 0) {
-                routeLine
-                VStack(alignment: .leading, spacing: 8) {
-                    Button(
-                        action: { onClick() },
-                        label: {
+        Button(
+            action: { onClick() },
+            label: {
+                ZStack(alignment: .bottom) {
+                    if !stopPlacement.isLast, !targeted, disruption == nil {
+                        HaloSeparator()
+                    }
+                    HStack(alignment: .center, spacing: 0) {
+                        routeLine
+                        VStack(alignment: .leading, spacing: 8) {
                             HStack(alignment: .center, spacing: 0) {
                                 if showStationAccessibility, activeElevatorAlerts > 0 || !stop.isWheelchairAccessible {
                                     HStack(alignment: .center) {
@@ -158,6 +158,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                                             .accessibilityLabel(Text("Boarding on track \(trackNumber)"))
                                     }
                                 }
+
                                 Spacer()
                                 rightSideContent()
 
@@ -173,29 +174,23 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                                     HStack {}
                                         .accessibilityLabel(Text("This stop is not accessible"))
                                 }
+                            }.padding(.trailing, 8)
+                            if let connectingRoutes, !connectingRoutes.isEmpty {
+                                scrollRoutes
+                                    .accessibilityElement()
+                                    .accessibilityLabel(scrollRoutesAccessibilityLabel)
                             }
-                        }
-                    )
-                    .preventScrollTaps()
+                        }.padding(.vertical, 12)
+                    }
                     .accessibilityElement(children: .combine)
-                    .accessibilityInputLabels([stop.name])
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityHeading(.h4)
-
-                    if let connectingRoutes, !connectingRoutes.isEmpty {
-                        scrollRoutes
-                            .accessibilityElement()
-                            .accessibilityLabel(scrollRoutesAccessibilityLabel)
-                    }
+                    .accessibilityInputLabels([stop.name])
                 }
-                .accessibilitySortPriority(1)
-                .padding(.leading, 8)
-                .padding(.vertical, 12)
-                .padding(.trailing, 8)
-                .padding(.bottom, stopPlacement.isLast ? 0 : 1)
-                .frame(minHeight: 56)
-            }.accessibilityElement(children: .contain)
-        }
+            }
+        )
+        .frame(minHeight: 56)
+        .preventScrollTaps()
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -12453,6 +12453,9 @@
         }
       }
     },
+    "New feature. %@" : {
+
+    },
     "Next stop" : {
       "comment" : "Label for a vehicle's next stop. For example: Next stop Alewife",
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -12454,7 +12454,50 @@
       }
     },
     "New feature. %@" : {
-
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nueva función. %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nouvelle fonctionnalité. %@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Nouvo karakteristik. %@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Novo recurso. %@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tính năng mới. %@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新功能。%@"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "新功能。 %@"
+          }
+        }
+      }
     },
     "Next stop" : {
       "comment" : "Label for a vehicle's next stop. For example: Next stop Alewife",

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingPieces.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingPieces.swift
@@ -9,6 +9,11 @@
 import SwiftUI
 
 enum OnboardingPieces {
+    enum Context {
+        case onboarding
+        case promo
+    }
+
     struct PageDescription<FocusValue: Hashable>: View {
         let headerText: Text
         let bodyText: Text
@@ -19,18 +24,22 @@ enum OnboardingPieces {
         let bodyDynamicTypeSize: DynamicTypeSize?
         let bodyAccessibilityHint: Text?
 
+        let context: Context
+
         init(
             headerText: Text,
             bodyText: Text,
             focusBinding: AccessibilityFocusState<FocusValue>.Binding,
             focusValue: FocusValue,
+            context: OnboardingPieces.Context,
             bodyAccessibilityHint: Text? = nil,
-            bodyDynamicTypeSize: DynamicTypeSize? = nil
+            bodyDynamicTypeSize: DynamicTypeSize? = nil,
         ) {
             self.headerText = headerText
             self.bodyText = bodyText
             self.focusBinding = focusBinding
             self.focusValue = focusValue
+            self.context = context
             self.bodyAccessibilityHint = bodyAccessibilityHint
             self.bodyDynamicTypeSize = bodyDynamicTypeSize
         }
@@ -39,6 +48,7 @@ enum OnboardingPieces {
             VStack(alignment: .leading, spacing: 16) {
                 headerText
                     .font(Typography.title1Bold)
+                    .accessibilityLabel(context == .promo ? Text("New feature. \(headerText)") : headerText)
                     .accessibilityHeading(.h1)
                     .accessibilityAddTraits(.isHeader)
                     .accessibilityFocused(focusBinding, equals: focusValue)

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -73,6 +73,7 @@ struct OnboardingScreenView: View {
                         ),
                         focusBinding: $focusHeader,
                         focusValue: .feedback,
+                        context: .onboarding,
                         bodyAccessibilityHint: Text("Use the \"More\" navigation tab to send app feedback"),
                         bodyDynamicTypeSize: .accessibility3
                     )
@@ -102,7 +103,8 @@ struct OnboardingScreenView: View {
                             "When using VoiceOver, we can hide maps to make the app easier to navigate."
                         ),
                         focusBinding: $focusHeader,
-                        focusValue: .hideMaps
+                        focusValue: .hideMaps,
+                        context: .onboarding,
                     )
                     .padding(32)
                     .background(Color.fill2)
@@ -134,7 +136,8 @@ struct OnboardingScreenView: View {
                         headerText: Text("See transit near you"),
                         bodyText: Text("We use your location to show you nearby transit options."),
                         focusBinding: $focusHeader,
-                        focusValue: .location
+                        focusValue: .location,
+                        context: .onboarding,
                     )
                     .padding(.bottom, 8)
                     if typeSize >= illustrationCutoff, typeSize < .accessibility3 {
@@ -168,15 +171,18 @@ struct OnboardingScreenView: View {
                             "By opting in, we can show you which stations are inaccessible or have elevator closures."
                         ),
                         focusBinding: $focusHeader,
-                        focusValue: .stationAccessibility
+                        focusValue: .stationAccessibility,
+                        context: .onboarding,
                     )
                     .padding(.bottom, 8)
-                    OnboardingPieces.SettingsToggle(getSetting: { settingsCache.get(.stationAccessibility) },
-                                                    toggleSetting: { settingsCache.set(
-                                                        .stationAccessibility,
-                                                        !settingsCache.get(.stationAccessibility)
-                                                    ) },
-                                                    label: Text("Station Accessibility Info"))
+                    OnboardingPieces.SettingsToggle(
+                        getSetting: { settingsCache.get(.stationAccessibility) },
+                        toggleSetting: { settingsCache.set(
+                            .stationAccessibility,
+                            !settingsCache.get(.stationAccessibility)
+                        ) },
+                        label: Text("Station Accessibility Info")
+                    )
                     OnboardingPieces.KeyButton(text: Text(
                         "Continue",
                         comment: "Button to advance to next scren in onboarding flow"

--- a/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
+++ b/iosApp/iosApp/Pages/Promo/PromoScreenView.swift
@@ -72,6 +72,7 @@ struct PromoScreenView: View {
                 bodyText: Text(promoDetailsString),
                 focusBinding: $focusHeader,
                 focusValue: .combinedStopAndTrip,
+                context: .promo,
                 bodyDynamicTypeSize: .accessibility3
             )
             .padding(.bottom, 16)
@@ -120,6 +121,7 @@ struct PromoScreenView: View {
                 bodyText: Text(promoDetailsString),
                 focusBinding: $focusHeader,
                 focusValue: .enhancedFavorites,
+                context: .promo,
                 bodyDynamicTypeSize: .accessibility3
             )
             .padding(.bottom, 16)

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -91,6 +91,8 @@ struct CollapsableStopList<RightSideContent: View>: View {
                     .foregroundStyle(Color.deemphasized)
                     .font(Typography.footnote)
                 }
+                .accessibilityAddTraits(.isHeader)
+                .accessibilityHeading(.h4)
                 .padding(.vertical, 12)
                 .padding(.trailing, 8)
             })

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -270,6 +270,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
         VStack(spacing: 0) {
             SheetHeader(
                 title: lineOrRoute.name,
+                titleAccessibilityLabel: lineOrRoute.label,
                 titleColor: textColor,
                 buttonColor: Color.translucentContrast,
                 onBack: onBack,

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -270,7 +270,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
         VStack(spacing: 0) {
             SheetHeader(
                 title: lineOrRoute.name,
-                titleAccessibilityLabel: lineOrRoute.label,
+                titleAccessibilityLabel: lineOrRoute.labelWithModeIfBus,
                 titleColor: textColor,
                 buttonColor: Color.translucentContrast,
                 onBack: onBack,

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
@@ -20,6 +20,8 @@ struct RoutePickerRow: View {
                 HStack(spacing: 0) {
                     HStack(spacing: 8) {
                         RoutePill(route: route.sortRoute, type: .fixed)
+                            // Route pill VoiceOver text is redundant except for bus
+                            .accessibilityHidden(route.type != .bus)
                         Text(route.sortRoute.longName)
                             .multilineTextAlignment(.leading)
                             .foregroundColor(Color.text)

--- a/iosApp/iosApp/Utils/LineOrRouteExtension.swift
+++ b/iosApp/iosApp/Utils/LineOrRouteExtension.swift
@@ -18,7 +18,7 @@ extension RouteCardData.LineOrRoute {
         RouteCardData.LineOrRouteLine(line: line, routes: routes)
     }
 
-    var label: String {
+    var labelWithModeIfBus: String {
         type == .bus
             ? String(format: NSLocalizedString(
                 "%1$@ bus",

--- a/iosApp/iosApp/Utils/LineOrRouteExtension.swift
+++ b/iosApp/iosApp/Utils/LineOrRouteExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import Shared
+import SwiftUI
 
 extension RouteCardData.LineOrRoute {
     static func route(_ route: Route) -> RouteCardData.LineOrRouteRoute {
@@ -15,5 +16,13 @@ extension RouteCardData.LineOrRoute {
 
     static func line(_ line: Line, _ routes: Set<Route>) -> RouteCardData.LineOrRouteLine {
         RouteCardData.LineOrRouteLine(line: line, routes: routes)
+    }
+
+    var label: String {
+        type == .bus
+            ? String(format: NSLocalizedString(
+                "%1$@ bus",
+                comment: "Bus route name label, with the value being the route number, ex. \"1 bus\", \"66 bus\""
+            ), name) : name
     }
 }

--- a/iosApp/iosApp/Utils/RouteStopDirectionExtension.swift
+++ b/iosApp/iosApp/Utils/RouteStopDirectionExtension.swift
@@ -27,6 +27,6 @@ extension RouteStopDirection {
             route: lineOrRoute.sortRoute
         ))
 
-        return .init(route: lineOrRoute.label, stop: stop.name, direction: directionLabel)
+        return .init(route: lineOrRoute.labelWithModeIfBus, stop: stop.name, direction: directionLabel)
     }
 }

--- a/iosApp/iosApp/Utils/RouteStopDirectionExtension.swift
+++ b/iosApp/iosApp/Utils/RouteStopDirectionExtension.swift
@@ -22,16 +22,11 @@ extension RouteStopDirection {
               let stop = global.getStop(stopId: stop)
         else { return nil }
 
-        let routeLabel = lineOrRoute.type == .bus
-            ? String(format: NSLocalizedString(
-                "%1$@ bus",
-                comment: "Bus route name label, with the value being the route number, ex. \"1 bus\", \"66 bus\""
-            ), lineOrRoute.name) : lineOrRoute.name
         let directionLabel = DirectionLabel.directionNameFormatted(.init(
             directionId: direction,
             route: lineOrRoute.sortRoute
         ))
 
-        return .init(route: routeLabel, stop: stop.name, direction: directionLabel)
+        return .init(route: lineOrRoute.label, stop: stop.name, direction: directionLabel)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Favorites | Address VoiceOver QA](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211025820891516?focus=true)

This addresses all of the issues in the ticket's AC, except for the toast focus order change, which I'll attempt in a follow up.
Any issues that applied to both Android and iOS were done for both.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Tested with VoiceOver and TalkBack on devices.
