### PR TITLE
fix(android.MapAndSheetPage): Show location services button when maps hidden

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -76,7 +77,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.koin.test.KoinTest
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalTestApi::class)
 class MapAndSheetPageTest : KoinTest {
     val builder = ObjectCollectionBuilder()
     val now = EasternTimeInstant.now()
@@ -409,6 +410,39 @@ class MapAndSheetPageTest : KoinTest {
         }
 
         composeTestRule.onNodeWithContentDescription("Mapbox Logo").assertDoesNotExist()
+    }
+
+    @Test
+    fun testLocationServicesButtonWhenMapHidden() {
+        val mockMapVM = mock<IMapViewModel>(MockMode.autofill)
+        every { mockMapVM.models } returns MutableStateFlow(MapViewModel.State.Overview)
+        loadMocks(hideMaps = true)
+        composeTestRule.setContent {
+            CompositionLocalProvider(
+                LocalLocationClient provides MockFusedLocationProviderClient()
+            ) {
+                MapAndSheetPage(
+                    Modifier,
+                    NearbyTransit(
+                        alertData = AlertsStreamDataResponse(builder.alerts),
+                        globalResponse = globalResponse,
+                        lastLoadedLocationState = remember { mutableStateOf(Position(0.0, 0.0)) },
+                        isTargetingState = remember { mutableStateOf(false) },
+                        scaffoldState = rememberBottomSheetScaffoldState(),
+                        locationDataManager = MockLocationDataManager(),
+                        viewportProvider = viewportProvider,
+                    ),
+                    SheetRoutes.NearbyTransit,
+                    false,
+                    {},
+                    {},
+                    bottomBar = {},
+                    mockMapVM,
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Location Services is off"))
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
@@ -53,6 +54,7 @@ import com.mbta.tid.mbta_app.android.alertDetails.AlertDetailsPage
 import com.mbta.tid.mbta_app.android.component.BarAndToastScaffold
 import com.mbta.tid.mbta_app.android.component.DragHandle
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
+import com.mbta.tid.mbta_app.android.component.LocationAuthButton
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
 import com.mbta.tid.mbta_app.android.component.sheet.BottomSheetScaffold
@@ -737,13 +739,35 @@ fun MapAndSheetPage(
                 searchFocusRequester,
                 onBarGloballyPositioned = {},
             ) {
-                SheetContent(
-                    Modifier.background(colorResource(R.color.sheet_background))
-                        .padding(outerSheetPadding)
-                        .padding(top = if (showSearchBar) 64.dp else 0.dp)
-                        .statusBarsPadding()
-                        .fillMaxSize()
-                )
+                Column(modifier = Modifier.background(colorResource(R.color.sheet_background))) {
+                    val shouldShowAuthButton =
+                        !nearbyTransit.locationDataManager.hasPermission &&
+                            (currentNavEntry?.allowTargeting == true)
+                    if (shouldShowAuthButton) {
+                        LocationAuthButton(
+                            nearbyTransit.locationDataManager,
+                            modifier =
+                                Modifier.align(Alignment.CenterHorizontally)
+                                    .padding(top = 80.dp)
+                                    .statusBarsPadding(),
+                        )
+                    }
+                    SheetContent(
+                        Modifier.background(colorResource(R.color.sheet_background))
+                            .padding(outerSheetPadding)
+                            .padding(
+                                top = if (showSearchBar && !shouldShowAuthButton) 80.dp else 0.dp
+                            )
+                            .then(
+                                if (showSearchBar) {
+                                    Modifier
+                                } else {
+                                    Modifier.statusBarsPadding()
+                                }
+                            )
+                            .fillMaxSize()
+                    )
+                }
             }
         } else {
             BottomSheetScaffold(


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Show location services button when map display hidden](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211055606783873?focus=true)

What is this PR for?
Button is now shown when map is hidden & user hasn't enabled location permissions

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally, navigated into stop details & turned on location permissions to confirm padding looks reasonable in all cases
<img width="636" height="1378" alt="image" src="https://github.com/user-attachments/assets/2084cf25-8d49-4a11-8a17-acdcc2b0cd75" />
* Added unit test

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
