### PR TITLE
fix?(shared.MapViewModel): Move map side effects into background

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -38,7 +38,6 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -411,7 +410,7 @@ public class MapViewModel(
     }
 
     private fun handleViewportCentering(state: State, density: Float?) {
-        CoroutineScope(Dispatchers.Default).launch {
+        CoroutineScope(defaultCoroutineDispatcher).launch {
             when (state) {
                 State.Overview -> {}
                 is State.StopSelected -> {
@@ -441,7 +440,7 @@ public class MapViewModel(
         currentNavEntry: SheetRoutes?,
         previousNavEntry: SheetRoutes?,
     ) {
-        CoroutineScope(Dispatchers.Default).launch {
+        CoroutineScope(defaultCoroutineDispatcher).launch {
             if (
                 (previousNavEntry is SheetRoutes.NearbyTransit ||
                     previousNavEntry is SheetRoutes.Favorites) &&
@@ -459,7 +458,9 @@ public class MapViewModel(
     }
 
     private fun followPuck(animationDuration: Long?) {
-        CoroutineScope(Dispatchers.Default).launch { viewportManager.follow(animationDuration) }
+        CoroutineScope(defaultCoroutineDispatcher).launch {
+            viewportManager.follow(animationDuration)
+        }
     }
 
     /**


### PR DESCRIPTION
### Summary

_Ticket:_ [Event buffer overflow MapViewModel](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211010043650124?focus=true)

What is this PR for?
This PR *potentially* fixes the event buffer overflow issue we've been seeing in prod. I haven't been able to reproduce this locally, but my best bet is that some events were taking a long time to process and filling up the buffer, contributing to the overflow. 

I added some logging to the duration of processing events (in ms), and found events that affected the map position took > 1s. 
<img width="720" height="316" alt="image" src="https://github.com/user-attachments/assets/e0dbb2b2-4ac7-4ba2-a4a1-b652732ddcf3" />

Potentially if a user is tapping around to a bunch of trips and navigating back and forth a lot, this could back up the event queue enough to cause an overflow. 

That is still somewhat speculative since I haven't been able to repro this issue, and the breadcrumbs in Sentry are somewhat varied, but this seems plausible. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally and confirmed I could still smoothly navigate between stops / trips
* Confirmed in logging that the duration of processing each event was < 1ms
<img width="780" height="403" alt="image" src="https://github.com/user-attachments/assets/79556bfe-eea4-41be-9922-1c7cce232273" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
