### PR TITLE
fix(android): Address a batch of flaky test

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -163,6 +163,7 @@ spotless {
                         for (fnText in
                             arrayOf(
                                 "waitUntil(",
+                                "waitUntil {",
                                 "waitUntilAtLeastOneExists(",
                                 "waitUntilDoesNotExist(",
                                 "waitUntilExactlyOneExists(",
@@ -171,7 +172,7 @@ spotless {
                             val column = line.value.indexOf(fnText, 0, false)
                             if (column != -1) {
                                 throw IllegalStateException(
-                                    "${file.path}:${line.index + 1}:${column + 1} calls $fnText. Replace with ${fnText.dropLast(1)}DefaultTimeout( to prevent CI flakiness."
+                                    "${file.path}:${line.index + 1}:${column + 1} calls $fnText. Replace with ${fnText.dropLast(1)}DefaultTimeout to prevent CI flakiness."
                                 )
                             }
                         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewModelTests.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.AppVersion
 import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.ITabPreferencesRepository
@@ -41,7 +42,7 @@ class ContentViewModelTests : KoinTest {
                 )
         }
 
-        composeTestRule.waitUntil { vm.defaultTab.value == DefaultTab.Nearby }
+        composeTestRule.waitUntilDefaultTimeout { vm.defaultTab.value == DefaultTab.Nearby }
     }
 
     @Test
@@ -63,6 +64,6 @@ class ContentViewModelTests : KoinTest {
                 )
         }
 
-        composeTestRule.waitUntil { vm.defaultTab.value == DefaultTab.Favorites }
+        composeTestRule.waitUntilDefaultTimeout { vm.defaultTab.value == DefaultTab.Favorites }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.rule.GrantPermissionRule
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.model.FeaturePromo
@@ -110,14 +111,14 @@ class ContentViewTests : KoinTest {
             }
         }
 
-        composeTestRule.waitUntil { onAttachCount == 1 && onDetatchCount == 0 }
+        composeTestRule.waitUntilDefaultTimeout { onAttachCount == 1 && onDetatchCount == 0 }
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
-        composeTestRule.waitUntil { onAttachCount == 1 && onDetatchCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { onAttachCount == 1 && onDetatchCount == 1 }
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        composeTestRule.waitUntil { onAttachCount == 2 && onDetatchCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { onAttachCount == 2 && onDetatchCount == 1 }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.viewModel.MockToastViewModel
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel
 import kotlinx.coroutines.flow.update
@@ -34,7 +35,7 @@ class BarAndToastScaffoldTest {
         toastVM.showToast(ToastViewModel.Toast(message = "Toast message", isTip = true))
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { toastShown }
+        composeTestRule.waitUntilDefaultTimeout { toastShown }
         composeTestRule.onNodeWithText("Toast message", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Tip: Toast message", useUnmergedTree = true)
@@ -58,7 +59,7 @@ class BarAndToastScaffoldTest {
         toastVM.showToast(ToastViewModel.Toast(message = "Toast message", isTip = false))
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { toastShown }
+        composeTestRule.waitUntilDefaultTimeout { toastShown }
         composeTestRule.onNodeWithText("Toast message", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Toast message", useUnmergedTree = true)
@@ -95,7 +96,7 @@ class BarAndToastScaffoldTest {
         )
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { toastShown }
+        composeTestRule.waitUntilDefaultTimeout { toastShown }
         composeTestRule
             .onNodeWithText("Action", useUnmergedTree = true)
             .assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -1,7 +1,10 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -12,6 +15,7 @@ import kotlin.time.Duration.Companion.minutes
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalTestApi::class)
 class ErrorBannerTests {
 
     @get:Rule val composeTestRule = createComposeRule()
@@ -23,11 +27,11 @@ class ErrorBannerTests {
 
         composeTestRule.setContent { ErrorBanner(viewModel) }
 
-        composeTestRule.onNodeWithText("Unable to connect").assertExists()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Unable to connect"))
 
         errorRepo.mutableFlow.tryEmit(ErrorBannerState.DataError(emptySet(), emptySet(), {}))
 
-        composeTestRule.onNodeWithText("Error loading data").assertExists()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Error loading data"))
 
         errorRepo.mutableFlow.tryEmit(
             ErrorBannerState.StalePredictions(
@@ -36,7 +40,7 @@ class ErrorBannerTests {
             )
         )
 
-        composeTestRule.onNodeWithText("Updated 2 minutes ago").assertExists()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Updated 2 minutes ago"))
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -15,12 +15,16 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.TestData
+import com.mbta.tid.mbta_app.viewModel.IToastViewModel
 import com.mbta.tid.mbta_app.viewModel.MockToastViewModel
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel
+import dev.mokkery.MockMode
+import dev.mokkery.mock
+import dev.mokkery.verify
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.junit.Ignore
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.KoinContext
@@ -382,30 +386,36 @@ class SaveFavoritesFlowTest {
     }
 
     @Test
-    @Ignore // TODO: Address flakiness
-    fun testFavoritingToastFallbackText() {
-        val toastVM = MockToastViewModel()
-        var displayedToast: ToastViewModel.Toast? = null
-        toastVM.onShowToast = { displayedToast = it }
+    fun testFavoritingToastFallbackText() = runBlocking {
+        val toastVM = mock<IToastViewModel>(MockMode.autofill)
 
         val busRoute = TestData.getRoute("15")
         val busStop = TestData.getStop("17861")
+        // no TestData for getting the appropriate labels for this favorite
+        val koin = testKoinApplication()
 
         composeTestRule.setContent {
-            SaveFavoritesFlow(
-                lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
-                stop = busStop,
-                directions = listOf(direction0),
-                selectedDirection = 0,
-                context = EditFavoritesContext.Favorites,
-                toastViewModel = toastVM,
-                isFavorite = { false },
-                updateFavorites = {},
-                onClose = {},
+            KoinContext(koin.koin) {
+                SaveFavoritesFlow(
+                    lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                    stop = busStop,
+                    directions = listOf(direction0),
+                    selectedDirection = 0,
+                    context = EditFavoritesContext.Favorites,
+                    toastViewModel = toastVM,
+                    isFavorite = { false },
+                    updateFavorites = {},
+                    onClose = {},
+                )
+            }
+        }
+        composeTestRule.awaitIdle()
+
+        verify {
+            toastVM.showToast(
+                ToastViewModel.Toast("Added to Favorites", duration = ToastViewModel.Duration.Short)
             )
         }
-
-        composeTestRule.waitUntilDefaultTimeout { displayedToast?.message == "Added to Favorites" }
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -314,7 +314,7 @@ class SaveFavoritesFlowTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add"))
         composeTestRule.onNodeWithText("Add").performClick()
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             displayedToast?.message ==
                 "<b>Westbound Green Line</b> at <b>Boylston</b> added to Favorites"
         }
@@ -348,7 +348,7 @@ class SaveFavoritesFlowTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add"))
         composeTestRule.onNodeWithText("Add").performClick()
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             displayedToast?.message == "<b>Green Line</b> at <b>Boylston</b> added to Favorites"
         }
     }
@@ -380,7 +380,7 @@ class SaveFavoritesFlowTest {
             }
         }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             displayedToast?.message == "<b>Outbound 15 bus</b> at <b>Ruggles</b> added to Favorites"
         }
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.pages.EditFavoritesPage
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LocationType
@@ -350,7 +351,7 @@ class EditFavoritesPageTest : KoinTest {
             viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0)
         }
 
-        composeTestRule.waitUntil { update == updatedWith }
+        composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
 
         // Should be deleted
         composeTestRule.onNodeWithText("Sample Route").assertIsNotDisplayed()
@@ -422,7 +423,7 @@ class EditFavoritesPageTest : KoinTest {
             viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0)
         }
 
-        composeTestRule.waitUntil { update == updatedWith }
+        composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
 
         composeTestRule.onNodeWithText("Sample Route").assertIsNotDisplayed()
         composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
@@ -439,7 +440,7 @@ class EditFavoritesPageTest : KoinTest {
         verifySuspend(VerifyMode.exactly(1)) {
             viewModel.updateFavorites(undo, EditFavoritesContext.Favorites, 0)
         }
-        composeTestRule.waitUntil { undo == updatedWith }
+        composeTestRule.waitUntilDefaultTimeout { undo == updatedWith }
 
         composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
         composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -140,6 +140,7 @@ class ViewportProviderTest {
                     .padding,
                 EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
             )
+            throw e
         }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -16,9 +16,7 @@ import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.MapAnimationDefaults
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Vehicle
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -119,17 +117,11 @@ class ViewportProviderTest {
 
         composeTestRule.waitUntilDefaultTimeout {
             mapViewportState.mapViewportStatus is ViewportStatus.State &&
-                (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
-                    OverviewViewportState
+                ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
+                        as OverviewViewportState)
+                    .options
+                    .padding == EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter)
         }
-
-        val viewportStatus = assertIs<ViewportStatus.State>(mapViewportState.mapViewportStatus)
-        val viewportInnerState = assertIs<OverviewViewportState>(viewportStatus.state)
-
-        assertEquals(
-            EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
-            viewportInnerState.options.padding,
-        )
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -140,7 +140,6 @@ class ViewportProviderTest {
                     .padding,
                 EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
             )
-            throw e
         }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -117,6 +117,8 @@ class ViewportProviderTest {
 
         composeTestRule.waitUntilDefaultTimeout {
             mapViewportState.mapViewportStatus is ViewportStatus.State &&
+                (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
+                    OverviewViewportState &&
                 ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
                         as OverviewViewportState)
                     .options

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.location
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -16,6 +17,7 @@ import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.MapAnimationDefaults
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Vehicle
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -114,15 +116,30 @@ class ViewportProviderTest {
             }
 
         withTimeout(10.seconds) { awaitAll(stopCenter, setPadding, vehicleOverview) }
-
-        composeTestRule.waitUntilDefaultTimeout {
-            mapViewportState.mapViewportStatus is ViewportStatus.State &&
-                (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
-                    OverviewViewportState &&
+        try {
+            composeTestRule.waitUntilDefaultTimeout {
+                mapViewportState.mapViewportStatus is ViewportStatus.State &&
+                    (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
+                        OverviewViewportState &&
+                    ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
+                            as OverviewViewportState)
+                        .options
+                        .padding ==
+                        EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter)
+            }
+        } catch (e: ComposeTimeoutException) {
+            assertTrue(mapViewportState.mapViewportStatus is ViewportStatus.State)
+            assertTrue(
+                (mapViewportState.mapViewportStatus as ViewportStatus.State).state
+                    is OverviewViewportState
+            )
+            assertEquals(
                 ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
                         as OverviewViewportState)
                     .options
-                    .padding == EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter)
+                    .padding,
+                EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
+            )
         }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -46,7 +46,7 @@ class ViewportProviderTest {
         viewportProvider.isVehicleOverview = true
 
         composeTestRule.setContent { LaunchedEffect(Unit) { viewportProvider.follow() } }
-        composeTestRule.waitUntil { viewportProvider.isFollowingPuck }
+        composeTestRule.waitUntilDefaultTimeout { viewportProvider.isFollowingPuck }
         assertTrue(viewportProvider.isFollowingPuck)
         assertFalse(viewportProvider.isVehicleOverview)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.location
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -118,16 +117,12 @@ class ViewportProviderTest {
 
         withTimeout(10.seconds) { awaitAll(stopCenter, setPadding, vehicleOverview) }
 
-        try {
-            composeTestRule.waitUntilDefaultTimeout {
-                mapViewportState.mapViewportStatus is ViewportStatus.State &&
-                    (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
-                        OverviewViewportState
-            }
-        } catch (e: ComposeTimeoutException) {
-            println("retryableTest timeout caught: ${mapViewportState.mapViewportStatus}")
-            throw e
+        composeTestRule.waitUntilDefaultTimeout {
+            mapViewportState.mapViewportStatus is ViewportStatus.State &&
+                (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
+                    OverviewViewportState
         }
+
         val viewportStatus = assertIs<ViewportStatus.State>(mapViewportState.mapViewportStatus)
         val viewportInnerState = assertIs<OverviewViewportState>(viewportStatus.state)
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/location/ViewportProviderTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.location
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -17,7 +16,6 @@ import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.MapAnimationDefaults
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Vehicle
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -116,30 +114,15 @@ class ViewportProviderTest {
             }
 
         withTimeout(10.seconds) { awaitAll(stopCenter, setPadding, vehicleOverview) }
-        try {
-            composeTestRule.waitUntilDefaultTimeout {
-                mapViewportState.mapViewportStatus is ViewportStatus.State &&
-                    (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
-                        OverviewViewportState &&
-                    ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
-                            as OverviewViewportState)
-                        .options
-                        .padding ==
-                        EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter)
-            }
-        } catch (e: ComposeTimeoutException) {
-            assertTrue(mapViewportState.mapViewportStatus is ViewportStatus.State)
-            assertTrue(
-                (mapViewportState.mapViewportStatus as ViewportStatus.State).state
-                    is OverviewViewportState
-            )
-            assertEquals(
+
+        composeTestRule.waitUntilDefaultTimeout {
+            mapViewportState.mapViewportStatus is ViewportStatus.State &&
+                (mapViewportState.mapViewportStatus as ViewportStatus.State).state is
+                    OverviewViewportState &&
                 ((mapViewportState.mapViewportStatus as ViewportStatus.State).state
                         as OverviewViewportState)
                     .options
-                    .padding,
-                EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter),
-            )
+                    .padding == EdgeInsets(paddingAfter, paddingAfter, paddingAfter, paddingAfter)
         }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -3,8 +3,10 @@ package com.mbta.tid.mbta_app.android.map
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -17,6 +19,7 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
@@ -40,6 +43,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalTestApi::class)
 class HomeMapViewTests {
 
     @get:Rule val composeTestRule = createComposeRule()
@@ -115,9 +119,9 @@ class HomeMapViewTests {
                 configManager,
             )
         }
-        composeTestRule
-            .onNodeWithContentDescription("Recenter map on my location")
-            .assertIsNotDisplayed()
+        composeTestRule.waitUntilDoesNotExistDefaultTimeout(
+            hasContentDescription("Recenter map on my location")
+        )
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -19,6 +19,7 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
@@ -359,7 +360,9 @@ class HomeMapViewTests {
             )
         }
 
-        composeTestRule.waitUntil { composeTestRule.onNodeWithTag("recenterButton").isDisplayed() }
+        composeTestRule.waitUntilDefaultTimeout {
+            composeTestRule.onNodeWithTag("recenterButton").isDisplayed()
+        }
         composeTestRule.onNodeWithTag("recenterButton").assertIsDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreViewModelTests.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.more
 import android.annotation.SuppressLint
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import java.util.Locale
@@ -30,7 +31,7 @@ class MoreViewModelTests {
             vm = MoreViewModel(subContext, {})
         }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             vm.sections.value.any { it.id == MoreSection.Category.Feedback }
         }
         assertEquals(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -382,10 +382,10 @@ class MapAndSheetPageTest : KoinTest {
             hasContentDescription("Loading...", substring = true)
         )
 
-        composeTestRule.waitUntil { mockConfigManager.loadConfigCalledCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { mockConfigManager.loadConfigCalledCount == 1 }
         mockConfigManager.mutableLastErrorTimestamp.value = EasternTimeInstant.now()
 
-        composeTestRule.waitUntil { mockConfigManager.loadConfigCalledCount == 2 }
+        composeTestRule.waitUntilDefaultTimeout { mockConfigManager.loadConfigCalledCount == 2 }
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
@@ -64,11 +65,11 @@ class MapAndSheetViewModelTest {
             }
         }
 
-        composeTestRule.waitUntil { nearbyVM.nearbyStopIds != null }
+        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyStopIds != null }
         assertEquals(response1, nearbyVM.nearbyStopIds)
 
         position = position2
-        composeTestRule.waitUntil { nearbyVM.nearbyStopIds != response1 }
+        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyStopIds != response1 }
         assertEquals(response2, nearbyVM.nearbyStopIds)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
@@ -58,7 +59,7 @@ class MorePageTests : KoinTest {
         composeTestRule.onNodeWithText("Map Display").assertIsOn().performClick()
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { hideMapValue }
+        composeTestRule.waitUntilDefaultTimeout { hideMapValue }
         assertTrue { hideMapValue }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/OnboardingPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/OnboardingPageTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import kotlin.test.assertEquals
@@ -35,19 +36,19 @@ class OnboardingPageTest {
         }
 
         composeTestRule.onNodeWithText("Continue").performClick()
-        composeTestRule.waitUntil { completedScreens.size == 1 }
+        composeTestRule.waitUntilDefaultTimeout { completedScreens.size == 1 }
         assertEquals(1, completedScreens.size)
 
         composeTestRule.onNodeWithText("Continue").performClick()
-        composeTestRule.waitUntil { completedScreens.size == 2 }
+        composeTestRule.waitUntilDefaultTimeout { completedScreens.size == 2 }
         assertEquals(2, completedScreens.size)
 
         composeTestRule.onNodeWithText("Continue").performClick()
-        composeTestRule.waitUntil { completedScreens.size == 3 }
+        composeTestRule.waitUntilDefaultTimeout { completedScreens.size == 3 }
         assertEquals(3, completedScreens.size)
 
         composeTestRule.onNodeWithText("Get started").performClick()
-        composeTestRule.waitUntil { completedScreens.size == 4 }
+        composeTestRule.waitUntilDefaultTimeout { completedScreens.size == 4 }
         assertEquals(OnboardingScreen.entries.toSet(), completedScreens)
         assertTrue(finished)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/promo/PromoPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/promo/PromoPageTest.kt
@@ -3,6 +3,7 @@ package com.mbta.tid.mbta_app.android.promo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import org.junit.Rule
 import org.junit.Test
@@ -27,6 +28,6 @@ class PromoPageTest {
 
         composeTestRule.onNodeWithText("Got it").performClick()
 
-        composeTestRule.waitUntil { calledOnAdvance && calledFinish }
+        composeTestRule.waitUntilDefaultTimeout { calledOnAdvance && calledFinish }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilNodeCountDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -209,7 +210,7 @@ class RouteStopListViewTest {
             }
         }
 
-        composeTestRule.waitUntil { lastSelectedRoute != null }
+        composeTestRule.waitUntilDefaultTimeout { lastSelectedRoute != null }
         assertEquals(route2.id, lastSelectedRoute)
 
         composeTestRule.onNodeWithText(route3.shortName).performClick()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteResult
@@ -523,7 +524,7 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { setPath == RoutePickerPath.Bus }
+        composeTestRule.waitUntilDefaultTimeout { setPath == RoutePickerPath.Bus }
     }
 
     @OptIn(ExperimentalTestApi::class)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.requestFocus
 import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilAtLeastOneExistsDefaultTimeout
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.history.Visit
 import com.mbta.tid.mbta_app.history.VisitHistory
@@ -128,7 +129,7 @@ class SearchBarOverlayTest : KoinTest {
         searchNode.performTextInput("sto")
         composeTestRule.waitUntilAtLeastOneExistsDefaultTimeout(hasText(searchedStop.name))
         composeTestRule.onNodeWithText(searchedStop.name).performClick()
-        composeTestRule.waitUntil { navigated.value }
+        composeTestRule.waitUntilDefaultTimeout { navigated.value }
     }
 
     @Test
@@ -200,7 +201,7 @@ class SearchBarOverlayTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Routes"))
         composeTestRule.onNodeWithText("3½").assertIsDisplayed()
         composeTestRule.onNodeWithText("Here - There").assertIsDisplayed().performClick()
-        composeTestRule.waitUntil { navigated }
+        composeTestRule.waitUntilDefaultTimeout { navigated }
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -43,11 +44,11 @@ class GetGlobalDataTest {
         var actualData: GlobalResponse? = null
         composeTestRule.setContent { actualData = getGlobalData("errorKey", globalRepo) }
         // Data should be set immediately from the repo, even before getGlobalData has completed
-        composeTestRule.waitUntil { globalData == actualData }
+        composeTestRule.waitUntilDefaultTimeout { globalData == actualData }
         assertEquals(globalData, actualData)
 
         requestSync.send(Unit)
-        composeTestRule.waitUntil { globalData == actualData }
+        composeTestRule.waitUntilDefaultTimeout { globalData == actualData }
         assertEquals(globalData, actualData)
     }
 
@@ -59,7 +60,7 @@ class GetGlobalDataTest {
 
         composeTestRule.setContent { getGlobalData("errorKey", globalRepo, errorRepo) }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             when (val errorState = errorRepo.state.value) {
                 is ErrorBannerState.DataError ->
                     errorState.messages == setOf("errorKey.getGlobalData")

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRailRouteShapesTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.SegmentedRouteShape
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -56,7 +57,9 @@ class GetRailRouteShapesTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { mapFriendlyRouteResponse == actualRailRouteShapes }
+        composeTestRule.waitUntilDefaultTimeout {
+            mapFriendlyRouteResponse == actualRailRouteShapes
+        }
         assertEquals(mapFriendlyRouteResponse, actualRailRouteShapes)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
@@ -55,12 +55,12 @@ class GetRouteStopsTest {
             actualRouteStops = getRouteStops(route.id, directionId, "errorKey", routeStopsRepo)
         }
 
-        composeTestRule.waitUntil { actualRouteStops != null }
+        composeTestRule.waitUntilDefaultTimeout { actualRouteStops != null }
         composeTestRule.waitForIdle()
         assertEquals(expectedRouteStops1, actualRouteStops)
 
         directionId = 1
-        composeTestRule.waitUntil { actualRouteStops != null }
+        composeTestRule.waitUntilDefaultTimeout { actualRouteStops != null }
         composeTestRule.waitForIdle()
         assertEquals(expectedRouteStops2, actualRouteStops)
     }
@@ -106,7 +106,7 @@ class GetRouteStopsTest {
 
         composeTestRule.setContent { getRouteStops("", 0, "errorKey", schedulesRepo, errorRepo) }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             when (val errorState = errorRepo.state.value) {
                 is ErrorBannerState.DataError -> errorState.messages == setOf("errorKey")
                 else -> false

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetScheduleTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -77,7 +78,7 @@ class GetScheduleTest {
             actualSchedules = getSchedule(stopIds = emptyList(), "errorKey", schedulesRepo)
         }
 
-        composeTestRule.waitUntil { actualSchedules != null }
+        composeTestRule.waitUntilDefaultTimeout { actualSchedules != null }
         assertNotNull(actualSchedules)
     }
 
@@ -91,7 +92,7 @@ class GetScheduleTest {
             getSchedule(stopIds = listOf("stop1"), "errorKey", schedulesRepo, errorRepo)
         }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             when (val errorState = errorRepo.state.value) {
                 is ErrorBannerState.DataError -> errorState.messages == setOf("errorKey")
                 else -> false

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetStopMapDataTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.state
 
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
@@ -31,7 +32,7 @@ class GetStopMapDataTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { stopMapResponse == actualStopMapResponse }
+        composeTestRule.waitUntilDefaultTimeout { stopMapResponse == actualStopMapResponse }
         assertEquals(stopMapResponse, actualStopMapResponse)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
@@ -36,8 +37,8 @@ class SubscribeToAlertsTest {
 
         var actualData: AlertsStreamDataResponse? = null
         composeRule.setContent { actualData = subscribeToAlerts(alertsUsecase) }
-        composeRule.waitUntil { connectCount == 1 }
-        composeRule.waitUntil { alertsStreamDataResponse == actualData }
+        composeRule.waitUntilDefaultTimeout { connectCount == 1 }
+        composeRule.waitUntilDefaultTimeout { alertsStreamDataResponse == actualData }
         assertEquals(alertsStreamDataResponse, actualData)
     }
 
@@ -72,17 +73,17 @@ class SubscribeToAlertsTest {
             }
         }
 
-        composeRule.waitUntil { connectCount == 1 }
+        composeRule.waitUntilDefaultTimeout { connectCount == 1 }
         Assert.assertEquals(0, disconnectCount)
 
         composeRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
-        composeRule.waitUntil { disconnectCount == 1 }
+        composeRule.waitUntilDefaultTimeout { disconnectCount == 1 }
         Assert.assertEquals(1, connectCount)
 
         composeRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        composeRule.waitUntil { connectCount == 2 }
+        composeRule.waitUntilDefaultTimeout { connectCount == 2 }
         Assert.assertEquals(1, disconnectCount)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToPredictionsTest.kt
@@ -67,9 +67,9 @@ class SubscribeToPredictionsTest {
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
-        composeTestRule.waitUntil { connectProps == listOf("place-a") }
+        composeTestRule.waitUntilDefaultTimeout { connectProps == listOf("place-a") }
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             predictions != null &&
                 predictions == predictionsOnJoin.toPredictionsStreamDataResponse()
         }
@@ -77,9 +77,9 @@ class SubscribeToPredictionsTest {
         assertEquals(0, disconnectCount)
 
         stopIds.value = listOf("place-b")
-        composeTestRule.waitUntil { disconnectCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { disconnectCount == 1 }
 
-        composeTestRule.waitUntil { connectProps == listOf("place-b") }
+        composeTestRule.waitUntilDefaultTimeout { connectProps == listOf("place-b") }
     }
 
     @Test
@@ -117,17 +117,17 @@ class SubscribeToPredictionsTest {
             }
         }
 
-        composeTestRule.waitUntil { connectCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { connectCount == 1 }
         assertEquals(0, disconnectCount)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
-        composeTestRule.waitUntil { disconnectCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { disconnectCount == 1 }
         assertEquals(1, connectCount)
 
         composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        composeTestRule.waitUntil { connectCount == 2 }
+        composeTestRule.waitUntilDefaultTimeout { connectCount == 2 }
         assertEquals(1, disconnectCount)
     }
 
@@ -158,7 +158,7 @@ class SubscribeToPredictionsTest {
             predictions = predictionsVM.predictionsFlow.collectAsState(initial = null).value
         }
 
-        composeTestRule.waitUntil { predictions != null }
+        composeTestRule.waitUntilDefaultTimeout { predictions != null }
         assertNotNull(predictions)
         assertTrue(connected)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -8,10 +8,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -22,6 +22,7 @@ import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.MockRouteCardDataViewModel
 import com.mbta.tid.mbta_app.viewModel.RouteCardDataViewModel
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -33,7 +34,7 @@ class SubscribeToVehiclesTest {
     // Test structure based on lifecycle tests:
     // https://github.com/androidx/androidx/blob/0b709f31b71110fe671ed8b4c03f96ad30a0cd37/lifecycle/lifecycle-runtime-compose/src/androidInstrumentedTest/kotlin/androidx/lifecycle/compose/LifecycleEffectTest.kt#L247
     @Test
-    fun testSubscribeToVehicles() = runComposeUiTest {
+    fun testSubscribeToVehicles() = runTest {
         val vehicle =
             ObjectCollectionBuilder().vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
         var connectProps: Pair<String, Int>? = null
@@ -48,20 +49,20 @@ class SubscribeToVehiclesTest {
 
         var stateFilter = mutableStateOf(StopDetailsFilter("route_1", 1))
 
-        setContent {
+        composeTestRule.setContent {
             var filter by remember { stateFilter }
             vehicles = subscribeToVehicles(filter, MockRouteCardDataViewModel(), vehiclesRepo)
         }
 
-        waitUntil { connectProps == Pair("route_1", 1) }
-        waitUntil { listOf(vehicle) == vehicles }
+        composeTestRule.waitUntilDefaultTimeout { connectProps == Pair("route_1", 1) }
+        composeTestRule.waitUntilDefaultTimeout { listOf(vehicle) == vehicles }
 
-        runOnUiThread { stateFilter.value = StopDetailsFilter("route_2", 1) }
-        waitUntil { connectProps == Pair("route_2", 1) }
+        composeTestRule.runOnUiThread { stateFilter.value = StopDetailsFilter("route_2", 1) }
+        composeTestRule.waitUntilDefaultTimeout { connectProps == Pair("route_2", 1) }
     }
 
     @Test
-    fun testDisconnectsOnPause() = runComposeUiTest {
+    fun testDisconnectsOnPause() = runTest {
         val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
 
         val vehicle =
@@ -80,32 +81,32 @@ class SubscribeToVehiclesTest {
 
         var stateFilter = mutableStateOf(StopDetailsFilter("route_1", 1))
 
-        setContent {
+        composeTestRule.setContent {
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 var filter by remember { stateFilter }
                 vehicles = subscribeToVehicles(filter, MockRouteCardDataViewModel(), vehiclesRepo)
             }
         }
 
-        waitUntil { connectCount == 1 }
+        composeTestRule.waitUntilDefaultTimeout { connectCount == 1 }
         // Disconnect called before connecting
         assertEquals(1, disconnectCount)
 
-        runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
+        composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) }
 
-        waitUntil { disconnectCount == 2 }
+        composeTestRule.waitUntilDefaultTimeout { disconnectCount == 2 }
         assertEquals(2, disconnectCount)
         assertEquals(1, connectCount)
 
-        runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
+        composeTestRule.runOnIdle { lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME) }
 
-        waitUntil { disconnectCount == 3 }
-        waitUntil { connectCount == 2 }
+        composeTestRule.waitUntilDefaultTimeout { disconnectCount == 3 }
+        composeTestRule.waitUntilDefaultTimeout { connectCount == 2 }
         assertEquals(2, connectCount)
     }
 
     @Test
-    fun testFiltersIrrelevantVehicles() = runComposeUiTest {
+    fun testFiltersIrrelevantVehicles() = runTest {
         val objects = ObjectCollectionBuilder()
 
         val route1 = objects.route { id = "A" }
@@ -170,12 +171,12 @@ class SubscribeToVehiclesTest {
         val routeCardDataVM =
             MockRouteCardDataViewModel(RouteCardDataViewModel.State(routeCardData))
 
-        setContent {
+        composeTestRule.setContent {
             val filter by remember { stateFilter }
             vehicles = subscribeToVehicles(filter, routeCardDataVM, vehiclesRepo)
         }
 
-        waitUntil { connectProps == Pair(line.id, 0) }
-        waitUntil { listOf(vehicle2) == vehicles }
+        composeTestRule.waitUntilDefaultTimeout { connectProps == Pair(line.id, 0) }
+        composeTestRule.waitUntilDefaultTimeout { listOf(vehicle2) == vehicles }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
@@ -250,7 +251,7 @@ class StopDetailsFilteredDeparturesViewTest {
         }
 
         composeTestRule.onNodeWithText("1 min").assertExists().performClick()
-        composeTestRule.waitUntil { tripFilter?.tripId == trip.id }
+        composeTestRule.waitUntilDefaultTimeout { tripFilter?.tripId == trip.id }
 
         assertEquals(tripFilter?.tripId, trip.id)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
@@ -232,7 +233,7 @@ class StopDetailsFilteredPickerViewTest {
 
         composeTestRule.onNodeWithText("at ${stop.name}").assertExists()
         composeTestRule.onNodeWithText("1 min").assertExists().performClick()
-        composeTestRule.waitUntil { tripFilter?.tripId == trip.id }
+        composeTestRule.waitUntilDefaultTimeout { tripFilter?.tripId == trip.id }
 
         assertEquals(tripFilter?.tripId, trip.id)
     }
@@ -389,7 +390,7 @@ class StopDetailsFilteredPickerViewTest {
 
         composeTestRule.onNodeWithText("Add").performClick()
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             updatedFavorites ==
                 Pair(
                     mapOf(
@@ -455,7 +456,7 @@ class StopDetailsFilteredPickerViewTest {
 
         composeTestRule.onNodeWithText("Add").assertDoesNotExist()
 
-        composeTestRule.waitUntil {
+        composeTestRule.waitUntilDefaultTimeout {
             updatedFavorites == Pair(mapOf(RouteStopDirection(route.id, stop.id, 0) to false), 0)
         }
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.android.pages.StopDetailsPage
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.viewModel.MockStopDetailsViewModel
@@ -55,7 +56,7 @@ class StopDetailsPageTest : KoinTest {
             }
         }
 
-        composeTestRule.waitUntil { activeSet && alertsSet && filtersSet && nowSet }
+        composeTestRule.waitUntilDefaultTimeout { activeSet && alertsSet && filtersSet && nowSet }
 
         assertTrue(activeSet && alertsSet && filtersSet && nowSet)
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManageFavoritesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManageFavoritesTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.Favorites
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
@@ -56,6 +57,6 @@ class ManageFavoritesTest {
         assertEquals(setOf(rsd0), managedFavorites!!.favoriteRoutes)
         composeTestRule.onNodeWithText("Click me").performClick()
         composeTestRule.awaitIdle()
-        composeTestRule.waitUntil { managedFavorites!!.favoriteRoutes == setOf(rsd1) }
+        composeTestRule.waitUntilDefaultTimeout { managedFavorites!!.favoriteRoutes == setOf(rsd1) }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertEquals
@@ -45,7 +46,7 @@ class SettingsCacheTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { gotSettings }
+        composeTestRule.waitUntilDefaultTimeout { gotSettings }
         assertEquals(listOf(false, true), hideMapsValues)
         assertEquals(listOf(false, false), debugModeValues)
     }
@@ -73,7 +74,7 @@ class SettingsCacheTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { gotSettings }
+        composeTestRule.waitUntilDefaultTimeout { gotSettings }
         assertEquals(listOf(true), hideMapsValues)
     }
 
@@ -103,9 +104,9 @@ class SettingsCacheTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntil { gotSettings }
+        composeTestRule.waitUntilDefaultTimeout { gotSettings }
         composeTestRule.onNodeWithText("Hide maps").performClick()
-        composeTestRule.waitUntil { savedSettings }
+        composeTestRule.waitUntilDefaultTimeout { savedSettings }
         composeTestRule.waitForIdle()
         // false while loading and still false after loading
         assertEquals(listOf(false, false, true), hideMapsValues)


### PR DESCRIPTION
### Summary

_Ticket:_ [CI | android flaky tests again](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211209894303557?focus=true)

What is this PR for?
This PR addresses the 4 itemized android tests that have been recently flaking and preventing PRs from merging.
It also broadens the usage of `waitUntilDefaultTimeout` to increase the timeout used across tests.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* For each of the itemized fixed tests, ran each one for 300 repetitions using [RetryableComposeTestRule](https://github.com/mbta/mobile_app/blob/main/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/RetryableComposeTestRule.kt) and confirmed there were no failures.

### Note
Seeing some failures on this PR and elsewhere on shared VM tests. I'm taking a closer look at those, but putting this up for review as-is to hopefully save us from a few CI failures in the meantime.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
