### PR TITLE
feat(iOS): Create explainer modifier

### DIFF
--- a/iosApp/iosApp/Pages/StopDetails/ExplainerPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/ExplainerPage.swift
@@ -9,7 +9,7 @@
 import Shared
 import SwiftUI
 
-struct Explainer {
+public struct Explainer {
     let type: ExplainerType
     let routeAccents: TripRouteAccents
 }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -79,19 +79,6 @@ struct StopDetailsPage: View {
 
     var body: some View {
         stopDetails
-            .fullScreenCover(
-                isPresented: .init(
-                    get: { stopDetailsVM.explainer != nil },
-                    set: { value in if !value { stopDetailsVM.explainer = nil } }
-                )
-            ) {
-                if let explainer = stopDetailsVM.explainer {
-                    ExplainerPage(
-                        explainer: explainer,
-                        onClose: { stopDetailsVM.explainer = nil }
-                    )
-                }
-            }
             .onChange(of: stopFilter) { newStopFilter in
                 if newStopFilter == nil {
                     internalRouteCardData = nil
@@ -101,12 +88,14 @@ struct StopDetailsPage: View {
                 errorBannerVM.setIsLoadingWhenPredictionsStale(isLoading: !(stopData?.predictionsLoaded ?? true))
             }
             .onChange(of: filters) { nextFilters in setTripFilter(filters: nextFilters) }
-            .onChange(of: RouteCardParams(alerts: nearbyVM.alerts,
-                                          global: stopDetailsVM.global,
-                                          now: now,
-                                          stopData: stopDetailsVM.stopData,
-                                          stopFilter: stopFilter,
-                                          stopId: stopId)) { newParams in
+            .onChange(of: RouteCardParams(
+                alerts: nearbyVM.alerts,
+                global: stopDetailsVM.global,
+                now: now,
+                stopData: stopDetailsVM.stopData,
+                stopFilter: stopFilter,
+                stopId: stopId
+            )) { newParams in
                 updateDepartures(routeCardParams: newParams)
             }
             .onChange(of: internalRouteCardData) { newInternalRouteCardData in

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -22,6 +22,7 @@ struct TripDetailsView: View {
     @ObservedObject var mapVM: iosApp.MapViewModel
     @ObservedObject var stopDetailsVM: StopDetailsViewModel
 
+    @State var explainer: Explainer?
     @State var stops: TripDetailsStopList?
 
     @EnvironmentObject var settingsCache: SettingsCache
@@ -51,7 +52,6 @@ struct TripDetailsView: View {
         self.mapVM = mapVM
         self.stopDetailsVM = stopDetailsVM
         self.onOpenAlertDetails = onOpenAlertDetails
-
         self.analytics = analytics
     }
 
@@ -61,6 +61,7 @@ struct TripDetailsView: View {
 
     var body: some View {
         content
+            .explainer($explainer)
             .task { stopDetailsVM.handleTripFilterChange(tripFilter) }
             .onAppear { updateStops() }
             .onDisappear {
@@ -153,7 +154,7 @@ struct TripDetailsView: View {
         default: nil
         }
         let onHeaderTap: (() -> Void)? = if let explainerType { {
-            stopDetailsVM.explainer = .init(type: explainerType, routeAccents: routeAccents)
+            explainer = .init(type: explainerType, routeAccents: routeAccents)
         } } else { nil }
 
         VStack(spacing: 0) {

--- a/iosApp/iosApp/Utils/ExplainerModifier.swift
+++ b/iosApp/iosApp/Utils/ExplainerModifier.swift
@@ -1,0 +1,35 @@
+//
+//  ExplainerModifier.swift
+//  iosApp
+//
+//  Created by Simon, Emma on 8/2/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct ExplainerModifier: ViewModifier {
+    @Binding var explainer: Explainer?
+
+    func body(content: Content) -> some View {
+        content.fullScreenCover(
+            isPresented: .init(
+                get: { explainer != nil },
+                set: { value in if !value { explainer = nil } }
+            )
+        ) {
+            if let displayedExplainer = explainer {
+                ExplainerPage(
+                    explainer: displayedExplainer,
+                    onClose: { explainer = nil }
+                )
+            }
+        }
+    }
+}
+
+public extension View {
+    func explainer(_ explainer: Binding<Explainer?>) -> some View {
+        modifier(ExplainerModifier(explainer: explainer))
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ Prep for iOS [Move StopDetailsViewModel to shared code](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210525354862284?focus=true)  

The iOS StopDetailsVM handles the explainer state currently, and this seemed like an easy and discrete thing to split out into a separate PR. Moving it into basic view state doesn't require adding this modifier, but it seemed more concise and reusable. Now the state is managed entirely in TripDetails.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

I started trying to add a couple simple tests, but it looks like testing fullScreenCover requires jumping through a few [ViewInspector hoops](https://github.com/nalexn/ViewInspector/blob/0.10.3/guide_popups.md#fullscreencover) that I don't know if it's worth bothering with.