### PR TITLE
fix(Android): set timeout in ViewportProvider.withViewport

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -12,11 +12,13 @@ import com.mapbox.maps.extension.compose.MapboxMap
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mapbox.maps.plugin.viewport.ViewportStatus
 import com.mapbox.maps.plugin.viewport.state.OverviewViewportState
+import com.mbta.tid.mbta_app.android.util.MapAnimationDefaults
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Vehicle
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -26,6 +28,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import org.junit.Rule
 import org.junit.Test
@@ -121,5 +124,13 @@ class ViewportProviderTest {
             EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
             viewportInnerState.options.padding,
         )
+    }
+
+    @Test
+    fun testLockTimeout() = runBlocking {
+        val viewportProvider = ViewportProvider(MapViewportState())
+        withTimeout(MapAnimationDefaults.duration * 3) {
+            assertNull(viewportProvider.withViewport<Nothing> { suspendCancellableCoroutine {} })
+        }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Event Buffer Overflow - MapVM](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211174356799335?focus=true)

At long last, we have [a repro](https://mbta.slack.com/archives/C062QNAJZ2M/p1756488543654999?thread_ts=1756488294.249999&cid=C062QNAJZ2M) for this bug.

The `try`/`finally` pattern is [the recommended way](https://kotlinlang.org/docs/cancellation-and-timeouts.html#closing-resources-with-finally) to run cleanup code in a suspend function that may be cancelled.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the repro no longer shows the bug. Added a unit test for the presence of the lock.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
