### PR TITLE
ci: clean up caches written by merge queue twice a day

### DIFF
--- a/.github/workflows/cache-cleanup.yaml
+++ b/.github/workflows/cache-cleanup.yaml
@@ -1,0 +1,22 @@
+name: Clean up GitHub Actions cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "32 */12 * * MON-FRI"
+
+jobs:
+  cleanup:
+    name: Clean up GitHub Actions cache
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh cache list \
+            --json id,lastAccessedAt,ref \
+            --limit 100 \
+            --sort last_accessed_at \
+            --order asc \
+            --jq '.[] | select(.ref | startswith("refs/heads/gh-readonly-queue/")) | .id' | \
+            xargs -n1 gh cache delete


### PR DESCRIPTION
### Summary

_Ticket:_ none

Noticed that a lot of our [GitHub Actions cache usage](https://github.com/mbta/mobile_app/actions/caches) is from merge queue branches, and being able to cache things from one attempt at merging a PR to the next is not very useful (if it even works at all, which it might not). It would be nice to just treat the cache as read-only in the merge queue, but there’s no clear way to do that, so the next best thing is to occasionally prune merge queue caches so that they aren’t as likely to crowd out actually useful cache data.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this jq filter is correct and the xargs Should™ delete each selected cache.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
