### PR TITLE
fix(Android): Follow vehicle only in track this trip

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -203,14 +203,21 @@ fun MapAndSheetPage(
                     currentNavEntry.stopFilter,
                     currentNavEntry.tripFilter,
                 )
+            is SheetRoutes.TripDetails ->
+                StopDetailsPageFilters(
+                    currentNavEntry.filter.stopId,
+                    currentNavEntry.filter.stopFilter,
+                    currentNavEntry.filter.tripDetailsFilter,
+                )
             else -> null
         })
 
     val selectedVehicleUpdate by tripDetailsViewModel.selectedVehicleUpdates.collectAsState()
     LaunchedEffect(selectedVehicleUpdate) {
+        val follow = currentNavEntry is SheetRoutes.TripDetails
         val stop = nearbyTransit.globalResponse?.getStop(filters?.stopId)
         filters?.tripFilter?.let {
-            mapViewModel.selectedTrip(filters.stopFilter, stop, it, selectedVehicleUpdate)
+            mapViewModel.selectedTrip(filters.stopFilter, stop, it, selectedVehicleUpdate, follow)
         }
     }
 
@@ -371,7 +378,7 @@ fun MapAndSheetPage(
             )
         } else {
             updateTripFilter(stopId, newTripFilter)
-            mapViewModel.selectedTrip(stopFilter, stop, newTripFilter, vehicle)
+            mapViewModel.selectedTrip(stopFilter, stop, newTripFilter, vehicle, false)
         }
     }
 

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -216,7 +216,8 @@ struct TripDetailsView: View {
                 stopFilter: stopFilter,
                 stop: stop,
                 tripFilter: tripDetailsFilter,
-                vehicle: vehicle
+                vehicle: vehicle,
+                follow: false
             )
         }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -141,7 +141,7 @@ internal class MapViewModelTests : KoinTest {
                 SheetRoutes.TripDetails(TripDetailsPageFilter("", stopFilter, tripFilter))
             )
             assertEquals(
-                MapViewModel.State.TripSelected(null, stopFilter, tripFilter, null),
+                MapViewModel.State.TripSelected(null, stopFilter, tripFilter, null, true),
                 awaitItem(),
             )
         }
@@ -176,9 +176,9 @@ internal class MapViewModelTests : KoinTest {
             viewModel.recenter()
             delay(10)
             assertEquals(2, timesFollowCalled)
-            viewModel.selectedTrip(null, null, tripDetailsFilter, vehicle)
+            viewModel.selectedTrip(null, null, tripDetailsFilter, vehicle, false)
             assertEquals(
-                MapViewModel.State.TripSelected(null, null, tripDetailsFilter, vehicle),
+                MapViewModel.State.TripSelected(null, null, tripDetailsFilter, vehicle, false),
                 awaitItem(),
             )
             delay(10)
@@ -205,9 +205,9 @@ internal class MapViewModelTests : KoinTest {
             viewModel.densityChanged(1f)
             assertEquals(MapViewModel.State.Overview, awaitItem())
             val stop = TestData.stops["70113"]!!
-            viewModel.selectedTrip(null, stop, tripDetailsFilter, vehicle)
+            viewModel.selectedTrip(null, stop, tripDetailsFilter, vehicle, false)
             assertEquals(
-                MapViewModel.State.TripSelected(stop, null, tripDetailsFilter, vehicle),
+                MapViewModel.State.TripSelected(stop, null, tripDetailsFilter, vehicle, false),
                 awaitItem(),
             )
             viewModel.navChanged(SheetRoutes.RouteDetails("", RouteDetailsContext.Details))


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Track this Trip | Center map on vehicle only](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210501361218469?focus=true)

Fixes vehicle's not updating while on trip details and also ensures that we're only following the vehicle. Let me know if you see any bugs!

### Testing

Adjusted tests for change in logic
