### PR TITLE
fix(Android): hide sheet if returning to search

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -389,7 +389,13 @@ fun MapAndSheetPage(
         }
     }
     LaunchedEffect(currentNavEntry) {
-        if (SheetRoutes.shouldResetSheetHeight(previousNavEntry, currentNavEntry)) {
+        if (
+            previousNavEntry !is SheetRoutes.Entrypoint &&
+                currentNavEntry is SheetRoutes.Entrypoint &&
+                searchExpanded
+        ) {
+            nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Hidden)
+        } else if (SheetRoutes.shouldResetSheetHeight(previousNavEntry, currentNavEntry)) {
             nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Medium)
         }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -389,11 +389,7 @@ fun MapAndSheetPage(
         }
     }
     LaunchedEffect(currentNavEntry) {
-        if (
-            previousNavEntry !is SheetRoutes.Entrypoint &&
-                currentNavEntry is SheetRoutes.Entrypoint &&
-                searchExpanded
-        ) {
+        if (currentNavEntry?.showSearchBar == true && searchExpanded) {
             nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Hidden)
         } else if (SheetRoutes.shouldResetSheetHeight(previousNavEntry, currentNavEntry)) {
             nearbyTransit.scaffoldState.bottomSheetState.animateTo(SheetValue.Medium)


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | sheet covers search when returning from full-height stop details](https://app.asana.com/1/15492006741476/project/1201654106676769/task/1211055599324062?focus=true)

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked manually that this fix resolves this issue.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
