### PR TITLE
feat(iOS): tap vehicle to track trip

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -365,7 +365,7 @@ fun MapAndSheetPage(
 
         if (routeId != null) analytics.tappedVehicle(routeId)
 
-        val newTripFilter = TripDetailsFilter(tripId, vehicle.id, stopSequence)
+        val newTripFilter = TripDetailsFilter(tripId, vehicle.id, stopSequence, true)
         val stop = nearbyTransit.globalResponse?.getStop(filters?.stopId)
         if (hasTrackThisTrip) {
             handleTripDetailsNavigation(

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -21,6 +21,7 @@ struct HomeMapView: View {
     @ObservedObject var viewportProvider: ViewportProvider
 
     @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject var settingsCache: SettingsCache
 
     var errorBannerRepository: IErrorBannerStateRepository
 


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Track this Trip | Tap vehicle on map to open](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211363468635850?focus=true)

Nice and straightforward with reference to #1309.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added a test for the new logic to match the test for the old logic.