### PR TITLE
fix(FavoritesView): Edit & add buttons have same scale

### DIFF
--- a/iosApp/iosApp/ComponentViews/NavTextButton.swift
+++ b/iosApp/iosApp/ComponentViews/NavTextButton.swift
@@ -14,6 +14,7 @@ struct NavTextButton: View {
     let backgroundColor: Color
     let textColor: Color
     var height: CGFloat? = nil
+    var width: CGFloat? = nil
     let action: () -> Void
 
     var body: some View {
@@ -25,7 +26,7 @@ struct NavTextButton: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
                     .foregroundColor(textColor)
-                    .frame(minHeight: height)
+                    .frame(minWidth: width, minHeight: height)
                     .background(backgroundColor)
                     .buttonBorderShape(.capsule)
                     .clipShape(Capsule())

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -23,6 +23,8 @@ struct FavoritesView: View {
     let inspection = Inspection<Self>()
     @State var now = Date.now
 
+    @ScaledMetric private var editButtonHeight: CGFloat = 32
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             SheetHeader(
@@ -34,7 +36,8 @@ struct FavoritesView: View {
                             string: NSLocalizedString("Edit", comment: "Button text to enter edit favorites flow"),
                             backgroundColor: Color.translucentContrast,
                             textColor: Color.fill2,
-                            height: 32
+                            height: editButtonHeight,
+                            width: 64
                         ) {
                             nearbyVM.pushNavEntry(.editFavorites)
                         }


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, found while doing release QA for favorites. The add button was set to scale but edit was not. Updated to scale both together

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Ran locally at different text sizes
<img width="1170" height="2532" alt="IMG_0399" src="https://github.com/user-attachments/assets/fb2e23b9-1ba8-46fb-a0c9-3fae76e6e677" /><img width="1170" height="2532" alt="IMG_0398" src="https://github.com/user-attachments/assets/2167a711-00e2-4eb1-9429-18138d8943bb" /><img width="1170" height="2532" alt="IMG_0397" src="https://github.com/user-attachments/assets/0e4d6975-efad-4d4d-8b19-c3a73955e7cd" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
