### PR TITLE
refactor: control RoutePill size and type independently + add Large

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,11 +38,14 @@ import com.mbta.tid.mbta_app.model.RouteType
 
 typealias RoutePillType = RoutePillSpec.Type
 
+typealias RoutePillHeight = RoutePillSpec.Height
+
 @Composable
 fun RoutePill(
     route: Route?,
     line: Line? = null,
     type: RoutePillType,
+    height: RoutePillHeight = RoutePillHeight.Medium,
     isActive: Boolean = true,
     contentDescription: RoutePillSpec.ContentDescription? = null,
     modifier: Modifier = Modifier,
@@ -52,7 +54,7 @@ fun RoutePill(
         route,
         line,
         isActive,
-        RoutePillSpec(route, line, type, contentDescription = contentDescription),
+        RoutePillSpec(route, line, type, height, contentDescription = contentDescription),
         modifier,
     )
 }
@@ -77,28 +79,27 @@ fun RoutePill(
         }
 
     val fontSize =
-        when (spec.size) {
-            RoutePillSpec.Size.CircleSmall,
-            RoutePillSpec.Size.FlexPillSmall -> 12.sp
-            else -> 16.sp
+        when (spec.height) {
+            RoutePillHeight.Small -> 12.sp
+            RoutePillHeight.Medium -> 16.sp
+            RoutePillHeight.Large -> 20.sp
         }
 
-    val iconSize =
-        when (spec.size) {
-            RoutePillSpec.Size.CircleSmall,
-            RoutePillSpec.Size.FlexPillSmall -> 16.dp
-            else -> 24.dp
+    val pillHeight =
+        when (spec.height) {
+            RoutePillHeight.Small -> 16.dp
+            RoutePillHeight.Medium -> 24.dp
+            RoutePillHeight.Large -> 32.dp
         }
 
     fun Modifier.withSizePadding() =
-        when (spec.size) {
-            RoutePillSpec.Size.FixedPill -> size(width = 50.dp, height = 24.dp)
-            RoutePillSpec.Size.Circle -> size(24.dp)
-            RoutePillSpec.Size.CircleSmall -> size(16.dp)
-            RoutePillSpec.Size.FlexPill ->
-                height(24.dp).padding(horizontal = 12.dp).widthIn(min = (48 - 12 * 2).dp)
-            RoutePillSpec.Size.FlexPillSmall ->
-                padding(horizontal = 8.dp).height(16.dp).widthIn(min = (36 - 8 * 2).dp)
+        when (spec.width) {
+            RoutePillSpec.Width.Fixed -> size(width = (pillHeight + 1.dp) * 2, height = pillHeight)
+            RoutePillSpec.Width.Circle -> size(pillHeight)
+            RoutePillSpec.Width.Flex ->
+                height(pillHeight)
+                    .padding(horizontal = pillHeight / 2)
+                    .widthIn(min = pillHeight / 2 + 12.dp)
         }
 
     fun Modifier.withColor() =
@@ -143,7 +144,7 @@ fun RoutePill(
             Icon(
                 painter = painter,
                 contentDescription = contentDescription,
-                modifier = finalModifier.size(iconSize),
+                modifier = finalModifier.size(pillHeight),
                 tint = if (isActive) textColor else LocalContentColor.current,
             )
         }
@@ -167,7 +168,12 @@ private fun RoutePillPreviews() {
             RoutePill(route = route, line = line, type = RoutePillType.Fixed, isActive = false)
             RoutePill(route = route, line = line, type = RoutePillType.Fixed)
             RoutePill(route = route, line = line, type = RoutePillType.Flex)
-            RoutePill(route = route, line = line, type = RoutePillType.FlexCompact)
+            RoutePill(
+                route = route,
+                line = line,
+                type = RoutePillType.FlexCompact,
+                height = RoutePillHeight.Small,
+            )
         }
     }
 

--- a/iosApp/iosApp/ComponentViews/RoutePill.swift
+++ b/iosApp/iosApp/ComponentViews/RoutePill.swift
@@ -18,24 +18,32 @@ struct RoutePill: View {
     let spec: RoutePillSpec
 
     private var fontSize: CGFloat {
-        switch spec.size {
-        case .circleSmall, .flexPillSmall: 12
-        default: 16
+        switch spec.height {
+        case .small: 12
+        case .medium: 16
+        case .large: 20
         }
     }
 
-    private var iconSize: CGFloat {
-        switch spec.size {
-        case .circleSmall, .flexPillSmall: 16
-        default: 24
+    private var pillHeight: CGFloat {
+        switch spec.height {
+        case .small: 16
+        case .medium: 24
+        case .large: 32
         }
     }
 
-    init(route: Route?, line: Line? = nil, type: RoutePillSpec.Type_, isActive: Bool = true) {
+    init(
+        route: Route?,
+        line: Line? = nil,
+        type: RoutePillSpec.Type_,
+        height: RoutePillSpec.Height = .medium,
+        isActive: Bool = true
+    ) {
         self.route = route
         self.line = line
         self.isActive = isActive
-        spec = .init(route: route, line: line, type: type)
+        spec = .init(route: route, line: line, type: type, height: height)
         textColor = .init(hex: spec.textColor)
         routeColor = .init(hex: spec.routeColor)
     }
@@ -56,20 +64,20 @@ struct RoutePill: View {
         case let .modeImage(mode):
             routeIcon(mode.mode)
                 .resizable()
-                .frame(width: iconSize, height: iconSize)
+                .frame(width: pillHeight, height: pillHeight)
         }
     }
 
     private struct FramePaddingModifier: ViewModifier {
         let spec: RoutePillSpec
+        let pillHeight: CGFloat
 
         func body(content: Content) -> some View {
-            switch spec.size {
-            case .fixedPill: content.frame(width: 50, height: 24)
-            case .circle: content.frame(width: 24, height: 24)
-            case .circleSmall: content.frame(width: 16, height: 16)
-            case .flexPill: content.frame(height: 24).padding(.horizontal, 12).frame(minWidth: 44)
-            case .flexPillSmall: content.frame(height: 16).padding(.horizontal, 8).frame(minWidth: 36)
+            switch spec.width {
+            case .fixed: content.frame(width: 2 * pillHeight + 2, height: pillHeight)
+            case .circle: content.frame(width: pillHeight, height: pillHeight)
+            case .flex: content.frame(height: pillHeight).padding(.horizontal, pillHeight / 2)
+                .frame(minWidth: pillHeight * 3 / 2 + 12)
             }
         }
     }
@@ -110,7 +118,7 @@ struct RoutePill: View {
             .textCase(route?.type == .commuterRail ? .none : .uppercase)
             .font(.custom("Helvetica Neue", size: fontSize).bold())
             .tracking(0.5)
-            .modifier(FramePaddingModifier(spec: spec))
+            .modifier(FramePaddingModifier(spec: spec, pillHeight: pillHeight))
             .minimumScaleFactor(0.4)
             .lineLimit(1)
             .modifier(ColorModifier(pill: self))

--- a/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
+++ b/iosApp/iosApp/Pages/Search/Results/SearchResultsContainer.swift
@@ -80,7 +80,8 @@ struct SearchResultView_Previews: PreviewProvider {
                                 textColor: "#FFFFFF",
                                 routeColor: "#ED8B00",
                                 content: RoutePillSpecContentText(text: "OL"),
-                                size: RoutePillSpec.Size.flexPillSmall,
+                                height: .small,
+                                width: .flex,
                                 shape: RoutePillSpec.Shape.capsule,
                                 contentDescription: nil
                             ),
@@ -95,7 +96,8 @@ struct SearchResultView_Previews: PreviewProvider {
                             textColor: "#000000",
                             routeColor: "#FFC72C",
                             content: RoutePillSpecContentText(text: "428"),
-                            size: .fixedPill,
+                            height: .medium,
+                            width: .fixed,
                             shape: .rectangle,
                             contentDescription: nil
                         )

--- a/iosApp/iosAppTests/Views/SearchResultViewTests.swift
+++ b/iosApp/iosAppTests/Views/SearchResultViewTests.swift
@@ -302,7 +302,8 @@ final class SearchResultViewTests: XCTestCase {
                             textColor: "000000",
                             routeColor: "000000",
                             content: RoutePillSpecContentEmpty.shared,
-                            size: .circle,
+                            height: .medium,
+                            width: .circle,
                             shape: .capsule,
                             contentDescription: nil
                         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -150,7 +150,8 @@ public object LoadingPlaceholders {
                 textColor = "8A9199",
                 routeColor = "8A9199",
                 content = RoutePillSpec.Content.Text("Loading"),
-                size = RoutePillSpec.Size.FlexPillSmall,
+                height = RoutePillSpec.Height.Small,
+                width = RoutePillSpec.Width.Flex,
                 shape = RoutePillSpec.Shape.Capsule,
                 contentDescription = null,
             )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpec.kt
@@ -6,7 +6,8 @@ public data class RoutePillSpec(
     val textColor: String,
     val routeColor: String,
     val content: Content,
-    val size: Size,
+    val height: Height,
+    val width: Width,
     val shape: Shape,
     val contentDescription: ContentDescription? = null,
 ) {
@@ -24,12 +25,16 @@ public data class RoutePillSpec(
         public data class ModeImage internal constructor(val mode: RouteType) : Content
     }
 
-    public enum class Size {
-        FixedPill,
+    public enum class Height {
+        Small,
+        Medium,
+        Large,
+    }
+
+    public enum class Width {
         Circle,
-        CircleSmall,
-        FlexPill,
-        FlexPillSmall,
+        Fixed,
+        Flex,
     }
 
     public enum class Shape {
@@ -55,6 +60,7 @@ public data class RoutePillSpec(
         route: Route?,
         line: Line?,
         type: Type,
+        height: Height = Height.Medium,
         context: Context = Context.Default,
         contentDescription: ContentDescription? = null,
     ) : this(
@@ -68,16 +74,11 @@ public data class RoutePillSpec(
             RouteType.BUS -> busPillContent(route, type, context)
             RouteType.FERRY -> ferryPillContent(route, type)
         },
+        height,
         when {
-            type == Type.Fixed -> Size.FixedPill
-            route?.longName?.startsWith("Green Line ") ?: false ->
-                if (type == Type.FlexCompact) {
-                    Size.CircleSmall
-                } else {
-                    Size.Circle
-                }
-            type == Type.FlexCompact -> Size.FlexPillSmall
-            else -> Size.FlexPill
+            type == Type.Fixed -> Width.Fixed
+            route?.longName?.startsWith("Green Line ") ?: false -> Width.Circle
+            else -> Width.Flex
         },
         when {
             route?.type == RouteType.BUS && !route.isShuttle -> Shape.Rectangle

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModel.kt
@@ -124,6 +124,7 @@ public class SearchViewModel(
                             route,
                             line,
                             RoutePillSpec.Type.FlexCompact,
+                            RoutePillSpec.Height.Small,
                             context,
                             stopRouteContentDescription(isStation, route),
                         )
@@ -150,7 +151,7 @@ public class SearchViewModel(
                         route,
                         line,
                         RoutePillSpec.Type.Fixed,
-                        RoutePillSpec.Context.Default,
+                        context = RoutePillSpec.Context.Default,
                     )
 
                 return RouteResult(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpecTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePillSpecTest.kt
@@ -2,12 +2,13 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.line
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.route
+import com.mbta.tid.mbta_app.parametric.parametricTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class RoutePillSpecTest {
     @Test
-    fun `test bus`() {
+    fun `test bus`() = parametricTest {
         val busRoute = route {
             type = RouteType.BUS
             color = "FFC72C"
@@ -15,42 +16,37 @@ class RoutePillSpecTest {
             textColor = "000000"
         }
 
-        val fixedPill = RoutePillSpec(busRoute, null, RoutePillSpec.Type.Fixed)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val pill = RoutePillSpec(busRoute, null, type, height)
+
+        val expectedWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "000000",
                 "FFC72C",
                 RoutePillSpec.Content.Text("62/76"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Rectangle,
             ),
-            fixedPill,
-        )
-        val flexPill = RoutePillSpec(busRoute, null, RoutePillSpec.Type.Flex)
-        assertEquals(
-            RoutePillSpec(
-                "000000",
-                "FFC72C",
-                RoutePillSpec.Content.Text("62/76"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Rectangle,
-            ),
-            flexPill,
+            pill,
         )
 
         val searchStationPill =
-            RoutePillSpec(
-                busRoute,
-                null,
-                RoutePillSpec.Type.FlexCompact,
-                RoutePillSpec.Context.SearchStation,
-            )
+            RoutePillSpec(busRoute, null, type, height, RoutePillSpec.Context.SearchStation)
         assertEquals(
             RoutePillSpec(
                 "000000",
                 "FFC72C",
                 RoutePillSpec.Content.ModeImage(RouteType.BUS),
-                RoutePillSpec.Size.FlexPillSmall,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Rectangle,
             ),
             searchStationPill,
@@ -58,7 +54,7 @@ class RoutePillSpecTest {
     }
 
     @Test
-    fun `test heavy rail`() {
+    fun `test heavy rail`() = parametricTest {
         val redLine = route {
             type = RouteType.HEAVY_RAIL
             color = "DA291C"
@@ -72,77 +68,43 @@ class RoutePillSpecTest {
             textColor = "FFFFFF"
         }
 
-        val redLineFixed = RoutePillSpec(redLine, null, RoutePillSpec.Type.Fixed)
-        val redLineFlex = RoutePillSpec(redLine, null, RoutePillSpec.Type.Flex)
-        val redLineFlexCompact = RoutePillSpec(redLine, null, RoutePillSpec.Type.FlexCompact)
-        val blueLineFixed = RoutePillSpec(blueLine, null, RoutePillSpec.Type.Fixed)
-        val blueLineFlex = RoutePillSpec(blueLine, null, RoutePillSpec.Type.Flex)
-        val blueLineFlexCompact = RoutePillSpec(blueLine, null, RoutePillSpec.Type.FlexCompact)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val redLinePill = RoutePillSpec(redLine, null, type, height)
+        val blueLinePill = RoutePillSpec(blueLine, null, type, height)
 
+        val expectedWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "DA291C",
                 RoutePillSpec.Content.Text("RL"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            redLineFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("RL"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            redLineFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("RL"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            redLineFlexCompact,
+            redLinePill,
         )
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "003DA5",
                 RoutePillSpec.Content.Text("BL"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            blueLineFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "003DA5",
-                RoutePillSpec.Content.Text("BL"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            blueLineFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "003DA5",
-                RoutePillSpec.Content.Text("BL"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            blueLineFlexCompact,
+            blueLinePill,
         )
     }
 
     @Test
-    fun `test light rail`() {
+    fun `test light rail`() = parametricTest {
         val greenLineC = route {
             type = RouteType.LIGHT_RAIL
             color = "00843D"
@@ -157,77 +119,55 @@ class RoutePillSpecTest {
             textColor = "FFFFFF"
         }
 
-        val greenLineCFixed = RoutePillSpec(greenLineC, null, RoutePillSpec.Type.Fixed)
-        val greenLineCFlex = RoutePillSpec(greenLineC, null, RoutePillSpec.Type.Flex)
-        val greenLineCFlexCompact = RoutePillSpec(greenLineC, null, RoutePillSpec.Type.FlexCompact)
-        val mattapanFixed = RoutePillSpec(mattapan, null, RoutePillSpec.Type.Fixed)
-        val mattapanFlex = RoutePillSpec(mattapan, null, RoutePillSpec.Type.Flex)
-        val mattapanFlexCompact = RoutePillSpec(mattapan, null, RoutePillSpec.Type.FlexCompact)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val greenLineCPill = RoutePillSpec(greenLineC, null, type, height)
+        val mattapanPill = RoutePillSpec(mattapan, null, type, height)
 
+        val expectedContent =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Content.Text("GL C")
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Content.Text("C")
+            }
+        val expectedGLWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Circle
+            }
+        val expectedMattapanWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "00843D",
-                RoutePillSpec.Content.Text("GL C"),
-                RoutePillSpec.Size.FixedPill,
+                expectedContent,
+                height,
+                expectedGLWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            greenLineCFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "00843D",
-                RoutePillSpec.Content.Text("C"),
-                RoutePillSpec.Size.Circle,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            greenLineCFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "00843D",
-                RoutePillSpec.Content.Text("C"),
-                RoutePillSpec.Size.CircleSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            greenLineCFlexCompact,
+            greenLineCPill,
         )
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "DA291C",
                 RoutePillSpec.Content.Text("M"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedMattapanWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            mattapanFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("M"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            mattapanFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("M"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            mattapanFlexCompact,
+            mattapanPill,
         )
     }
 
     @Test
-    fun `test commuter rail`() {
+    fun `test commuter rail`() = parametricTest {
         val middleborough = route {
             type = RouteType.COMMUTER_RAIL
             color = "80276C"
@@ -241,78 +181,49 @@ class RoutePillSpecTest {
             textColor = "FFFFFF"
         }
 
-        val middleboroughFixed = RoutePillSpec(middleborough, null, RoutePillSpec.Type.Fixed)
-        val middleboroughFlex = RoutePillSpec(middleborough, null, RoutePillSpec.Type.Flex)
-        val middleboroughFlexCompact =
-            RoutePillSpec(middleborough, null, RoutePillSpec.Type.FlexCompact)
-        val providenceFixed = RoutePillSpec(providence, null, RoutePillSpec.Type.Fixed)
-        val providenceFlex = RoutePillSpec(providence, null, RoutePillSpec.Type.Flex)
-        val providenceFlexCompact = RoutePillSpec(providence, null, RoutePillSpec.Type.FlexCompact)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val middleboroughPill = RoutePillSpec(middleborough, null, type, height)
+        val providencePill = RoutePillSpec(providence, null, type, height)
 
+        val modePillContent =
+            when (type) {
+                RoutePillSpec.Type.Fixed,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Content.Text("CR")
+                RoutePillSpec.Type.Flex -> null
+            }
+        val expectedWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "80276C",
-                RoutePillSpec.Content.Text("CR"),
-                RoutePillSpec.Size.FixedPill,
+                modePillContent ?: RoutePillSpec.Content.Text("Middleborough/Lakeville"),
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            middleboroughFixed,
+            middleboroughPill,
         )
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "80276C",
-                RoutePillSpec.Content.Text("Middleborough/Lakeville"),
-                RoutePillSpec.Size.FlexPill,
+                modePillContent ?: RoutePillSpec.Content.Text("Providence/Stoughton"),
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            middleboroughFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "80276C",
-                RoutePillSpec.Content.Text("CR"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            middleboroughFlexCompact,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "80276C",
-                RoutePillSpec.Content.Text("CR"),
-                RoutePillSpec.Size.FixedPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            providenceFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "80276C",
-                RoutePillSpec.Content.Text("Providence/Stoughton"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            providenceFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "80276C",
-                RoutePillSpec.Content.Text("CR"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            providenceFlexCompact,
+            providencePill,
         )
     }
 
     @Test
-    fun `test ferry`() {
+    fun `test ferry`() = parametricTest {
         val ferry = route {
             type = RouteType.FERRY
             color = "008EAA"
@@ -320,44 +231,37 @@ class RoutePillSpecTest {
             textColor = "FFFFFF"
         }
 
-        val ferryFixed = RoutePillSpec(ferry, null, RoutePillSpec.Type.Fixed)
-        val ferryFlex = RoutePillSpec(ferry, null, RoutePillSpec.Type.Flex)
-        val ferryFlexCompact = RoutePillSpec(ferry, null, RoutePillSpec.Type.FlexCompact)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val ferryPill = RoutePillSpec(ferry, null, type, height)
 
+        val modePillContent =
+            when (type) {
+                RoutePillSpec.Type.Fixed,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Content.ModeImage(RouteType.FERRY)
+                RoutePillSpec.Type.Flex -> null
+            }
+        val expectedWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "008EAA",
-                RoutePillSpec.Content.ModeImage(RouteType.FERRY),
-                RoutePillSpec.Size.FixedPill,
+                modePillContent ?: RoutePillSpec.Content.Text("Hingham/Hull Ferry"),
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            ferryFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "008EAA",
-                RoutePillSpec.Content.Text("Hingham/Hull Ferry"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            ferryFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "008EAA",
-                RoutePillSpec.Content.ModeImage(RouteType.FERRY),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            ferryFlexCompact,
+            ferryPill,
         )
     }
 
     @Test
-    fun `test lines`() {
+    fun `test lines`() = parametricTest {
         val redLine = line {
             color = "DA291C"
             longName = "Red Line"
@@ -369,72 +273,38 @@ class RoutePillSpecTest {
             textColor = "FFFFFF"
         }
 
-        val rlFixed = RoutePillSpec(null, redLine, RoutePillSpec.Type.Fixed)
-        val rlFlex = RoutePillSpec(null, redLine, RoutePillSpec.Type.Flex)
-        val rlFlexCompact = RoutePillSpec(null, redLine, RoutePillSpec.Type.FlexCompact)
-        val glFixed = RoutePillSpec(null, greenLine, RoutePillSpec.Type.Fixed)
-        val glFlex = RoutePillSpec(null, greenLine, RoutePillSpec.Type.Flex)
-        val glFlexCompact = RoutePillSpec(null, greenLine, RoutePillSpec.Type.FlexCompact)
+        val type: RoutePillSpec.Type = anyEnumValue()
+        val height: RoutePillSpec.Height = anyEnumValue()
+        val rlPill = RoutePillSpec(null, redLine, type, height)
+        val glPill = RoutePillSpec(null, greenLine, type, height)
 
+        val expectedWidth =
+            when (type) {
+                RoutePillSpec.Type.Fixed -> RoutePillSpec.Width.Fixed
+                RoutePillSpec.Type.Flex,
+                RoutePillSpec.Type.FlexCompact -> RoutePillSpec.Width.Flex
+            }
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "DA291C",
                 RoutePillSpec.Content.Text("Red Line"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            rlFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("Red Line"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            rlFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "DA291C",
-                RoutePillSpec.Content.Text("Red Line"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            rlFlexCompact,
+            rlPill,
         )
         assertEquals(
             RoutePillSpec(
                 "FFFFFF",
                 "00843D",
                 RoutePillSpec.Content.Text("GL"),
-                RoutePillSpec.Size.FixedPill,
+                height,
+                expectedWidth,
                 RoutePillSpec.Shape.Capsule,
             ),
-            glFixed,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "00843D",
-                RoutePillSpec.Content.Text("GL"),
-                RoutePillSpec.Size.FlexPill,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            glFlex,
-        )
-        assertEquals(
-            RoutePillSpec(
-                "FFFFFF",
-                "00843D",
-                RoutePillSpec.Content.Text("GL"),
-                RoutePillSpec.Size.FlexPillSmall,
-                RoutePillSpec.Shape.Capsule,
-            ),
-            glFlexCompact,
+            glPill,
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/SearchViewModelTest.kt
@@ -213,7 +213,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "DA291C",
                                 RoutePillSpec.Content.Text("RL"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Capsule,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     redLine.label,
@@ -225,7 +226,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "7C878E",
                                 RoutePillSpec.Content.ModeImage(RouteType.BUS),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "Silver Line",
@@ -237,7 +239,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "80276C",
                                 RoutePillSpec.Content.Text("CR"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Capsule,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "Commuter Rail",
@@ -249,7 +252,8 @@ class SearchViewModelTest {
                                 textColor = "000000",
                                 routeColor = "FFC72C",
                                 RoutePillSpec.Content.ModeImage(RouteType.BUS),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     null,
@@ -268,7 +272,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "DA291C",
                                 RoutePillSpec.Content.Text("RL"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Capsule,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     redLine.label,
@@ -280,7 +285,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "7C878E",
                                 RoutePillSpec.Content.Text("SL1"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "SL1",
@@ -292,7 +298,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "7C878E",
                                 RoutePillSpec.Content.Text("SL2"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "SL2",
@@ -304,7 +311,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "80276C",
                                 RoutePillSpec.Content.Text("CR"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Capsule,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     crFitchburg.longName,
@@ -316,7 +324,8 @@ class SearchViewModelTest {
                                 textColor = "FFFFFF",
                                 routeColor = "80276C",
                                 RoutePillSpec.Content.Text("CR"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Capsule,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     crHaverhill.longName,
@@ -328,7 +337,8 @@ class SearchViewModelTest {
                                 textColor = "000000",
                                 routeColor = "FFC72C",
                                 RoutePillSpec.Content.Text("15"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "15",
@@ -340,7 +350,8 @@ class SearchViewModelTest {
                                 textColor = "000000",
                                 routeColor = "FFC72C",
                                 RoutePillSpec.Content.Text("67"),
-                                RoutePillSpec.Size.FlexPillSmall,
+                                RoutePillSpec.Height.Small,
+                                RoutePillSpec.Width.Flex,
                                 RoutePillSpec.Shape.Rectangle,
                                 RoutePillSpec.ContentDescription.StopSearchResultRoute(
                                     "67",


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Track this Trip | Sheet contents](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210501361218460?focus=true)

The sheet header calls for a large pill, and it seemed reasonable to split the height of the pill from the fixed/flex/flex-but-abbreviating-some-modes type.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked in IDE previews that everything still looks right.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
