### PR TITLE
feat(iOS): Add placeholder trip details page

### DIFF
--- a/iosApp/iosApp/ComponentViews/ActionButton.swift
+++ b/iosApp/iosApp/ComponentViews/ActionButton.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2024 MBTA. All rights reserved.
 //
 
-import Foundation
 import SwiftUI
 
 struct ActionButton: View {

--- a/iosApp/iosApp/ComponentViews/FollowButton.swift
+++ b/iosApp/iosApp/ComponentViews/FollowButton.swift
@@ -1,0 +1,34 @@
+//
+//  FollowButton.swift
+//  iosApp
+//
+//  Created by esimon on 9/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import SwiftUI
+
+struct FollowButton: View {
+    var action: () -> Void
+    var routeAccents: TripRouteAccents
+
+    var body: some View {
+        Button(action: action, label: {
+            HStack(alignment: .center, spacing: 8) {
+                Image(.liveData)
+                    .resizable()
+                    .frame(width: 12, height: 12)
+                    .accessibilityHidden(true)
+
+                Text("Follow").font(Typography.callout)
+            }
+            .padding(.vertical, 7)
+            .padding(.leading, 12)
+            .padding(.trailing, 16)
+            .foregroundStyle(routeAccents.textColor)
+        })
+        .frame(minWidth: 97, minHeight: 36)
+        .background(routeAccents.color)
+        .withRoundedBorder(radius: 88, width: 2)
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -289,6 +289,22 @@ struct ContentView: View {
                     .transition(transition)
                     .animation(.easeOut, value: stopId)
 
+                case let .tripDetails(filter: filter):
+                    // Wrapping in a TabView helps the page to animate in as a single unit
+                    // Otherwise only the header animates
+                    TabView {
+                        TripDetailsPage(
+                            filter: filter,
+                            onClose: { nearbyVM.goBack() },
+                        )
+                        .toolbar(.hidden, for: .tabBar)
+                    }
+                    // Set id per trip so that transitioning from one trip to another is handled by removing
+                    // the existing trip view & creating a new one
+                    .id(filter.tripId)
+                    .transition(transition)
+                    .animation(.easeOut, value: filter.tripId)
+
                 default: EmptyView()
                 }
             }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -9951,7 +9951,6 @@
     },
     "Follow" : {
       "comment" : "Text on a button to enter a focused view that follows a single vehicle on a trip",
-      "extractionState" : "manual",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -35,10 +35,7 @@ struct MorePage: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
                 .background(Color.fill3)
-                Rectangle()
-                    .fill(Color.halo)
-                    .frame(height: 2)
-                    .frame(maxWidth: .infinity)
+                HaloSeparator(height: 2)
 
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -62,6 +62,12 @@ struct TripDetailsView: View {
         } else { nil }
     }
 
+    func onFollowTrip() {
+        if let dataFilter = tripDetailsVMState?.tripData?.tripFilter, dataFilter == tripFilter {
+            nearbyVM.pushNavEntry(.tripDetails(filter: dataFilter))
+        }
+    }
+
     var body: some View {
         content
             .explainer($explainer)
@@ -175,7 +181,7 @@ struct TripDetailsView: View {
         _ spec: TripHeaderSpec?,
         _ onTap: (() -> Void)?,
         _ route: Route,
-        _ routeAccents: TripRouteAccents
+        _ routeAccents: TripRouteAccents,
     ) -> some View {
         if let spec {
             TripHeaderCard(
@@ -185,7 +191,8 @@ struct TripDetailsView: View {
                 route: route,
                 routeAccents: routeAccents,
                 onTap: onTap,
-                now: now
+                now: now,
+                onFollowTrip: settingsCache.get(.trackThisTrip) ? onFollowTrip : nil,
             )
         }
     }

--- a/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripHeaderCard.swift
@@ -26,6 +26,7 @@ struct TripHeaderCard: View {
     let routeAccents: TripRouteAccents
     let onTap: (() -> Void)?
     let now: EasternTimeInstant
+    let onFollowTrip: (() -> Void)?
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -274,7 +275,10 @@ struct TripHeaderCard: View {
         VStack {
             switch spec {
             case .finishingAnotherTrip, .noVehicle: if onTap != nil { InfoIcon() }
-            case .vehicle: liveIndicator
+            case .vehicle:
+                if let onFollowTrip {
+                    FollowButton(action: onFollowTrip, routeAccents: routeAccents)
+                } else { liveIndicator }
             case .scheduled: EmptyView()
             }
 
@@ -365,7 +369,8 @@ struct TripVehicleCard_Previews: PreviewProvider {
                 route: red,
                 routeAccents: TripRouteAccents(route: red),
                 onTap: nil,
-                now: now
+                now: now,
+                onFollowTrip: nil,
             )
         }
         .withFixedSettings([:])

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -1,0 +1,25 @@
+//
+//  TripDetailsPage.swift
+//  iosApp
+//
+//  Created by esimon on 9/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct TripDetailsPage: View {
+    var filter: TripDetailsPageFilter
+    var onClose: () -> Void
+
+    var body: some View {
+        VStack {
+            SheetHeader(title: "Trip details", onClose: onClose)
+            HaloScrollView {
+                Text(verbatim: "trip id: \(filter.tripId)")
+                Text(verbatim: "vehicle id: \(filter.vehicleId)")
+            }
+        }
+    }
+}

--- a/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
+++ b/iosApp/iosApp/Utils/SheetNavigationStackEntry.swift
@@ -23,6 +23,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
     case routeDetails(SheetRoutes.RouteDetails)
     case routePicker(SheetRoutes.RoutePicker)
     case stopDetails(stopId: String, stopFilter: StopDetailsFilter?, tripFilter: TripDetailsFilter?)
+    case tripDetails(filter: TripDetailsPageFilter)
 
     var id: Int {
         hashValue
@@ -49,6 +50,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         case .nearby: .nearbyTransit
         case .routeDetails: .routeDetails
         case let .stopDetails(_, stopFilter, _): stopFilter == nil ? .stopDetailsUnfiltered : .stopDetailsFiltered
+        case .tripDetails: .tripDetails
         default: nil
         }
     }
@@ -63,6 +65,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
         case .routeDetails: "routeDetails"
         case .routePicker: "routePicker"
         case .stopDetails: "stopDetails"
+        case .tripDetails: "tripDetails"
         }
     }
 
@@ -104,6 +107,7 @@ enum SheetNavigationStackEntry: Hashable, Identifiable {
             )
         case let .routeDetails(sheetRoute): sheetRoute
         case let .routePicker(sheetRoute): sheetRoute
+        case let .tripDetails(filter): SheetRoutes.TripDetails(filter: filter)
         case .alertDetails: nil
         case .more: nil
         }
@@ -126,6 +130,7 @@ struct SheetItem: Identifiable {
         case .routeDetails: "routeDetails"
         case .routePicker: "routePicker"
         case let .stopDetails(stopId, _, _): stopId
+        case let .tripDetails(filter): filter.tripId
         default: ""
         }
     }

--- a/iosApp/iosApp/ViewModels/SettingsViewModel.swift
+++ b/iosApp/iosApp/ViewModels/SettingsViewModel.swift
@@ -75,6 +75,7 @@ class SettingsViewModel: ObservableObject {
                 ),
             ]),
             MoreSection(id: .featureFlags, items: [
+                .toggle(label: "Track this Trip", setting: .trackThisTrip),
                 .toggle(
                     label: NSLocalizedString(
                         "Debug Mode",

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -350,4 +350,88 @@ final class TripDetailsViewTests: XCTestCase {
         ))
         XCTAssertEqual(nearbyVM.navigationStack, [oldNavEntry, newNavEntry])
     }
+
+    @MainActor
+    func testDisplaysFollowButton() throws {
+        let now = EasternTimeInstant.now()
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { _ in }
+        let pattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: pattern)
+        let targetStop = objects.stop { _ in }
+        let vehicleStop = objects.stop { _ in }
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.tripId = trip.id
+            vehicle.routeId = route.id
+            vehicle.currentStatus = .inTransitTo
+            vehicle.stopId = vehicleStop.id
+        }
+
+        let schedule = objects.schedule { schedule in
+            schedule.routeId = route.id
+            schedule.stopId = targetStop.id
+            schedule.trip = trip
+        }
+        let prediction = objects.prediction(schedule: schedule) { prediction in
+            prediction.departureTime = now.plus(seconds: 5)
+            prediction.vehicleId = vehicle.id
+        }
+
+        loadKoinMocks(objects: objects)
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(objects: objects)
+
+        let tripFilter = TripDetailsPageFilter(
+            tripId: trip.id,
+            vehicleId: vehicle.id,
+            routeId: route.id,
+            directionId: 0,
+            stopId: targetStop.id,
+            stopSequence: nil
+        )
+        let tripDetailsVM = MockTripDetailsViewModel(initialState: .init(
+            tripData: .init(
+                tripFilter: tripFilter,
+                trip: trip,
+                tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
+                tripPredictions: .init(objects: objects),
+                tripPredictionsLoaded: true,
+                vehicle: vehicle
+            ),
+            stopList: .init(trip: trip, stops: [.init(
+                stop: targetStop,
+                stopSequence: 0,
+                disruption: nil,
+                schedule: schedule,
+                prediction: prediction,
+                predictionStop: targetStop,
+                vehicle: vehicle,
+                routes: [route]
+            )]),
+            awaitingPredictionsAfterBackground: false
+        ))
+
+        var sut = TripDetailsView(
+            tripFilter: tripFilter,
+            now: now,
+            alertSummaries: [:],
+            onOpenAlertDetails: { _ in },
+            errorBannerVM: MockErrorBannerViewModel(),
+            nearbyVM: nearbyVM,
+            mapVM: MockMapViewModel(),
+            tripDetailsVM: tripDetailsVM,
+        )
+
+        let exp = sut.on(\.didLoadData) { view in
+            try view.find(TripHeaderCard.self).find(button: "Follow").tap()
+            if case let .tripDetails(filter) = nearbyVM.navigationStack.last {
+                XCTAssertEqual(tripFilter, filter)
+            } else {
+                XCTFail("Nav was not updated to trip details")
+            }
+        }
+        ViewHosting.host(view: sut.withFixedSettings([.trackThisTrip: true]))
+        wait(for: [exp], timeout: 1)
+    }
 }

--- a/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripHeaderCardTests.swift
@@ -34,7 +34,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         try XCTAssertNotNil(sut.inspect().find(text: stop.name))
@@ -58,7 +59,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         try XCTAssertNotNil(inTransitSut.inspect().find(text: "Next stop"))
 
@@ -73,7 +75,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         try XCTAssertNotNil(incomingSut.inspect().find(text: "Approaching"))
 
@@ -88,7 +91,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         try XCTAssertNotNil(stoppedSut.inspect().find(text: "Now at"))
     }
@@ -107,7 +111,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         try XCTAssertNotNil(sut.inspect().find(text: "Finishing another trip"))
         try XCTAssertThrowsError(sut.inspect().find(text: stop.name))
@@ -127,7 +132,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         try XCTAssertNotNil(sut.inspect().find(text: "Location not available yet"))
         try XCTAssertThrowsError(sut.inspect().find(text: stop.name))
@@ -152,7 +158,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         XCTAssertNotNil(try targeted.inspect().find(imageName: "stop-pin-indicator"))
@@ -164,7 +171,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         XCTAssertThrowsError(try notTargeted.inspect().find(imageName: "stop-pin-indicator"))
@@ -203,7 +211,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         try XCTAssertNotNil(sut.inspect().find(text: "Waiting to depart"))
@@ -251,7 +260,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         try XCTAssertNotNil(sut.inspect().find(text: "Track 4"))
@@ -284,7 +294,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         try XCTAssertNotNil(sut.inspect().find(text: "Scheduled to depart"))
@@ -322,7 +333,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: { tapExpectation.fulfill() },
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
 
         try sut.inspect().find(ViewType.ZStack.self).callOnTapGesture()
@@ -344,7 +356,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertEqual(
             "displays more information",
@@ -358,7 +371,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: nil,
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertEqual(
             "",
@@ -376,7 +390,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertNotNil(try withVehicleAtStop.inspect().find(
             viewWithAccessibilityLabel: "Selected bus Approaching stop, selected stop"
@@ -391,7 +406,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertNotNil(try withVehicleAtOtherStop.inspect().find(
             viewWithAccessibilityLabel: "Selected bus Approaching other stop"
@@ -416,7 +432,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertNotNil(try withScheduleAtStop.inspect().find(
             viewWithAccessibilityLabel: "Selected bus scheduled to depart stop, selected stop"
@@ -438,7 +455,8 @@ final class TripHeaderCardTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertNotNil(try withScheduleAtOtherStop.inspect().find(
             viewWithAccessibilityLabel: "Selected bus scheduled to depart other stop"
@@ -470,11 +488,38 @@ final class TripHeaderCardTests: XCTestCase {
             route: crRoute,
             routeAccents: .init(type: .commuterRail),
             onTap: {},
-            now: now
+            now: now,
+            onFollowTrip: nil,
         )
         XCTAssertNotNil(try withTrackNumber.inspect().find(viewWithAccessibilityLabel: "Boarding on track 4"))
         XCTAssertNotNil(try withTrackNumber.inspect().find(
             viewWithAccessibilityLabel: "Selected train Now at North Station, selected stop"
         ))
+    }
+
+    func testFollowButton() throws {
+        let followExp = expectation(description: "follow button tapped")
+        let now = EasternTimeInstant.now()
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let route = objects.route { _ in }
+        let trip = objects.trip { _ in }
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.currentStatus = .inTransitTo
+            vehicle.tripId = trip.id
+        }
+        let sut = TripHeaderCard(
+            spec: .vehicle(vehicle, stop, nil, false),
+            trip: trip,
+            targetId: "",
+            route: route,
+            routeAccents: .init(route: route),
+            onTap: nil,
+            now: now,
+            onFollowTrip: { followExp.fulfill() }
+        )
+
+        try sut.inspect().find(button: "Follow").tap()
+        wait(for: [followExp])
     }
 }

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -1,0 +1,39 @@
+//
+//  TripDetailsPageTests.swift
+//  iosApp
+//
+//  Created by esimon on 9/17/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class TripDetailsPageTests: XCTestCase {
+    override func setUp() {
+        executionTimeAllowance = 60
+    }
+
+    @MainActor
+    func testDisplaysTripId() throws {
+        let filter = TripDetailsPageFilter(
+            tripId: "trip id", vehicleId: nil, routeId: "", directionId: 0, stopId: "", stopSequence: nil
+        )
+        let sut = TripDetailsPage(filter: filter, onClose: {})
+        XCTAssertNotNil(try sut.inspect().find(text: "trip id: \(filter.tripId)"))
+    }
+
+    @MainActor
+    func testClose() throws {
+        let closeExp = expectation(description: "Page closed")
+        let sut = TripDetailsPage(
+            filter: .init(tripId: "", vehicleId: nil, routeId: "", directionId: 0, stopId: "", stopSequence: nil),
+            onClose: { closeExp.fulfill() }
+        )
+        try sut.inspect().find(ActionButton.self).implicitAnyView().button().tap()
+        wait(for: [closeExp], timeout: 1)
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Track this Trip | Placeholder entrypoint ](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211363462053632?focus=true)

Track this trip placeholder page, includes the specced follow button and feature toggle.

I noticed an issue where trips frequently stopped loading on stop details when navigating back from the new page, but it seemed out of scope to debug it as part of this.

iOS
- [X] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - Only new string was "Follow", which already existed since it was added for Android, removed manual state
  ~- [ ] Add temporary machine translations, marked "Needs Review"~


### Testing

Added tests for follow button behavior, and some dummy tests for the new page.
