### PR TITLE
refactor: put deep link parsing into shared code

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -17,10 +17,10 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockStopRepository
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.TestData
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -38,13 +38,13 @@ import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetTabViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetTabViewModelTest.kt
@@ -2,9 +2,9 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
@@ -17,12 +17,12 @@ import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultT
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.NearbyRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel
 import dev.mokkery.MockMode

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -22,13 +22,13 @@ import com.mbta.tid.mbta_app.history.VisitHistory
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteResult
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopResult
 import com.mbta.tid.mbta_app.model.StopResultRoute
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockVisitHistoryRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -8,7 +8,6 @@ import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
@@ -16,6 +15,7 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -35,11 +35,12 @@ import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.subscribeToAlerts
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.FeaturePromo
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.DeepLinkState
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel
 import io.github.dellisd.spatialk.geojson.Position
@@ -49,6 +50,7 @@ import org.koin.compose.koinInject
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ContentView(
+    deepLinkState: DeepLinkState = DeepLinkState.None,
     socket: PhoenixSocket = koinInject(),
     viewModel: ContentViewModel = koinViewModel(),
     favoritesViewModel: IFavoritesViewModel = koinInject(),
@@ -97,6 +99,12 @@ fun ContentView(
     var navBarVisible by remember { mutableStateOf(true) }
 
     LaunchedEffect(Unit) { mapViewModel.setViewportManager(viewportProvider) }
+
+    LaunchedEffect(deepLinkState) {
+        when (deepLinkState) {
+            DeepLinkState.None -> {}
+        }
+    }
 
     LifecycleResumeEffect(null) {
         socket.attach()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -20,6 +20,7 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.initializeSentry
+import com.mbta.tid.mbta_app.routes.DeepLinkState
 
 class MainActivity : ComponentActivity() {
     private lateinit var fusedLocationClient: FusedLocationProviderClient
@@ -50,13 +51,8 @@ class MainActivity : ComponentActivity() {
         )
 
         val deepLinkUri = intent.data?.takeIf { intent.action == Intent.ACTION_VIEW }
-        when {
-            deepLinkUri?.path == "/" -> {}
-            deepLinkUri != null -> {
-                Log.w("MainActivity", "Unhandled deep link URI $deepLinkUri")
-            }
-            else -> {}
-        }
+        val deepLinkState =
+            deepLinkUri?.let { DeepLinkState.from(it.toString()) } ?: DeepLinkState.None
 
         setContent {
             MyApplicationTheme {
@@ -65,7 +61,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background,
                 ) {
                     CompositionLocalProvider(LocalLocationClient provides fusedLocationClient) {
-                        ContentView()
+                        ContentView(deepLinkState)
                     }
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/SheetRoutes.kt
@@ -6,11 +6,11 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.toRoute
 import com.mbta.tid.mbta_app.json
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlin.reflect.typeOf
 
 val SheetRoutes.Companion.EntrypointSaver

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/BottomNavBar.kt
@@ -24,8 +24,8 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.Routes
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -27,11 +27,11 @@ import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.FavoriteBridge
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.FavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IToastViewModel

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -63,9 +63,9 @@ import com.mbta.tid.mbta_app.android.util.toPoint
 import com.mbta.tid.mbta_app.dependencyInjection.RepositoryDI
 import com.mbta.tid.mbta_app.map.StopLayerGenerator
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel
 import com.mbta.tid.mbta_app.viewModel.MapViewModel.State

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitTabViewModel.kt
@@ -3,10 +3,10 @@ package com.mbta.tid.mbta_app.android.nearbyTransit
 import androidx.compose.ui.unit.Dp
 import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopDetailsFilter.Companion.shouldPopLastStopEntry
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.getValue
 import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.favorites.FavoritesView
 import com.mbta.tid.mbta_app.android.util.managedTargetLocation
-import com.mbta.tid.mbta_app.model.SheetRoutes
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IToastViewModel
 import org.koin.compose.koinInject

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -86,7 +86,6 @@ import com.mbta.tid.mbta_app.android.util.selectedStopId
 import com.mbta.tid.mbta_app.android.util.stateJsonSaver
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.history.Visit
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
@@ -96,6 +95,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import com.mbta.tid.mbta_app.viewModel.IFavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -18,12 +18,12 @@ import com.mbta.tid.mbta_app.android.util.managePinnedRoutes
 import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.FavoriteUpdateBridge
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -38,7 +38,6 @@ import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
@@ -46,6 +45,7 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
@@ -37,12 +37,12 @@ import com.mbta.tid.mbta_app.model.FavoriteUpdateBridge
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -16,11 +16,11 @@ import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.FavoriteUpdateBridge
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
 @Composable

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -10,10 +10,10 @@ import com.mbta.tid.mbta_app.android.component.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.android.util.timer
 import com.mbta.tid.mbta_app.model.FavoriteBridge
 import com.mbta.tid.mbta_app.model.FavoriteUpdateBridge
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlin.time.Duration.Companion.seconds
 import org.koin.compose.koinInject
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -21,7 +21,6 @@ import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
@@ -31,6 +30,7 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import org.koin.compose.koinInject
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/NavHostControllerExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/NavHostControllerExtension.kt
@@ -3,7 +3,7 @@ package com.mbta.tid.mbta_app.android.util
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
 import com.mbta.tid.mbta_app.android.fromNavBackStackEntry
-import com.mbta.tid.mbta_app.model.SheetRoutes
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 

--- a/bin/filter-xcodeproj-diff.rb
+++ b/bin/filter-xcodeproj-diff.rb
@@ -82,7 +82,7 @@ end
 
 using DiffCrawler
 
-data = YAML.safe_load_file(ARGV[0] || raise('usage: filter-xcodeproj-diff.rb path/to/diff.yml')) || {}
+data = YAML.safe_load_file(ARGV[0] || raise('usage: filter-xcodeproj-diff.rb path/to/diff.yml'), aliases: true) || {}
 
 data.crawl!
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -75,6 +75,9 @@ struct ContentView: View {
                 _ = try await RepositoryDI().global.getGlobalData()
             } catch {}
         }
+        .onAppear {
+            readDeepLinkState()
+        }
         .onChange(of: contentVM.defaultTab) { newTab in
             selectedTab = switch newTab {
             case .favorites: .favorites
@@ -104,6 +107,7 @@ struct ContentView: View {
             if newPhase == .active {
                 socketProvider.socket.attach()
                 nearbyVM.joinAlertsChannel()
+                readDeepLinkState()
             } else if newPhase == .background {
                 nearbyVM.leaveAlertsChannel()
                 socketProvider.socket.detach()
@@ -537,6 +541,13 @@ struct ContentView: View {
             searchObserver.isSearching && nearbyVM.navigationStack.lastSafe().isEntrypoint
                 ? Color.fill2 : Color.clear
         ).ignoresSafeArea(.all)
+    }
+
+    private func readDeepLinkState() {
+        switch onEnum(of: AppDelegate.deepLinkState) {
+        case .none: break
+        }
+        AppDelegate.deepLinkState = .None.shared
     }
 
     private func recenterOnVehicleButtonInfo() -> (RouteType, Vehicle, Stop)? {

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -6,6 +6,8 @@ import SwiftPhoenixClient
 import SwiftUI
 
 class AppDelegate: NSObject, UIApplicationDelegate {
+    static var deepLinkState: DeepLinkState = .None.shared
+
     func application(
         _: UIApplication,
         didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
@@ -26,17 +28,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     ) -> Bool {
         // Get URL components from the incoming user activity.
         guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-              let incomingURL = userActivity.webpageURL,
-              let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+              let incomingURL = userActivity.webpageURL else {
             return false
         }
 
-        if components.path == "/" {
-            // just opening app, let default route happen
+        if let deepLinkState = DeepLinkState.companion.from(url: incomingURL.absoluteString) {
+            Self.deepLinkState = deepLinkState
             return true
         } else {
-            // unhandled path
-            debugPrint("Unhandled deep link URI", components)
             return false
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TabPreferencesRepository.kt
@@ -4,7 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.mbta.tid.mbta_app.model.SheetRoutes
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/routes/DeepLinkState.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/routes/DeepLinkState.kt
@@ -1,0 +1,21 @@
+package com.mbta.tid.mbta_app.routes
+
+import io.ktor.http.Url
+
+public sealed class DeepLinkState {
+    public data object None : DeepLinkState()
+
+    public companion object {
+        public fun from(url: String): DeepLinkState? {
+            val url = Url(url)
+            return when (url.encodedPath) {
+                "",
+                "/" -> None
+                else -> {
+                    println("Unhandled deep link URI $url")
+                    null
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/routes/SheetRoutes.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/routes/SheetRoutes.kt
@@ -1,5 +1,7 @@
-package com.mbta.tid.mbta_app.model
+package com.mbta.tid.mbta_app.routes
 
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import kotlinx.serialization.Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.map.StopLayerGenerator
 import com.mbta.tid.mbta_app.map.style.FeatureCollection
 import com.mbta.tid.mbta_app.model.GlobalMapData
 import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
@@ -28,6 +27,7 @@ import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.IMapLayerManager
 import com.mbta.tid.mbta_app.utils.ViewportManager

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/routes/DeepLinkStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/routes/DeepLinkStateTest.kt
@@ -1,0 +1,21 @@
+package com.mbta.tid.mbta_app.routes
+
+import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.parametric.parametricTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DeepLinkStateTest {
+    @Test
+    fun `matches root`() = parametricTest {
+        val variant: AppVariant = anyEnumValue()
+        assertEquals(DeepLinkState.None, DeepLinkState.from(variant.backendRoot))
+    }
+
+    @Test
+    fun `returns null on unknown path`() = parametricTest {
+        val variant: AppVariant = anyEnumValue()
+        assertNull(DeepLinkState.from("${variant.backendRoot}/some-unknown-path"))
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/routes/SheetRouteTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/routes/SheetRouteTest.kt
@@ -1,5 +1,6 @@
-package com.mbta.tid.mbta_app.model
+package com.mbta.tid.mbta_app.routes
 
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import kotlin.test.Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -4,12 +4,12 @@ import app.cash.turbine.test
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.Alert
-import com.mbta.tid.mbta_app.model.SheetRoutes
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
+import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.IMapLayerManager
 import com.mbta.tid.mbta_app.utils.TestData


### PR DESCRIPTION
### Summary

_Ticket:_ none

This was something I stumbled into as part of my notifications spike, although I’ve cleaned it up a bit from the way I did it then.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the apps still build. None of the new code actually does anything yet, since we only have shallow links for now.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
