### PR TITLE
fix(MapVM): use actual current time for alerts if alerts change

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -36,6 +36,7 @@ import dev.mokkery.answering.autofill.AutofillProvider
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.mock
+import kotlin.time.Clock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -59,6 +60,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -97,6 +99,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -141,6 +144,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -185,6 +189,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -221,6 +226,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -258,6 +264,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -295,6 +302,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )
@@ -375,6 +383,7 @@ class HomeMapViewTests {
                 MockRailRouteShapeRepository(),
                 MockSentryRepository(),
                 MockStopRepository(),
+                Clock.System,
                 Dispatchers.Default,
                 Dispatchers.IO,
             )

--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -29,6 +29,7 @@ public actual fun viewModelModule(): Module = module {
             get(),
             get(),
             get(),
+            get(),
             get(named("coroutineDispatcherDefault")),
             get(named("coroutineDispatcherIO")),
         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -154,7 +154,7 @@ public class MapViewModel(
 
     @Composable
     override fun runLogic(): State {
-        val timerTime by timer(updateInterval = 300.seconds, clock = clock)
+        val alertCheckTimer by timer(updateInterval = 300.seconds, clock = clock)
         val globalData by globalRepository.state.collectAsState()
         var globalMapData by remember { mutableStateOf<GlobalMapData?>(null) }
         val routeCardData by routeCardDataViewModel.models.collectAsState()
@@ -180,7 +180,7 @@ public class MapViewModel(
 
         LaunchedEffect(null) { globalRepository.getGlobalData() }
         LaunchedEffect(null) { allRailRouteShapes = fetchRailRouteShapes() }
-        LaunchedEffect(timerTime, globalData, alerts) {
+        LaunchedEffect(alertCheckTimer, globalData, alerts) {
             globalMapData = globalMapData(EasternTimeInstant.now(clock), globalData, alerts)
         }
         LaunchedEffect(allRailRouteShapes, globalData, globalMapData) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -36,6 +36,7 @@ import com.mbta.tid.mbta_app.utils.ViewportManager
 import com.mbta.tid.mbta_app.utils.timer
 import com.mbta.tid.mbta_app.viewModel.MapViewModel.Event
 import com.mbta.tid.mbta_app.viewModel.MapViewModel.Event.RecenterType
+import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -84,6 +85,7 @@ public class MapViewModel(
     private val railRouteShapeRepository: IRailRouteShapeRepository,
     private val sentryRepository: ISentryRepository,
     private val stopRepository: IStopRepository,
+    private val clock: Clock,
     private val defaultCoroutineDispatcher: CoroutineDispatcher,
     private val iOCoroutineDispatcher: CoroutineDispatcher,
 ) : MoleculeViewModel<Event, MapViewModel.State>(), IMapViewModel {
@@ -152,7 +154,7 @@ public class MapViewModel(
 
     @Composable
     override fun runLogic(): State {
-        val now by timer(updateInterval = 300.seconds)
+        val timerTime by timer(updateInterval = 300.seconds, clock = clock)
         val globalData by globalRepository.state.collectAsState()
         var globalMapData by remember { mutableStateOf<GlobalMapData?>(null) }
         val routeCardData by routeCardDataViewModel.models.collectAsState()
@@ -178,8 +180,8 @@ public class MapViewModel(
 
         LaunchedEffect(null) { globalRepository.getGlobalData() }
         LaunchedEffect(null) { allRailRouteShapes = fetchRailRouteShapes() }
-        LaunchedEffect(now, globalData, alerts) {
-            globalMapData = globalMapData(now, globalData, alerts)
+        LaunchedEffect(timerTime, globalData, alerts) {
+            globalMapData = globalMapData(EasternTimeInstant.now(clock), globalData, alerts)
         }
         LaunchedEffect(allRailRouteShapes, globalData, globalMapData) {
             allRailRouteSourceData = routeLineData(globalData, globalMapData, allRailRouteShapes)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/mocks/MockClock.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/mocks/MockClock.kt
@@ -1,0 +1,39 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.mbta.tid.mbta_app.mocks
+
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+import kotlin.time.TimeSource
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
+
+class MockClock(private val startInstant: Instant, timeSource: TimeSource.WithComparableMarks) :
+    Clock {
+    val startTime = EasternTimeInstant(startInstant)
+    private val startMark = timeSource.markNow()
+
+    override fun now() = startInstant + startMark.elapsedNow()
+}
+
+@Suppress("TestFunctionName")
+fun TestScope.MockClock(startTime: Instant = Clock.System.now()) =
+    MockClock(startTime, testTimeSource)
+
+class MockClockTest {
+    @Test
+    fun `advances with test time`() = runTest {
+        val clock = MockClock()
+        val nowBefore = clock.now()
+        advanceTimeBy(10.seconds)
+        val nowAfter = clock.now()
+        assertEquals(10.seconds, nowAfter - nowBefore)
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -25,6 +25,7 @@ public actual fun viewModelModule(): Module = module {
             get(),
             get(),
             get(),
+            get(),
             get(named("coroutineDispatcherDefault")),
             get(named("coroutineDispatcherIO")),
         )

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -25,6 +25,7 @@ public actual fun viewModelModule(): Module = module {
             get(),
             get(),
             get(),
+            get(),
             get(named("coroutineDispatcherDefault")),
             get(named("coroutineDispatcherIO")),
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Reflect alerts on the map as quickly as in the sheet](https://app.asana.com/1/15492006741476/project/1201654106676769/task/1211292609179112?focus=true)

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Wrote a new test to reproduce the issue that went from failing to passing with this change.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
