### PR TITLE
fix(android.BardAndToastScaffold): Only include 'tip: ' prefix for toasts that are tips

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -12,11 +13,12 @@ import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalTestApi::class)
 class BarAndToastScaffoldTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testToastDisplay() {
+    fun testTipToastDisplay() {
         val toastVM = MockToastViewModel()
         var toastShown = false
 
@@ -37,6 +39,33 @@ class BarAndToastScaffoldTest {
         composeTestRule
             .onNodeWithContentDescription("Tip: Toast message", useUnmergedTree = true)
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun testToastDisplayNotTip() {
+        val toastVM = MockToastViewModel()
+        var toastShown = false
+
+        toastVM.onShowToast = { toast ->
+            toastVM.models.update { ToastViewModel.State.Visible(toast) }
+            toastShown = true
+        }
+
+        composeTestRule.setContent {
+            BarAndToastScaffold(toastViewModel = toastVM) { Text("Content") }
+        }
+
+        toastVM.showToast(ToastViewModel.Toast(message = "Toast message", isTip = false))
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntil { toastShown }
+        composeTestRule.onNodeWithText("Toast message", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Toast message", useUnmergedTree = true)
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Tip:", useUnmergedTree = true, substring = true)
+            .assertDoesNotExist()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffold.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffold.kt
@@ -83,7 +83,9 @@ fun BarAndToastScaffold(
             is ToastViewModel.State.Hidden -> ""
             is ToastViewModel.State.Visible ->
                 AnnotatedString.fromHtml(
-                        stringResource(R.string.toast_tip_prefix, state.toast.message)
+                        if (state.toast.isTip)
+                            stringResource(R.string.toast_tip_prefix, state.toast.message)
+                        else state.toast.message
                     )
                     .text
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -272,6 +272,7 @@ fun RouteStopListView(
                         ToastViewModel.ToastAction.Close(
                             onClose = { showFirstTimeFavoritesToast = false }
                         ),
+                    isTip = true,
                 )
             toastViewModel.showToast(toast)
             firstTimeToast = toast


### PR DESCRIPTION
### Summary

What is this PR for?
No ticket, noticed during release QA of TalkBack on android. Every toast was being announced as a tip. Now, only toasts with `isTip = true` are announced as tips, same as on iOS. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally
* Added unit test

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
