### PR TITLE
fix(fastlane): never create provisioning profiles from CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -166,7 +166,11 @@ platform :ios do
       force: false,
       keychain_path: keychain_path
     )
-    get_provisioning_profile(app_identifier: app_identifier(options[:scheme]), output_path: 'iosApp/secrets')
+    get_provisioning_profile(
+      app_identifier: app_identifier(options[:scheme]),
+      output_path: 'iosApp/secrets',
+      readonly: ENV.fetch('CI', nil)
+    )
   end
 
   desc <<~DESC.chomp


### PR DESCRIPTION
### Summary

_Ticket:_ none

Provisioning profiles have to have the right name; if the one with the right name is broken, creating a new one won’t solve anything, and repairing the broken one (which has to be done manually with `bundle exec fastlane ios repair_provisioning_profiles`) is the correct fix. If a new provisioning profile has been created, even repairing the correct provisioning profile may not fix CI deployments if the new provisioning profile gets selected for download instead of the correct profile.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Not realistically testable until the provisioning profiles break again (which will happen during notifications but doesn’t need to happen before then).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
