### PR TITLE
fix(Android): add layers to new map when map gets recreated

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -267,7 +267,7 @@ public class MapViewModel(
                         }
                     }
                     is Event.LayerManagerInitialized -> {
-                        if (layerManager == null) layerManager = event.layerManager
+                        layerManager = event.layerManager
                     }
                     is Event.LocationPermissionsChanged -> {
                         if (event.hasPermission && viewportManager.isDefault()) {


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Route shapes & stops hidden after more page](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211055606783875?focus=true)

When moving to the More page and back, the map gets recreated but the ViewModel doesn’t, so a new layer manager is passed into the same ViewModel, and it needs to be actually used.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this solves the issue. Added a unit test.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
