### PR TITLE
fix?(ViewModel): completely ignore event buffer overflows

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoleculeViewModel.kt
@@ -26,7 +26,7 @@ public abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel()
         MutableSharedFlow<Event>(
             replay = 20,
             extraBufferCapacity = 20,
-            onBufferOverflow = BufferOverflow.SUSPEND,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
 
     /**
@@ -49,9 +49,7 @@ public abstract class MoleculeViewModel<Event, Model> : MoleculeScopeViewModel()
         }
 
     protected fun fireEvent(event: Event) {
-        if (!events.tryEmit(event)) {
-            error("Event buffer overflow in ${this::class}")
-        }
+        events.tryEmit(event)
     }
 
     @Composable protected abstract fun runLogic(events: Flow<Event>): Model


### PR DESCRIPTION
### Summary

_Ticket:_ [Event Buffer Overflow - MapVM](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211174356799335?focus=true)

If we magically knew that we would never actually have an event buffer overflow in local development, then there’d be no point doing #1281, and this would be adequate.

Pairs nicely with #1280 to reduce the likelihood that the event that gets dropped is vital input data.

### Testing

Not actually tested, it’s 5:30 pm and I need to log off.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
