### PR TITLE
fix?(ViewModel): stop crashing on event buffer overflows

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.captureToImage
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -22,6 +23,7 @@ import kotlin.math.abs
 import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import org.junit.Assert.fail
 import org.koin.core.qualifier.named
 import org.koin.dsl.koinApplication
@@ -126,8 +128,11 @@ fun testKoinApplication(
 ) = koinApplication {
     modules(
         module {
-            single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) { Dispatchers.Default }
-            single<CoroutineDispatcher>(named("coroutineDispatcherIO")) { Dispatchers.IO }
+            single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
+                Dispatchers.Default
+            }
+            single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherIO)) { Dispatchers.IO }
+            single<BufferOverflow>(named(KoinName.OnEventBufferOverflow)) { BufferOverflow.SUSPEND }
 
             single<Analytics> { analytics }
             single<PhoenixSocket> { socket }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.channels.BufferOverflow
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,7 +20,13 @@ class ErrorBannerTests {
     @Test
     fun testRespondsToState() {
         val errorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-        val viewModel = ErrorBannerViewModel(errorRepo, MockSentryRepository(), Clock.System)
+        val viewModel =
+            ErrorBannerViewModel(
+                errorRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
 
         composeTestRule.setContent { ErrorBanner(viewModel) }
 
@@ -44,7 +51,12 @@ class ErrorBannerTests {
         val networkErrorRepo =
             MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
         val networkErrorVM =
-            ErrorBannerViewModel(networkErrorRepo, MockSentryRepository(), Clock.System)
+            ErrorBannerViewModel(
+                networkErrorRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
 
         composeTestRule.setContent { ErrorBanner(networkErrorVM) }
 
@@ -62,7 +74,13 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository(), Clock.System)
+        val dataErrorVM =
+            ErrorBannerViewModel(
+                dataErrorRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
         composeTestRule.setContent { ErrorBanner(dataErrorVM) }
 
         composeTestRule.onNodeWithText("Error loading data").assertExists()
@@ -78,7 +96,13 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM =
+            ErrorBannerViewModel(
+                staleRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
         composeTestRule.setContent { ErrorBanner(staleVM) }
 
         composeTestRule.onNodeWithText("Updated 2 minutes ago").assertExists()
@@ -94,7 +118,13 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM =
+            ErrorBannerViewModel(
+                staleRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
         composeTestRule.setContent { ErrorBanner(staleVM) }
 
         composeTestRule.onNodeWithText("Updated 1 minute ago").assertExists()
@@ -110,7 +140,13 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM =
+            ErrorBannerViewModel(
+                staleRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
         staleVM.setIsLoadingWhenPredictionsStale(true)
         composeTestRule.setContent { ErrorBanner(staleVM) }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
@@ -20,6 +20,7 @@ import dev.mokkery.resetCalls
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import kotlin.time.Clock
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -55,6 +56,7 @@ class FavoritesViewTest {
                         errorRepository = MockErrorBannerStateRepository(),
                         MockSentryRepository(),
                         Clock.System,
+                        onEventBufferOverflow = BufferOverflow.SUSPEND,
                     ),
                 toastViewModel = toastVM,
                 alertData = AlertsStreamDataResponse(objects),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -31,6 +31,7 @@ import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -52,6 +53,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         val configManager = MapboxConfigManager()
@@ -89,6 +91,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)
@@ -132,6 +135,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider =
             ViewportProvider(
@@ -175,6 +179,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)
@@ -210,6 +215,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)
@@ -246,6 +252,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)
@@ -282,6 +289,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)
@@ -360,6 +368,7 @@ class HomeMapViewTests {
                 MockStopRepository(),
                 Dispatchers.Default,
                 Dispatchers.IO,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
         val viewportProvider = ViewportProvider(MapViewportState())
         viewModel.setViewportManager(viewportProvider)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.channels.BufferOverflow
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -58,6 +59,7 @@ class SubscribeToPredictionsTest {
                 MockErrorBannerStateRepository(),
                 MockSentryRepository(),
                 Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         composeTestRule.setContent {
@@ -106,6 +108,7 @@ class SubscribeToPredictionsTest {
                 MockErrorBannerStateRepository(),
                 MockSentryRepository(),
                 Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         composeTestRule.setContent {
@@ -150,6 +153,7 @@ class SubscribeToPredictionsTest {
                 MockErrorBannerStateRepository(),
                 MockSentryRepository(),
                 Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         composeTestRule.setContent {
@@ -180,7 +184,12 @@ class SubscribeToPredictionsTest {
                 onCheckPredictionsStale = { checkPredictionsStaleCount += 1 }
             )
         val errorBannerViewModel =
-            ErrorBannerViewModel(mockErrorRepo, MockSentryRepository(), Clock.System)
+            ErrorBannerViewModel(
+                mockErrorRepo,
+                MockSentryRepository(),
+                Clock.System,
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
+            )
 
         composeTestRule.setContent {
             var stopIds by remember { stopIds }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
@@ -17,6 +17,7 @@ import com.mbta.tid.mbta_app.initKoin
 import com.mbta.tid.mbta_app.repositories.AccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.CurrentAppVersionRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import org.koin.core.module.dsl.*
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -39,6 +40,7 @@ class MainApplication : Application() {
                 else MockAnalytics(),
                 CurrentAppVersionRepository(BuildConfig.VERSION_NAME),
                 socket.wrapped(),
+                if (BuildConfig.DEBUG) BufferOverflow.SUSPEND else BufferOverflow.DROP_OLDEST,
             ) + koinViewModelModule(),
             this,
         )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -44,6 +44,7 @@ import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.channels.BufferOverflow
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
@@ -186,11 +187,22 @@ class ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository(), Clock.System)
+    val dataErrorVM =
+        ErrorBannerViewModel(
+            dataErrorRepo,
+            MockSentryRepository(),
+            Clock.System,
+            onEventBufferOverflow = BufferOverflow.SUSPEND,
+        )
 
     val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
     val networkErrorVM =
-        ErrorBannerViewModel(networkErrorRepo, MockSentryRepository(), Clock.System)
+        ErrorBannerViewModel(
+            networkErrorRepo,
+            MockSentryRepository(),
+            Clock.System,
+            onEventBufferOverflow = BufferOverflow.SUSPEND,
+        )
 
     val staleRepo =
         MockErrorBannerStateRepository(
@@ -200,8 +212,20 @@ class ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
-    val staleLoadingVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+    val staleVM =
+        ErrorBannerViewModel(
+            staleRepo,
+            MockSentryRepository(),
+            Clock.System,
+            onEventBufferOverflow = BufferOverflow.SUSPEND,
+        )
+    val staleLoadingVM =
+        ErrorBannerViewModel(
+            staleRepo,
+            MockSentryRepository(),
+            Clock.System,
+            onEventBufferOverflow = BufferOverflow.SUSPEND,
+        )
 
     // The preview requires Koin to contain the cache in order to render,
     // but it won't actually use the debug value set here when displayed

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -91,12 +91,19 @@ struct ProductionAppView: View {
         return socket
     }
 
+    #if DEBUG
+        private static let onEventBufferOverflow = Kotlinx_coroutines_coreBufferOverflow.suspend
+    #else
+        private static let onEventBufferOverflow = Kotlinx_coroutines_coreBufferOverflow.dropOldest
+    #endif
+
     private static func initKoin(socket: PhoenixSocket) {
         let nativeModule: Koin_coreModule = MakeNativeModuleKt.makeNativeModule(
             accessibilityStatus: AccessibilityStatusRepository(),
             analytics: AnalyticsProvider.shared,
             currentAppVersion: CurrentAppVersionRepository(),
-            socket: socket
+            socket: socket,
+            onEventBufferOverflow: Self.onEventBufferOverflow
         )
         HelpersKt.doInitKoin(appVariant: appVariant, nativeModule: nativeModule)
     }

--- a/iosApp/iosAppTests/Views/ErrorBannerTests.swift
+++ b/iosApp/iosAppTests/Views/ErrorBannerTests.swift
@@ -20,7 +20,8 @@ final class ErrorBannerTests: XCTestCase {
         let errorBannerVM = ErrorBannerViewModel(
             errorRepository: repo,
             sentryRepository: MockSentryRepository(),
-            clock: SystemClock
+            clock: SystemClock,
+            onEventBufferOverflow: .suspend
         )
 
         let sut = ErrorBanner(errorBannerVM)

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -89,7 +89,8 @@ final class SearchResultViewTests: XCTestCase {
                 analytics: MockAnalytics(),
                 globalRepository: MockGlobalRepository(),
                 searchResultRepository: FakeRepo(getSearchResultsExpectation: getSearchResultsExpectation),
-                visitHistoryUsecase: .init(repository: MockVisitHistoryRepository())
+                visitHistoryUsecase: .init(repository: MockVisitHistoryRepository()),
+                onEventBufferOverflow: .suspend
             )
         )
 

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -1,31 +1,48 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
+    single { ErrorBannerViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IErrorBannerViewModel::class)
     single {
-            FavoritesViewModel(get(), get(), get(), get(named("coroutineDispatcherDefault")), get())
+            FavoritesViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
         }
         .bind(IFavoritesViewModel::class)
     viewModel {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
-    singleOf(::SearchViewModel).bind(ISearchViewModel::class)
+            MapViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(named(KoinName.CoroutineDispatcherIO)),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
+        }
+        .bind(IMapViewModel::class)
+    single {
+            SearchRoutesViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchRoutesViewModel::class)
+    single {
+            SearchViewModel(get(), get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchViewModel::class)
     // Use singleOf to ensure a shared ToastViewModel across all views that need it, it should be
     // injected using koinInject() rather than koinViewModel(), because if it gets destroyed by the
     // VM lifecycle management, it will break the toast state across different composables.
-    singleOf(::ToastViewModel).bind(IToastViewModel::class)
+    single { ToastViewModel(get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IToastViewModel::class)
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -48,9 +48,13 @@ internal fun appModule(appVariant: AppVariant) = module {
         module { single { MobileBackendClient(appVariant) } },
         module { single { FileSystem.SYSTEM } },
         module {
-            single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) { Dispatchers.Default }
+            single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
+                Dispatchers.Default
+            }
         },
-        module { single<CoroutineDispatcher>(named("coroutineDispatcherIO")) { Dispatchers.IO } },
+        module {
+            single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherIO)) { Dispatchers.IO }
+        },
         repositoriesModule(RealRepositories()),
     )
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/KoinName.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/KoinName.kt
@@ -1,0 +1,7 @@
+package com.mbta.tid.mbta_app.dependencyInjection
+
+public enum class KoinName {
+    CoroutineDispatcherDefault,
+    CoroutineDispatcherIO,
+    OnEventBufferOverflow,
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
@@ -14,7 +14,9 @@ import com.mbta.tid.mbta_app.repositories.PredictionsRepository
 import com.mbta.tid.mbta_app.repositories.TripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.VehicleRepository
 import com.mbta.tid.mbta_app.repositories.VehiclesRepository
+import kotlinx.coroutines.channels.BufferOverflow
 import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 public fun makeNativeModule(
@@ -22,12 +24,14 @@ public fun makeNativeModule(
     analytics: Analytics,
     currentAppVersion: ICurrentAppVersionRepository,
     socket: PhoenixSocket,
+    onEventBufferOverflow: BufferOverflow,
 ): Module {
     return module {
         single<IAccessibilityStatusRepository> { accessibilityStatus }
         single<Analytics> { analytics }
         single<ICurrentAppVersionRepository> { currentAppVersion }
         single<PhoenixSocket> { socket }
+        single<BufferOverflow>(named(KoinName.OnEventBufferOverflow)) { onEventBufferOverflow }
         factory<IAlertsRepository> { AlertsRepository(get()) }
         factory<IPredictionsRepository> { PredictionsRepository(get()) }
         factory<ITripPredictionsRepository> { TripPredictionsRepository(get()) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
@@ -16,6 +16,7 @@ import io.sentry.kotlin.multiplatform.SentryLevel
 import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -40,8 +41,11 @@ public class ErrorBannerViewModel(
     private val errorRepository: IErrorBannerStateRepository,
     private val sentryRepository: ISentryRepository,
     private val clock: Clock,
+    onEventBufferOverflow: BufferOverflow,
 ) :
-    MoleculeViewModel<ErrorBannerViewModel.Event, ErrorBannerViewModel.State>(),
+    MoleculeViewModel<ErrorBannerViewModel.Event, ErrorBannerViewModel.State>(
+        onEventBufferOverflow = onEventBufferOverflow
+    ),
     IErrorBannerViewModel {
 
     public data class State(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -22,6 +22,7 @@ import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getSchedules
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.subscribeToPredictions
 import io.github.dellisd.spatialk.geojson.Position
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -56,8 +57,12 @@ public class FavoritesViewModel(
     private val tabPreferencesRepository: ITabPreferencesRepository,
     private val coroutineDispatcher: CoroutineDispatcher,
     private val analytics: Analytics,
-) : MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(), IFavoritesViewModel {
-
+    onEventBufferOverflow: BufferOverflow,
+) :
+    MoleculeViewModel<FavoritesViewModel.Event, FavoritesViewModel.State>(
+        onEventBufferOverflow = onEventBufferOverflow
+    ),
+    IFavoritesViewModel {
     public sealed class Context {
         public data object Favorites : Context()
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -38,6 +38,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -84,8 +85,10 @@ public class MapViewModel(
     private val stopRepository: IStopRepository,
     private val defaultCoroutineDispatcher: CoroutineDispatcher,
     private val iOCoroutineDispatcher: CoroutineDispatcher,
-) : MoleculeViewModel<Event, MapViewModel.State>(), IMapViewModel {
-
+    onEventBufferOverflow: BufferOverflow,
+) :
+    MoleculeViewModel<Event, MapViewModel.State>(onEventBufferOverflow = onEventBufferOverflow),
+    IMapViewModel {
     private lateinit var viewportManager: ViewportManager
     private val routeCardDataUpdates = MutableStateFlow<List<RouteCardData>?>(null)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
@@ -21,12 +21,13 @@ public expect abstract class MoleculeScopeViewModel() {
  * Implementers should reexpose `val models get() = internalModels` and provide wrappers for
  * `fireEvent` for the types of event that they offer.
  */
-public abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel() {
+public abstract class MoleculeViewModel<Event, Model>(onEventBufferOverflow: BufferOverflow) :
+    MoleculeScopeViewModel() {
     private val events =
         MutableSharedFlow<Event>(
             replay = 20,
             extraBufferCapacity = 20,
-            onBufferOverflow = BufferOverflow.SUSPEND,
+            onBufferOverflow = onEventBufferOverflow,
         )
 
     /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModel.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,8 +37,11 @@ internal constructor(
     private val analytics: Analytics,
     private val globalRepository: IGlobalRepository,
     private val searchResultRepository: ISearchResultRepository,
+    onEventBufferOverflow: BufferOverflow,
 ) :
-    MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>(),
+    MoleculeViewModel<SearchRoutesViewModel.Event, SearchRoutesViewModel.State>(
+        onEventBufferOverflow = onEventBufferOverflow
+    ),
     ISearchRoutesViewModel {
     public sealed interface Event {
         public data class SetPath internal constructor(val path: RoutePickerPath) : Event

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
@@ -23,6 +23,7 @@ import com.mbta.tid.mbta_app.repositories.ISearchResultRepository
 import com.mbta.tid.mbta_app.usecases.VisitHistoryUsecase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -76,7 +77,12 @@ public class SearchViewModel(
     private val globalRepository: IGlobalRepository,
     private val searchResultRepository: ISearchResultRepository,
     private val visitHistoryUsecase: VisitHistoryUsecase,
-) : MoleculeViewModel<SearchViewModel.Event, SearchViewModel.State>(), ISearchViewModel {
+    onEventBufferOverflow: BufferOverflow,
+) :
+    MoleculeViewModel<SearchViewModel.Event, SearchViewModel.State>(
+        onEventBufferOverflow = onEventBufferOverflow
+    ),
+    ISearchViewModel {
     public sealed interface Event {
         public data class SetQuery internal constructor(val query: String) : Event
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModel.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.produceState
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel.Event
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel.Toast
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,8 +19,9 @@ public interface IToastViewModel {
     public fun showToast(toast: Toast)
 }
 
-public class ToastViewModel internal constructor() :
-    IToastViewModel, MoleculeViewModel<Event, ToastViewModel.State>() {
+public class ToastViewModel internal constructor(onEventBufferOverflow: BufferOverflow) :
+    IToastViewModel,
+    MoleculeViewModel<Event, ToastViewModel.State>(onEventBufferOverflow = onEventBufferOverflow) {
 
     /**
      * These are parallel to [androidx.compose.material3.SnackbarDuration], because the Jetpack

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.viewModel
 
 import app.cash.turbine.test
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.ErrorBannerState
@@ -31,6 +32,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -55,11 +57,14 @@ internal class ErrorBannerViewModelTest : KoinTest {
         startKoin {
             modules(
                 module {
-                    single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) {
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
                         coroutineDispatcher
                     }
                     single<INetworkConnectivityMonitor> { mockNetworkMonitor }
                     single<Clock> { clock }
+                    single<BufferOverflow>(named(KoinName.OnEventBufferOverflow)) {
+                        BufferOverflow.SUSPEND
+                    }
                 },
                 repositoriesModule(
                     MockRepositories().apply {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.viewModel
 import app.cash.turbine.test
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.Alert
@@ -37,6 +38,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -106,10 +108,11 @@ internal class FavoritesViewModelTest : KoinTest {
         startKoin {
             modules(
                 module {
-                    single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) {
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
                         coroutineDispatcher
                     }
                     single<Analytics> { analytics }
+                    single(named(KoinName.OnEventBufferOverflow)) { BufferOverflow.SUSPEND }
                 },
                 repositoriesModule(
                     MockRepositories().apply {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.viewModel
 
 import app.cash.turbine.test
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.Alert
@@ -30,6 +31,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -73,18 +75,17 @@ internal class MapViewModelTests : KoinTest {
         startKoin {
             modules(
                 module {
-                    single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) {
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
                         coroutineDispatcher
                     }
-                },
-                module {
-                    single<CoroutineDispatcher>(named("coroutineDispatcherIO")) {
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherIO)) {
                         coroutineDispatcher
                     }
+                    single<Clock> { Clock.System }
+                    single(named(KoinName.OnEventBufferOverflow)) { BufferOverflow.SUSPEND }
                 },
                 repositoriesModule(MockRepositories().apply { useObjects(TestData.clone()) }),
                 viewModelModule(),
-                module { single<Clock> { Clock.System } },
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchRoutesViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 
@@ -44,6 +45,7 @@ class SearchRoutesViewModelTest {
                         fail("Standard search should not be called here")
                     }
                 },
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         testViewModelFlow(searchVM).test {
@@ -82,6 +84,7 @@ class SearchRoutesViewModelTest {
                         fail("Standard search should not be called here")
                     }
                 },
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         testViewModelFlow(searchVM).test {
@@ -114,6 +117,7 @@ class SearchRoutesViewModelTest {
                         fail("Standard search should not be called here")
                     }
                 },
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         testViewModelFlow(searchVM).test {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.fail
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
@@ -86,6 +87,7 @@ class SearchViewModelTest {
                     }
                 },
                 VisitHistoryUsecase(visitHistoryRepo),
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         testViewModelFlow(searchVM).test {
@@ -190,6 +192,7 @@ class SearchViewModelTest {
                         }
                     )
                 ),
+                onEventBufferOverflow = BufferOverflow.SUSPEND,
             )
 
         val state =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ToastViewModelTest.kt
@@ -3,12 +3,13 @@ package com.mbta.tid.mbta_app.viewModel
 import app.cash.turbine.test
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.test.runTest
 
 class ToastViewModelTest {
     @Test
     fun testShowAndHideToast() = runTest {
-        val vm = ToastViewModel()
+        val vm = ToastViewModel(onEventBufferOverflow = BufferOverflow.SUSPEND)
         testViewModelFlow(vm).test {
             assertEquals(ToastViewModel.State.Hidden, awaitItem())
             vm.showToast(ToastViewModel.Toast("Message"))

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/Helpers.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.dependencyInjection.IRepositories
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.appModule
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
@@ -23,6 +24,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.datetime.toKotlinInstant
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.startKoin
@@ -84,10 +86,13 @@ public fun startKoinIOSTestApp() {
                 viewModelModule() +
                 module {
                     single<Analytics> { MockAnalytics() }
-                    single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) {
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherDefault)) {
                         Dispatchers.Default
                     }
-                    single<CoroutineDispatcher>(named("coroutineDispatcherIO")) { Dispatchers.IO }
+                    single<CoroutineDispatcher>(named(KoinName.CoroutineDispatcherIO)) {
+                        Dispatchers.IO
+                    }
+                    single(named(KoinName.OnEventBufferOverflow)) { BufferOverflow.SUSPEND }
                 }
         )
     }
@@ -97,7 +102,12 @@ public fun startKoinIOSTestApp() {
 public fun startKoinE2E() {
     startKoin {
         modules(
-            endToEndModule() + viewModelModule() + module { single<Analytics> { MockAnalytics() } }
+            endToEndModule() +
+                viewModelModule() +
+                module {
+                    single<Analytics> { MockAnalytics() }
+                    single(named(KoinName.OnEventBufferOverflow)) { BufferOverflow.SUSPEND }
+                }
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -1,26 +1,44 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
+    single { ErrorBannerViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IErrorBannerViewModel::class)
     single {
-        FavoritesViewModel(get(), get(), get(), get(named("coroutineDispatcherDefault")), get())
-    }
+            FavoritesViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
+        }
+        .bind(IFavoritesViewModel::class)
     single {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::SearchRoutesViewModel)
-    singleOf(::SearchViewModel)
-    singleOf(::ToastViewModel)
+            MapViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(named(KoinName.CoroutineDispatcherIO)),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
+        }
+        .bind(IMapViewModel::class)
+    single {
+            SearchRoutesViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchRoutesViewModel::class)
+    single {
+            SearchViewModel(get(), get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchViewModel::class)
+    single { ToastViewModel(get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IToastViewModel::class)
 }

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -1,26 +1,44 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import com.mbta.tid.mbta_app.dependencyInjection.KoinName
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
 public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
+    single { ErrorBannerViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IErrorBannerViewModel::class)
     single {
-        FavoritesViewModel(get(), get(), get(), get(named("coroutineDispatcherDefault")), get())
-    }
+            FavoritesViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
+        }
+        .bind(IFavoritesViewModel::class)
     single {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
-    singleOf(::SearchViewModel).bind(ISearchViewModel::class)
-    singleOf(::ToastViewModel).bind(IToastViewModel::class)
+            MapViewModel(
+                get(),
+                get(),
+                get(),
+                get(named(KoinName.CoroutineDispatcherDefault)),
+                get(named(KoinName.CoroutineDispatcherIO)),
+                get(named(KoinName.OnEventBufferOverflow)),
+            )
+        }
+        .bind(IMapViewModel::class)
+    single {
+            SearchRoutesViewModel(get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchRoutesViewModel::class)
+    single {
+            SearchViewModel(get(), get(), get(), get(), get(named(KoinName.OnEventBufferOverflow)))
+        }
+        .bind(ISearchViewModel::class)
+    single { ToastViewModel(get(named(KoinName.OnEventBufferOverflow))) }
+        .bind(IToastViewModel::class)
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Event Buffer Overflow - MapVM](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211174356799335?focus=true)

When I was first setting up the Molecule infrastructure, the reason I thought it made sense to crash if there was an event buffer overflow was that the buffer shouldn’t overflow unless we’ve messed up somehow, like sending to a ViewModel but forgetting to read its state. In the absence of an identifiable cause for our event buffer overflows, we may conclude that sometimes the buffer just overflows and it needs to not be a huge deal.

I maintain my belief that event buffer overflows would cause absurdly irritating bugs if they just happened silently, so what I want is to continue crashing on event buffer overflows in debug builds (so that we can discover them if they are severe enough to notice for ourselves) but to just discard the oldest event if the event buffer overflows in release builds (so that users get a better experience than just the app crashing, and so that we can finally move on from this buffer overflow issue). Getting the answer to the question “is this a debug build or a release build?” all the way into the event flow construction is not fun, and doing all this just to maintain our ability to discover event buffer overflows if they happen to us will only pay off if we actually wind up overflowing an event buffer in our own development process. Maybe #1282 will be enough instead.

I think discarding the oldest event is better than discarding the newest event. If we were comfortable discarding the newest event, we could also record that in Sentry by continuing to use `SUSPEND` but just doing `Sentry.captureMessage` instead of `error` if the `trySend` fails, but there is no mechanism I can discover which will let us both detect that the buffer has overflowed and discard the oldest event.

Pairs nicely with #1280, which moves more input state changes out of the event flow, so that it’s less likely that some significant input state change will be lost.

### Testing

Checked that tests pass on both iOS and Android.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
