### PR TITLE
feat(Android): sheet contents for track this trip

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPageTest.kt
@@ -1,15 +1,25 @@
 package com.mbta.tid.mbta_app.android.pages
 
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.TripResponse
+import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
+import com.mbta.tid.mbta_app.repositories.MockTripRepository
+import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
 class TripDetailsPageTest {
-
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
@@ -18,11 +28,57 @@ class TripDetailsPageTest {
         composeTestRule.setContent {
             TripDetailsPage(
                 filter = TripDetailsPageFilter("tripId", "vehicleId", "routeId", 0, "stopId", null),
+                allAlerts = AlertsStreamDataResponse(emptyMap()),
+                openModal = {},
+                openSheetRoute = {},
                 onClose = { onCloseCalled = true },
             )
         }
 
         composeTestRule.onNodeWithContentDescription("Close").performClick()
         assertTrue(onCloseCalled)
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testHasContent() {
+        val objects = TestData.clone()
+        val routePattern = objects.getRoutePattern("Orange-3-0")
+        val trip =
+            objects.trip(routePattern) {
+                stopIds = objects.getTrip(routePattern.representativeTripId).stopIds
+            }
+        val targetStop = objects.getStop("place-dwnxg")
+        loadKoinMocks(objects) {
+            this.trip =
+                MockTripRepository(
+                    tripSchedulesResponse =
+                        TripSchedulesResponse.StopIds(checkNotNull(trip.stopIds)),
+                    tripResponse = TripResponse(trip),
+                )
+        }
+        composeTestRule.setContent {
+            TripDetailsPage(
+                filter =
+                    TripDetailsPageFilter(
+                        tripId = trip.id,
+                        vehicleId = null,
+                        routeId = trip.routeId,
+                        directionId = trip.directionId,
+                        stopId = targetStop.id,
+                        stopSequence = null,
+                    ),
+                allAlerts = AlertsStreamDataResponse(objects),
+                openModal = {},
+                openSheetRoute = {},
+                onClose = {},
+            )
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Forest Hills"))
+        composeTestRule.onNodeWithText("OL").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Forest Hills").assertIsDisplayed()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(targetStop.name))
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -111,6 +111,7 @@ class TripDetailsViewTest {
                 openSheetRoute = openedSheetRoutes::add,
                 openModal = {},
                 now,
+                isTripDetailsPage = false,
                 tripDetailsVM = viewModel,
                 analytics = analytics,
             )
@@ -188,6 +189,7 @@ class TripDetailsViewTest {
                 openSheetRoute = openedSheetRoutes::add,
                 openModal = {},
                 now,
+                isTripDetailsPage = false,
                 tripDetailsVM = viewModel,
                 analytics = analytics,
             )
@@ -218,6 +220,7 @@ class TripDetailsViewTest {
                 tripFilter = tripFilter,
                 stopList = TripDetailsStopList(trip, emptyList()),
                 now = now,
+                isTripDetailsPage = false,
                 alertSummaries = emptyMap(),
                 globalResponse = GlobalResponse(objects),
             )
@@ -245,6 +248,35 @@ class TripDetailsViewTest {
                 tripFilter = tripFilter,
                 stopList = TripDetailsStopList(trip, emptyList()),
                 now = now,
+                isTripDetailsPage = false,
+                alertSummaries = emptyMap(),
+                globalResponse = GlobalResponse(objects),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Follow").assertDoesNotExist()
+    }
+
+    @Test
+    fun testNoFollowButtonWhenOnTripDetails() {
+        loadKoinMocks(objects) {
+            settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to true))
+        }
+
+        composeTestRule.setContent {
+            TripDetails(
+                trip = trip,
+                headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                onHeaderTap = null,
+                onOpenAlertDetails = {},
+                onFollowTrip = {},
+                onTapStop = {},
+                route = route,
+                tripFilter = tripFilter,
+                stopList = TripDetailsStopList(trip, emptyList()),
+                now = now,
+                isTripDetailsPage = true,
                 alertSummaries = emptyMap(),
                 globalResponse = GlobalResponse(objects),
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/RoutePill.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.android.component
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -49,6 +50,7 @@ fun RoutePill(
     isActive: Boolean = true,
     contentDescription: RoutePillSpec.ContentDescription? = null,
     modifier: Modifier = Modifier,
+    border: BorderStroke? = null,
 ) {
     RoutePill(
         route,
@@ -56,6 +58,7 @@ fun RoutePill(
         isActive,
         RoutePillSpec(route, line, type, height, contentDescription = contentDescription),
         modifier,
+        border,
     )
 }
 
@@ -66,6 +69,7 @@ fun RoutePill(
     isActive: Boolean = true,
     spec: RoutePillSpec,
     modifier: Modifier = Modifier,
+    border: BorderStroke? = null,
 ) {
     val textColor = Color.fromHex(spec.textColor)
     val routeColor = Color.fromHex(spec.routeColor)
@@ -105,6 +109,7 @@ fun RoutePill(
     fun Modifier.withColor() =
         if (isActive) {
             background(routeColor, shape)
+                .then(if (border != null) Modifier.border(border, shape) else Modifier)
         } else {
             border(1.dp, routeColor, shape).padding(1.dp)
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -69,6 +69,7 @@ import com.mbta.tid.mbta_app.android.routeDetails.RouteDetailsView
 import com.mbta.tid.mbta_app.android.routePicker.RoutePickerView
 import com.mbta.tid.mbta_app.android.routePicker.backgroundColor
 import com.mbta.tid.mbta_app.android.search.SearchBarOverlay
+import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.state.subscribeToVehicles
 import com.mbta.tid.mbta_app.android.typeMap
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
@@ -536,8 +537,18 @@ fun MapAndSheetPage(
             analytics.track(AnalyticsScreen.TripDetails)
         }
 
-        SheetPage(colorResource(R.color.fill2)) {
-            TripDetailsPage(filter = navRoute.filter, onClose = { navController.popBackStack() })
+        val global = getGlobalData("TripDetailsSheetContents")
+        val route = global?.getRoute(navRoute.filter.routeId)
+        val routeColor = route?.color?.let { Color.fromHex(it) }
+
+        SheetPage(routeColor ?: colorResource(R.color.fill2)) {
+            TripDetailsPage(
+                filter = navRoute.filter,
+                allAlerts = nearbyTransit.alertData,
+                openModal = ::openModal,
+                openSheetRoute = navController::navigate,
+                onClose = { navController.popBackStack() },
+            )
         }
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
@@ -1,21 +1,96 @@
 package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import com.mbta.tid.mbta_app.android.component.SheetHeader
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.ModalRoutes
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.state.getGlobalData
+import com.mbta.tid.mbta_app.android.stopDetails.AlertCardSpec
+import com.mbta.tid.mbta_app.android.stopDetails.TripDetailsView
+import com.mbta.tid.mbta_app.android.tripDetails.TripDetailsPageHeader
+import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.timer
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.routes.SheetRoutes
+import com.mbta.tid.mbta_app.viewModel.ITripDetailsPageViewModel
+import kotlin.time.Duration.Companion.seconds
+import org.koin.compose.currentKoinScope
+import org.koin.compose.koinInject
 
 @Composable
-fun TripDetailsPage(filter: TripDetailsPageFilter, onClose: () -> Unit) {
-    Column {
-        SheetHeader(title = "", onClose = onClose)
-        Text("TODO: Populate with actual trip view")
-        Text("Trip: ${filter.tripId}")
-        Text("Vehicle: ${filter.vehicleId}")
-        Text("Route: ${filter.routeId}")
-        Text("Direction: ${filter.directionId}")
-        Text("Stop: ${filter.stopId}")
-        Text("Stop Sequence: ${filter.stopSequence}")
+fun TripDetailsPage(
+    filter: TripDetailsPageFilter,
+    allAlerts: AlertsStreamDataResponse?,
+    openModal: (ModalRoutes) -> Unit,
+    openSheetRoute: (SheetRoutes) -> Unit,
+    onClose: () -> Unit,
+    tripDetailsPageVM: ITripDetailsPageViewModel = koinInject(),
+) {
+    val now by timer(updateInterval = 5.seconds)
+    val global = getGlobalData("TripDetailsPage")
+
+    val route = global?.getRoute(filter.routeId)
+
+    tripDetailsPageVM.koinScope = currentKoinScope()
+    val tripDetailsPageState by tripDetailsPageVM.models.collectAsState()
+
+    LaunchedEffect(allAlerts) { tripDetailsPageVM.setAlerts(allAlerts) }
+    LaunchedEffect(filter) { tripDetailsPageVM.setFilter(filter) }
+
+    val direction = tripDetailsPageState.direction
+    val alertSummaries = tripDetailsPageState.alertSummaries
+
+    fun openAlertDetails(alert: Alert, spec: AlertCardSpec) {
+        openModal(
+            ModalRoutes.AlertDetails(
+                alertId = alert.id,
+                lineId = null,
+                routeIds = if (spec == AlertCardSpec.Elevator) null else listOfNotNull(route?.id),
+                stopId = filter.stopId,
+            )
+        )
+    }
+
+    Column(Modifier.verticalScroll(rememberScrollState())) {
+        if (route != null && direction != null) {
+            TripDetailsPageHeader(route, direction, onClose)
+        } else {
+            CompositionLocalProvider(IsLoadingSheetContents provides true) {
+                TripDetailsPageHeader(
+                    route ?: ObjectCollectionBuilder.Single.route(),
+                    Direction(
+                        stringResource(R.string.loading),
+                        stringResource(R.string.loading),
+                        0,
+                    ),
+                    onClose,
+                )
+            }
+        }
+        TripDetailsView(
+            filter,
+            allAlerts = allAlerts,
+            alertSummaries = alertSummaries,
+            onOpenAlertDetails = { openAlertDetails(it, AlertCardSpec.Downstream) },
+            openSheetRoute = openSheetRoute,
+            openModal = openModal,
+            now = now,
+            isTripDetailsPage = true,
+            modifier = Modifier.padding(horizontal = 10.dp),
+        )
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -272,6 +272,7 @@ fun StopDetailsFilteredDeparturesView(
                 openSheetRoute = openSheetRoute,
                 openModal = openModal,
                 now = now,
+                isTripDetailsPage = false,
                 modifier = Modifier.padding(horizontal = 10.dp),
             )
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -52,6 +52,7 @@ fun TripDetailsView(
     openSheetRoute: (SheetRoutes) -> Unit,
     openModal: (ModalRoutes) -> Unit,
     now: EasternTimeInstant,
+    isTripDetailsPage: Boolean,
     modifier: Modifier = Modifier,
     tripDetailsVM: ITripDetailsViewModel = koinInject(),
     analytics: Analytics = koinInject(),
@@ -161,6 +162,7 @@ fun TripDetailsView(
             now,
             alertSummaries,
             globalResponse,
+            isTripDetailsPage,
             modifier,
         )
     } else {
@@ -192,6 +194,7 @@ fun TripDetailsView(
                     now,
                     emptyMap(),
                     globalResponse ?: GlobalResponse(ObjectCollectionBuilder()),
+                    isTripDetailsPage,
                 )
             }
         }
@@ -212,6 +215,7 @@ fun TripDetails(
     now: EasternTimeInstant,
     alertSummaries: Map<String, AlertSummary?>,
     globalResponse: GlobalResponse,
+    isTripDetailsPage: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val routeAccents = TripRouteAccents(route)
@@ -237,7 +241,7 @@ fun TripDetails(
                 now,
                 onTap = onHeaderTap,
                 onFollowTrip =
-                    if (hasTrackThisTrip) {
+                    if (hasTrackThisTrip && !isTripDetailsPage) {
                         onFollowTrip
                     } else null,
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/tripDetails/TripDetailsPageHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/tripDetails/TripDetailsPageHeader.kt
@@ -1,0 +1,146 @@
+package com.mbta.tid.mbta_app.android.tripDetails
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.MyApplicationTheme
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.ActionButton
+import com.mbta.tid.mbta_app.android.component.ActionButtonKind
+import com.mbta.tid.mbta_app.android.component.DirectionLabel
+import com.mbta.tid.mbta_app.android.component.RoutePill
+import com.mbta.tid.mbta_app.android.component.RoutePillHeight
+import com.mbta.tid.mbta_app.android.component.RoutePillType
+import com.mbta.tid.mbta_app.android.util.fromHex
+import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import com.mbta.tid.mbta_app.android.util.routeModeLabel
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single
+import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.utils.TestData
+
+@Composable
+fun TripDetailsPageHeader(route: Route?, direction: Direction?, onClose: () -> Unit) {
+    Row(
+        Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp),
+        Arrangement.spacedBy(8.dp),
+        Alignment.CenterVertically,
+    ) {
+        Row(
+            Modifier.weight(1f).padding(top = 4.dp).semantics(mergeDescendants = true) {
+                heading()
+            },
+            Arrangement.spacedBy(8.dp),
+            Alignment.CenterVertically,
+        ) {
+            val pillDescription = routeModeLabel(LocalContext.current, line = null, route)
+            if (route != null) {
+                RoutePill(
+                    route = route,
+                    type = RoutePillType.FlexCompact,
+                    height = RoutePillHeight.Large,
+                    modifier =
+                        Modifier.semantics { contentDescription = pillDescription }
+                            .placeholderIfLoading(),
+                    border =
+                        BorderStroke(
+                            2.dp,
+                            colorResource(
+                                    if (route.id == "Blue" || route.type == RouteType.COMMUTER_RAIL)
+                                        R.color.halo_dark
+                                    else R.color.halo_light
+                                )
+                                .copy(alpha = 0.6f),
+                        ),
+                )
+            }
+            if (direction != null) {
+                DirectionLabel(
+                    direction,
+                    modifier = Modifier.semantics { heading() }.weight(1f).placeholderIfLoading(),
+                    textColor = route?.textColor?.let { Color.fromHex(it) } ?: Color.Unspecified,
+                )
+            } else {
+                Spacer(Modifier.weight(1f))
+            }
+        }
+
+        ActionButton(ActionButtonKind.Close) { onClose() }
+    }
+}
+
+@Preview
+@Composable
+private fun TripDetailsPageHeaderPreview() {
+    val objects = TestData.clone()
+
+    @Composable
+    fun HeaderPreview(route: Route, directionId: Int) {
+        val direction =
+            Direction(
+                route.directionNames[directionId],
+                route.directionDestinations[directionId],
+                directionId,
+            )
+        Box(Modifier.background(Color.fromHex(route.color))) {
+            TripDetailsPageHeader(route, direction, onClose = {})
+        }
+    }
+
+    @Composable
+    fun HeaderPreview(routeId: String, directionId: Int) {
+        val route = objects.getRoute(routeId)
+        HeaderPreview(route, directionId)
+    }
+
+    MyApplicationTheme {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            HeaderPreview("Green-C", 0)
+            HeaderPreview("Red", 0)
+            HeaderPreview("Orange", 1)
+            HeaderPreview(
+                Single.route {
+                    id = "Blue"
+                    color = "003DA5"
+                    directionDestinations = listOf("Bowdoin", "Wonderland")
+                    directionNames = listOf("West", "East")
+                    longName = "Blue Line"
+                    textColor = "FFFFFF"
+                    type = RouteType.HEAVY_RAIL
+                },
+                1,
+            )
+            HeaderPreview("743", 1)
+            HeaderPreview("15", 0)
+            HeaderPreview("CR-Newburyport", 0)
+            HeaderPreview(
+                Single.route {
+                    color = "008EAA"
+                    directionDestinations = listOf("Hingham or Hull", "Long Wharf or Rowes Wharf")
+                    directionNames = listOf("Outbound", "Inbound")
+                    longName = "Hingham/Hull Ferry"
+                    textColor = "FFFFFF"
+                    type = RouteType.FERRY
+                },
+                1,
+            )
+        }
+    }
+}

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -48,6 +48,7 @@ public actual fun viewModelModule(): Module = module {
         }
         .bind(IStopDetailsViewModel::class)
     singleOf(::ToastViewModel).bind(IToastViewModel::class)
+    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
     single {
             TripDetailsViewModel(
                 get(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -1,0 +1,148 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSignificance
+import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
+import com.mbta.tid.mbta_app.model.discardTrackChangesAtCRCore
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
+import kotlin.jvm.JvmName
+import kotlinx.coroutines.flow.StateFlow
+import org.koin.core.scope.Scope
+
+public interface ITripDetailsPageViewModel {
+    public val models: StateFlow<TripDetailsPageViewModel.State>
+
+    public var koinScope: Scope?
+
+    public fun setAlerts(alerts: AlertsStreamDataResponse?)
+
+    public fun setFilter(filter: TripDetailsPageFilter?)
+
+    public fun setNow(now: EasternTimeInstant)
+}
+
+public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsViewModel) :
+    MoleculeViewModel<TripDetailsPageViewModel.Event, TripDetailsPageViewModel.State>(),
+    ITripDetailsPageViewModel {
+    public sealed class Event
+
+    public data class State(
+        val direction: Direction?,
+        val alertSummaries: Map<String, AlertSummary?>,
+    )
+
+    @set:JvmName("setAlertsState")
+    private var alerts by mutableStateOf<AlertsStreamDataResponse?>(null)
+    @set:JvmName("setFilterState")
+    private var filter by mutableStateOf<TripDetailsPageFilter?>(null)
+    @set:JvmName("setNowState") private var now by mutableStateOf(EasternTimeInstant.now())
+
+    @Composable
+    override fun runLogic(): State {
+        val global = getGlobalData("TripDetailsPage")
+
+        val route = global?.getRoute(filter?.routeId)
+        val stop = global?.getStop(filter?.stopId)
+
+        val tripDetailsState by tripDetailsVM.models.collectAsState()
+        val trip = tripDetailsState.tripData?.trip
+
+        LaunchedEffect(alerts) { tripDetailsVM.setAlerts(alerts) }
+        LaunchedEffect(filter) { tripDetailsVM.setFilters(filter) }
+
+        val patterns =
+            remember(global, filter, route, trip) {
+                val filter = filter
+                val allPatterns =
+                    if (filter != null && global != null && route != null)
+                        global.getPatternsFor(filter.stopId, RouteCardData.LineOrRoute.Route(route))
+                    else emptyList()
+                if (trip != null) allPatterns.filter { it.id == trip.routePatternId }
+                else if (filter != null) allPatterns.filter { it.directionId == filter.directionId }
+                else allPatterns
+            }
+        val direction =
+            remember(route, filter, trip) {
+                val filter = filter
+                if (route != null && filter != null) {
+                    Direction(
+                        name = route.directionNames[filter.directionId],
+                        destination =
+                            trip?.headsign ?: route.directionDestinations[filter.directionId],
+                        id = filter.directionId,
+                    )
+                } else {
+                    null
+                }
+            }
+
+        val alertsToSummarize =
+            remember(alerts, filter, patterns, now, global) {
+                val alerts = alerts
+                val filter = filter
+                if (alerts != null && filter != null) {
+                    val activeRelevantAlerts =
+                        alerts.alerts.values.filter {
+                            it.isActive(time = now) && it.significance >= AlertSignificance.Minor
+                        }
+                    val isCRCore = stop?.isCRCore ?: false
+                    Alert.applicableAlerts(
+                            activeRelevantAlerts,
+                            filter.directionId,
+                            listOf(filter.routeId),
+                            null,
+                            filter.tripId,
+                        )
+                        .discardTrackChangesAtCRCore(isCRCore)
+                } else emptyList()
+            }
+        var alertSummaries: Map<String, AlertSummary?> by remember { mutableStateOf(emptyMap()) }
+
+        suspend fun updateAlertSummaries(clearExisting: Boolean = false) {
+            val filter = filter
+            if (global == null || filter == null) return
+            if (clearExisting) alertSummaries = emptyMap()
+
+            alertSummaries =
+                alertsToSummarize.associate {
+                    it.id to it.summary(filter.stopId, filter.directionId, patterns, now, global)
+                }
+        }
+
+        LaunchedEffect(filter?.stopId, filter?.directionId) {
+            updateAlertSummaries(clearExisting = true)
+        }
+        LaunchedEffect(global, alertsToSummarize, patterns, now) { updateAlertSummaries() }
+
+        return State(direction, alertSummaries)
+    }
+
+    override val models: StateFlow<State>
+        get() = internalModels
+
+    override var koinScope: Scope? = null
+
+    override fun setAlerts(alerts: AlertsStreamDataResponse?) {
+        this.alerts = alerts
+    }
+
+    override fun setFilter(filter: TripDetailsPageFilter?) {
+        this.filter = filter
+    }
+
+    override fun setNow(now: EasternTimeInstant) {
+        this.now = now
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
@@ -1,0 +1,199 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import app.cash.turbine.test
+import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
+import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.utils.TestData
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+
+class TripDetailsPageViewModelTest : KoinTest {
+    private fun setUpKoin(
+        objects: ObjectCollectionBuilder,
+        repositoriesBlock: MockRepositories.() -> Unit = {},
+    ) {
+        startKoin {
+            modules(
+                repositoriesModule(
+                    MockRepositories().apply {
+                        useObjects(objects)
+                        repositoriesBlock()
+                    }
+                )
+            )
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        stopKoin()
+    }
+
+    @Test
+    fun `uses trip headsign in direction`() = runTest {
+        val objects = TestData.clone()
+        val route = objects.getRoute("Red")
+        val routePattern = objects.getRoutePattern("Red-1-0")
+        val trip = objects.trip(routePattern)
+        val targetStop = objects.getStop("place-knncl")
+
+        setUpKoin(objects)
+
+        val tripFilter =
+            TripDetailsPageFilter(
+                tripId = trip.id,
+                vehicleId = null,
+                routeId = route.id,
+                directionId = trip.directionId,
+                stopId = targetStop.id,
+                stopSequence = null,
+            )
+        val tripState =
+            TripDetailsViewModel.State(
+                tripData =
+                    TripData(
+                        tripFilter = tripFilter,
+                        trip = trip,
+                        tripSchedules = null,
+                        tripPredictions = null,
+                        vehicle = null,
+                    )
+            )
+        val tripDetailsVMModels = MutableStateFlow(tripState)
+        val tripDetailsVM =
+            mock<ITripDetailsViewModel>(MockMode.autofill) {
+                every { models } returns tripDetailsVMModels
+            }
+        val vm = TripDetailsPageViewModel(tripDetailsVM)
+        vm.setFilter(tripFilter)
+        testViewModelFlow(vm).test {
+            assertEquals(
+                TripDetailsPageViewModel.State(
+                    Direction("South", "Ashmont", trip.directionId),
+                    alertSummaries = emptyMap(),
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `falls back to direction destination before trip loads`() = runTest {
+        val objects = TestData.clone()
+        val route = objects.getRoute("Red")
+        val routePattern = objects.getRoutePattern("Red-1-0")
+        val trip = objects.trip(routePattern)
+        val targetStop = objects.getStop("place-knncl")
+
+        setUpKoin(objects)
+
+        val tripFilter =
+            TripDetailsPageFilter(
+                tripId = trip.id,
+                vehicleId = null,
+                routeId = route.id,
+                directionId = trip.directionId,
+                stopId = targetStop.id,
+                stopSequence = null,
+            )
+        val tripState = TripDetailsViewModel.State(tripData = null)
+        val tripDetailsVMModels = MutableStateFlow(tripState)
+        val tripDetailsVM =
+            mock<ITripDetailsViewModel>(MockMode.autofill) {
+                every { models } returns tripDetailsVMModels
+            }
+        val vm = TripDetailsPageViewModel(tripDetailsVM)
+        vm.setFilter(tripFilter)
+        testViewModelFlow(vm).test {
+            assertEquals(
+                TripDetailsPageViewModel.State(
+                    Direction("South", "Ashmont/Braintree", trip.directionId),
+                    alertSummaries = emptyMap(),
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun `calculates summary for alerts`() = runTest {
+        val objects = TestData.clone()
+        val route = objects.getRoute("Red")
+        val routePattern = objects.getRoutePattern("Red-1-0")
+        val trip = objects.trip(routePattern)
+        val targetStop = objects.getStop("place-knncl")
+        val alertStop = objects.getStop("place-fldcr")
+
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                activePeriod(EasternTimeInstant.now() - 1.hours, null)
+                informedEntity(
+                    listOf(
+                        Alert.InformedEntity.Activity.Board,
+                        Alert.InformedEntity.Activity.Exit,
+                        Alert.InformedEntity.Activity.Ride,
+                    ),
+                    route = route.id,
+                    stop = alertStop.id,
+                )
+            }
+
+        setUpKoin(objects)
+
+        val tripFilter =
+            TripDetailsPageFilter(
+                tripId = trip.id,
+                vehicleId = null,
+                routeId = route.id,
+                directionId = trip.directionId,
+                stopId = targetStop.id,
+                stopSequence = null,
+            )
+        val tripState = TripDetailsViewModel.State(tripData = null)
+        val tripDetailsVMModels = MutableStateFlow(tripState)
+        val tripDetailsVM =
+            mock<ITripDetailsViewModel>(MockMode.autofill) {
+                every { models } returns tripDetailsVMModels
+            }
+        val vm = TripDetailsPageViewModel(tripDetailsVM)
+        vm.setAlerts(AlertsStreamDataResponse(objects))
+        vm.setFilter(tripFilter)
+        testViewModelFlow(vm).test {
+            assertEquals(
+                TripDetailsPageViewModel.State(
+                    Direction("South", "Ashmont/Braintree", trip.directionId),
+                    alertSummaries =
+                        mapOf(
+                            alert.id to
+                                AlertSummary(
+                                    effect = Alert.Effect.Suspension,
+                                    location = AlertSummary.Location.SingleStop(alertStop.name),
+                                    timeframe = null,
+                                )
+                        ),
+                ),
+                awaitItemSatisfying { it.alertSummaries.isNotEmpty() },
+            )
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -44,6 +44,7 @@ public actual fun viewModelModule(): Module = module {
         }
         .bind(IStopDetailsViewModel::class)
     singleOf(::ToastViewModel)
+    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
     single {
             TripDetailsViewModel(
                 get(),

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -44,6 +44,7 @@ public actual fun viewModelModule(): Module = module {
         }
         .bind(IStopDetailsViewModel::class)
     singleOf(::ToastViewModel).bind(IToastViewModel::class)
+    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
     single {
             TripDetailsViewModel(
                 get(),


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Track this Trip | Sheet contents](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210501361218460?focus=true)

<img width="360" height="800" alt="Screenshot_20250909_122915" src="https://github.com/user-attachments/assets/ee707c80-c5bc-473e-b2c1-0e15fd00f285" />

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Added tests for the UI contents and the ViewModel logic.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
