### PR TITLE
fix(Android): handle setSheetPadding applying while animateToOverview queued

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -1,11 +1,32 @@
 package com.mbta.tid.mbta_app.android.location
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.mapbox.maps.EdgeInsets
+import com.mapbox.maps.extension.compose.MapEffect
+import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
+import com.mapbox.maps.plugin.viewport.ViewportStatus
+import com.mapbox.maps.plugin.viewport.state.OverviewViewportState
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.Vehicle
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Rule
 import org.junit.Test
 
@@ -23,5 +44,80 @@ class ViewportProviderTest {
         composeTestRule.waitUntil { viewportProvider.isFollowingPuck }
         assertTrue(viewportProvider.isFollowingPuck)
         assertFalse(viewportProvider.isVehicleOverview)
+    }
+
+    @Test
+    fun testLazyPadding() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val stop =
+            objects.stop {
+                latitude = 42.3531
+                longitude = -71.0697
+            }
+        val vehicle =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                latitude = 42.3547
+                longitude = -71.0702
+            }
+        val mapViewportState =
+            MapViewportState().apply {
+                setCameraOptions {
+                    center(ViewportProvider.Companion.Defaults.center)
+                    zoom(ViewportProvider.Companion.Defaults.zoom)
+                    pitch(0.0)
+                    bearing(0.0)
+                    transitionToFollowPuckState()
+                }
+            }
+        val viewportProvider = ViewportProvider(mapViewportState)
+        val density = Density(1f)
+        val paddingBefore = 0.0
+        val paddingAfter = 1.0
+        val mapLoaded = CompletableDeferred<Unit>()
+        composeTestRule.setContent {
+            MapboxMap(mapViewportState = mapViewportState) {
+                MapEffect { mapLoaded.complete(Unit) }
+            }
+        }
+
+        withTimeout(10.seconds) { mapLoaded.await() }
+
+        withTimeout(10.seconds) {
+            viewportProvider.setSheetPadding(
+                PaddingValues(paddingBefore.dp),
+                density,
+                LayoutDirection.Ltr,
+            )
+        }
+
+        val stopCenter =
+            async(Dispatchers.Default) {
+                delay(1.milliseconds)
+                viewportProvider.stopCenter(stop)
+            }
+        val setPadding =
+            async(Dispatchers.Default) {
+                delay(2.milliseconds)
+                viewportProvider.setSheetPadding(
+                    PaddingValues(paddingAfter.dp),
+                    density,
+                    LayoutDirection.Ltr,
+                )
+            }
+        val vehicleOverview =
+            async(Dispatchers.Default) {
+                delay(3.milliseconds)
+                viewportProvider.vehicleOverview(vehicle, stop, 1f)
+            }
+
+        withTimeout(10.seconds) { awaitAll(stopCenter, setPadding, vehicleOverview) }
+
+        val viewportStatus = assertIs<ViewportStatus.State>(mapViewportState.mapViewportStatus)
+        val viewportInnerState = assertIs<OverviewViewportState>(viewportStatus.state)
+        assertEquals(
+            EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
+            viewportInnerState.options.padding,
+        )
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -113,6 +113,8 @@ class ViewportProviderTest {
 
         withTimeout(10.seconds) { awaitAll(stopCenter, setPadding, vehicleOverview) }
 
+        composeTestRule.waitUntil { mapViewportState.mapViewportStatus is ViewportStatus.State }
+
         val viewportStatus = assertIs<ViewportStatus.State>(mapViewportState.mapViewportStatus)
         val viewportInnerState = assertIs<OverviewViewportState>(viewportStatus.state)
         assertEquals(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -751,16 +751,20 @@ fun MapAndSheetPage(
                         }
                     },
                 ) {
-                    HomeMapView(
-                        sheetPadding =
+                    val searchBarHeight by viewModel.searchBarHeight.collectAsState()
+                    val mapPadding =
+                        remember(sheetPadding, searchBarHeight) {
                             sheetPadding.plus(
                                 PaddingValues(
                                     start = 0.dp,
                                     end = 0.dp,
-                                    top = (viewModel.searchBarHeight.value ?: 0.dp),
+                                    top = (searchBarHeight ?: 0.dp),
                                     bottom = 0.dp,
                                 )
-                            ),
+                            )
+                        }
+                    HomeMapView(
+                        sheetPadding = mapPadding,
                         lastLoadedLocation = nearbyTransit.lastLoadedLocation,
                         isTargetingState = nearbyTransit.isTargetingState,
                         locationDataManager = nearbyTransit.locationDataManager,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Map animation race condition?](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210805266121129?focus=true)

Ugh.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that some steps that used to sometimes reproduce this issue (have a favorite far away from your current location, expand the favorites sheet, tap that favorite) now do not reproduce this issue. Added a test which fails without the lazy `animateToOverview` options and passes with it.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
