### PR TITLE
refactor: move viewModelModule definition into shared code

### DIFF
--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.android.kt
@@ -1,63 +1,12 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.definition.Definition
+import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
-import org.koin.core.qualifier.named
-import org.koin.dsl.bind
-import org.koin.dsl.module
+import org.koin.core.module.dsl.viewModel as realViewModel
+import org.koin.core.qualifier.Qualifier
 
-// Use singleOf or single to ensure a shared VM across all views that need it. It should be
-// injected using koinInject() rather than koinViewModel(), because if it gets destroyed by the
-// VM lifecycle management, it will break VMs that share state across multiple views
-public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
-    single {
-            FavoritesViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherDefault")),
-                get(),
-            )
-        }
-        .bind(IFavoritesViewModel::class)
-    single {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
-    singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
-    singleOf(::SearchViewModel).bind(ISearchViewModel::class)
-    single {
-            StopDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(IStopDetailsViewModel::class)
-    singleOf(::ToastViewModel).bind(IToastViewModel::class)
-    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
-    single {
-            TripDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(ITripDetailsViewModel::class)
-}
+internal actual inline fun <reified T : MoleculeScopeViewModel> Module.viewModel(
+    qualifier: Qualifier?,
+    noinline definition: Definition<T>,
+): KoinDefinition<T> = realViewModel(qualifier, definition)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
@@ -1,5 +1,74 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.definition.Definition
+import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.named
+import org.koin.dsl.bind
+import org.koin.dsl.module
 
-public expect fun viewModelModule(): Module
+/**
+ * On Android, creates a ViewModel factory with a navigation-integrated lifecycle; on iOS, just
+ * creates a singleton. Some ViewModels need to be shared across navigation layers, so those should
+ * just be declared with a platform-independent [single].
+ */
+internal expect inline fun <reified T : MoleculeScopeViewModel> Module.viewModel(
+    qualifier: Qualifier? = null,
+    noinline definition: Definition<T>,
+): KoinDefinition<T>
+
+public fun viewModelModule(): Module = module {
+    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
+    single {
+            FavoritesViewModel(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(named("coroutineDispatcherDefault")),
+                get(),
+            )
+        }
+        .bind(IFavoritesViewModel::class)
+    single {
+            MapViewModel(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(named("coroutineDispatcherDefault")),
+                get(named("coroutineDispatcherIO")),
+            )
+        }
+        .bind(IMapViewModel::class)
+    singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
+    singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
+    singleOf(::SearchViewModel).bind(ISearchViewModel::class)
+    single {
+            StopDetailsViewModel(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(named("coroutineDispatcherIO")),
+            )
+        }
+        .bind(IStopDetailsViewModel::class)
+    singleOf(::ToastViewModel).bind(IToastViewModel::class)
+    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
+    single {
+            TripDetailsViewModel(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(named("coroutineDispatcherIO")),
+            )
+        }
+        .bind(ITripDetailsViewModel::class)
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.ios.kt
@@ -1,59 +1,11 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.definition.Definition
+import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
-import org.koin.core.qualifier.named
-import org.koin.dsl.bind
-import org.koin.dsl.module
+import org.koin.core.qualifier.Qualifier
 
-public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
-    single {
-        FavoritesViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(),
-        )
-    }
-    single {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
-    singleOf(::SearchRoutesViewModel)
-    singleOf(::SearchViewModel)
-    single {
-            StopDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(IStopDetailsViewModel::class)
-    singleOf(::ToastViewModel)
-    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
-    single {
-            TripDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(ITripDetailsViewModel::class)
-}
+internal actual inline fun <reified T : MoleculeScopeViewModel> Module.viewModel(
+    qualifier: Qualifier?,
+    noinline definition: Definition<T>,
+): KoinDefinition<T> = single(qualifier = qualifier, definition = definition)

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.jvm.kt
@@ -1,59 +1,11 @@
 package com.mbta.tid.mbta_app.viewModel
 
+import org.koin.core.definition.Definition
+import org.koin.core.definition.KoinDefinition
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.singleOf
-import org.koin.core.qualifier.named
-import org.koin.dsl.bind
-import org.koin.dsl.module
+import org.koin.core.qualifier.Qualifier
 
-public actual fun viewModelModule(): Module = module {
-    singleOf(::ErrorBannerViewModel).bind(IErrorBannerViewModel::class)
-    single {
-        FavoritesViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(),
-        )
-    }
-    single {
-        MapViewModel(
-            get(),
-            get(),
-            get(),
-            get(),
-            get(),
-            get(named("coroutineDispatcherDefault")),
-            get(named("coroutineDispatcherIO")),
-        )
-    }
-    singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
-    singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
-    singleOf(::SearchViewModel).bind(ISearchViewModel::class)
-    single {
-            StopDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(IStopDetailsViewModel::class)
-    singleOf(::ToastViewModel).bind(IToastViewModel::class)
-    singleOf(::TripDetailsPageViewModel).bind(ITripDetailsPageViewModel::class)
-    single {
-            TripDetailsViewModel(
-                get(),
-                get(),
-                get(),
-                get(),
-                get(),
-                get(named("coroutineDispatcherIO")),
-            )
-        }
-        .bind(ITripDetailsViewModel::class)
-}
+internal actual inline fun <reified T : MoleculeScopeViewModel> Module.viewModel(
+    qualifier: Qualifier?,
+    noinline definition: Definition<T>,
+): KoinDefinition<T> = single(qualifier = qualifier, definition = definition)


### PR DESCRIPTION
### Summary

_Ticket:_ none

I realized that we aren’t actually using the Android-only Koin `viewModel` factory for anything and so we don’t actually benefit from using `expect`/`actual` to split the `viewModelModule` definition by platform, but I’m not sure if that’ll actually remain the case indefinitely. This way, everything is still only defined once, but if we do eventually decide to reintroduce the Android-navigation-lifecycle-integrated Koin `viewModel`, we don’t have to reintroduce the platform distinction.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the Android and iOS tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
