### PR TITLE
fix(Android): use correct padding for sheet with hide maps

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -719,6 +719,7 @@ fun MapAndSheetPage(
             ) {
                 SheetContent(
                     Modifier.background(colorResource(R.color.sheet_background))
+                        .padding(outerSheetPadding)
                         .padding(top = if (showSearchBar) 64.dp else 0.dp)
                         .statusBarsPadding()
                         .fillMaxSize()


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Can't scroll to bottom of favorites](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211117039157377?focus=true)

Oops.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that it’s now possible to scroll all the way down in favorites and nearby transit.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
