### PR TITLE
fix(iOS): add Voice Control label for collapsed stops in trip details

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2595,6 +2595,155 @@
         }
       }
     },
+    "%ldstops away" : {
+      "comment" : "Voice Control alias to abbreviate “7 stops away” to “7stops” rather than just “7”",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%ldstop away"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%ldstops away"
+                }
+              }
+            }
+          }
+        },
+        "es" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldparada antes de"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldparadas antes de"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldarrêt restant"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldarrêts restants"
+                }
+              }
+            }
+          }
+        },
+        "ht" : {
+          "variations" : {
+            "plural" : {
+              "few" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldkanpe lwen"
+                }
+              },
+              "many" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldkanpe lwen"
+                }
+              },
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldkanpe lwen"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldkanpe lwen"
+                }
+              },
+              "two" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldkanpe lwen"
+                }
+              }
+            }
+          }
+        },
+        "pt-BR" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldparada"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldparadas"
+                }
+              }
+            }
+          }
+        },
+        "vi" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "%ldđiểm dừng nữa"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hans-CN" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "还有%ld站"
+                }
+              }
+            }
+          }
+        },
+        "zh-Hant-TW" : {
+          "variations" : {
+            "plural" : {
+              "other" : {
+                "stringUnit" : {
+                  "state" : "needs_review",
+                  "value" : "還有%ld站"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "711 for TTY callers; VRS for ASL callers" : {
       "comment" : "Footnote under the More page support phone number, these are the instructions for accessible support via teletypewriter or video relay service",
       "localizations" : {

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -125,13 +125,14 @@ struct TripStops: View {
                                 )
                                 .foregroundStyle(Color.text)
                                 .padding(.leading, 0)
-                                .accessibilityLabel(Text(
-                                    "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
-                                    comment: """
-                                    VoiceOver label for how many stops away a vehicle is from a stop,
-                                    ex 'bus is 4 stops away from Harvard'
-                                    """
-                                ))
+                                .accessibilityLabel(nStopsAwayLabel(stopsAway: stopsAway, target: target))
+                                .accessibilityInputLabels([
+                                    Text(
+                                        "\(stopsAway, specifier: "%ld")stops away",
+                                        comment: "Voice Control alias to abbreviate “7 stops away” to “7stops” rather than just “7”"
+                                    ),
+                                    nStopsAwayLabel(stopsAway: stopsAway, target: target),
+                                ])
                                 .accessibilityHint(stopsExpanded ? Text(
                                     "Hides remaining stops",
                                     comment: """
@@ -189,6 +190,16 @@ struct TripStops: View {
         }
         .padding(.horizontal, 10)
         .padding(.bottom, 48)
+    }
+
+    private func nStopsAwayLabel(stopsAway: Int, target: TripDetailsStopList.Entry) -> Text {
+        Text(
+            "\(routeTypeText) is \(stopsAway, specifier: "%ld") stops away from \(target.stop.name)",
+            comment: """
+            VoiceOver label for how many stops away a vehicle is from a stop,
+            ex 'bus is 4 stops away from Harvard'
+            """
+        )
     }
 }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Better Voice Control options for "X stops away" ](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211055599324068?focus=true)

Asked [in Slack](https://mbta.slack.com/archives/C05QMG9GS9M/p1756403147173279) if these deviations from the acceptance criteria are legit.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Manually checked that this works. Checked if `accessibilityInputLabels` is supported in ViewInspector, but it is not.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
