### PR TITLE
fix(iOS): Make error banner padding consistent

### DIFF
--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -26,7 +26,7 @@ struct FavoritesView: View {
     @ScaledMetric private var editButtonHeight: CGFloat = 32
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"),
                 rightActionContents: {
@@ -43,9 +43,9 @@ struct FavoritesView: View {
                         }
                     }
                 }
-            )
+            ).padding(.bottom, 16)
 
-            ErrorBanner(errorBannerVM)
+            ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
             RouteCardList(
                 routeCardData: favoritesVMState.routeCardData,
                 emptyView: {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
@@ -39,9 +39,10 @@ struct NearbyTransitPage: View {
     var body: some View {
         ZStack {
             Color.sheetBackground.ignoresSafeArea(.all)
-            VStack(spacing: 16) {
+            VStack(spacing: 0) {
                 SheetHeader(title: NSLocalizedString("Nearby Transit", comment: "Header for nearby transit sheet"))
-                ErrorBanner(errorBannerVM).padding(.horizontal, 16)
+                    .padding(.bottom, 16)
+                ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
                 NearbyTransitView(
                     location: $location,
                     setIsReturningFromBackground: { errorBannerVM.setIsLoadingWhenPredictionsStale(isLoading: $0) },

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -275,7 +275,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
                 onBack: onBack,
                 onClose: onClose
             )
-            ErrorBanner(errorBannerVM)
+            ErrorBanner(errorBannerVM, padding: .init([.horizontal, .top], 16))
             DirectionPicker(
                 availableDirections: parameters.availableDirections.map { Int32(truncating: $0) },
                 directions: parameters.directions,

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -75,7 +75,7 @@ struct RoutePickerView: View {
             path.backgroundColor.edgesIgnoringSafeArea(.all)
             VStack(spacing: 0) {
                 header
-                ErrorBanner(errorBannerVM)
+                ErrorBanner(errorBannerVM, padding: .init([.horizontal, .top], 16))
                 if isRootPath {
                     ScrollView {
                         rootContent

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -157,7 +157,7 @@ struct StopDetailsFilteredView: View {
                 )
             }
 
-            VStack(spacing: 8) {
+            VStack(spacing: 0) {
                 StopDetailsFilteredHeader(
                     route: stopData?.lineOrRoute.sortRoute,
                     line: line,
@@ -167,7 +167,7 @@ struct StopDetailsFilteredView: View {
                     onFavorite: { inSaveFavoritesFlow = true },
                     onClose: { nearbyVM.goBack() }
                 )
-                ErrorBanner(errorBannerVM).padding(.horizontal, 16)
+                ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
             }
             .fixedSize(horizontal: false, vertical: true)
             .dynamicTypeSize(...DynamicTypeSize.accessibility1)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -81,17 +81,17 @@ struct StopDetailsUnfilteredView: View {
         ZStack {
             Color.fill2.ignoresSafeArea(.all)
             VStack(spacing: 0) {
-                VStack(spacing: 16) {
+                VStack(spacing: 0) {
                     SheetHeader(
                         title: stop?.name ?? "Invalid Stop",
                         onClose: { nearbyVM.goBack() }
-                    )
+                    ).padding(.bottom, 16)
                     if debugMode {
                         DebugView {
                             Text(verbatim: "stop id: \(stopId)")
-                        }
+                        }.padding([.horizontal, .bottom], 16)
                     }
-                    ErrorBanner(errorBannerVM).padding(.horizontal, 16)
+                    ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
                     if servedRoutes.count > 1 {
                         StopDetailsFilterPills(
                             servedRoutes: servedRoutes,


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, noticed while testing [Better offline detection](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211153035458994?focus=true)

The error banner had inconsistent padding across the pages it existed on. This makes sure it always has padding on every side, and that the padding does not add extra space to the layout when the error banner is hidden.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~


### Testing

Checked every place that the banner exists with the network banner active

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211386270270377