### PR TITLE
fix: treat last stops on typical patterns as arrival-only if no trips exist

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
@@ -59,7 +59,7 @@ class MapAndSheetPageTest {
         val route = objects.route { type = RouteType.BUS }
         objects.routePattern(route) {
             typicality = RoutePattern.Typicality.Typical
-            representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
+            representativeTrip { stopIds = listOf(stop1.id, stop2.id, "terminal-stop") }
         }
 
         val alertData = AlertsStreamDataResponse(objects)

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -112,7 +112,7 @@ final class NearbyTransitViewTests: XCTestCase {
             pattern.representativeTrip { trip in
                 trip.headsign = "Charles River Loop"
                 trip.routePatternId = pattern.id
-                trip.stopIds = [stop1.id]
+                trip.stopIds = [stop1.id, "terminal-stop"]
             }
         }
         objects.routePattern(route: route52) { pattern in
@@ -123,7 +123,7 @@ final class NearbyTransitViewTests: XCTestCase {
             pattern.representativeTrip { trip in
                 trip.headsign = "Dedham Mall"
                 trip.routePatternId = pattern.id
-                trip.stopIds = [stop1.id]
+                trip.stopIds = [stop1.id, "terminal-stop"]
             }
         }
         objects.routePattern(route: route52) { pattern in
@@ -134,7 +134,7 @@ final class NearbyTransitViewTests: XCTestCase {
             pattern.representativeTrip { trip in
                 trip.headsign = "Watertown Yard"
                 trip.routePatternId = pattern.id
-                trip.stopIds = [stop2.id]
+                trip.stopIds = [stop2.id, "terminal-stop"]
             }
         }
         objects.routePattern(route: route52) { pattern in
@@ -145,7 +145,7 @@ final class NearbyTransitViewTests: XCTestCase {
             pattern.representativeTrip { trip in
                 trip.headsign = "Watertown Yard"
                 trip.routePatternId = pattern.id
-                trip.stopIds = [stop2.id]
+                trip.stopIds = [stop2.id, "terminal-stop"]
             }
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1188,6 +1188,8 @@ public data class RouteCardData(
                     } ?: true
                 } ?: false
 
+            // If we don’t have any upcoming trips to tell us whether or not service is
+            // arrival-only, trust the typical-last-stop-on-route-pattern state.
             val shouldBeFilteredAsArrivalOnly =
                 if (isSubway) {
                     // On subway, only filter out arrival only patterns at the typical last stop.
@@ -1195,9 +1197,10 @@ public data class RouteCardData(
                     // headsign(s) at
                     // a temporary terminal to acknowledge the missing typical service.
                     this.isTypicalLastStopOnRoutePattern(stop, globalData) &&
-                        (this.upcomingTrips?.isArrivalOnly() ?: false)
+                        (this.upcomingTrips?.isArrivalOnly() ?: true)
                 } else {
-                    this.upcomingTrips?.isArrivalOnly() ?: false
+                    this.upcomingTrips?.isArrivalOnly()
+                        ?: this.isTypicalLastStopOnRoutePattern(stop, globalData)
                 }
 
             val hasUnseenTypicalPattern =
@@ -1216,6 +1219,7 @@ public data class RouteCardData(
             return this.routePatterns
                 ?.filter { it.typicality == RoutePattern.Typicality.Typical }
                 ?.map { it.representativeTripId }
+                ?.takeUnless { it.isEmpty() }
                 ?.all { representativeTripId ->
                     val representativeTrip = globalData.trips[representativeTripId]
                     val lastStopIdInPattern =


### PR DESCRIPTION
### Summary

_Ticket:_ [Impossible direction shown at terminal when alert](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211034220968547?focus=true)

This isn’t actually caused by the alert, but by the absence of scheduled or predicted trips to tell us whether or not service is arrival-only at that stop. Falling back to checking that the stop is the last stop on all its typical route patterns seems like the most robust approach.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added shared unit test for new logic. Fixed unit tests that broke under this logic (none of which were intentionally asserting something that this logic changed).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
