### PR TITLE
feat: tap version number to show build number

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import com.mbta.tid.mbta_app.android.BuildConfig
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -103,5 +104,16 @@ class MorePageTests : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(dependency.licenseText))
         composeTestRule.onNodeWithText(dependency.name).assertIsDisplayed()
         composeTestRule.onNodeWithText(dependency.licenseText).assertIsDisplayed()
+    }
+
+    @Test
+    fun testShowsBuildNumberOnTap() {
+        composeTestRule.setContent { MorePage(bottomBar = {}) }
+
+        val versionText = "version ${BuildConfig.VERSION_NAME}"
+        val versionAndBuildText = "$versionText (${BuildConfig.VERSION_CODE})"
+        composeTestRule.onNodeWithText(versionAndBuildText).assertDoesNotExist()
+        composeTestRule.onNodeWithText(versionText).performClick()
+        composeTestRule.onNodeWithText(versionAndBuildText).assertIsDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,6 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -53,6 +57,7 @@ fun MorePage(bottomBar: @Composable () -> Unit) {
 
     val sections by viewModel.sections.collectAsState()
     val dependencies = Dependency.getAllDependencies()
+    var showingBuildNumber by remember { mutableStateOf(false) }
 
     Scaffold(bottomBar = bottomBar) { outerSheetPadding ->
         Column(Modifier.padding(outerSheetPadding).background(colorResource(R.color.fill3))) {
@@ -70,10 +75,20 @@ fun MorePage(bottomBar: @Composable () -> Unit) {
                                 modifier = Modifier.semantics { heading() },
                             )
                             Text(
-                                stringResource(
-                                    R.string.app_version_number,
-                                    BuildConfig.VERSION_NAME,
-                                ),
+                                if (showingBuildNumber)
+                                    stringResource(
+                                        R.string.app_version_and_build,
+                                        BuildConfig.VERSION_NAME,
+                                        BuildConfig.VERSION_CODE,
+                                    )
+                                else
+                                    stringResource(
+                                        R.string.app_version_number,
+                                        BuildConfig.VERSION_NAME,
+                                    ),
+                                if (!showingBuildNumber)
+                                    Modifier.clickable { showingBuildNumber = true }
+                                else Modifier,
                                 style = Typography.footnote,
                             )
                         }

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -40,6 +40,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">un problema mecánico anterior</string>
     <string name="an_earlier_signal_problem">Un problema de señal anterior</string>
     <string name="an_earlier_signal_problem_lowercase">un problema de señal anterior</string>
+    <string name="app_version_and_build">versión %1$s (%2$s)</string>
     <string name="app_version_number">versión %1$s</string>
     <string name="approaching">Acercándose</string>
     <string name="arriving_abbr">LLEGAN.</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -40,6 +40,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">un problème mécanique antérieur</string>
     <string name="an_earlier_signal_problem">Un problème signalétique antérieur</string>
     <string name="an_earlier_signal_problem_lowercase">un problème de signal antérieur</string>
+    <string name="app_version_and_build">version %1$s (%2$s)</string>
     <string name="app_version_number">version %1$s</string>
     <string name="approaching">Proche</string>
     <string name="arriving_abbr">ARR</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -43,6 +43,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">yon pwoblèm mekanik ki te pase anvan</string>
     <string name="an_earlier_signal_problem">Yon Siyal Ki Rive Pi Bonè</string>
     <string name="an_earlier_signal_problem_lowercase">yon pwoblèm siyal ki te pase anvan</string>
+    <string name="app_version_and_build">vèsyon %1$s (%2$s)</string>
     <string name="app_version_number">vèsyon %1$s</string>
     <string name="approaching">Ap apwoche</string>
     <string name="arriving_abbr">ARR</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -40,6 +40,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">um problema mecânico anterior</string>
     <string name="an_earlier_signal_problem">Um problema de sinal anterior</string>
     <string name="an_earlier_signal_problem_lowercase">um problema de sinal anterior</string>
+    <string name="app_version_and_build">versão %1$s (%2$s)</string>
     <string name="app_version_number">versão %1$s</string>
     <string name="approaching">Chegando</string>
     <string name="arriving_abbr">CHE</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -38,6 +38,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">một vấn đề cơ khí trước đó</string>
     <string name="an_earlier_signal_problem">Một vấn đề về đèn tín hiệu trước đó</string>
     <string name="an_earlier_signal_problem_lowercase">vấn đề về đèn tín hiệu trước đó</string>
+    <string name="app_version_and_build">phiên bản %1$s (%2$s)</string>
     <string name="app_version_number">phiên bản %1$s</string>
     <string name="approaching">Đang đến gần</string>
     <string name="arriving_abbr">ARR</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -38,6 +38,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">早前的机械故障</string>
     <string name="an_earlier_signal_problem">早前的信号问题</string>
     <string name="an_earlier_signal_problem_lowercase">早前的信号问题</string>
+    <string name="app_version_and_build">版本 %1$s（%2$s）</string>
     <string name="app_version_number">版本%1$s</string>
     <string name="approaching">正在接近</string>
     <string name="arriving_abbr">到站</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -38,6 +38,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">早前的機械故障</string>
     <string name="an_earlier_signal_problem">早前的信號問題</string>
     <string name="an_earlier_signal_problem_lowercase">早前的信號問題</string>
+    <string name="app_version_and_build">版本 %1$s（%2$s）</string>
     <string name="app_version_number">版本 %1$s</string>
     <string name="approaching">正在接近</string>
     <string name="arriving_abbr">到站</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="an_earlier_mechanical_problem_lowercase">an earlier mechanical problem</string>
     <string name="an_earlier_signal_problem">An Earlier Signal Problem</string>
     <string name="an_earlier_signal_problem_lowercase">an earlier signal problem</string>
+    <string name="app_version_and_build">version %1$s (%2$s)</string>
     <string name="app_version_number">version %1$s</string>
     <string name="approaching">Approaching</string>
     <string name="arriving_abbr">ARR</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -21025,6 +21025,59 @@
         }
       }
     },
+    "version %@ (%@)" : {
+      "comment" : "Version number and more detailed build number label on the More page",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "version %1$@ (%2$@)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "versión %1$@ (%2$@)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "version %1$@ (%2$@)"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "vèsyon %1$@ (%2$@)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "versão %1$@ (%2$@)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "phiên bản %1$@ (%2$@)"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "版本 %1$@（%2$@）"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "版本 %1$@（%2$@）"
+          }
+        }
+      }
+    },
     "View details" : {
       "comment" : "Button that shows more informaton about an alert",
       "localizations" : {

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -13,6 +13,7 @@ struct MorePage: View {
     let inspection = Inspection<Self>()
 
     var viewModel = SettingsViewModel()
+    @State var showingBuildNumber = false
 
     var body: some View {
         NavigationStack {
@@ -23,13 +24,26 @@ struct MorePage: View {
                         .accessibilityAddTraits(.isHeader)
                         .accessibilityHeading(.h1)
                     Spacer()
-                    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+                    let infoPlist = Bundle.main.infoDictionary
+                    let version = infoPlist?["CFBundleShortVersionString"] as? String
+                    let build = infoPlist?["CFBundleVersion"] as? String ?? "?"
                     if let version {
-                        Text(
-                            "version \(version)",
-                            comment: "Version number label on the More page"
-                        )
-                        .font(Typography.footnote)
+                        if showingBuildNumber {
+                            Text(
+                                "version \(version) (\(build))",
+                                comment: "Version number and more detailed build number label on the More page"
+                            )
+                            .font(Typography.footnote)
+                        } else {
+                            Text(
+                                "version \(version)",
+                                comment: "Version number label on the More page"
+                            )
+                            .font(Typography.footnote)
+                            .onTapGesture {
+                                showingBuildNumber = true
+                            }
+                        }
                     }
                 }
                 .padding(.horizontal, 16)

--- a/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
+++ b/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
@@ -70,4 +70,27 @@ final class MorePageTests: XCTestCase {
 
         await fulfillment(of: [exp], timeout: 5)
     }
+
+    @MainActor func testShowsBuildNumberOnTap() {
+        let sut = MorePage()
+
+        let infoPlist = Bundle.main.infoDictionary
+        guard let version = infoPlist?["CFBundleShortVersionString"] as? String,
+              let build = infoPlist?["CFBundleVersion"] as? String else {
+            XCTFail("version info not found")
+            return
+        }
+        let versionText = "version \(version)"
+        let versionAndBuildText = "\(versionText) (\(build))"
+
+        let exp = sut.inspection.inspect { view in
+            XCTAssertThrowsError(try view.find(text: versionAndBuildText))
+            try view.find(text: versionText).callOnTapGesture()
+            XCTAssertNotNil(try view.find(text: versionAndBuildText))
+        }
+
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+
+        wait(for: [exp], timeout: 1)
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Display build number somewhere in app](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1209527076283999)

I remember being skeptical that this was a two point ticket, and behold, it took an hour.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Added a UI test on each platform. Checked that the value is actually read from the correct place and should have the correct value in real builds.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
