### PR TITLE
test(Android): load Koin mocks into global Koin so they propagate to ViewModels

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
@@ -23,9 +23,9 @@ import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.everySuspend
 import dev.mokkery.mock
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 @OptIn(ExperimentalTestApi::class)
@@ -36,17 +36,18 @@ class ContentViewTests : KoinTest {
         GrantPermissionRule.grant(android.Manifest.permission.ACCESS_FINE_LOCATION)
     @get:Rule val composeTestRule = createComposeRule()
 
-    val koinApplication = testKoinApplication()
+    @Before
+    fun setUp() {
+        loadKoinMocks()
+    }
 
     @Test
     fun testSwitchingTabs() {
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    ContentView()
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                ContentView()
             }
         }
 
@@ -73,12 +74,10 @@ class ContentViewTests : KoinTest {
             )
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    ContentView(viewModel = vm)
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                ContentView(viewModel = vm)
             }
         }
 
@@ -94,19 +93,14 @@ class ContentViewTests : KoinTest {
         var onAttachCount = 0
         var onDetatchCount = 0
 
-        val koinApplication =
-            testKoinApplication(
-                socket = MockPhoenixSocket({ onAttachCount += 1 }, { onDetatchCount += 1 })
-            )
+        loadKoinMocks(socket = MockPhoenixSocket({ onAttachCount += 1 }, { onDetatchCount += 1 }))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient(),
-                    LocalLifecycleOwner provides lifecycleOwner,
-                ) {
-                    ContentView()
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient(),
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                ContentView()
             }
         }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -12,7 +12,6 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class AlertDetailsPageTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -116,19 +115,17 @@ class AlertDetailsPageTest {
                 )
             }
 
-        val koin = testKoinApplication(objects)
+        loadKoinMocks(objects)
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                AlertDetailsPage(
-                    alertId = alert.id,
-                    lineId = null,
-                    routeIds = listOf(route.id),
-                    stopId = null,
-                    alerts = AlertsStreamDataResponse(objects),
-                    goBack = {},
-                )
-            }
+            AlertDetailsPage(
+                alertId = alert.id,
+                lineId = null,
+                routeIds = listOf(route.id),
+                stopId = null,
+                alerts = AlertsStreamDataResponse(objects),
+                goBack = {},
+            )
         }
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
@@ -23,7 +23,6 @@ import kotlin.test.assertTrue
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 @OptIn(ExperimentalTestApi::class)
 class SaveFavoritesFlowTest {
@@ -289,22 +288,20 @@ class SaveFavoritesFlowTest {
         var displayedToast: ToastViewModel.Toast? = null
         toastVM.onShowToast = { displayedToast = it }
 
-        val koin = testKoinApplication(TestData)
+        loadKoinMocks(TestData)
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                SaveFavoritesFlow(
-                    lineOrRoute = line,
-                    stop = stop,
-                    directions = listOf(direction0, direction1),
-                    selectedDirection = 0,
-                    context = EditFavoritesContext.Favorites,
-                    toastViewModel = toastVM,
-                    isFavorite = { false },
-                    updateFavorites = {},
-                    onClose = {},
-                )
-            }
+            SaveFavoritesFlow(
+                lineOrRoute = line,
+                stop = stop,
+                directions = listOf(direction0, direction1),
+                selectedDirection = 0,
+                context = EditFavoritesContext.Favorites,
+                toastViewModel = toastVM,
+                isFavorite = { false },
+                updateFavorites = {},
+                onClose = {},
+            )
         }
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add"))
@@ -322,22 +319,20 @@ class SaveFavoritesFlowTest {
         var displayedToast: ToastViewModel.Toast? = null
         toastVM.onShowToast = { displayedToast = it }
 
-        val koin = testKoinApplication(TestData)
+        loadKoinMocks(TestData)
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                SaveFavoritesFlow(
-                    lineOrRoute = line,
-                    stop = stop,
-                    directions = listOf(direction0, direction1),
-                    selectedDirection = 0,
-                    context = EditFavoritesContext.Favorites,
-                    toastViewModel = toastVM,
-                    isFavorite = { false },
-                    updateFavorites = {},
-                    onClose = {},
-                )
-            }
+            SaveFavoritesFlow(
+                lineOrRoute = line,
+                stop = stop,
+                directions = listOf(direction0, direction1),
+                selectedDirection = 0,
+                context = EditFavoritesContext.Favorites,
+                toastViewModel = toastVM,
+                isFavorite = { false },
+                updateFavorites = {},
+                onClose = {},
+            )
         }
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("East", substring = true).performClick()
@@ -358,22 +353,20 @@ class SaveFavoritesFlowTest {
         val busRoute = TestData.getRoute("15")
         val busStop = TestData.getStop("17861")
 
-        val koin = testKoinApplication(TestData)
+        loadKoinMocks(TestData)
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                SaveFavoritesFlow(
-                    lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
-                    stop = busStop,
-                    directions = listOf(direction0),
-                    selectedDirection = 0,
-                    context = EditFavoritesContext.Favorites,
-                    toastViewModel = toastVM,
-                    isFavorite = { false },
-                    updateFavorites = {},
-                    onClose = {},
-                )
-            }
+            SaveFavoritesFlow(
+                lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                stop = busStop,
+                directions = listOf(direction0),
+                selectedDirection = 0,
+                context = EditFavoritesContext.Favorites,
+                toastViewModel = toastVM,
+                isFavorite = { false },
+                updateFavorites = {},
+                onClose = {},
+            )
         }
 
         composeTestRule.waitUntil {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -21,7 +21,6 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class DeparturesTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -288,17 +287,12 @@ class DeparturesTest {
         var tapAnalytics: Pair<String, Map<String, String>>? = null
         var onClickCalled = false
 
-        val koinApplication =
-            testKoinApplication(
-                analytics = MockAnalytics({ event, props -> tapAnalytics = Pair(event, props) })
-            )
+        loadKoinMocks(
+            analytics = MockAnalytics({ event, props -> tapAnalytics = Pair(event, props) })
+        )
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                Departures(stopData, GlobalResponse(objects), now, { true }) {
-                    onClickCalled = true
-                }
-            }
+            Departures(stopData, GlobalResponse(objects), now, { true }) { onClickCalled = true }
         }
 
         composeTestRule.onNodeWithText(aTrip.headsign).assertIsDisplayed().performClick()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -23,9 +23,9 @@ import io.github.dellisd.spatialk.geojson.Position
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 class RouteCardListTest : KoinTest {
@@ -157,9 +157,12 @@ class RouteCardListTest : KoinTest {
 
     val globalResponse = GlobalResponse(builder)
 
-    val koinApplication = testKoinApplication(builder)
-
     @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder)
+    }
 
     @OptIn(ExperimentalTestApi::class)
     @Test
@@ -177,17 +180,15 @@ class RouteCardListTest : KoinTest {
             )
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                Column {
-                    RouteCardList(
-                        routeCardData = routeCardData,
-                        emptyView = { Text("This would be the empty view") },
-                        global = globalResponse,
-                        now = EasternTimeInstant.now(),
-                        isFavorite = { false },
-                        onOpenStopDetails = { _, _ -> },
-                    )
-                }
+            Column {
+                RouteCardList(
+                    routeCardData = routeCardData,
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { _, _ -> },
+                )
             }
         }
 
@@ -205,19 +206,17 @@ class RouteCardListTest : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testRouteCardListShowsEmptyView() {
-        val emptyNearbyKoinApplication = testKoinApplication()
+        loadKoinMocks()
         composeTestRule.setContent {
-            KoinContext(emptyNearbyKoinApplication.koin) {
-                Column {
-                    RouteCardList(
-                        routeCardData = emptyList(),
-                        emptyView = { Text("This would be the empty view") },
-                        global = globalResponse,
-                        now = EasternTimeInstant.now(),
-                        isFavorite = { false },
-                        onOpenStopDetails = { _, _ -> },
-                    )
-                }
+            Column {
+                RouteCardList(
+                    routeCardData = emptyList(),
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { _, _ -> },
+                )
             }
         }
 
@@ -245,17 +244,15 @@ class RouteCardListTest : KoinTest {
 
         var clickedStopId: String? = null
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                Column {
-                    RouteCardList(
-                        routeCardData = routeCardData,
-                        emptyView = { Text("This would be the empty view") },
-                        global = globalResponse,
-                        now = EasternTimeInstant.now(),
-                        isFavorite = { false },
-                        onOpenStopDetails = { stopId, _ -> clickedStopId = stopId },
-                    )
-                }
+            Column {
+                RouteCardList(
+                    routeCardData = routeCardData,
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { stopId, _ -> clickedStopId = stopId },
+                )
             }
         }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
@@ -12,7 +11,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class RouteCardTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -65,29 +63,25 @@ class RouteCardTest {
                 type = RouteType.LIGHT_RAIL
             }
 
-        val koinApplication = testKoinApplication {}
-
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                RouteCard(
-                    RouteCardData(
-                        RouteCardData.LineOrRoute.Route(route),
-                        listOf(
-                            RouteCardData.RouteStopData(
-                                RouteCardData.LineOrRoute.Route(route),
-                                stop,
-                                emptyList(),
-                                emptyList(),
-                            )
-                        ),
-                        now,
+            RouteCard(
+                RouteCardData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            RouteCardData.LineOrRoute.Route(route),
+                            stop,
+                            emptyList(),
+                            emptyList(),
+                        )
                     ),
-                    GlobalResponse(objects),
                     now,
-                    isFavorite = { false },
-                    showStopHeader = true,
-                ) { _, _ ->
-                }
+                ),
+                GlobalResponse(objects),
+                now,
+                isFavorite = { false },
+                showStopHeader = true,
+            ) { _, _ ->
             }
         }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -13,7 +13,6 @@ import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class StopHeaderTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -43,20 +42,18 @@ class StopHeaderTest {
         val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopHeader(
-                    RouteCardData.RouteStopData(
-                        RouteCardData.LineOrRoute.Route(route),
-                        stop,
-                        emptyList(),
-                        emptyList(),
-                    )
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    stop,
+                    emptyList(),
+                    emptyList(),
                 )
-            }
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertDoesNotExist()
@@ -68,20 +65,18 @@ class StopHeaderTest {
         val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE }
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopHeader(
-                    RouteCardData.RouteStopData(
-                        RouteCardData.LineOrRoute.Route(route),
-                        stop,
-                        emptyList(),
-                        emptyList(),
-                    )
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    RouteCardData.LineOrRoute.Route(route),
+                    stop,
+                    emptyList(),
+                    emptyList(),
                 )
-            }
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithText("Not accessible").assertIsDisplayed()
@@ -96,34 +91,32 @@ class StopHeaderTest {
         val alert = objects.alert { effect = Alert.Effect.ElevatorClosure }
 
         val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopHeader(
-                    RouteCardData.RouteStopData(
-                        lineOrRoute,
-                        stop,
-                        emptyList(),
-                        listOf(
-                            RouteCardData.Leaf(
-                                lineOrRoute,
-                                stop,
-                                0,
-                                emptyList(),
-                                emptySet(),
-                                emptyList(),
-                                listOf(alert),
-                                true,
-                                true,
-                                emptyList(),
-                                RouteCardData.Context.StopDetailsUnfiltered,
-                            )
-                        ),
-                    )
+            StopHeader(
+                RouteCardData.RouteStopData(
+                    lineOrRoute,
+                    stop,
+                    emptyList(),
+                    listOf(
+                        RouteCardData.Leaf(
+                            lineOrRoute,
+                            stop,
+                            0,
+                            emptyList(),
+                            emptySet(),
+                            emptyList(),
+                            listOf(alert),
+                            true,
+                            true,
+                            emptyList(),
+                            RouteCardData.Context.StopDetailsUnfiltered,
+                        )
+                    ),
                 )
-            }
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithText("1 elevator closed").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.pages.EditFavoritesPage
-import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LocationType
@@ -32,9 +32,9 @@ import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 class EditFavoritesPageTest : KoinTest {
@@ -245,9 +245,12 @@ class EditFavoritesPageTest : KoinTest {
 
     val globalResponse = GlobalResponse(builder)
 
-    val koinApplication = testKoinApplication(builder)
-
     @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder)
+    }
 
     @OptIn(ExperimentalTestApi::class)
     @Test
@@ -265,9 +268,7 @@ class EditFavoritesPageTest : KoinTest {
                 )
             )
 
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
-        }
+        composeTestRule.setContent { EditFavoritesPage(globalResponse, viewModel) {} }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
         composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
@@ -286,9 +287,7 @@ class EditFavoritesPageTest : KoinTest {
                 FavoritesViewModel.State(false, emptySet(), false, emptyList(), emptyList(), null)
             )
 
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
-        }
+        composeTestRule.setContent { EditFavoritesPage(globalResponse, viewModel) {} }
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("No stops added"))
@@ -331,9 +330,7 @@ class EditFavoritesPageTest : KoinTest {
             updatedWith = update
         }
 
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { EditFavoritesPage(globalResponse, viewModel) {} }
-        }
+        composeTestRule.setContent { EditFavoritesPage(globalResponse, viewModel) {} }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
         composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
@@ -405,11 +402,7 @@ class EditFavoritesPageTest : KoinTest {
         toastVM.onHideToast = { displayedToast = null }
         toastVM.onShowToast = { displayedToast = it }
 
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                EditFavoritesPage(globalResponse, viewModel, toastVM) {}
-            }
-        }
+        composeTestRule.setContent { EditFavoritesPage(globalResponse, viewModel, toastVM) {} }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
         composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -26,6 +26,7 @@ import com.mapbox.maps.CameraState
 import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.location.IViewportProvider
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
@@ -33,7 +34,6 @@ import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.IMapboxConfigManager
 import com.mbta.tid.mbta_app.android.pages.MapAndSheetPage
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
-import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -74,7 +74,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -204,8 +203,8 @@ class MapAndSheetPageTest : KoinTest {
             ),
         )
 
-    fun koinApplication(hideMaps: Boolean = false) =
-        testKoinApplication(
+    fun loadMocks(hideMaps: Boolean = false) =
+        loadKoinMocks(
             builder,
             repositoryOverrides = {
                 nearby =
@@ -228,32 +227,29 @@ class MapAndSheetPageTest : KoinTest {
     fun testMapAndSheetPageDisplaysCorrectly() {
         val mockMapVM = mock<IMapViewModel>(MockMode.autofill)
         every { mockMapVM.models } returns MutableStateFlow(MapViewModel.State.Overview)
-        val koinApplication = koinApplication()
+        loadMocks()
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    MapAndSheetPage(
-                        Modifier,
-                        NearbyTransit(
-                            alertData = AlertsStreamDataResponse(builder.alerts),
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState =
-                                remember { mutableStateOf(Position(0.0, 0.0)) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(),
-                            viewportProvider = viewportProvider,
-                        ),
-                        SheetRoutes.NearbyTransit,
-                        false,
-                        {},
-                        {},
-                        bottomBar = {},
-                        mockMapVM,
-                    )
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = MockLocationDataManager(),
+                        viewportProvider = viewportProvider,
+                    ),
+                    SheetRoutes.NearbyTransit,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mockMapVM,
+                )
             }
         }
 
@@ -288,40 +284,37 @@ class MapAndSheetPageTest : KoinTest {
         val mockErrorVM = mock<IErrorBannerViewModel>(MockMode.autofill)
         every { mockErrorVM.models } returns MutableStateFlow(ErrorBannerViewModel.State())
 
-        val koinApplication = koinApplication()
+        loadMocks()
         composeTestRule.setContent {
             var entrypoint by remember {
                 mutableStateOf<SheetRoutes.Entrypoint>(SheetRoutes.NearbyTransit)
             }
 
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    MapAndSheetPage(
-                        Modifier,
-                        NearbyTransit(
-                            alertData = AlertsStreamDataResponse(builder.alerts),
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState =
-                                remember { mutableStateOf(Position(0.0, 0.0)) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(),
-                            viewportProvider = viewportProvider,
-                        ),
-                        entrypoint,
-                        false,
-                        {},
-                        {},
-                        bottomBar = {},
-                        mockMapVM,
-                        errorBannerViewModel = mockErrorVM,
-                    )
-                }
-
-                LaunchedEffect(Unit) { entrypoint = SheetRoutes.Favorites }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = MockLocationDataManager(),
+                        viewportProvider = viewportProvider,
+                    ),
+                    entrypoint,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mockMapVM,
+                    errorBannerViewModel = mockErrorVM,
+                )
             }
+
+            LaunchedEffect(Unit) { entrypoint = SheetRoutes.Favorites }
         }
 
         composeTestRule.waitForIdle()
@@ -348,33 +341,30 @@ class MapAndSheetPageTest : KoinTest {
         every { mockMapVM.models } returns MutableStateFlow(MapViewModel.State.Overview)
         val mockConfigManager = MockConfigManager()
 
-        val koinApplication = koinApplication()
+        loadMocks()
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    MapAndSheetPage(
-                        Modifier,
-                        NearbyTransit(
-                            alertData = AlertsStreamDataResponse(builder.alerts),
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState =
-                                remember { mutableStateOf(Position(0.0, 0.0)) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(),
-                            viewportProvider = viewportProvider,
-                        ),
-                        SheetRoutes.NearbyTransit,
-                        false,
-                        {},
-                        {},
-                        bottomBar = {},
-                        mapViewModel = mockMapVM,
-                        mapboxConfigManager = mockConfigManager,
-                    )
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = MockLocationDataManager(),
+                        viewportProvider = viewportProvider,
+                    ),
+                    SheetRoutes.NearbyTransit,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mapViewModel = mockMapVM,
+                    mapboxConfigManager = mockConfigManager,
+                )
             }
         }
 
@@ -392,32 +382,29 @@ class MapAndSheetPageTest : KoinTest {
     fun testHidesMap() {
         val mockMapVM = mock<IMapViewModel>(MockMode.autofill)
         every { mockMapVM.models } returns MutableStateFlow(MapViewModel.State.Overview)
-        val koinApplication = koinApplication(hideMaps = true)
+        loadMocks(hideMaps = true)
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient()
-                ) {
-                    MapAndSheetPage(
-                        Modifier,
-                        NearbyTransit(
-                            alertData = AlertsStreamDataResponse(builder.alerts),
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState =
-                                remember { mutableStateOf(Position(0.0, 0.0)) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = MockLocationDataManager(),
-                            viewportProvider = viewportProvider,
-                        ),
-                        SheetRoutes.NearbyTransit,
-                        false,
-                        {},
-                        {},
-                        bottomBar = {},
-                        mockMapVM,
-                    )
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = MockLocationDataManager(),
+                        viewportProvider = viewportProvider,
+                    ),
+                    SheetRoutes.NearbyTransit,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mockMapVM,
+                )
             }
         }
 
@@ -470,34 +457,31 @@ class MapAndSheetPageTest : KoinTest {
 
         everySuspend { viewportProvider.follow(any()) } calls { followCallCount += 1 }
 
-        val koinApplication = testKoinApplication(builder, clock = mockClock)
+        loadKoinMocks(builder, clock = mockClock)
         locationDataManager.hasPermission = true
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                CompositionLocalProvider(
-                    LocalLocationClient provides MockFusedLocationProviderClient(),
-                    LocalLifecycleOwner provides lifecycleOwner,
-                ) {
-                    MapAndSheetPage(
-                        Modifier,
-                        NearbyTransit(
-                            alertData = AlertsStreamDataResponse(builder.alerts),
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState =
-                                remember { mutableStateOf(Position(0.0, 0.0)) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = locationDataManager,
-                            viewportProvider = viewportProvider,
-                        ),
-                        SheetRoutes.NearbyTransit,
-                        false,
-                        {},
-                        {},
-                        bottomBar = {},
-                        mockMapVM,
-                    )
-                }
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient(),
+                LocalLifecycleOwner provides lifecycleOwner,
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = locationDataManager,
+                        viewportProvider = viewportProvider,
+                    ),
+                    SheetRoutes.NearbyTransit,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mockMapVM,
+                )
             }
         }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
@@ -10,9 +10,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffoldState
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
-import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -32,7 +32,6 @@ import dev.mokkery.mock
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class MapAndSheetPageTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -65,37 +64,34 @@ class MapAndSheetPageTest {
         val alertData = AlertsStreamDataResponse(objects)
         val globalResponse = GlobalResponse(objects)
 
-        val koin =
-            testKoinApplication(objects) {
-                nearby = NearbyRepository()
-                settings = MockSettingsRepository(mapOf(Settings.HideMaps to true))
-            }
+        loadKoinMocks(objects) {
+            nearby = NearbyRepository()
+            settings = MockSettingsRepository(mapOf(Settings.HideMaps to true))
+        }
 
         val locationDataManager = MockLocationDataManager(stop1.position)
         val viewportProvider = ViewportProvider(MapViewportState())
         val mockMapVM = mock<IMapViewModel>(MockMode.autofill)
         every { mockMapVM.models } returns MutableStateFlow(MapViewModel.State.Overview)
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                MapAndSheetPage(
-                    nearbyTransit =
-                        NearbyTransit(
-                            alertData = alertData,
-                            globalResponse = globalResponse,
-                            lastLoadedLocationState = remember { mutableStateOf(null) },
-                            isTargetingState = remember { mutableStateOf(false) },
-                            scaffoldState = rememberBottomSheetScaffoldState(),
-                            locationDataManager = locationDataManager,
-                            viewportProvider = viewportProvider,
-                        ),
-                    sheetNavEntrypoint = SheetRoutes.NearbyTransit,
-                    navBarVisible = false,
-                    showNavBar = {},
-                    hideNavBar = {},
-                    bottomBar = {},
-                    mapViewModel = mockMapVM,
-                )
-            }
+            MapAndSheetPage(
+                nearbyTransit =
+                    NearbyTransit(
+                        alertData = alertData,
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(null) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = locationDataManager,
+                        viewportProvider = viewportProvider,
+                    ),
+                sheetNavEntrypoint = SheetRoutes.NearbyTransit,
+                navBarVisible = false,
+                showNavBar = {},
+                hideNavBar = {},
+                bottomBar = {},
+                mapViewModel = mockMapVM,
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
@@ -17,7 +17,6 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 class MorePageTests : KoinTest {
@@ -37,7 +36,7 @@ class MorePageTests : KoinTest {
     fun testSettings() {
         var hideMapValue = false
 
-        val koinApplication = testKoinApplication {
+        loadKoinMocks {
             settings =
                 MockSettingsRepository(
                     onSaveSettings = { settings ->
@@ -47,9 +46,7 @@ class MorePageTests : KoinTest {
                     }
                 )
         }
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
-        }
+        composeTestRule.setContent { MorePage(bottomBar = {}) }
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Settings"))
@@ -65,10 +62,8 @@ class MorePageTests : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testLinksExist() {
-        val koinApplication = testKoinApplication()
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
-        }
+        loadKoinMocks()
+        composeTestRule.setContent { MorePage(bottomBar = {}) }
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Send App Feedback"))
@@ -92,10 +87,8 @@ class MorePageTests : KoinTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testSoftwareLicenses() {
-        val koinApplication = testKoinApplication()
-        composeTestRule.setContent {
-            KoinContext(koinApplication.koin) { MorePage(bottomBar = {}) }
-        }
+        loadKoinMocks()
+        composeTestRule.setContent { MorePage(bottomBar = {}) }
 
         val dependencies = Dependency.getAllDependencies()
         val dependency = dependencies.first()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilNodeCountDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -31,7 +31,6 @@ import kotlin.test.fail
 import kotlinx.coroutines.flow.update
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 
 class RouteStopListViewTest {
@@ -72,58 +71,55 @@ class RouteStopListViewTest {
 
         val clicks = mutableListOf<RouteDetailsRowContext>()
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment(
-                                    listOf(
-                                        RouteBranchSegment.BranchStop(
-                                            stop1.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
-                                        RouteBranchSegment.BranchStop(
-                                            stop2.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
-                                        RouteBranchSegment.BranchStop(
-                                            stop3.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment(
+                                listOf(
+                                    RouteBranchSegment.BranchStop(
+                                        stop1.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
                                     ),
-                                    name = null,
-                                    isTypical = true,
-                                )
-                            ),
-                        routeId = mainRoute.id,
-                    )
-            }
+                                    RouteBranchSegment.BranchStop(
+                                        stop2.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        stop3.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
+                                    ),
+                                ),
+                                name = null,
+                                isTypical = true,
+                            )
+                        ),
+                    routeId = mainRoute.id,
+                )
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(mainRoute),
-                    RouteDetailsContext.Details,
-                    GlobalResponse(objects),
-                    onClick = clicks::add,
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = MockToastViewModel(),
-                    rightSideContent = { context, _ ->
-                        when (context) {
-                            is RouteDetailsRowContext.Details ->
-                                Text("rightSideContent for ${context.stop.name}")
-                            else -> fail("Wrong row context provided")
-                        }
-                    },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(mainRoute),
+                RouteDetailsContext.Details,
+                GlobalResponse(objects),
+                onClick = clicks::add,
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = MockToastViewModel(),
+                rightSideContent = { context, _ ->
+                    when (context) {
+                        is RouteDetailsRowContext.Details ->
+                            Text("rightSideContent for ${context.stop.name}")
+                        else -> fail("Wrong row context provided")
+                    }
+                },
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
@@ -183,30 +179,27 @@ class RouteStopListViewTest {
 
         var lastSelectedRoute: String? = null
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments = listOf(),
-                        onGet = { routeId, _ -> lastSelectedRoute = routeId },
-                    )
-            }
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments = listOf(),
+                    onGet = { routeId, _ -> lastSelectedRoute = routeId },
+                )
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
-                    RouteDetailsContext.Details,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = MockToastViewModel(),
-                    defaultSelectedRouteId = route2.id,
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
+                RouteDetailsContext.Details,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = MockToastViewModel(),
+                defaultSelectedRouteId = route2.id,
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitUntil { lastSelectedRoute != null }
@@ -253,63 +246,60 @@ class RouteStopListViewTest {
                 }
             }
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment(
-                                    listOf(
-                                        RouteBranchSegment.BranchStop(
-                                            stop1.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
-                                        RouteBranchSegment.BranchStop(
-                                            stop2.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment(
+                                listOf(
+                                    RouteBranchSegment.BranchStop(
+                                        stop1.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
                                     ),
-                                    name = null,
-                                    isTypical = true,
-                                ),
-                                RouteBranchSegment(
-                                    listOf(
-                                        RouteBranchSegment.BranchStop(
-                                            stop3NonTypical.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
-                                        RouteBranchSegment.BranchStop(
-                                            stop4NonTypical.id,
-                                            RouteBranchSegment.Lane.Center,
-                                            emptyList(),
-                                        ),
+                                    RouteBranchSegment.BranchStop(
+                                        stop2.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
                                     ),
-                                    name = null,
-                                    isTypical = false,
                                 ),
+                                name = null,
+                                isTypical = true,
                             ),
-                        routeId = mainRoute.id,
-                    )
-            }
+                            RouteBranchSegment(
+                                listOf(
+                                    RouteBranchSegment.BranchStop(
+                                        stop3NonTypical.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
+                                    ),
+                                    RouteBranchSegment.BranchStop(
+                                        stop4NonTypical.id,
+                                        RouteBranchSegment.Lane.Center,
+                                        emptyList(),
+                                    ),
+                                ),
+                                name = null,
+                                isTypical = false,
+                            ),
+                        ),
+                    routeId = mainRoute.id,
+                )
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(mainRoute),
-                    RouteDetailsContext.Details,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = MockToastViewModel(),
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(mainRoute),
+                RouteDetailsContext.Details,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = MockToastViewModel(),
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
@@ -344,29 +334,26 @@ class RouteStopListViewTest {
                 representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
             }
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments = listOf(RouteBranchSegment.of(listOf(stop1.id, stop2.id))),
-                        routeId = mainRoute.id,
-                    )
-            }
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments = listOf(RouteBranchSegment.of(listOf(stop1.id, stop2.id))),
+                    routeId = mainRoute.id,
+                )
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(mainRoute),
-                    RouteDetailsContext.Details,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = MockToastViewModel(),
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(mainRoute),
+                RouteDetailsContext.Details,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = MockToastViewModel(),
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
@@ -382,39 +369,36 @@ class RouteStopListViewTest {
         val objects = TestData.clone()
         val route = RouteCardData.LineOrRoute.Route(objects.getRoute("Red"))
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment.of(
-                                    listOf("place-alfcl", "place-davis", "place-portr")
-                                )
-                            ),
-                        routeId = route.id,
-                    )
-            }
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment.of(
+                                listOf("place-alfcl", "place-davis", "place-portr")
+                            )
+                        ),
+                    routeId = route.id,
+                )
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    route,
-                    RouteDetailsContext.Favorites,
-                    GlobalResponse(objects),
-                    onClick = {
-                        when (it) {
-                            is RouteDetailsRowContext.Details -> {}
-                            is RouteDetailsRowContext.Favorites -> it.onTapStar()
-                        }
-                    },
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = MockToastViewModel(),
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                route,
+                RouteDetailsContext.Favorites,
+                GlobalResponse(objects),
+                onClick = {
+                    when (it) {
+                        is RouteDetailsRowContext.Details -> {}
+                        is RouteDetailsRowContext.Favorites -> it.onTapStar()
+                    }
+                },
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = MockToastViewModel(),
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Davis"))
@@ -435,18 +419,17 @@ class RouteStopListViewTest {
     fun testTriggersHintToast() {
         val objects = TestData.clone()
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment.of(
-                                    listOf("place-alfcl", "place-davis", "place-portr")
-                                )
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment.of(
+                                listOf("place-alfcl", "place-davis", "place-portr")
                             )
-                    )
-            }
+                        )
+                )
+        }
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -458,19 +441,17 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             toastState = toastVM.models.collectAsState()
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
-                    RouteDetailsContext.Favorites,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = toastVM,
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                RouteDetailsContext.Favorites,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = toastVM,
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -486,18 +467,17 @@ class RouteStopListViewTest {
     fun testBackButton() {
         val objects = TestData.clone()
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment.of(
-                                    listOf("place-alfcl", "place-davis", "place-portr")
-                                )
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment.of(
+                                listOf("place-alfcl", "place-davis", "place-portr")
                             )
-                    )
-            }
+                        )
+                )
+        }
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -512,19 +492,17 @@ class RouteStopListViewTest {
         var backTapped = false
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
-                    RouteDetailsContext.Favorites,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = { backTapped = true },
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = toastVM,
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                RouteDetailsContext.Favorites,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = { backTapped = true },
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                toastViewModel = toastVM,
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -540,18 +518,17 @@ class RouteStopListViewTest {
     fun testCloseButton() {
         val objects = TestData.clone()
 
-        val koin =
-            testKoinApplication(objects) {
-                routeStops =
-                    MockRouteStopsRepository(
-                        segments =
-                            listOf(
-                                RouteBranchSegment.of(
-                                    listOf("place-alfcl", "place-davis", "place-portr")
-                                )
+        loadKoinMocks(objects) {
+            routeStops =
+                MockRouteStopsRepository(
+                    segments =
+                        listOf(
+                            RouteBranchSegment.of(
+                                listOf("place-alfcl", "place-davis", "place-portr")
                             )
-                    )
-            }
+                        )
+                )
+        }
         val toastVM = MockToastViewModel()
         var toastShown = false
         toastVM.onShowToast = { toast ->
@@ -566,19 +543,17 @@ class RouteStopListViewTest {
         var closeTapped = false
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RouteStopListView(
-                    RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
-                    RouteDetailsContext.Favorites,
-                    GlobalResponse(objects),
-                    onClick = {},
-                    onBack = {},
-                    onClose = { closeTapped = true },
-                    errorBannerViewModel = koinInject(),
-                    toastViewModel = toastVM,
-                    rightSideContent = { _, _ -> },
-                )
-            }
+            RouteStopListView(
+                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                RouteDetailsContext.Favorites,
+                GlobalResponse(objects),
+                onClick = {},
+                onBack = {},
+                onClose = { closeTapped = true },
+                errorBannerViewModel = koinInject(),
+                toastViewModel = toastVM,
+                rightSideContent = { _, _ -> },
+            )
         }
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteResult
@@ -28,7 +28,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 
 class RoutePickerViewTest {
@@ -36,22 +35,19 @@ class RoutePickerViewTest {
 
     @Test
     fun testDisplaysLoadingIndicator() {
-        val koin =
-            testKoinApplication(ObjectCollectionBuilder()) { global = IdleGlobalRepository() }
+        loadKoinMocks(ObjectCollectionBuilder()) { global = IdleGlobalRepository() }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -66,22 +62,19 @@ class RoutePickerViewTest {
             type = RouteType.HEAVY_RAIL
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -93,22 +86,19 @@ class RoutePickerViewTest {
     fun testDisplaysModePaths() {
         val objects = ObjectCollectionBuilder()
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -126,22 +116,19 @@ class RoutePickerViewTest {
             type = RouteType.HEAVY_RAIL
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -160,22 +147,19 @@ class RoutePickerViewTest {
             type = RouteType.LIGHT_RAIL
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -207,22 +191,19 @@ class RoutePickerViewTest {
             type = RouteType.LIGHT_RAIL
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -249,22 +230,19 @@ class RoutePickerViewTest {
             type = RouteType.BUS
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Silver,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Silver,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -282,22 +260,19 @@ class RoutePickerViewTest {
             type = RouteType.COMMUTER_RAIL
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.CommuterRail,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.CommuterRail,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -312,22 +287,19 @@ class RoutePickerViewTest {
             type = RouteType.FERRY
         }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Ferry,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Ferry,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -346,25 +318,22 @@ class RoutePickerViewTest {
         var selectedRouteId: String? = null
         var selectedContext: RouteDetailsContext? = null
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { routeId, context ->
-                        selectedRouteId = routeId
-                        selectedContext = context
-                    },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { routeId, context ->
+                    selectedRouteId = routeId
+                    selectedContext = context
+                },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -385,22 +354,19 @@ class RoutePickerViewTest {
 
         var backCalled = false
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = { backCalled = true },
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = { backCalled = true },
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -420,22 +386,19 @@ class RoutePickerViewTest {
 
         var closeCalled = false
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Root,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = { closeCalled = true },
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Root,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = { closeCalled = true },
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -462,26 +425,23 @@ class RoutePickerViewTest {
                 type = RouteType.BUS
             }
 
-        val koin =
-            testKoinApplication(objects) {
-                global = MockGlobalRepository(GlobalResponse(objects))
-                searchResults =
-                    MockSearchResultRepository(routeResults = listOf(RouteResult(route = route1)))
-            }
+        loadKoinMocks(objects) {
+            global = MockGlobalRepository(GlobalResponse(objects))
+            searchResults =
+                MockSearchResultRepository(routeResults = listOf(RouteResult(route = route1)))
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -503,23 +463,20 @@ class RoutePickerViewTest {
         val searchVM = MockSearchRoutesViewModel()
         searchVM.onSetPath = { setPath = it }
 
-        val koin =
-            testKoinApplication(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
+        loadKoinMocks(objects) { global = MockGlobalRepository(GlobalResponse(objects)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                    searchRoutesViewModel = searchVM,
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+                searchRoutesViewModel = searchVM,
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -543,25 +500,22 @@ class RoutePickerViewTest {
                 type = RouteType.BUS
             }
 
-        val koin =
-            testKoinApplication(objects) {
-                global = MockGlobalRepository(GlobalResponse(objects))
-                searchResults = MockSearchResultRepository(routeResults = emptyList())
-            }
+        loadKoinMocks(objects) {
+            global = MockGlobalRepository(GlobalResponse(objects))
+            searchResults = MockSearchResultRepository(routeResults = emptyList())
+        }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = {},
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = {},
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -583,27 +537,24 @@ class RoutePickerViewTest {
     fun testFilterFocusCallback() {
         val objects = ObjectCollectionBuilder()
 
-        val koin =
-            testKoinApplication(objects) {
-                global = MockGlobalRepository(GlobalResponse(objects))
-                searchResults = MockSearchResultRepository(routeResults = emptyList())
-            }
+        loadKoinMocks(objects) {
+            global = MockGlobalRepository(GlobalResponse(objects))
+            searchResults = MockSearchResultRepository(routeResults = emptyList())
+        }
 
         var filterExpanded = false
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                RoutePickerView(
-                    path = RoutePickerPath.Bus,
-                    context = RouteDetailsContext.Favorites,
-                    onOpenPickerPath = { _, _ -> },
-                    onOpenRouteDetails = { _, _ -> },
-                    onRouteSearchExpandedChange = { filterExpanded = it },
-                    onBack = {},
-                    onClose = {},
-                    errorBannerViewModel = koinInject(),
-                )
-            }
+            RoutePickerView(
+                path = RoutePickerPath.Bus,
+                context = RouteDetailsContext.Favorites,
+                onOpenPickerPath = { _, _ -> },
+                onOpenRouteDetails = { _, _ -> },
+                onRouteSearchExpandedChange = { filterExpanded = it },
+                onBack = {},
+                onClose = {},
+                errorBannerViewModel = koinInject(),
+            )
         }
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.requestFocus
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilAtLeastOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.history.Visit
@@ -33,7 +33,6 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.test.KoinTest
 
 @ExperimentalTestApi
@@ -55,30 +54,26 @@ class SearchBarOverlayTest : KoinTest {
     fun testSearchBarOverlayBehavesCorrectly() {
         val mockVisitHistoryRepository = MockVisitHistoryRepository()
 
-        val koinApplication =
-            testKoinApplication(builder) {
-                visitHistory = mockVisitHistoryRepository
-                searchResults =
-                    MockSearchResultRepository(
-                        stopResults =
-                            listOf(
-                                StopResult(
-                                    id = searchedStop.id,
-                                    rank = 2,
-                                    name = searchedStop.name,
-                                    zone = "stopZone",
-                                    isStation = false,
-                                    routes =
-                                        listOf(
-                                            StopResultRoute(
-                                                type = RouteType.BUS,
-                                                icon = "routeIcon",
-                                            )
-                                        ),
-                                )
+        loadKoinMocks(builder) {
+            visitHistory = mockVisitHistoryRepository
+            searchResults =
+                MockSearchResultRepository(
+                    stopResults =
+                        listOf(
+                            StopResult(
+                                id = searchedStop.id,
+                                rank = 2,
+                                name = searchedStop.name,
+                                zone = "stopZone",
+                                isStation = false,
+                                routes =
+                                    listOf(
+                                        StopResultRoute(type = RouteType.BUS, icon = "routeIcon")
+                                    ),
                             )
-                    )
-            }
+                        )
+                )
+        }
 
         val navigated = mutableStateOf(false)
         val expanded = mutableStateOf(false)
@@ -86,18 +81,16 @@ class SearchBarOverlayTest : KoinTest {
         val currentNavEntry = mutableStateOf<SheetRoutes?>(null)
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                val focusRequester = remember { FocusRequester() }
-                SearchBarOverlay(
-                    expanded.value,
-                    currentNavEntry.value?.showSearchBar ?: true,
-                    { expanded.value = it },
-                    onStopNavigation = { navigated.value = true },
-                    onRouteNavigation = {},
-                    inputFieldFocusRequester = focusRequester,
-                ) {
-                    Text("Content")
-                }
+            val focusRequester = remember { FocusRequester() }
+            SearchBarOverlay(
+                expanded.value,
+                currentNavEntry.value?.showSearchBar ?: true,
+                { expanded.value = it },
+                onStopNavigation = { navigated.value = true },
+                onRouteNavigation = {},
+                inputFieldFocusRequester = focusRequester,
+            ) {
+                Text("Content")
             }
         }
 
@@ -133,25 +126,21 @@ class SearchBarOverlayTest : KoinTest {
 
     @Test
     fun testHidesRoutesByDefault() {
-        val koinApplication =
-            testKoinApplication(builder) {
-                searchResults =
-                    MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
-            }
+        loadKoinMocks(builder) {
+            searchResults = MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
+        }
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                val focusRequester = remember { FocusRequester() }
-                SearchBarOverlay(
-                    expanded = true,
-                    showSearchBar = true,
-                    onExpandedChange = {},
-                    onStopNavigation = {},
-                    onRouteNavigation = {},
-                    inputFieldFocusRequester = focusRequester,
-                    content = {},
-                )
-            }
+            val focusRequester = remember { FocusRequester() }
+            SearchBarOverlay(
+                expanded = true,
+                showSearchBar = true,
+                onExpandedChange = {},
+                onStopNavigation = {},
+                onRouteNavigation = {},
+                inputFieldFocusRequester = focusRequester,
+                content = {},
+            )
         }
 
         val searchNode = composeTestRule.onNode(hasSetTextAction())
@@ -166,28 +155,24 @@ class SearchBarOverlayTest : KoinTest {
 
     @Test
     fun testShowsRoutesWhenEnabled() {
-        val koinApplication =
-            testKoinApplication(builder) {
-                searchResults =
-                    MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
-                settings = MockSettingsRepository(mapOf(Settings.SearchRouteResults to true))
-            }
+        loadKoinMocks(builder) {
+            searchResults = MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
+            settings = MockSettingsRepository(mapOf(Settings.SearchRouteResults to true))
+        }
 
         var navigated = false
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                val focusRequester = remember { FocusRequester() }
-                SearchBarOverlay(
-                    expanded = true,
-                    showSearchBar = true,
-                    onExpandedChange = {},
-                    onStopNavigation = {},
-                    onRouteNavigation = { navigated = true },
-                    inputFieldFocusRequester = focusRequester,
-                    content = {},
-                )
-            }
+            val focusRequester = remember { FocusRequester() }
+            SearchBarOverlay(
+                expanded = true,
+                showSearchBar = true,
+                onExpandedChange = {},
+                onStopNavigation = {},
+                onRouteNavigation = { navigated = true },
+                inputFieldFocusRequester = focusRequester,
+                content = {},
+            )
         }
 
         val searchNode = composeTestRule.onNode(hasSetTextAction())
@@ -205,28 +190,24 @@ class SearchBarOverlayTest : KoinTest {
 
     @Test
     fun testOnExpandedChangeNotCalledOnFirstLoad() {
-        val koinApplication =
-            testKoinApplication(builder) {
-                searchResults =
-                    MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
-                settings = MockSettingsRepository(mapOf(Settings.SearchRouteResults to true))
-            }
+        loadKoinMocks(builder) {
+            searchResults = MockSearchResultRepository(routeResults = listOf(RouteResult(route)))
+            settings = MockSettingsRepository(mapOf(Settings.SearchRouteResults to true))
+        }
 
         var onExpandedCalledWith: Boolean? = null
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                val focusRequester = remember { FocusRequester() }
-                SearchBarOverlay(
-                    expanded = false,
-                    showSearchBar = true,
-                    onExpandedChange = { expandedVal -> onExpandedCalledWith = expandedVal },
-                    onStopNavigation = {},
-                    onRouteNavigation = {},
-                    inputFieldFocusRequester = focusRequester,
-                    content = {},
-                )
-            }
+            val focusRequester = remember { FocusRequester() }
+            SearchBarOverlay(
+                expanded = false,
+                showSearchBar = true,
+                onExpandedChange = { expandedVal -> onExpandedCalledWith = expandedVal },
+                onStopNavigation = {},
+                onRouteNavigation = {},
+                inputFieldFocusRequester = focusRequester,
+                content = {},
+            )
         }
 
         val searchNode = composeTestRule.onNode(hasSetTextAction())

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
@@ -40,7 +40,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class StopDetailsFilteredDeparturesViewTest {
     val builder = ObjectCollectionBuilder()
@@ -144,11 +143,13 @@ class StopDetailsFilteredDeparturesViewTest {
             override suspend fun setSettings(settings: Map<Settings, Boolean>) {}
         }
 
-    private val koinApplication = testKoinApplication(builder) { settings = settingsRepository }
-
     @get:Rule val composeTestRule = createComposeRule()
 
-    @Before fun resetSettings() = settings.clear()
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder) { settings = settingsRepository }
+        settings.clear()
+    }
 
     @Test
     fun testStopDetailsRouteViewDisplaysCorrectly(): Unit = runBlocking {
@@ -178,23 +179,21 @@ class StopDetailsFilteredDeparturesViewTest {
         val viewModel = MockStopDetailsViewModel(StopDetailsViewModel.State(routeData))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("1 min").assertExists()
@@ -230,23 +229,21 @@ class StopDetailsFilteredDeparturesViewTest {
         val viewModel = MockStopDetailsViewModel(StopDetailsViewModel.State(routeData))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = { tripFilter = it },
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = { tripFilter = it },
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("1 min").assertExists().performClick()
@@ -330,25 +327,23 @@ class StopDetailsFilteredDeparturesViewTest {
 
         val viewModel = MockStopDetailsViewModel(StopDetailsViewModel.State(routeData))
 
-        val koinApplication = testKoinApplication(objects) { settings = settingsRepository }
+        loadKoinMocks(objects) { settings = settingsRepository }
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = stopFilter,
-                    tripFilter = tripFilter,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = stopFilter,
+                tripFilter = tripFilter,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("Trip cancelled").assertIsDisplayed()
@@ -386,23 +381,21 @@ class StopDetailsFilteredDeparturesViewTest {
         val viewModel = MockStopDetailsViewModel()
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = StopDetailsFilter(route.id, 0),
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = Direction(null, null, 0),
-                    allAlerts = null,
-                    now = now,
-                    viewModel = viewModel,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = StopDetailsFilter(route.id, 0),
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = Direction(null, null, 0),
+                allAlerts = null,
+                now = now,
+                viewModel = viewModel,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.onNodeWithText("Service ended").assertIsDisplayed()
@@ -470,23 +463,21 @@ class StopDetailsFilteredDeparturesViewTest {
             MockStopDetailsViewModel(StopDetailsViewModel.State(routeData, alertSummaries))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    viewModel = viewModel,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                viewModel = viewModel,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -582,25 +573,23 @@ class StopDetailsFilteredDeparturesViewTest {
         val viewModel =
             MockStopDetailsViewModel(StopDetailsViewModel.State(routeData, alertSummaries))
 
-        val koinApplication = testKoinApplication(objects) { settings = settingsRepository }
+        loadKoinMocks(objects) { settings = settingsRepository }
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -670,23 +659,21 @@ class StopDetailsFilteredDeparturesViewTest {
             MockStopDetailsViewModel(StopDetailsViewModel.State(routeData, alertSummaries))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = alertResponse,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = alertResponse,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("Service suspended", true).assertIsDisplayed()
@@ -734,23 +721,21 @@ class StopDetailsFilteredDeparturesViewTest {
             MockStopDetailsViewModel(StopDetailsViewModel.State(routeData, mapOf(alert.id to null)))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("Elevator Closure").assertDoesNotExist()
@@ -821,23 +806,21 @@ class StopDetailsFilteredDeparturesViewTest {
             MockStopDetailsViewModel(StopDetailsViewModel.State(routeData, alertSummaries))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("Delays due to heavy ridership").assertIsDisplayed()
@@ -873,23 +856,21 @@ class StopDetailsFilteredDeparturesViewTest {
         val viewModel = MockStopDetailsViewModel(StopDetailsViewModel.State(routeData))
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredDeparturesView(
-                    stopId = inaccessibleStop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    leaf = leaf,
-                    selectedDirection = routeStopData.directions.first(),
-                    allAlerts = null,
-                    now = now,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = false,
-                    openModal = {},
-                    openSheetRoute = {},
-                    viewModel = viewModel,
-                )
-            }
+            StopDetailsFilteredDeparturesView(
+                stopId = inaccessibleStop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = routeStopData.directions.first(),
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+                viewModel = viewModel,
+            )
         }
 
         composeTestRule.onNodeWithText("This stop is not accessible").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerViewTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
@@ -32,7 +32,6 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 
 class StopDetailsFilteredPickerViewTest {
@@ -137,11 +136,13 @@ class StopDetailsFilteredPickerViewTest {
             override suspend fun setSettings(settings: Map<Settings, Boolean>) {}
         }
 
-    private val koinApplication = testKoinApplication { settings = settingsRepository }
-
     @get:Rule val composeTestRule = createComposeRule()
 
-    @Before fun resetSettings() = settings.clear()
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder) { settings = settingsRepository }
+        settings.clear()
+    }
 
     @Test
     fun testStopDetailsRouteViewDisplaysCorrectly(): Unit = runBlocking {
@@ -162,25 +163,23 @@ class StopDetailsFilteredPickerViewTest {
         val routeStopData = routeCardData.single().stopData.single()
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule.onNodeWithText("at ${stop.name}").assertExists()
@@ -209,25 +208,23 @@ class StopDetailsFilteredPickerViewTest {
         val routeStopData = routeCardData.single().stopData.single()
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = { tripFilter = it },
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = { tripFilter = it },
+                tileScrollState = rememberScrollState(),
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule.onNodeWithText("at ${stop.name}").assertExists()
@@ -265,25 +262,23 @@ class StopDetailsFilteredPickerViewTest {
         val routeStopData = routeCardData.single().stopData.single()
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule.onNodeWithText("Elevator Alert Header").assertIsDisplayed()
@@ -310,25 +305,23 @@ class StopDetailsFilteredPickerViewTest {
         val routeStopData = routeCardData.single().stopData.single()
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = inaccessibleStop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = inaccessibleStop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule.onNodeWithText("This stop is not accessible").assertIsDisplayed()
@@ -357,27 +350,25 @@ class StopDetailsFilteredPickerViewTest {
         var updatedFavorites: Pair<Map<RouteStopDirection, Boolean>, Int>? = null
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { false },
-                    updateFavorites = { favMap, direction ->
-                        updatedFavorites = Pair(favMap, direction)
-                    },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = { false },
+                updateFavorites = { favMap, direction ->
+                    updatedFavorites = Pair(favMap, direction)
+                },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule
@@ -423,27 +414,25 @@ class StopDetailsFilteredPickerViewTest {
         var updatedFavorites: Pair<Map<RouteStopDirection, Boolean>, Int>? = null
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsFilteredPickerView(
-                    stopId = stop.id,
-                    stopFilter = filterState,
-                    tripFilter = null,
-                    routeStopData = routeStopData,
-                    allAlerts = null,
-                    now = now,
-                    errorBannerViewModel = koinInject(),
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    isFavorite = { true },
-                    updateFavorites = { favMap, direction ->
-                        updatedFavorites = Pair(favMap, direction)
-                    },
-                    openModal = {},
-                    openSheetRoute = {},
-                    onClose = {},
-                )
-            }
+            StopDetailsFilteredPickerView(
+                stopId = stop.id,
+                stopFilter = filterState,
+                tripFilter = null,
+                routeStopData = routeStopData,
+                allAlerts = null,
+                now = now,
+                errorBannerViewModel = koinInject(),
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = { true },
+                updateFavorites = { favMap, direction ->
+                    updatedFavorites = Pair(favMap, direction)
+                },
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
         }
 
         composeTestRule

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
@@ -5,14 +5,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.UpcomingFormat
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class StopDetailsNoTripCardTests {
 
@@ -20,15 +19,13 @@ class StopDetailsNoTripCardTests {
 
     @Test
     fun testPredictionsUnavailable() {
-        val koin = testKoinApplication()
+        loadKoinMocks()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopDetailsNoTripCard(
-                    status = UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                    accentColor = Color.Black,
-                    routeType = RouteType.BUS,
-                )
-            }
+            StopDetailsNoTripCard(
+                status = UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
+                accentColor = Color.Black,
+                routeType = RouteType.BUS,
+            )
         }
 
         composeTestRule.onNodeWithTag("live_data_slash").assertIsDisplayed()
@@ -43,18 +40,14 @@ class StopDetailsNoTripCardTests {
 
     @Test
     fun testPredictionsUnavailableHideMaps() {
-        val koin = testKoinApplication {
-            settings = MockSettingsRepository(mapOf(Settings.HideMaps to true))
-        }
+        loadKoinMocks { settings = MockSettingsRepository(mapOf(Settings.HideMaps to true)) }
 
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopDetailsNoTripCard(
-                    status = UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                    accentColor = Color.Black,
-                    routeType = RouteType.BUS,
-                )
-            }
+            StopDetailsNoTripCard(
+                status = UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
+                accentColor = Color.Black,
+                routeType = RouteType.BUS,
+            )
         }
 
         composeTestRule
@@ -67,15 +60,13 @@ class StopDetailsNoTripCardTests {
 
     @Test
     fun testServiceEnded() {
-        val koin = testKoinApplication()
+        loadKoinMocks()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopDetailsNoTripCard(
-                    status = UpcomingFormat.NoTripsFormat.ServiceEndedToday,
-                    accentColor = Color.Black,
-                    routeType = RouteType.FERRY,
-                )
-            }
+            StopDetailsNoTripCard(
+                status = UpcomingFormat.NoTripsFormat.ServiceEndedToday,
+                accentColor = Color.Black,
+                routeType = RouteType.FERRY,
+            )
         }
         composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
         composeTestRule.onNodeWithText("Service ended").assertIsDisplayed()
@@ -83,15 +74,13 @@ class StopDetailsNoTripCardTests {
 
     @Test
     fun testNoSchedulesToday() {
-        val koin = testKoinApplication()
+        loadKoinMocks()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                StopDetailsNoTripCard(
-                    status = UpcomingFormat.NoTripsFormat.NoSchedulesToday,
-                    accentColor = Color.Black,
-                    routeType = RouteType.COMMUTER_RAIL,
-                )
-            }
+            StopDetailsNoTripCard(
+                status = UpcomingFormat.NoTripsFormat.NoSchedulesToday,
+                accentColor = Color.Black,
+                routeType = RouteType.COMMUTER_RAIL,
+            )
         }
         composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
         composeTestRule.onNodeWithText("No service today").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsPageTest.kt
@@ -4,15 +4,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.pages.StopDetailsPage
-import com.mbta.tid.mbta_app.android.testKoinApplication
 import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.viewModel.MockStopDetailsViewModel
 import junit.framework.TestCase.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 import org.koin.test.KoinTest
 
@@ -20,7 +20,10 @@ class StopDetailsPageTest : KoinTest {
 
     @get:Rule val composeTestRule = createComposeRule()
 
-    val koinApplication = testKoinApplication()
+    @Before
+    fun setUp() {
+        loadKoinMocks()
+    }
 
     @Test
     fun testUpdatesVM() {
@@ -39,20 +42,18 @@ class StopDetailsPageTest : KoinTest {
         viewModel.onSetNow = { nowSet = true }
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                StopDetailsPage(
-                    allAlerts = alerts,
-                    filters = filters,
-                    onClose = {},
-                    updateStopFilter = {},
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    openModal = {},
-                    openSheetRoute = {},
-                    errorBannerViewModel = koinInject(),
-                    stopDetailsViewModel = viewModel,
-                )
-            }
+            StopDetailsPage(
+                allAlerts = alerts,
+                filters = filters,
+                onClose = {},
+                updateStopFilter = {},
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                openModal = {},
+                openSheetRoute = {},
+                errorBannerViewModel = koinInject(),
+                stopDetailsViewModel = viewModel,
+            )
         }
 
         composeTestRule.waitUntil { activeSet && alertsSet && filtersSet && nowSet }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -25,7 +25,6 @@ import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 
 class StopDetailsUnfilteredRoutesViewTest {
@@ -129,27 +128,25 @@ class StopDetailsUnfilteredRoutesViewTest {
                 )
             )
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
 
-            KoinContext(koin.koin) {
-                StopDetailsUnfilteredRoutesView(
-                    stop = stop,
-                    routeCardData = routeCardData,
-                    servedRoutes = emptyList(),
-                    errorBannerViewModel = koinInject(),
-                    now = now,
-                    globalData = globalResponse,
-                    isFavorite = { false },
-                    onClose = {},
-                    onTapRoutePill = {},
-                    updateStopFilter = filterState::value::set,
-                    openModal = {},
-                )
-            }
+            StopDetailsUnfilteredRoutesView(
+                stop = stop,
+                routeCardData = routeCardData,
+                servedRoutes = emptyList(),
+                errorBannerViewModel = koinInject(),
+                now = now,
+                globalData = globalResponse,
+                isFavorite = { false },
+                onClose = {},
+                onTapRoutePill = {},
+                updateStopFilter = filterState::value::set,
+                openModal = {},
+            )
         }
 
         composeTestRule.onNodeWithText("Sample Route").assertExists()
@@ -174,27 +171,25 @@ class StopDetailsUnfilteredRoutesViewTest {
                 )
             )
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
 
-            KoinContext(koin.koin) {
-                StopDetailsUnfilteredRoutesView(
-                    stop = inaccessibleStop,
-                    routeCardData = routeCardData,
-                    servedRoutes = emptyList(),
-                    errorBannerViewModel = koinInject(),
-                    now = now,
-                    globalData = globalResponse,
-                    isFavorite = { false },
-                    onClose = {},
-                    onTapRoutePill = {},
-                    updateStopFilter = filterState::value::set,
-                    openModal = {},
-                )
-            }
+            StopDetailsUnfilteredRoutesView(
+                stop = inaccessibleStop,
+                routeCardData = routeCardData,
+                servedRoutes = emptyList(),
+                errorBannerViewModel = koinInject(),
+                now = now,
+                globalData = globalResponse,
+                isFavorite = { false },
+                onClose = {},
+                onTapRoutePill = {},
+                updateStopFilter = filterState::value::set,
+                openModal = {},
+            )
         }
 
         composeTestRule.onNodeWithText("This stop is not accessible").assertExists()
@@ -226,27 +221,25 @@ class StopDetailsUnfilteredRoutesViewTest {
                 )
             )
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
             val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
 
-            KoinContext(koin.koin) {
-                StopDetailsUnfilteredRoutesView(
-                    stop = stop,
-                    routeCardData = routeCardData,
-                    servedRoutes = emptyList(),
-                    errorBannerViewModel = koinInject(),
-                    now = now,
-                    globalData = globalResponse,
-                    isFavorite = { false },
-                    onClose = {},
-                    onTapRoutePill = {},
-                    updateStopFilter = filterState::value::set,
-                    openModal = {},
-                )
-            }
+            StopDetailsUnfilteredRoutesView(
+                stop = stop,
+                routeCardData = routeCardData,
+                servedRoutes = emptyList(),
+                errorBannerViewModel = koinInject(),
+                now = now,
+                globalData = globalResponse,
+                isFavorite = { false },
+                onClose = {},
+                onTapRoutePill = {},
+                updateStopFilter = filterState::value::set,
+                openModal = {},
+            )
         }
 
         composeTestRule.onNodeWithText("Elevator alert").assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
@@ -30,10 +30,11 @@ import com.mbta.tid.mbta_app.viewModel.MockStopDetailsViewModel
 import com.mbta.tid.mbta_app.viewModel.StopDetailsViewModel
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
+import org.koin.core.context.loadKoinModules
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -110,9 +111,12 @@ class StopDetailsViewTest {
     val settingsRepository =
         MockSettingsRepository(settings = mapOf(Pair(Settings.StationAccessibility, true)))
 
-    val koinApplication = testKoinApplication(builder) { settings = settingsRepository }
-
     @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder) { settings = settingsRepository }
+    }
 
     @OptIn(ExperimentalTestApi::class)
     @Test
@@ -155,30 +159,26 @@ class StopDetailsViewTest {
                 )
             )
 
+        loadKoinModules(module { single { unfilteredVM }.bind(IStopDetailsViewModel::class) })
+
         composeTestRule.setContent {
-            KoinContext(
-                koinApplication
-                    .modules(module { single { unfilteredVM }.bind(IStopDetailsViewModel::class) })
-                    .koin
-            ) {
-                val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
-                StopDetailsView(
-                    stopId = stop.id,
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    onClose = {},
-                    stopFilter = null,
-                    tripFilter = null,
-                    allAlerts = null,
-                    now = now,
-                    updateStopFilter = filterState::value::set,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = koinInject(),
-                    openModal = {},
-                    openSheetRoute = {},
-                )
-            }
+            val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
+            StopDetailsView(
+                stopId = stop.id,
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                onClose = {},
+                stopFilter = null,
+                tripFilter = null,
+                allAlerts = null,
+                now = now,
+                updateStopFilter = filterState::value::set,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                errorBannerViewModel = koinInject(),
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Stop"))
@@ -222,32 +222,28 @@ class StopDetailsViewTest {
                 )
             )
 
+        loadKoinModules(module { single { filteredVM }.bind(IStopDetailsViewModel::class) })
+
         composeTestRule.setContent {
-            KoinContext(
-                koinApplication
-                    .modules(module { single { filteredVM }.bind(IStopDetailsViewModel::class) })
-                    .koin
-            ) {
-                val filterState = remember {
-                    mutableStateOf<StopDetailsFilter?>(StopDetailsFilter(route.id, 0))
-                }
-                StopDetailsView(
-                    stopId = stop.id,
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    onClose = {},
-                    stopFilter = filterState.value,
-                    tripFilter = null,
-                    allAlerts = null,
-                    now = now,
-                    updateStopFilter = filterState::value::set,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = koinInject(),
-                    openModal = {},
-                    openSheetRoute = {},
-                )
+            val filterState = remember {
+                mutableStateOf<StopDetailsFilter?>(StopDetailsFilter(route.id, 0))
             }
+            StopDetailsView(
+                stopId = stop.id,
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                onClose = {},
+                stopFilter = filterState.value,
+                tripFilter = null,
+                allAlerts = null,
+                now = now,
+                updateStopFilter = filterState::value::set,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                errorBannerViewModel = koinInject(),
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("at Sample Stop"))
@@ -313,30 +309,26 @@ class StopDetailsViewTest {
                 )
             )
 
+        loadKoinModules(module { single { unfilteredVM }.bind(IStopDetailsViewModel::class) })
+
         composeTestRule.setContent {
-            KoinContext(
-                koinApplication
-                    .modules(module { single { unfilteredVM }.bind(IStopDetailsViewModel::class) })
-                    .koin
-            ) {
-                val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
-                StopDetailsView(
-                    stopId = stop.id,
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    onClose = {},
-                    stopFilter = filterState.value,
-                    tripFilter = null,
-                    allAlerts = AlertsStreamDataResponse(builder),
-                    now = now,
-                    updateStopFilter = filterState::value::set,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = koinInject(),
-                    openModal = {},
-                    openSheetRoute = {},
-                )
-            }
+            val filterState = remember { mutableStateOf<StopDetailsFilter?>(null) }
+            StopDetailsView(
+                stopId = stop.id,
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                onClose = {},
+                stopFilter = filterState.value,
+                tripFilter = null,
+                allAlerts = AlertsStreamDataResponse(builder),
+                now = now,
+                updateStopFilter = filterState::value::set,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                errorBannerViewModel = koinInject(),
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.onNodeWithText(alert.header!!).assertExists()
@@ -385,32 +377,27 @@ class StopDetailsViewTest {
                     ),
                 )
             )
+        loadKoinModules(module { single { filteredVM }.bind(IStopDetailsViewModel::class) })
         composeTestRule.setContent {
-            KoinContext(
-                koinApplication
-                    .modules(module { single { filteredVM }.bind(IStopDetailsViewModel::class) })
-                    .koin
-            ) {
-                val filterState = remember {
-                    mutableStateOf<StopDetailsFilter?>(StopDetailsFilter(route.id, 0))
-                }
-                StopDetailsView(
-                    stopId = stop.id,
-                    stopFilter = filterState.value,
-                    tripFilter = null,
-                    allAlerts = AlertsStreamDataResponse(builder),
-                    now = now,
-                    isFavorite = { false },
-                    updateFavorites = { _, _ -> },
-                    onClose = {},
-                    updateStopFilter = filterState::value::set,
-                    updateTripFilter = {},
-                    tileScrollState = rememberScrollState(),
-                    errorBannerViewModel = koinInject(),
-                    openModal = {},
-                    openSheetRoute = {},
-                )
+            val filterState = remember {
+                mutableStateOf<StopDetailsFilter?>(StopDetailsFilter(route.id, 0))
             }
+            StopDetailsView(
+                stopId = stop.id,
+                stopFilter = filterState.value,
+                tripFilter = null,
+                allAlerts = AlertsStreamDataResponse(builder),
+                now = now,
+                isFavorite = { false },
+                updateFavorites = { _, _ -> },
+                onClose = {},
+                updateStopFilter = filterState::value::set,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                errorBannerViewModel = koinInject(),
+                openModal = {},
+                openSheetRoute = {},
+            )
         }
 
         composeTestRule.onNodeWithText(alert.header!!).assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -31,9 +31,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 @OptIn(ExperimentalTestApi::class)
 class TripDetailsViewTest {
@@ -75,7 +75,10 @@ class TripDetailsViewTest {
             vehicle,
         )
 
-    val koinApplication = testKoinApplication(objects)
+    @Before
+    fun setUp() {
+        loadKoinMocks(objects)
+    }
 
     @Test
     fun testOpensDownstreamStop() {
@@ -100,19 +103,17 @@ class TripDetailsViewTest {
         val viewModel = MockTripDetailsViewModel(tripVMState)
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                TripDetailsView(
-                    tripFilter,
-                    allAlerts = alertData,
-                    alertSummaries = emptyMap(),
-                    onOpenAlertDetails = {},
-                    openSheetRoute = openedSheetRoutes::add,
-                    openModal = {},
-                    now,
-                    tripDetailsVM = viewModel,
-                    analytics = analytics,
-                )
-            }
+            TripDetailsView(
+                tripFilter,
+                allAlerts = alertData,
+                alertSummaries = emptyMap(),
+                onOpenAlertDetails = {},
+                openSheetRoute = openedSheetRoutes::add,
+                openModal = {},
+                now,
+                tripDetailsVM = viewModel,
+                analytics = analytics,
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -179,19 +180,17 @@ class TripDetailsViewTest {
         val viewModel = MockTripDetailsViewModel(tripVMState)
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                TripDetailsView(
-                    tripFilter,
-                    allAlerts = alerts,
-                    alertSummaries = emptyMap(),
-                    onOpenAlertDetails = {},
-                    openSheetRoute = openedSheetRoutes::add,
-                    openModal = {},
-                    now,
-                    tripDetailsVM = viewModel,
-                    analytics = analytics,
-                )
-            }
+            TripDetailsView(
+                tripFilter,
+                allAlerts = alerts,
+                alertSummaries = emptyMap(),
+                onOpenAlertDetails = {},
+                openSheetRoute = openedSheetRoutes::add,
+                openModal = {},
+                now,
+                tripDetailsVM = viewModel,
+                analytics = analytics,
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -201,31 +200,27 @@ class TripDetailsViewTest {
 
     @Test
     fun testFollowButtonWhenTrackThisTrip() {
-
-        val koinApplication =
-            testKoinApplication(objects) {
-                settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to true))
-            }
+        loadKoinMocks(objects) {
+            settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to true))
+        }
 
         var onFollowCalled = false
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                TripDetails(
-                    trip = trip,
-                    headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
-                    onHeaderTap = null,
-                    onOpenAlertDetails = {},
-                    onFollowTrip = { onFollowCalled = true },
-                    onTapStop = {},
-                    route = route,
-                    tripFilter = tripFilter,
-                    stopList = TripDetailsStopList(trip, emptyList()),
-                    now = now,
-                    alertSummaries = emptyMap(),
-                    globalResponse = GlobalResponse(objects),
-                )
-            }
+            TripDetails(
+                trip = trip,
+                headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                onHeaderTap = null,
+                onOpenAlertDetails = {},
+                onFollowTrip = { onFollowCalled = true },
+                onTapStop = {},
+                route = route,
+                tripFilter = tripFilter,
+                stopList = TripDetailsStopList(trip, emptyList()),
+                now = now,
+                alertSummaries = emptyMap(),
+                globalResponse = GlobalResponse(objects),
+            )
         }
 
         composeTestRule.waitForIdle()
@@ -236,29 +231,23 @@ class TripDetailsViewTest {
 
     @Test
     fun testNoFollowButtonByDefault() {
-
-        val koinApplication =
-            testKoinApplication(objects) {
-                settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to false))
-            }
+        loadKoinMocks { settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to false)) }
 
         composeTestRule.setContent {
-            KoinContext(koinApplication.koin) {
-                TripDetails(
-                    trip = trip,
-                    headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
-                    onHeaderTap = null,
-                    onOpenAlertDetails = {},
-                    onFollowTrip = {},
-                    onTapStop = {},
-                    route = route,
-                    tripFilter = tripFilter,
-                    stopList = TripDetailsStopList(trip, emptyList()),
-                    now = now,
-                    alertSummaries = emptyMap(),
-                    globalResponse = GlobalResponse(objects),
-                )
-            }
+            TripDetails(
+                trip = trip,
+                headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                onHeaderTap = null,
+                onOpenAlertDetails = {},
+                onFollowTrip = {},
+                onTapStop = {},
+                route = route,
+                tripFilter = tripFilter,
+                stopList = TripDetailsStopList(trip, emptyList()),
+                now = now,
+                alertSummaries = emptyMap(),
+                globalResponse = GlobalResponse(objects),
+            )
         }
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.hasTextMatching
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.MapStopRoute
@@ -29,7 +29,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Month
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 
 class TripStopRowTest {
     @get:Rule val composeTestRule = createComposeRule()
@@ -269,24 +268,22 @@ class TripStopRowTest {
                 elevatorAlerts = elevatorAlerts,
             )
 
-        val koin = testKoinApplication {
+        loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
 
         var testEntry by mutableStateOf(entry(inaccessibleStop))
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                TripStopRow(
-                    testEntry,
-                    trip,
-                    now,
-                    onTapLink = {},
-                    onOpenAlertDetails = {},
-                    route,
-                    TripRouteAccents(route),
-                    alertSummaries = emptyMap(),
-                )
-            }
+            TripStopRow(
+                testEntry,
+                trip,
+                now,
+                onTapLink = {},
+                onOpenAlertDetails = {},
+                route,
+                TripRouteAccents(route),
+                alertSummaries = emptyMap(),
+            )
         }
 
         composeTestRule

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/SettingsCacheTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.testKoinApplication
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.assertEquals
@@ -16,7 +16,6 @@ import kotlin.test.fail
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.koin.compose.KoinContext
 import org.koin.compose.koinInject
 
 class SettingsCacheTest {
@@ -30,18 +29,16 @@ class SettingsCacheTest {
                 mapOf(Settings.HideMaps to true),
                 onGetSettings = { gotSettings = true },
             )
-        val koin = testKoinApplication { settings = settingsRepo }
+        loadKoinMocks { settings = settingsRepo }
 
         val hideMapsValues = mutableListOf<Boolean>()
         val debugModeValues = mutableListOf<Boolean>()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                val cache: SettingsCache = koinInject()
-                val hideMaps = cache.get(Settings.HideMaps)
-                hideMapsValues.add(hideMaps)
-                val debugMode = cache.get(Settings.DevDebugMode)
-                debugModeValues.add(debugMode)
-            }
+            val cache: SettingsCache = koinInject()
+            val hideMaps = cache.get(Settings.HideMaps)
+            hideMapsValues.add(hideMaps)
+            val debugMode = cache.get(Settings.DevDebugMode)
+            debugModeValues.add(debugMode)
         }
 
         composeTestRule.waitForIdle()
@@ -58,17 +55,15 @@ class SettingsCacheTest {
                 mapOf(Settings.HideMaps to true),
                 onGetSettings = { gotSettings = true },
             )
-        val koin = testKoinApplication { settings = settingsRepo }
+        loadKoinMocks { settings = settingsRepo }
 
         val hideMapsValues = mutableListOf<Boolean>()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                val cache: SettingsCache = koinInject()
-                cache.get(Settings.StationAccessibility)
-                if (gotSettings) {
-                    val hideMaps = cache.get(Settings.HideMaps)
-                    hideMapsValues.add(hideMaps)
-                }
+            val cache: SettingsCache = koinInject()
+            cache.get(Settings.StationAccessibility)
+            if (gotSettings) {
+                val hideMaps = cache.get(Settings.HideMaps)
+                hideMapsValues.add(hideMaps)
             }
         }
 
@@ -90,16 +85,14 @@ class SettingsCacheTest {
                     savedSettings = true
                 },
             )
-        val koin = testKoinApplication { settings = settingsRepo }
+        loadKoinMocks { settings = settingsRepo }
 
         val hideMapsValues = mutableListOf<Boolean>()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                val cache: SettingsCache = koinInject()
-                val hideMaps = cache.get(Settings.HideMaps)
-                hideMapsValues.add(hideMaps)
-                Button({ cache.set(Settings.HideMaps, true) }) { Text("Hide maps") }
-            }
+            val cache: SettingsCache = koinInject()
+            val hideMaps = cache.get(Settings.HideMaps)
+            hideMapsValues.add(hideMaps)
+            Button({ cache.set(Settings.HideMaps, true) }) { Text("Hide maps") }
         }
 
         composeTestRule.waitForIdle()
@@ -119,16 +112,14 @@ class SettingsCacheTest {
                 mapOf(Settings.HideMaps to false),
                 onGetSettings = { fail("Should not be getting settings from repo") },
             )
-        val koin = testKoinApplication { settings = settingsRepo }
+        loadKoinMocks { settings = settingsRepo }
 
         val settingValues = mutableListOf<Boolean>()
         composeTestRule.setContent {
-            KoinContext(koin.koin) {
-                val cache: SettingsCache = koinInject()
-                settingValues.add(cache.get(Settings.HideMaps))
-                cache.set(Settings.HideMaps, true)
-                settingValues.add(cache.get(Settings.HideMaps))
-            }
+            val cache: SettingsCache = koinInject()
+            settingValues.add(cache.get(Settings.HideMaps))
+            cache.set(Settings.HideMaps, true)
+            settingValues.add(cache.get(Settings.HideMaps))
         }
 
         composeTestRule.waitForIdle()


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Track this Trip | Sheet contents](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210501361218460?focus=true), tangentially

Since the `KoinContext` is only inherited through Compose, it doesn’t make it down to the ViewModels.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all the tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
