### PR TITLE
fix(ios.DepartureTile): Don't show stretched tiles at large text sizes

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -28,11 +28,11 @@ struct DepartureTile: View {
     // the ideal width is measured on the background in the initial render, then used on subsequent renders.
     @State var computedMultilineWidth: CGFloat? = nil
 
+    let maxTileWidth: CGFloat = 195.0
+
     var body: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
-                let _ = print("KB: Headsign \(data.headsign)")
-
                 if let headsign = data.headsign {
                     if let computedMultilineWidth {
                         Text(headsign)
@@ -41,10 +41,9 @@ struct DepartureTile: View {
                             .font(Typography.footnoteSemibold)
                             .multilineTextAlignment(.leading)
                     } else {
-                        let _ = print("KB: Computing size \(headsign)")
                         Text(headsign)
                             .lineLimit(1)
-                            .frame(maxWidth: 195)
+                            .frame(maxWidth: maxTileWidth)
                             .font(Typography.footnoteSemibold)
                             .multilineTextAlignment(.leading)
                             .background {
@@ -54,14 +53,18 @@ struct DepartureTile: View {
                                         GeometryReader { geo in
                                             Color.clear.onAppear {
                                                 let width = geo.size.width
-                                                // Sometimes width is 0, setting to default of 195 is better
-                                                // than 0 which stretches the tiles really tall, but why
-                                                // is this happening??
-                                                //      if width < 195.0 && width > 0.0 {
-                                                computedMultilineWidth = width
-                                                //   } else {
-                                                //       computedMultilineWidth = 195
-                                                //    }
+                                                /*
+                                                 Sometimes at large text sizes, when navigating from unfiltered stop
+                                                 details, the first TYPICAL_LEAF_ROWS or BRANCHING_LEAF_ROWS end up
+                                                 with a geo.size.width of 0.0. This results in the tile stretching
+                                                 very tall with no visible headsign. If for some reason the width is
+                                                 0.0, set it to the max width of 195 so that it at least renders.
+                                                 */
+                                                if width > 0.0, width < maxTileWidth {
+                                                    computedMultilineWidth = width
+                                                } else {
+                                                    computedMultilineWidth = maxTileWidth
+                                                }
                                             }
                                         }
                                     ).hidden()
@@ -80,7 +83,7 @@ struct DepartureTile: View {
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 10)
-        .frame(maxWidth: 195, minHeight: 56, maxHeight: .infinity)
+        .frame(maxWidth: maxTileWidth, minHeight: 56, maxHeight: .infinity)
         .background(isSelected ? Color.fill3 : Color.deselectedToggle2.opacity(0.6))
         .foregroundStyle(isSelected ? Color.text : Color.deselectedToggleText)
         .clipShape(.rect(cornerRadius: 8))

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -26,19 +26,22 @@ struct DepartureTile: View {
     // Calculating the size based on an approach taken in
     // https://nilcoalescing.com/blog/AdaptiveLayoutsWithViewThatFits/#expandable-text-with-line-limit
     // the ideal width is measured on the background in the initial render, then used on subsequent renders.
-    @State var computedMultilineSize: CGSize? = nil
+    @State var computedMultilineWidth: CGFloat? = nil
 
     var body: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 4) {
+                let _ = print("KB: Headsign \(data.headsign)")
+
                 if let headsign = data.headsign {
-                    if let computedMultilineSize {
+                    if let computedMultilineWidth {
                         Text(headsign)
                             .fixedSize(horizontal: false, vertical: true)
-                            .frame(width: computedMultilineSize.width)
+                            .frame(width: computedMultilineWidth)
                             .font(Typography.footnoteSemibold)
                             .multilineTextAlignment(.leading)
                     } else {
+                        let _ = print("KB: Computing size \(headsign)")
                         Text(headsign)
                             .lineLimit(1)
                             .frame(maxWidth: 195)
@@ -50,7 +53,15 @@ struct DepartureTile: View {
                                     .background(
                                         GeometryReader { geo in
                                             Color.clear.onAppear {
-                                                computedMultilineSize = geo.size
+                                                let width = geo.size.width
+                                                // Sometimes width is 0, setting to default of 195 is better
+                                                // than 0 which stretches the tiles really tall, but why
+                                                // is this happening??
+                                                //      if width < 195.0 && width > 0.0 {
+                                                computedMultilineWidth = width
+                                                //   } else {
+                                                //       computedMultilineWidth = 195
+                                                //    }
                                             }
                                         }
                                     ).hidden()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -635,9 +635,9 @@ public data class RouteCardData(
 
     public companion object {
         // For regular non-branching service, we always show up to 2 departure rows for each leaf
-        internal const val TYPICAL_LEAF_ROWS = 5
+        internal const val TYPICAL_LEAF_ROWS = 2
         // For branching non-bus service we show up to 3 departure or disruption rows for each leaf
-        internal const val BRANCHING_LEAF_ROWS = 5
+        internal const val BRANCHING_LEAF_ROWS = 3
 
         /**
          * Build a sorted list of route cards containing realtime data for the given stops.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -635,9 +635,9 @@ public data class RouteCardData(
 
     public companion object {
         // For regular non-branching service, we always show up to 2 departure rows for each leaf
-        internal const val TYPICAL_LEAF_ROWS = 2
+        internal const val TYPICAL_LEAF_ROWS = 5
         // For branching non-bus service we show up to 3 departure or disruption rows for each leaf
-        internal const val BRANCHING_LEAF_ROWS = 3
+        internal const val BRANCHING_LEAF_ROWS = 5
 
         /**
          * Build a sorted list of route cards containing realtime data for the given stops.


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Tiles sometimes stretched too tall at larger text sizes](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211055599324054?focus=true)

What is this PR for?

This PR does a simple fix for the issue of stretched tiles & missing headsigns without getting at the root cause. 

I was only able to reproduce this issue when at a larger text size **and** navigating to filtered stop details from unfiltered; going straight to filtered was no problem. Based on logging the  `computedMultilineSize` was calculated seemingly correctly once, then set to 0 on subsequent rerender, causing the stretching. 

I haven't figured out why these would be set to 0 in the first place, but based on discussion at standup, this is an adequate fix given how frequently users might encounter this issue. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Ran locally and confirmed that tiles no longer stretched when coming from unfiltered stop details at a larger text size (though the formatting is a little off due to the tiles being wider than necessary)
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/df9932f1-b615-4664-84b8-efd5d8b32903" />
<img width="333" height="720" alt="image" src="https://github.com/user-attachments/assets/227af983-a82d-4830-a020-f30939782aa1" />



<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
