### PR TITLE
fix(Android): don’t animate favorite button when switching trips

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -45,7 +45,7 @@ fun Departures(
     stopData: RouteCardData.RouteStopData,
     globalData: GlobalResponse?,
     now: EasternTimeInstant,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     analytics: Analytics = koinInject(),
     onClick: (RouteCardData.Leaf) -> Unit,
 ) {
@@ -65,7 +65,7 @@ fun Departures(
                             stopData.stop.id,
                             leaf.directionId,
                         )
-                    ),
+                    ) ?: false,
                     leaf.alertsHere().isNotEmpty(),
                     stopData.lineOrRoute.type,
                     noTrips,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -49,7 +49,7 @@ fun RouteCard(
     data: RouteCardData,
     globalData: GlobalResponse?,
     now: EasternTimeInstant,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     showStopHeader: Boolean,
     onOpenStopDetails: (String, StopDetailsFilter) -> Unit,
 ) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/StopDetailsPage.kt
@@ -50,8 +50,8 @@ fun StopDetailsPage(
     val awaitingPredictionsAfterBackground =
         stopDetailsViewModel.models.collectAsState().value.awaitingPredictionsAfterBackground
 
-    fun isFavorite(routeStopDirection: RouteStopDirection): Boolean {
-        return favorites?.contains(routeStopDirection) ?: false
+    fun isFavorite(routeStopDirection: RouteStopDirection): Boolean? {
+        return favorites?.contains(routeStopDirection)
     }
 
     fun updateFavorites(updatedFavorites: Map<RouteStopDirection, Boolean>, defaultDirection: Int) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -31,7 +31,7 @@ fun StopDetailsFilteredView(
     tripFilter: TripDetailsFilter?,
     allAlerts: AlertsStreamDataResponse?,
     now: EasternTimeInstant,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     updateFavorites: (Map<RouteStopDirection, Boolean>, Int) -> Unit,
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -57,7 +57,7 @@ fun StopDetailsUnfilteredRoutesView(
     errorBannerViewModel: IErrorBannerViewModel,
     now: EasternTimeInstant,
     globalData: GlobalResponse?,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     onClose: () -> Unit,
     onTapRoutePill: (PillFilter) -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -28,7 +28,7 @@ import org.koin.compose.koinInject
 fun StopDetailsUnfilteredView(
     stopId: String,
     now: EasternTimeInstant,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,
     openModal: (ModalRoutes) -> Unit,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsView.kt
@@ -22,7 +22,7 @@ fun StopDetailsView(
     tripFilter: TripDetailsFilter?,
     allAlerts: AlertsStreamDataResponse?,
     now: EasternTimeInstant,
-    isFavorite: (RouteStopDirection) -> Boolean,
+    isFavorite: (RouteStopDirection) -> Boolean?,
     updateFavorites: (Map<RouteStopDirection, Boolean>, Int) -> Unit,
     onClose: () -> Unit,
     updateStopFilter: (StopDetailsFilter?) -> Unit,


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Favorites button animates every time the trip filter changes on stop details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211176145248868?focus=true)

I thought that I had wired the `null`-when-loading `isFavorite` state all the way through, but apparently not.

The `manageFavorites` state gets reset every time the trip filter changes, because the trip filter change is a navigation to a new page, so this still flickers out when switching trips, which is better than animating but not by much. I tried to fix that with changes to the Android navigation subsystem, but nothing I tried actually worked.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Checked that the animation no longer plays in this case.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
