### PR TITLE
fix: remove unnecessary use of OkHttp internal API

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToAlerts.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToAlerts.kt
@@ -9,14 +9,12 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.model.response.isNullOrEmpty
 import com.mbta.tid.mbta_app.usecases.AlertsUsecase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import okhttp3.internal.notifyAll
 import org.koin.compose.koinInject
 
 class AlertsViewModel(private val alertsUsecase: AlertsUsecase) : ViewModel() {
@@ -27,11 +25,7 @@ class AlertsViewModel(private val alertsUsecase: AlertsUsecase) : ViewModel() {
         alertsUsecase.connect {
             when (it) {
                 is ApiResult.Ok -> {
-                    val oldAlerts = _alerts.value
-
                     _alerts.value = it.data
-                    if (oldAlerts.isNullOrEmpty() && !it.data.isEmpty())
-                        synchronized(alertFlow) { alertFlow.notifyAll() }
                 }
                 is ApiResult.Error -> {
                     Log.e("AlertsViewModel", "subscribeToAlerts failed: $it")


### PR DESCRIPTION
### Summary

_Ticket:_ none

This appears to have snuck in in #557, and I don’t think it has any effect at all, since we aren’t otherwise using the JVM synchronization primitives (there’s no `wait` for this `notifyAll` to unblock).

Should unblock #1141 and #1311.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the app still builds.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
