### PR TITLE
fix?(shared.VMTests): Address flakiness in molecule tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -389,11 +389,15 @@ internal class FavoritesViewModelTest : KoinTest {
             )
             // static data usually loads before realtime, but not always
             awaitItemSatisfying {
-                (it.routeCardData == expectedRealtimeData &&
-                    it.staticRouteCardData == expectedStaticData) &&
-                    !it.awaitingPredictionsAfterBackground &&
-                    it.favorites == favorites.routeStopDirection &&
-                    it.loadedLocation == stop1.position
+                it ==
+                    FavoritesViewModel.State(
+                        false,
+                        favorites.routeStopDirection,
+                        false,
+                        expectedRealtimeData,
+                        expectedStaticData,
+                        stop1.position,
+                    )
             }
         }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -388,16 +388,13 @@ internal class FavoritesViewModelTest : KoinTest {
                 awaitItem(),
             )
             // static data usually loads before realtime, but not always
-            assertEquals(
-                FavoritesViewModel.State(
-                    awaitingPredictionsAfterBackground = false,
-                    favorites = favorites.routeStopDirection,
-                    routeCardData = expectedRealtimeData,
-                    staticRouteCardData = expectedStaticData,
-                    loadedLocation = stop1.position,
-                ),
-                awaitItemSatisfying { it.routeCardData != null && it.staticRouteCardData != null },
-            )
+            awaitItemSatisfying {
+                (it.routeCardData == expectedRealtimeData &&
+                    it.staticRouteCardData == expectedStaticData) &&
+                    !it.awaitingPredictionsAfterBackground &&
+                    it.favorites == favorites.routeStopDirection &&
+                    it.loadedLocation == stop1.position
+            }
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
@@ -27,7 +27,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -202,15 +201,11 @@ class StopDetailsViewModelTest : KoinTest {
         viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
         viewModel.setNow(EasternTimeInstant.now())
 
-        launch {
-            testViewModelFlow(viewModel).test {
-                awaitItemSatisfying { it.routeData is StopDetailsViewModel.RouteData.Filtered }
-            }
+        testViewModelFlow(viewModel).test {
+            awaitItemSatisfying { it.routeData is StopDetailsViewModel.RouteData.Filtered }
         }
 
-        launch { testViewModelFlow(routeCardVM).test { awaitItemSatisfying { it.data != null } } }
-
-        testScheduler.advanceUntilIdle()
+        testViewModelFlow(routeCardVM).test { awaitItemSatisfying { it.data != null } }
     }
 
     @Test
@@ -298,18 +293,11 @@ class StopDetailsViewModelTest : KoinTest {
         viewModel.setNow(EasternTimeInstant.now())
         viewModel.setActive(active = true, wasSentToBackground = false)
 
-        launch {
-            testViewModelFlow(viewModel).test { awaitItemSatisfying { it.routeData != null } }
-        }
+        testViewModelFlow(viewModel).test { awaitItemSatisfying { it.routeData != null } }
 
-        launch {
-            viewModel.filterUpdates.test {
-                awaitItem()
-                awaitItemSatisfying { it?.stopFilter == StopDetailsFilter("87", 1, true) }
-            }
+        viewModel.filterUpdates.test {
+            awaitItemSatisfying { it?.stopFilter == StopDetailsFilter("87", 1, true) }
         }
-
-        testScheduler.advanceUntilIdle()
     }
 
     @Test
@@ -346,19 +334,11 @@ class StopDetailsViewModelTest : KoinTest {
         viewModel.setFilters(filters)
         viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
         viewModel.setNow(now)
+        testViewModelFlow(viewModel).test { awaitItemSatisfying { it.routeData != null } }
 
-        launch {
-            testViewModelFlow(viewModel).test { awaitItemSatisfying { it.routeData != null } }
+        viewModel.filterUpdates.test {
+            awaitItemSatisfying { it?.tripFilter == TripDetailsFilter(trip.id, null, 0, false) }
         }
-
-        launch {
-            viewModel.filterUpdates.test {
-                awaitItem()
-                awaitItemSatisfying { it?.tripFilter == TripDetailsFilter(trip.id, null, 0, false) }
-            }
-        }
-
-        testScheduler.advanceUntilIdle()
     }
 
     @Test
@@ -409,30 +389,15 @@ class StopDetailsViewModelTest : KoinTest {
         viewModel.setNow(now)
         viewModel.setActive(active = true, wasSentToBackground = false)
 
-        launch {
-            viewModel.filterUpdates.test {
-                awaitItem()
-                awaitItemSatisfying { it?.tripFilter?.tripId == trip0.id }
-                awaitItem()
-                awaitItemSatisfying { it?.tripFilter?.tripId == trip1.id }
-            }
+        testViewModelFlow(viewModel).test {
+            viewModel.setFilters(initialFilters)
+            awaitItemSatisfying { it.routeData?.filters?.stopFilter?.directionId == 0 }
+            viewModel.setFilters(
+                StopDetailsPageFilters("place-rugg", StopDetailsFilter("Orange", 1, false), null)
+            )
+            awaitItemSatisfying { it.routeData?.filters?.stopFilter?.directionId == 1 }
         }
 
-        launch {
-            testViewModelFlow(viewModel).test {
-                viewModel.setFilters(initialFilters)
-                awaitItemSatisfying { it.routeData?.filters?.stopFilter?.directionId == 0 }
-                viewModel.setFilters(
-                    StopDetailsPageFilters(
-                        "place-rugg",
-                        StopDetailsFilter("Orange", 1, false),
-                        null,
-                    )
-                )
-                awaitItemSatisfying { it.routeData?.filters?.stopFilter?.directionId == 1 }
-            }
-        }
-
-        testScheduler.advanceUntilIdle()
+        viewModel.filterUpdates.test { awaitItemSatisfying { it?.tripFilter?.tripId == trip1.id } }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [CI | android flaky tests again](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211209894303557?focus=true)

What is this PR for?
The change to FavoritesVM follows an existing flaky molecule fix of broadening the `awaitItemSatisfying` conditions.

The changes to the StopDetailVM are newer territory , since those tests had some extra complexity of testing multiple flows at once. See[ slack thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1757094457414739) about how the existing tests broke the functionality of `awaitItemSatisfying` in mysterious ways. Updating it to only call `awaitItem` from within `awaitItemSatisfying` seems to have made it work more reliably. 
iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Ran tests locally and confirmed that they passed - time will tell for CI.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
