### PR TITLE
fix: correctly handle Phoenix join timeouts & log repeated data errors to Sentry

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.FavoritesViewModel
 import com.mbta.tid.mbta_app.viewModel.IToastViewModel
@@ -18,6 +19,7 @@ import dev.mokkery.mock
 import dev.mokkery.resetCalls
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
+import kotlin.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +51,11 @@ class FavoritesViewTest {
                 openSheetRoute = {},
                 favoritesViewModel = favoritesVM,
                 errorBannerViewModel =
-                    ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository()),
+                    ErrorBannerViewModel(
+                        errorRepository = MockErrorBannerStateRepository(),
+                        MockSentryRepository(),
+                        Clock.System,
+                    ),
                 toastViewModel = toastVM,
                 alertData = AlertsStreamDataResponse(objects),
                 globalResponse = GlobalResponse(objects),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -18,18 +18,17 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 import org.koin.test.KoinTest
 
 class NearbyTransitViewTest : KoinTest {
@@ -180,7 +179,6 @@ class NearbyTransitViewTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testNearbyTransitViewDisplaysCorrectly() {
-        val errorBannerVM = ErrorBannerViewModel(MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 NearbyTransitView(
@@ -191,7 +189,7 @@ class NearbyTransitViewTest : KoinTest {
                     setIsTargeting = {},
                     onOpenStopDetails = { _, _ -> },
                     noNearbyStopsView = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -211,8 +209,6 @@ class NearbyTransitViewTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testRouteCardAnalyticsPinnedWithEnhanced() {
-        val errorBannerVM = ErrorBannerViewModel(MockErrorBannerStateRepository())
-
         var analyticsLoggedProps: Map<String, String> = mapOf()
 
         val koinApplication =
@@ -251,7 +247,7 @@ class NearbyTransitViewTest : KoinTest {
                     setIsTargeting = {},
                     onOpenStopDetails = { _, _ -> },
                     noNearbyStopsView = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -267,7 +263,6 @@ class NearbyTransitViewTest : KoinTest {
     @Test
     fun testNearbyTransitViewNoNearbyStops() {
         val emptyNearbyKoinApplication = testKoinApplication()
-        val errorBannerVM = ErrorBannerViewModel(MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(emptyNearbyKoinApplication.koin) {
                 NearbyTransitView(
@@ -278,7 +273,7 @@ class NearbyTransitViewTest : KoinTest {
                     setIsTargeting = {},
                     onOpenStopDetails = { _, _ -> },
                     noNearbyStopsView = { Text("This would be the no nearby stops view") },
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -21,10 +21,8 @@ import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import com.mbta.tid.mbta_app.utils.TestData
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.MockToastViewModel
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel
 import kotlin.test.assertEquals
@@ -34,6 +32,7 @@ import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 class RouteStopListViewTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -104,7 +103,6 @@ class RouteStopListViewTest {
                         routeId = mainRoute.id,
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -115,7 +113,7 @@ class RouteStopListViewTest {
                     onClick = clicks::add,
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = MockToastViewModel(),
                     rightSideContent = { context, _ ->
                         when (context) {
@@ -193,7 +191,6 @@ class RouteStopListViewTest {
                         onGet = { routeId, _ -> lastSelectedRoute = routeId },
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -204,7 +201,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = MockToastViewModel(),
                     defaultSelectedRouteId = route2.id,
                     rightSideContent = { _, _ -> },
@@ -298,7 +295,6 @@ class RouteStopListViewTest {
                         routeId = mainRoute.id,
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -309,7 +305,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = MockToastViewModel(),
                     rightSideContent = { _, _ -> },
                 )
@@ -356,7 +352,6 @@ class RouteStopListViewTest {
                         routeId = mainRoute.id,
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -367,7 +362,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = MockToastViewModel(),
                     rightSideContent = { _, _ -> },
                 )
@@ -400,7 +395,6 @@ class RouteStopListViewTest {
                         routeId = route.id,
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -416,7 +410,7 @@ class RouteStopListViewTest {
                     },
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = MockToastViewModel(),
                     rightSideContent = { _, _ -> },
                 )
@@ -453,7 +447,6 @@ class RouteStopListViewTest {
                             )
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -473,7 +466,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = toastVM,
                     rightSideContent = { _, _ -> },
                 )
@@ -505,7 +498,6 @@ class RouteStopListViewTest {
                             )
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -528,7 +520,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = { backTapped = true },
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = toastVM,
                     rightSideContent = { _, _ -> },
                 )
@@ -560,7 +552,6 @@ class RouteStopListViewTest {
                             )
                     )
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -583,7 +574,7 @@ class RouteStopListViewTest {
                     onClick = {},
                     onBack = {},
                     onClose = { closeTapped = true },
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     toastViewModel = toastVM,
                     rightSideContent = { _, _ -> },
                 )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
@@ -21,16 +21,15 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.repositories.IdleGlobalRepository
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockSearchResultRepository
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.MockSearchRoutesViewModel
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 class RoutePickerViewTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -39,7 +38,6 @@ class RoutePickerViewTest {
     fun testDisplaysLoadingIndicator() {
         val koin =
             testKoinApplication(ObjectCollectionBuilder()) { global = IdleGlobalRepository() }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -51,7 +49,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -70,7 +68,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -82,7 +79,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -98,7 +95,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -110,7 +106,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -132,7 +128,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -144,7 +139,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -167,7 +162,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -179,7 +173,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -215,7 +209,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -227,7 +220,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -258,7 +251,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -270,7 +262,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -292,7 +284,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -304,7 +295,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -323,7 +314,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -335,7 +325,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -358,7 +348,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -373,7 +362,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -398,7 +387,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -410,7 +398,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = { backCalled = true },
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -434,7 +422,6 @@ class RoutePickerViewTest {
 
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -446,7 +433,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = { closeCalled = true },
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -481,7 +468,6 @@ class RoutePickerViewTest {
                 searchResults =
                     MockSearchResultRepository(routeResults = listOf(RouteResult(route = route1)))
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -493,7 +479,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -520,8 +506,6 @@ class RoutePickerViewTest {
         val koin =
             testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
-
         composeTestRule.setContent {
             KoinContext(koin.koin) {
                 RoutePickerView(
@@ -532,7 +516,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     searchRoutesViewModel = searchVM,
                 )
             }
@@ -564,7 +548,6 @@ class RoutePickerViewTest {
                 global = MockGlobalRepository(GlobalResponse(objects))
                 searchResults = MockSearchResultRepository(routeResults = emptyList())
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koin.koin) {
@@ -576,7 +559,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = {},
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }
@@ -605,7 +588,6 @@ class RoutePickerViewTest {
                 global = MockGlobalRepository(GlobalResponse(objects))
                 searchResults = MockSearchResultRepository(routeResults = emptyList())
             }
-        val errorBannerVM = ErrorBannerViewModel(errorRepository = MockErrorBannerStateRepository())
 
         var filterExpanded = false
 
@@ -619,7 +601,7 @@ class RoutePickerViewTest {
                     onRouteSearchExpandedChange = { filterExpanded = it },
                     onBack = {},
                     onClose = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -17,10 +17,12 @@ import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -51,7 +53,12 @@ class SubscribeToPredictionsTest {
         var stopIds = mutableStateOf(listOf("place-a"))
         var predictions: PredictionsStreamDataResponse? =
             PredictionsStreamDataResponse(ObjectCollectionBuilder())
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
+        val errorBannerViewModel =
+            ErrorBannerViewModel(
+                MockErrorBannerStateRepository(),
+                MockSentryRepository(),
+                Clock.System,
+            )
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }
@@ -94,7 +101,12 @@ class SubscribeToPredictionsTest {
         var stopIds = mutableStateOf(listOf("place-a"))
         var predictions: PredictionsStreamDataResponse? =
             PredictionsStreamDataResponse(ObjectCollectionBuilder())
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
+        val errorBannerViewModel =
+            ErrorBannerViewModel(
+                MockErrorBannerStateRepository(),
+                MockSentryRepository(),
+                Clock.System,
+            )
 
         composeTestRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
@@ -133,7 +145,12 @@ class SubscribeToPredictionsTest {
             )
 
         var predictions: PredictionsStreamDataResponse? = null
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
+        val errorBannerViewModel =
+            ErrorBannerViewModel(
+                MockErrorBannerStateRepository(),
+                MockSentryRepository(),
+                Clock.System,
+            )
 
         composeTestRule.setContent {
             val predictionsVM =
@@ -162,7 +179,8 @@ class SubscribeToPredictionsTest {
             MockErrorBannerStateRepository(
                 onCheckPredictionsStale = { checkPredictionsStaleCount += 1 }
             )
-        val errorBannerViewModel = ErrorBannerViewModel(mockErrorRepo)
+        val errorBannerViewModel =
+            ErrorBannerViewModel(mockErrorRepo, MockSentryRepository(), Clock.System)
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
@@ -23,10 +23,8 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ISettingsRepository
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
@@ -35,6 +33,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 class StopDetailsFilteredPickerViewTest {
     val builder = ObjectCollectionBuilder()
@@ -130,8 +129,6 @@ class StopDetailsFilteredPickerViewTest {
             ),
         )
 
-    private val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
-
     private val settings = mutableMapOf<Settings, Boolean>()
     private val settingsRepository =
         object : ISettingsRepository {
@@ -177,7 +174,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = {},
                     tileScrollState = rememberScrollState(),
@@ -228,7 +225,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = { tripFilter = it },
                     tileScrollState = rememberScrollState(),
@@ -288,7 +285,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = {},
                     tileScrollState = rememberScrollState(),
@@ -337,7 +334,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = {},
                     tileScrollState = rememberScrollState(),
@@ -388,7 +385,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = {},
                     tileScrollState = rememberScrollState(),
@@ -458,7 +455,7 @@ class StopDetailsFilteredPickerViewTest {
                     global = globalResponse,
                     now = now,
                     viewModel = viewModel,
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     updateStopFilter = {},
                     updateTripFilter = {},
                     tileScrollState = rememberScrollState(),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -10,12 +10,11 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.android.pages.StopDetailsPage
 import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import junit.framework.TestCase.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 import org.koin.test.KoinTest
 
 class StopDetailsPageTest : KoinTest {
@@ -30,7 +29,6 @@ class StopDetailsPageTest : KoinTest {
         val filters = mutableStateOf(StopDetailsPageFilters("stop", null, null))
 
         var routeCardDataUpdated = false
-        val errorBannerVM = ErrorBannerViewModel(MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
@@ -47,7 +45,7 @@ class StopDetailsPageTest : KoinTest {
                     tileScrollState = rememberScrollState(),
                     openModal = {},
                     openSheetRoute = {},
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                 )
             }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -17,17 +17,16 @@ import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 class StopDetailsUnfilteredRoutesViewTest {
     val builder = ObjectCollectionBuilder()
@@ -112,8 +111,6 @@ class StopDetailsUnfilteredRoutesViewTest {
             mutableMapOf(stop.id to listOf(routePatternOne.id, routePatternTwo.id)),
         )
 
-    private val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
-
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
@@ -143,7 +140,7 @@ class StopDetailsUnfilteredRoutesViewTest {
                     stop = stop,
                     routeCardData = routeCardData,
                     servedRoutes = emptyList(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     now = now,
                     globalData = globalResponse,
                     isFavorite = { false },
@@ -188,7 +185,7 @@ class StopDetailsUnfilteredRoutesViewTest {
                     stop = inaccessibleStop,
                     routeCardData = routeCardData,
                     servedRoutes = emptyList(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     now = now,
                     globalData = globalResponse,
                     isFavorite = { false },
@@ -240,7 +237,7 @@ class StopDetailsUnfilteredRoutesViewTest {
                     stop = stop,
                     routeCardData = routeCardData,
                     servedRoutes = emptyList(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     now = now,
                     globalData = globalResponse,
                     isFavorite = { false },

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -20,15 +20,14 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
+import org.koin.compose.koinInject
 
 class StopDetailsViewTest {
     val builder = ObjectCollectionBuilder()
@@ -143,7 +142,6 @@ class StopDetailsViewTest {
             )
         )
 
-        val errorBannerVM = ErrorBannerViewModel(MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
@@ -159,7 +157,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = errorBannerVM,
+                    errorBannerViewModel = koinInject(),
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -202,7 +200,6 @@ class StopDetailsViewTest {
                 GlobalResponse(builder),
             )
         )
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
@@ -221,7 +218,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -279,7 +276,6 @@ class StopDetailsViewTest {
                 )
             )
         )
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
 
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
@@ -296,7 +292,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     openModal = {},
                     openSheetRoute = {},
                 )
@@ -338,7 +334,6 @@ class StopDetailsViewTest {
                 GlobalResponse(builder),
             )
         )
-        val errorBannerViewModel = ErrorBannerViewModel(MockErrorBannerStateRepository())
         composeTestRule.setContent {
             KoinContext(koinApplication.koin) {
                 val filterState = remember {
@@ -356,7 +351,7 @@ class StopDetailsViewTest {
                     updateStopFilter = filterState::value::set,
                     updateTripDetailsFilter = {},
                     tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = errorBannerViewModel,
+                    errorBannerViewModel = koinInject(),
                     openModal = {},
                     openSheetRoute = {},
                 )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -36,11 +36,13 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
@@ -177,12 +179,18 @@ private fun RefreshButton(
 class ErrorBannerPreviews() {
     val dataErrorRepo =
         MockErrorBannerStateRepository(
-            state = ErrorBannerState.DataError(messages = setOf("foo"), action = {})
+            state =
+                ErrorBannerState.DataError(
+                    messages = setOf("foo"),
+                    details = setOf("bar"),
+                    action = {},
+                )
         )
-    val dataErrorVM = ErrorBannerViewModel(dataErrorRepo)
+    val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository(), Clock.System)
 
     val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-    val networkErrorVM = ErrorBannerViewModel(networkErrorRepo)
+    val networkErrorVM =
+        ErrorBannerViewModel(networkErrorRepo, MockSentryRepository(), Clock.System)
 
     val staleRepo =
         MockErrorBannerStateRepository(
@@ -192,8 +200,8 @@ class ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val staleVM = ErrorBannerViewModel(staleRepo)
-    val staleLoadingVM = ErrorBannerViewModel(staleRepo)
+    val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+    val staleLoadingVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
 
     // The preview requires Koin to contain the cache in order to render,
     // but it won't actually use the debug value set here when displayed

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewModel.kt
@@ -245,7 +245,7 @@ class StopDetailsViewModel(
                     is ApiResult.Error -> {
                         _tripData.update { it?.copy(vehicle = null) }
 
-                        errorBannerRepository.setDataError(errorKey) {
+                        errorBannerRepository.setDataError(errorKey, outcome.toString()) {
                             clearAndLoadTripDetails(tripFilter)
                         }
                     }
@@ -389,7 +389,7 @@ class StopDetailsViewModel(
                 }
                 is ApiResult.Error -> {
                     Log.e("StopDetailsViewModel", "loadTrip failed: $response")
-                    errorBannerRepository.setDataError(errorKey) {
+                    errorBannerRepository.setDataError(errorKey, details = response.toString()) {
                         clearAndLoadTripDetails(tripFilter)
                     }
                     null

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
@@ -25,7 +25,11 @@ suspend fun <T : Any> fetchApi(
     when (result) {
         is ApiResult.Error -> {
             Log.e("fetchApi", "API request $errorKey failed: $result")
-            errorBannerRepo.setDataError(key = errorKey, action = onRefreshAfterError)
+            errorBannerRepo.setDataError(
+                key = errorKey,
+                details = result.toString(),
+                action = onRefreshAfterError,
+            )
         }
         is ApiResult.Ok -> {
             errorBannerRepo.clearDataError(key = errorKey)

--- a/iosApp/iosApp/ComponentViews/ErrorBanner.swift
+++ b/iosApp/iosApp/ComponentViews/ErrorBanner.swift
@@ -91,7 +91,7 @@ struct ErrorBanner: View {
     VStack(spacing: 16) {
         ErrorBanner(MockErrorBannerViewModel(initialState: .init(
             loadingWhenPredictionsStale: false,
-            errorState: .DataError(messages: Set(), action: {})
+            errorState: .DataError(messages: Set(), details: Set(), action: {})
         )))
         ErrorBanner(MockErrorBannerViewModel(initialState:
             .init(loadingWhenPredictionsStale: false,

--- a/iosApp/iosApp/Utils/FetchApi.swift
+++ b/iosApp/iosApp/Utils/FetchApi.swift
@@ -33,6 +33,6 @@ func fetchApi<T>(
         errorBannerRepo.clearDataError(key: errorKey)
         await onSuccess(result.data)
     case let .error(error):
-        errorBannerRepo.setDataError(key: errorKey, action: onRefreshAfterError)
+        errorBannerRepo.setDataError(key: errorKey, details: error.description(), action: onRefreshAfterError)
     }
 }

--- a/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/StopDetailsViewModel.swift
@@ -312,10 +312,11 @@ class StopDetailsViewModel: ObservableObject {
                 case let .ok(result):
                     self.tripData?.vehicle = result.data.vehicle
                     self.errorBannerRepository.clearDataError(key: errorKey)
-                case .error:
+                case let .error(error):
                     self.tripData?.vehicle = nil
                     self.errorBannerRepository.setDataError(
                         key: errorKey,
+                        details: error.description(),
                         action: { self.clearAndLoadTripDetails(tripFilter) }
                     )
                 }
@@ -422,9 +423,10 @@ class StopDetailsViewModel: ObservableObject {
                 case let .ok(okResponse):
                     self.errorBannerRepository.clearDataError(key: errorKey)
                     return okResponse.data.trip
-                case .error:
+                case let .error(error):
                     self.errorBannerRepository.setDataError(
                         key: errorKey,
+                        details: error.description(),
                         action: { self.clearAndLoadTripDetails(tripFilter) }
                     )
                     return nil

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -678,7 +678,9 @@ final class NearbyTransitViewTests: XCTestCase {
     @MainActor
     func testNearbyErrorMessage() throws {
         let repositories = MockRepositories()
-        repositories.errorBanner = MockErrorBannerStateRepository(state: .DataError(messages: [], action: {}))
+        repositories.errorBanner = MockErrorBannerStateRepository(
+            state: .DataError(messages: [], details: [], action: {})
+        )
         loadKoinMocks(repositories: repositories)
         let sut = NearbyTransitView(
             predictionsRepository: MockPredictionsRepository(),

--- a/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/RouteStopListViewTests.swift
@@ -55,7 +55,7 @@ final class RouteStopListViewTests: XCTestCase {
             onGet: { _, _ in gotRouteStops.send() }
         )
         HelpersKt.loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RouteStopListView(
             lineOrRoute: .route(mainRoute),
@@ -136,7 +136,7 @@ final class RouteStopListViewTests: XCTestCase {
             onGet: { routeId, _ in lastSelectedRoute = routeId; getRouteStopsSubject.send() }
         )
         HelpersKt.loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RouteStopListView(
             lineOrRoute: .line(line, [route1, route2, route3]),
@@ -204,7 +204,7 @@ final class RouteStopListViewTests: XCTestCase {
             onGet: { _, _ in gotRouteStops.send() }
         )
         HelpersKt.loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RouteStopListView(
             lineOrRoute: .route(mainRoute),
@@ -264,7 +264,7 @@ final class RouteStopListViewTests: XCTestCase {
             onGet: { _, _ in gotRouteStops.send() }
         )
         HelpersKt.loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: MockErrorBannerStateRepository())
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RouteStopListView(
             lineOrRoute: .route(mainRoute),

--- a/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerViewTests.swift
+++ b/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerViewTests.swift
@@ -25,7 +25,7 @@ final class RoutePickerViewTests: XCTestCase {
         repositories.global = MockGlobalRepository(response: GlobalResponse(objects: objects))
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -54,7 +54,7 @@ final class RoutePickerViewTests: XCTestCase {
         repositories.global = MockGlobalRepository(response: GlobalResponse(objects: objects))
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -83,7 +83,7 @@ final class RoutePickerViewTests: XCTestCase {
         repositories.global = MockGlobalRepository(response: GlobalResponse(objects: objects))
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -106,7 +106,7 @@ final class RoutePickerViewTests: XCTestCase {
         repositories.global = MockGlobalRepository(response: GlobalResponse(objects: objects))
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -135,7 +135,7 @@ final class RoutePickerViewTests: XCTestCase {
         repositories.global = MockGlobalRepository(response: GlobalResponse(objects: objects))
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -181,7 +181,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -225,7 +225,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -260,7 +260,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -294,7 +294,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -333,7 +333,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -372,7 +372,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
 
         let sut = RoutePickerView(
             context: RouteDetailsContext.Favorites(),
@@ -420,7 +420,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
         let mockSearchVM = MockSearchRoutesViewModel(
             initialState: SearchRoutesViewModel.StateResults(routeIds: [route1.id])
         )
@@ -458,7 +458,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
         let mockSearchVM = MockSearchRoutesViewModel()
 
         let exp = expectation(description: "Path updated in route search VM")
@@ -506,7 +506,7 @@ final class RoutePickerViewTests: XCTestCase {
         )
         repositories.errorBanner = MockErrorBannerStateRepository()
         loadKoinMocks(repositories: repositories)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repositories.errorBanner)
+        let errorBannerVM = ViewModelDI().errorBanner
         let mockSearchVM = MockSearchRoutesViewModel(
             initialState: SearchRoutesViewModel.StateResults(routeIds: [])
         )

--- a/iosApp/iosAppTests/Utils/FetchApiTests.swift
+++ b/iosApp/iosAppTests/Utils/FetchApiTests.swift
@@ -25,7 +25,7 @@ final class FetchApiTests: XCTestCase {
 
     func testCallsSuccessAndClearsError() async throws {
         let errorBannerRepo = ErrorBannerStateRepository()
-        errorBannerRepo.setDataError(key: "a", action: {})
+        errorBannerRepo.setDataError(key: "a", details: "", action: {})
         XCTAssertNotNil(errorBannerRepo.state.value)
         let expSuccess = expectation(description: "calls onSuccess")
         await fetchApi(

--- a/iosApp/iosAppTests/Views/ErrorBannerTests.swift
+++ b/iosApp/iosAppTests/Views/ErrorBannerTests.swift
@@ -17,7 +17,11 @@ final class ErrorBannerTests: XCTestCase {
     @MainActor
     func testRespondsToState() throws {
         let repo = MockErrorBannerStateRepository(state: nil)
-        let errorBannerVM = ErrorBannerViewModel(errorRepository: repo)
+        let errorBannerVM = ErrorBannerViewModel(
+            errorRepository: repo,
+            sentryRepository: MockSentryRepository(),
+            clock: SystemClock
+        )
 
         let sut = ErrorBanner(errorBannerVM)
 
@@ -80,11 +84,12 @@ final class ErrorBannerTests: XCTestCase {
     }
 
     @MainActor func testDebugModeNotShownByDefault() throws {
-        let sut = ErrorBanner(MockErrorBannerViewModel(initialState: .init(loadingWhenPredictionsStale: false,
-                                                                           errorState: .DataError(
-                                                                               messages: ["Fake message"],
-                                                                               action: {}
-                                                                           ))))
+        let sut = ErrorBanner(
+            MockErrorBannerViewModel(initialState: .init(
+                loadingWhenPredictionsStale: false,
+                errorState: .DataError(messages: ["Fake message"], details: [], action: {})
+            ))
+        )
 
         ViewHosting.host(view: sut.withFixedSettings([:]))
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ErrorBannerState.kt
@@ -13,8 +13,11 @@ public sealed class ErrorBannerState {
         public fun minutesAgo(): Long = (EasternTimeInstant.now() - lastUpdated).inWholeMinutes
     }
 
-    public data class DataError(val messages: Set<String>, override val action: () -> Unit) :
-        ErrorBannerState()
+    public data class DataError(
+        val messages: Set<String>,
+        internal val details: Set<String>,
+        override val action: () -> Unit,
+    ) : ErrorBannerState()
 
     public data class NetworkError(override val action: (() -> Unit)?) : ErrorBannerState()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SocketError.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/SocketError.kt
@@ -4,4 +4,5 @@ internal object SocketError {
     const val FAILURE = "channel failure"
     const val RECEIVED_ERROR = "channel received error"
     const val FAILED_TO_PARSE = "channel failed to parse"
+    const val TIMEOUT = "channel timed out"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ApiResult.kt
@@ -5,7 +5,9 @@ import io.ktor.client.plugins.ResponseException
 public sealed class ApiResult<out T : Any> {
     public data class Ok<T : Any>(val data: T) : ApiResult<T>()
 
-    public data class Error<T : Any>(val code: Int? = null, val message: String) : ApiResult<T>()
+    public data class Error<T : Any>(val code: Int? = null, val message: String) : ApiResult<T>() {
+        override fun toString(): String = if (code != null) "Error $code: $message" else message
+    }
 
     @Throws(IllegalStateException::class)
     internal fun dataOrThrow(): T {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobilePhoenixInterfaces.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/network/MobilePhoenixInterfaces.kt
@@ -18,6 +18,16 @@ public interface PhoenixPush {
     public fun receive(status: PhoenixPushStatus, callback: ((PhoenixMessage) -> Unit)): PhoenixPush
 }
 
+// if this is part of the interface then it’s not inherited by the Swift extension
+public fun PhoenixPush.receiveAll(
+    onOk: (PhoenixMessage) -> Unit,
+    onError: (PhoenixMessage) -> Unit,
+    onTimeout: (PhoenixMessage) -> Unit,
+): PhoenixPush =
+    receive(PhoenixPushStatus.Ok, onOk)
+        .receive(PhoenixPushStatus.Error, onError)
+        .receive(PhoenixPushStatus.Timeout, onTimeout)
+
 public interface PhoenixChannel {
     public fun onEvent(event: String, callback: ((PhoenixMessage) -> Unit))
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -47,9 +47,11 @@ internal constructor(initialState: ErrorBannerState? = null) : KoinComponent {
                 networkStatus == NetworkStatus.Disconnected -> ErrorBannerState.NetworkError(null)
                 dataErrors.isNotEmpty() ->
                     // encapsulate all the different error actions within one error
-                    ErrorBannerState.DataError(dataErrors.keys) {
-                        dataErrors.values.forEach { it.action() }
-                    }
+                    ErrorBannerState.DataError(
+                        messages = dataErrors.keys,
+                        details = dataErrors.values.flatMap { it.details }.toSet(),
+                        action = { dataErrors.values.forEach { it.action() } },
+                    )
                 predictionsStale != null -> predictionsStale
                 else -> null
             }
@@ -77,8 +79,8 @@ internal constructor(initialState: ErrorBannerState? = null) : KoinComponent {
         updateState()
     }
 
-    public fun setDataError(key: String, action: () -> Unit) {
-        dataErrors[key] = ErrorBannerState.DataError(setOf(key), action)
+    public fun setDataError(key: String, details: String, action: () -> Unit) {
+        dataErrors[key] = ErrorBannerState.DataError(setOf(key), setOf(details), action)
         updateState()
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SentryRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SentryRepository.kt
@@ -1,10 +1,13 @@
 package com.mbta.tid.mbta_app.repositories
 
+import io.sentry.kotlin.multiplatform.Scope
 import io.sentry.kotlin.multiplatform.Sentry
 
 public interface ISentryRepository {
 
     public fun captureMessage(msg: String)
+
+    public fun captureMessage(msg: String, additionalDetails: Scope.() -> Unit)
 
     public fun captureException(throwable: Throwable)
 }
@@ -14,6 +17,10 @@ internal class SentryRepository : ISentryRepository {
         Sentry.captureMessage(msg)
     }
 
+    override fun captureMessage(msg: String, additionalDetails: Scope.() -> Unit) {
+        Sentry.captureMessage(msg) { it.additionalDetails() }
+    }
+
     override fun captureException(throwable: Throwable) {
         Sentry.captureException(throwable)
     }
@@ -21,6 +28,10 @@ internal class SentryRepository : ISentryRepository {
 
 public class MockSentryRepository : ISentryRepository {
     override fun captureMessage(msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun captureMessage(msg: String, additionalDetails: Scope.() -> Unit) {
         TODO("Not yet implemented")
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
@@ -6,8 +6,8 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
-import com.mbta.tid.mbta_app.network.PhoenixPushStatus
 import com.mbta.tid.mbta_app.network.PhoenixSocket
+import com.mbta.tid.mbta_app.network.receiveAll
 import com.mbta.tid.mbta_app.phoenix.PredictionsForStopsChannel
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.time.Duration.Companion.minutes
@@ -53,13 +53,14 @@ internal class TripPredictionsRepository(private val socket: PhoenixSocket) :
         channel?.onDetach { message -> println("leaving channel ${message.subject}") }
         channel
             ?.attach()
-            ?.receive(PhoenixPushStatus.Ok) { message ->
-                println("joined channel ${message.subject}")
-                handleNewDataMessage(message, onReceive)
-            }
-            ?.receive(PhoenixPushStatus.Error) {
-                onReceive(ApiResult.Error(message = SocketError.RECEIVED_ERROR))
-            }
+            ?.receiveAll(
+                onOk = { message ->
+                    println("joined channel ${message.subject}")
+                    handleNewDataMessage(message, onReceive)
+                },
+                onError = { onReceive(ApiResult.Error(message = SocketError.RECEIVED_ERROR)) },
+                onTimeout = { onReceive(ApiResult.Error(message = SocketError.TIMEOUT)) },
+            )
     }
 
     override fun disconnect() {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
@@ -9,8 +9,13 @@ import androidx.compose.runtime.setValue
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import io.sentry.kotlin.multiplatform.SentryLevel
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,7 +36,11 @@ public interface IErrorBannerViewModel {
     public fun setSheetRoute(sheetRoute: SheetRoutes?)
 }
 
-public class ErrorBannerViewModel(private val errorRepository: IErrorBannerStateRepository) :
+public class ErrorBannerViewModel(
+    private val errorRepository: IErrorBannerStateRepository,
+    private val sentryRepository: ISentryRepository,
+    private val clock: Clock,
+) :
     MoleculeViewModel<ErrorBannerViewModel.Event, ErrorBannerViewModel.State>(),
     IErrorBannerViewModel {
 
@@ -50,6 +59,12 @@ public class ErrorBannerViewModel(private val errorRepository: IErrorBannerState
         public data object ClearState : Event
     }
 
+    private data class ClearedDataError(
+        val keys: Set<String>,
+        val details: Set<String>,
+        val clearedAt: EasternTimeInstant,
+    )
+
     @Composable
     override fun runLogic(events: Flow<Event>): State {
         var awaitingPredictionsAfterBackground: Boolean by remember { mutableStateOf(false) }
@@ -57,9 +72,59 @@ public class ErrorBannerViewModel(private val errorRepository: IErrorBannerState
 
         var errorState: ErrorBannerState? by remember { mutableStateOf(null) }
 
+        var clearedError: ClearedDataError? by remember { mutableStateOf(null) }
+
         LaunchedEffect(Unit) {
             errorRepository.subscribeToNetworkStatusChanges()
-            errorRepository.state.collect { errorState = it }
+            errorRepository.state.collect { newErrorState ->
+                val previousErrorState = errorState
+                val previousClearedError = clearedError
+                if (previousErrorState is ErrorBannerState.DataError && newErrorState == null) {
+                    clearedError =
+                        ClearedDataError(
+                            previousErrorState.messages,
+                            previousErrorState.details,
+                            EasternTimeInstant.now(clock),
+                        )
+                } else if (
+                    previousErrorState == null &&
+                        newErrorState is ErrorBannerState.DataError &&
+                        previousClearedError != null
+                ) {
+                    // data error was cleared and then came back instantly, that’s not good
+                    val oldKeys = previousClearedError.keys
+                    val newKeys = newErrorState.messages
+                    val commonKeys = oldKeys intersect newKeys
+                    if (
+                        EasternTimeInstant.now(clock) - previousClearedError.clearedAt <
+                            1.minutes && commonKeys.isNotEmpty()
+                    ) {
+                        sentryRepository.captureMessage(
+                            "Recurring DataError ${commonKeys.sorted()}"
+                        ) {
+                            addBreadcrumb(
+                                Breadcrumb(
+                                    SentryLevel.ERROR,
+                                    type = "error",
+                                    message = "Recurring DataError",
+                                    category = null,
+                                    mutableMapOf(
+                                        "previousClearedError.keys" to previousClearedError.keys,
+                                        "previousClearedError.details" to
+                                            previousClearedError.details,
+                                        "previousClearedError.clearedAt" to
+                                            previousClearedError.clearedAt,
+                                        "newErrorState.messages" to newErrorState.messages,
+                                        "newErrorState.details" to newErrorState.details,
+                                    ),
+                                )
+                            )
+                        }
+                    }
+                    clearedError = null
+                }
+                errorState = newErrorState
+            }
         }
 
         LaunchedEffect(Unit) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
@@ -24,7 +24,11 @@ internal suspend fun <T : Any> fetchApi(
     when (result) {
         is ApiResult.Error -> {
             println("fetchApi error: API request $errorKey failed: $result")
-            errorBannerRepo.setDataError(key = errorKey, action = onRefreshAfterError)
+            errorBannerRepo.setDataError(
+                key = errorKey,
+                details = result.toString(),
+                action = onRefreshAfterError,
+            )
         }
         is ApiResult.Ok -> {
             errorBannerRepo.clearDataError(key = errorKey)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
@@ -50,7 +50,7 @@ class ErrorBannerStateRepositoryTest {
 
         repo.checkPredictionsStale(EasternTimeInstant.now() - 3.minutes, 1) {}
 
-        repo.setDataError("global") {}
+        repo.setDataError("global", "") {}
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
 
@@ -64,9 +64,9 @@ class ErrorBannerStateRepositoryTest {
         val repo = ErrorBannerStateRepository()
         val actionsCalled = mutableSetOf<String>()
 
-        repo.setDataError("a") { actionsCalled.add("a") }
-        repo.setDataError("b") { actionsCalled.add("b") }
-        repo.setDataError("c") { actionsCalled.add("c") }
+        repo.setDataError("a", "") { actionsCalled.add("a") }
+        repo.setDataError("b", "") { actionsCalled.add("b") }
+        repo.setDataError("c", "") { actionsCalled.add("c") }
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
         repo.state.value?.action?.invoke()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
@@ -7,14 +7,28 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import dev.mokkery.MockMode
+import dev.mokkery.answering.calls
+import dev.mokkery.answering.throwsErrorWith
+import dev.mokkery.every
+import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import dev.mokkery.verify
+import dev.mokkery.verifyNoMoreCalls
+import io.sentry.kotlin.multiplatform.Scope
+import io.sentry.kotlin.multiplatform.SentryLevel
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -32,6 +46,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
     private fun setUpKoin(
         coroutineDispatcher: CoroutineDispatcher,
+        clock: Clock = Clock.System,
         repositoriesBlock: MockRepositories.() -> Unit = {},
     ) {
 
@@ -44,6 +59,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
                         coroutineDispatcher
                     }
                     single<INetworkConnectivityMonitor> { mockNetworkMonitor }
+                    single<Clock> { clock }
                 },
                 repositoriesModule(
                     MockRepositories().apply {
@@ -75,11 +91,10 @@ internal class ErrorBannerViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
 
-            errorRepo.setDataError("FakeError", action)
-            assertEquals(
-                setOf("FakeError"),
-                (awaitItem().errorState as ErrorBannerState.DataError).messages,
-            )
+            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            val state = awaitItem().errorState
+            assertEquals(setOf("FakeError"), (state as ErrorBannerState.DataError).messages)
+            assertEquals(setOf("FakeDetails"), state.details)
         }
     }
 
@@ -96,11 +111,9 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("FakeError", action)
-            assertEquals(
-                setOf("FakeError"),
-                (awaitItem().errorState as ErrorBannerState.DataError).messages,
-            )
+            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            val nextState = awaitItem().errorState
+            assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
         }
@@ -136,11 +149,10 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("FakeError", action)
-            assertEquals(
-                setOf("FakeError"),
-                (awaitItem().errorState as ErrorBannerState.DataError).messages,
-            )
+            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            val nextState = awaitItem().errorState
+            assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
+            assertEquals(setOf("FakeDetails"), nextState.details)
             viewModel.setSheetRoute(SheetRoutes.Favorites)
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
         }
@@ -161,11 +173,10 @@ internal class ErrorBannerViewModelTest : KoinTest {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             viewModel.setSheetRoute(SheetRoutes.Favorites)
             advanceUntilIdle()
-            errorRepo.setDataError("FakeError", action)
-            assertEquals(
-                setOf("FakeError"),
-                (awaitItem().errorState as ErrorBannerState.DataError).messages,
-            )
+            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            val nextState = awaitItem().errorState
+            assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
+            assertEquals(setOf("FakeDetails"), nextState.details)
             viewModel.setSheetRoute(SheetRoutes.Favorites)
         }
     }
@@ -193,6 +204,109 @@ internal class ErrorBannerViewModelTest : KoinTest {
                 ),
                 awaitItem(),
             )
+        }
+    }
+
+    @Test
+    fun `records recurring DataErrors in Sentry`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val errorRepo = ErrorBannerStateRepository()
+        val sentryScope = mock<Scope>(MockMode.autofill)
+        val sentryRepo =
+            mock<ISentryRepository>(MockMode.autofill) {
+                every { captureMessage(any(), any()) } calls
+                    { (_: String, additionalDetails: Scope.() -> Unit) ->
+                        sentryScope.additionalDetails()
+                    }
+            }
+
+        val clock =
+            object : Clock {
+                var now = Clock.System.now()
+
+                override fun now() = now
+            }
+
+        setUpKoin(dispatcher, clock) {
+            errorBanner = errorRepo
+            sentry = sentryRepo
+        }
+
+        val viewModel: ErrorBannerViewModel = get()
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
+            errorRepo.setDataError("ErrorKey", "error details") {}
+            var nextState = awaitItem().errorState
+            assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
+            assertEquals(setOf("error details"), nextState.details)
+            clock.now += 1.seconds
+            val clearedAt = clock.now
+            viewModel.clearState()
+            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
+            clock.now += 1.seconds
+            errorRepo.setDataError("ErrorKey", "error details") {}
+            nextState = awaitItem().errorState
+            assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
+            assertEquals(setOf("error details"), nextState.details)
+            verify { sentryRepo.captureMessage("Recurring DataError [ErrorKey]", any()) }
+            verify {
+                sentryScope.addBreadcrumb(
+                    Breadcrumb(
+                        level = SentryLevel.ERROR,
+                        type = "error",
+                        message = "Recurring DataError",
+                        category = null,
+                        data =
+                            mutableMapOf(
+                                "previousClearedError.keys" to setOf("ErrorKey"),
+                                "previousClearedError.details" to setOf("error details"),
+                                "previousClearedError.clearedAt" to EasternTimeInstant(clearedAt),
+                                "newErrorState.messages" to setOf("ErrorKey"),
+                                "newErrorState.details" to setOf("error details"),
+                            ),
+                    )
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `does not record DataErrors if over a minute since cleared`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val errorRepo = ErrorBannerStateRepository()
+        val sentryRepo =
+            mock<ISentryRepository>(MockMode.autofill) {
+                every { captureMessage(any(), any()) } throwsErrorWith
+                    "should not have captured Sentry message"
+            }
+
+        val clock =
+            object : Clock {
+                var now = Clock.System.now()
+
+                override fun now() = now
+            }
+
+        setUpKoin(dispatcher, clock) {
+            errorBanner = errorRepo
+            sentry = sentryRepo
+        }
+
+        val viewModel: ErrorBannerViewModel = get()
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
+            errorRepo.setDataError("ErrorKey", "error details") {}
+            assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
+            viewModel.clearState()
+            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
+            clock.now += 2.minutes
+            errorRepo.setDataError("ErrorKey", "error details") {}
+            assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
+            verifyNoMoreCalls(sentryRepo)
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -15,6 +15,7 @@ import com.mbta.tid.mbta_app.endToEnd.endToEndModule
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.viewModelModule
 import kotlin.experimental.ExperimentalObjCName
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -128,3 +129,5 @@ public fun EasternTimeInstant.plusHours(hours: Int): EasternTimeInstant = this +
 
 @ObjCName("minus")
 public fun EasternTimeInstant.minusHours(hours: Int): EasternTimeInstant = this - hours.hours
+
+public val SystemClock: Clock = Clock.System

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/PlatformModule.kt
@@ -4,6 +4,7 @@ import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.network.NetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.utils.IOSSystemPaths
 import com.mbta.tid.mbta_app.utils.SystemPaths
+import kotlin.time.Clock
 import org.koin.dsl.module
 
 internal fun platformModule() = module {
@@ -11,5 +12,6 @@ internal fun platformModule() = module {
         module { single { createDataStore() } },
         module { single<SystemPaths> { IOSSystemPaths() } },
         module { single<INetworkConnectivityMonitor> { NetworkConnectivityMonitor() } },
+        module { single<Clock> { Clock.System } },
     )
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Investigate android sometimes caught in error loading data](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211025820891519?focus=true)

I was completely unable to reproduce the issue in the linked ticket, but hopefully the Phoenix and Sentry changes here will give us more information to debug that with.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added new unit tests for new logic. Checked that all existing tests pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
