### PR TITLE
fix: use isListedRoute to hide unlisted connecting routes

### DIFF
--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -598,8 +598,8 @@ class TripDetailsStopListTest {
             }
         val routeExcluded =
             objects.route {
-                id = "116117"
                 sortOrder = 0
+                isListedRoute = false
             }
 
         val patternCurrent1 = pattern("V1", routeCurrent, RoutePattern.Typicality.Atypical)


### PR DESCRIPTION
### Summary

_Ticket:_ [Replace hardcoded route ID list with listed_route: false](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1211374343402152?focus=true)

Love a nice 0.1 point task.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Updated the relevant test and checked that it still passes.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
