### PR TITLE
chore: Refactor LineOrRoute out of RouteCardData

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -11,7 +11,7 @@ import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.TestData
@@ -34,7 +34,7 @@ class SaveFavoritesFlowTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     val line =
-        RouteCardData.LineOrRoute.Line(
+        LineOrRoute.Line(
             TestData.getLine("line-Green"),
             setOf(
                 TestData.getRoute("Green-B"),
@@ -212,7 +212,7 @@ class SaveFavoritesFlowTest {
 
         composeTestRule.setContent {
             SaveFavoritesFlow(
-                lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                lineOrRoute = LineOrRoute.Route(busRoute),
                 stop = busStop,
                 directions = listOf(direction0),
                 selectedDirection = 0,
@@ -361,7 +361,7 @@ class SaveFavoritesFlowTest {
 
         composeTestRule.setContent {
             SaveFavoritesFlow(
-                lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                lineOrRoute = LineOrRoute.Route(busRoute),
                 stop = busStop,
                 directions = listOf(direction0),
                 selectedDirection = 0,
@@ -389,7 +389,7 @@ class SaveFavoritesFlowTest {
 
         composeTestRule.setContent {
             SaveFavoritesFlow(
-                lineOrRoute = RouteCardData.LineOrRoute.Route(busRoute),
+                lineOrRoute = LineOrRoute.Route(busRoute),
                 stop = busStop,
                 directions = listOf(direction0),
                 selectedDirection = 0,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -9,6 +9,7 @@ import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
@@ -41,7 +42,7 @@ class DeparturesTest {
         val aTrip = objects.trip { headsign = "A" }
         val bTrip = objects.trip { headsign = "B" }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         val context = RouteCardData.Context.NearbyTransit
         val stopData =
             RouteCardData.RouteStopData(
@@ -117,7 +118,7 @@ class DeparturesTest {
         val aSchedule = objects.schedule { stopHeadsign = "A Stop Headsign" }
         val bTrip = objects.trip { headsign = "B" }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         val context = RouteCardData.Context.NearbyTransit
         val stopData =
             RouteCardData.RouteStopData(
@@ -192,7 +193,7 @@ class DeparturesTest {
                 }
             )
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(route))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(route))
         val context = RouteCardData.Context.NearbyTransit
         val stopData =
             RouteCardData.RouteStopData(
@@ -237,7 +238,7 @@ class DeparturesTest {
         val aTrip = objects.trip { headsign = "A" }
         val bTrip = objects.trip { headsign = "B" }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         val context = RouteCardData.Context.NearbyTransit
         val stopData =
             RouteCardData.RouteStopData(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
@@ -29,10 +30,10 @@ class RouteCardTest {
         composeTestRule.setContent {
             RouteCard(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            RouteCardData.LineOrRoute.Route(route),
+                            LineOrRoute.Route(route),
                             stop,
                             emptyList(),
                             emptyList(),
@@ -66,10 +67,10 @@ class RouteCardTest {
         composeTestRule.setContent {
             RouteCard(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            RouteCardData.LineOrRoute.Route(route),
+                            LineOrRoute.Route(route),
                             stop,
                             emptyList(),
                             emptyList(),
@@ -105,10 +106,10 @@ class RouteCardTest {
         composeTestRule.setContent {
             RouteCard(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     listOf(
                         RouteCardData.RouteStopData(
-                            RouteCardData.LineOrRoute.Route(route),
+                            LineOrRoute.Route(route),
                             stop,
                             emptyList(),
                             emptyList(),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopHeaderTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
@@ -26,7 +27,7 @@ class StopHeaderTest {
         composeTestRule.setContent {
             StopHeader(
                 RouteCardData.RouteStopData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     stop,
                     emptyList(),
                     emptyList(),
@@ -48,7 +49,7 @@ class StopHeaderTest {
         composeTestRule.setContent {
             StopHeader(
                 RouteCardData.RouteStopData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     stop,
                     emptyList(),
                     emptyList(),
@@ -71,7 +72,7 @@ class StopHeaderTest {
         composeTestRule.setContent {
             StopHeader(
                 RouteCardData.RouteStopData(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     stop,
                     emptyList(),
                     emptyList(),
@@ -90,7 +91,7 @@ class StopHeaderTest {
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
         val alert = objects.alert { effect = Alert.Effect.ElevatorClosure }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         loadKoinMocks {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -13,6 +13,7 @@ import com.mbta.tid.mbta_app.android.pages.EditFavoritesPage
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -60,7 +61,7 @@ class EditFavoritesPageTest : KoinTest {
             lineId = line.id
             routePatternIds = mutableListOf("pattern_1", "pattern_2")
         }
-    val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+    val lineOrRoute = LineOrRoute.Route(route)
     val routePatternOne =
         builder.routePattern(route) {
             id = "pattern_1"
@@ -145,7 +146,7 @@ class EditFavoritesPageTest : KoinTest {
             lineId = greenLine.id
             routePatternIds = mutableListOf("pattern_gl")
         }
-    val greenLineOrRoute = RouteCardData.LineOrRoute.Line(greenLine, setOf(greenLineRoute))
+    val greenLineOrRoute = LineOrRoute.Line(greenLine, setOf(greenLineRoute))
     val greenLineRoutePatternOne =
         builder.routePattern(greenLineRoute) {
             id = "pattern_gl"

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -10,10 +10,10 @@ import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.hasClickActionLabel
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RouteType
 import kotlin.test.assertTrue
@@ -43,7 +43,7 @@ class CollapsableStopListTest {
             }
         composeTestRule.setContent {
             CollapsableStopList(
-                RouteCardData.LineOrRoute.Route(mainRoute),
+                LineOrRoute.Route(mainRoute),
                 segment =
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -92,7 +92,7 @@ class CollapsableStopListTest {
             }
         composeTestRule.setContent {
             CollapsableStopList(
-                RouteCardData.LineOrRoute.Route(mainRoute),
+                LineOrRoute.Route(mainRoute),
                 segment =
                     RouteDetailsStopList.Segment(
                         listOf(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -15,9 +15,9 @@ import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilNodeCountDefaultTimeout
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -105,7 +105,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(mainRoute),
+                LineOrRoute.Route(mainRoute),
                 RouteDetailsContext.Details,
                 GlobalResponse(objects),
                 onClick = clicks::add,
@@ -190,7 +190,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
+                LineOrRoute.Line(line, setOf(route1, route2, route3)),
                 RouteDetailsContext.Details,
                 GlobalResponse(objects),
                 onClick = {},
@@ -291,7 +291,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(mainRoute),
+                LineOrRoute.Route(mainRoute),
                 RouteDetailsContext.Details,
                 GlobalResponse(objects),
                 onClick = {},
@@ -345,7 +345,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(mainRoute),
+                LineOrRoute.Route(mainRoute),
                 RouteDetailsContext.Details,
                 GlobalResponse(objects),
                 onClick = {},
@@ -368,7 +368,7 @@ class RouteStopListViewTest {
     @Test
     fun testFavoritesWithConfirmationDialog() {
         val objects = TestData.clone()
-        val route = RouteCardData.LineOrRoute.Route(objects.getRoute("Red"))
+        val route = LineOrRoute.Route(objects.getRoute("Red"))
 
         loadKoinMocks(objects) {
             routeStops =
@@ -443,7 +443,7 @@ class RouteStopListViewTest {
         composeTestRule.setContent {
             toastState = toastVM.models.collectAsState()
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                LineOrRoute.Route(objects.getRoute("Red")),
                 RouteDetailsContext.Favorites,
                 GlobalResponse(objects),
                 onClick = {},
@@ -494,7 +494,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                LineOrRoute.Route(objects.getRoute("Red")),
                 RouteDetailsContext.Favorites,
                 GlobalResponse(objects),
                 onClick = {},
@@ -545,7 +545,7 @@ class RouteStopListViewTest {
 
         composeTestRule.setContent {
             RouteStopListView(
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
+                LineOrRoute.Route(objects.getRoute("Red")),
                 RouteDetailsContext.Favorites,
                 GlobalResponse(objects),
                 onClick = {},

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRowTest.kt
@@ -7,8 +7,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.utils.TestData
@@ -28,7 +28,7 @@ class RoutePickerRootRowTest {
                 type = RouteType.HEAVY_RAIL
             }
 
-        composeTestRule.setContent { RoutePickerRootRow(RouteCardData.LineOrRoute.Route(route)) {} }
+        composeTestRule.setContent { RoutePickerRootRow(LineOrRoute.Route(route)) {} }
 
         composeTestRule.onNodeWithText("Red Line").assertIsDisplayed()
         composeTestRule.onNodeWithText("Red Line").assertHasClickAction()
@@ -40,9 +40,7 @@ class RoutePickerRootRowTest {
         val line = objects.getLine("line-Green")
         val routes = objects.routes.values.filter { it.lineId == line.id }.toSet()
 
-        composeTestRule.setContent {
-            RoutePickerRootRow(RouteCardData.LineOrRoute.Line(line, routes)) {}
-        }
+        composeTestRule.setContent { RoutePickerRootRow(LineOrRoute.Line(line, routes)) {} }
 
         composeTestRule.onNodeWithText("Green Line").assertIsDisplayed()
     }
@@ -59,7 +57,7 @@ class RoutePickerRootRowTest {
 
         var tapped = false
         composeTestRule.setContent {
-            RoutePickerRootRow(RouteCardData.LineOrRoute.Route(route)) { tapped = true }
+            RoutePickerRootRow(LineOrRoute.Route(route)) { tapped = true }
         }
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRowTest.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 import org.junit.Rule
 import org.junit.Test
@@ -24,7 +24,7 @@ class RoutePickerRowTest {
                 type = RouteType.BUS
             }
 
-        composeTestRule.setContent { RoutePickerRow(RouteCardData.LineOrRoute.Route(route)) {} }
+        composeTestRule.setContent { RoutePickerRow(LineOrRoute.Route(route)) {} }
 
         composeTestRule.onNodeWithText("66").assertIsDisplayed()
         composeTestRule.onNodeWithText("Harvard Square - Nubian Station").assertHasClickAction()
@@ -40,9 +40,7 @@ class RoutePickerRowTest {
                 type = RouteType.FERRY
             }
 
-        composeTestRule.setContent {
-            RoutePickerRow(RouteCardData.LineOrRoute.Route(route)) { tapped = true }
-        }
+        composeTestRule.setContent { RoutePickerRow(LineOrRoute.Route(route)) { tapped = true } }
 
         composeTestRule.onNodeWithText(route.longName).performClick()
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -131,7 +132,7 @@ class SubscribeToVehiclesTest {
                 onConnect = { routeId, directionId -> connectProps = Pair(routeId, directionId) },
             )
 
-        val line = RouteCardData.LineOrRoute.Line(objects.line(), routes = setOf(route1, route2))
+        val line = LineOrRoute.Line(objects.line(), routes = setOf(route1, route2))
         val stop = objects.stop()
         val routeCardData =
             listOf(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -14,6 +14,7 @@ import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Prediction
@@ -300,7 +301,7 @@ class StopDetailsFilteredDeparturesViewTest {
         val globalResponse =
             GlobalResponse(objects, mutableMapOf(stop.id to listOf(routePattern.id)))
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         val leaf =
             RouteCardData.Leaf(
                 lineOrRoute,
@@ -363,7 +364,7 @@ class StopDetailsFilteredDeparturesViewTest {
         val route = objects.route { id = "Green-B" }
         val line = objects.line { id = "Green" }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(route))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(route))
         val leaf =
             RouteCardData.Leaf(
                 lineOrRoute,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -54,7 +55,7 @@ class StopDetailsViewTest {
             lineId = "line_1"
             routePatternIds = mutableListOf("pattern_1", "pattern_2")
         }
-    val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+    val lineOrRoute = LineOrRoute.Route(route)
     val routePatternOne =
         builder.routePattern(route) {
             id = "pattern_1"

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/RouteModeLabelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/RouteModeLabelTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 import kotlin.test.assertEquals
 import org.junit.Rule
@@ -118,7 +118,7 @@ class RouteModeLabelTest {
                 type = RouteType.BUS
                 lineId = line.id
             }
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(route))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(route))
 
         composeTestRule.setContent { Text(routeModeLabel(LocalContext.current, lineOrRoute)) }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
@@ -40,7 +40,7 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.getLabels
 import com.mbta.tid.mbta_app.model.Direction
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
@@ -52,7 +52,7 @@ import org.koin.compose.koinInject
 
 @Composable
 fun SaveFavoritesFlow(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     stop: Stop,
     directions: List<Direction>,
     selectedDirection: Int,
@@ -141,7 +141,7 @@ fun SaveFavoritesFlow(
 
 @Composable
 fun FavoriteConfirmationDialog(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     stop: Stop,
     directions: List<Direction>,
     selectedDirection: Int,
@@ -276,7 +276,7 @@ class Previews() {
         MyApplicationTheme {
             Column(Modifier.background(colorResource(R.color.fill3))) {
                 FavoriteConfirmationDialog(
-                    RouteCardData.LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
+                    LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
                     stop = objects.getStop("place-boyls"),
                     directions =
                         listOf(
@@ -299,7 +299,7 @@ class Previews() {
         MyApplicationTheme {
             Column(Modifier.background(colorResource(R.color.fill3))) {
                 FavoriteConfirmationDialog(
-                    RouteCardData.LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
+                    LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
                     stop = objects.getStop("place-unsqu"),
                     directions =
                         listOf(Direction(id = 0, name = "West", destination = "Copley & West")),
@@ -319,7 +319,7 @@ class Previews() {
         MyApplicationTheme {
             Column(Modifier.background(colorResource(R.color.fill3))) {
                 FavoriteConfirmationDialog(
-                    RouteCardData.LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
+                    LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
                     stop = objects.getStop("place-unsqu"),
                     directions =
                         listOf(Direction(id = 0, name = "West", destination = "Copley & West")),
@@ -339,7 +339,7 @@ class Previews() {
         MyApplicationTheme {
             Column(Modifier.background(colorResource(R.color.fill3))) {
                 FavoriteConfirmationDialog(
-                    RouteCardData.LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
+                    LineOrRoute.Line(objects.getLine("line-Green"), emptySet()),
                     stop = objects.getStop("place-boyls"),
                     directions =
                         listOf(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -28,6 +28,7 @@ import com.mbta.tid.mbta_app.android.component.PillDecoration
 import com.mbta.tid.mbta_app.android.generated.drawableByName
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.LeafFormat
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -179,7 +180,7 @@ private fun DeparturesPreview() {
     val global = GlobalResponse(objects)
     val context = RouteCardData.Context.NearbyTransit
 
-    val lineOrRoute = RouteCardData.LineOrRoute.Route(redLine)
+    val lineOrRoute = LineOrRoute.Route(redLine)
     val stopData =
         RouteCardData.RouteStopData(
             lineOrRoute,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/TransitHeader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/TransitHeader.kt
@@ -23,12 +23,12 @@ import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.android.util.routeModeLabel
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteType
 
 @Composable
 fun TransitHeader(
-    transit: RouteCardData.LineOrRoute,
+    transit: LineOrRoute,
     rightContent: (@Composable (textColor: Color) -> Unit)? = null,
 ) {
     val (modeIcon, modeDescription) = routeIcon(transit.sortRoute)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -31,12 +31,12 @@ import com.mbta.tid.mbta_app.android.component.StopListToggleGroup
 import com.mbta.tid.mbta_app.android.component.StopPlacement
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
 import com.mbta.tid.mbta_app.android.util.Typography
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 
 @Composable
 fun CollapsableStopList(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     segment: RouteDetailsStopList.Segment,
     onClick: (RouteDetailsStopList.Entry) -> Unit,
     onClickLabel: @Composable (RouteDetailsStopList.Entry) -> String? = { null },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -61,11 +61,11 @@ import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
 import com.mbta.tid.mbta_app.android.util.rememberSuspend
 import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.RouteType
@@ -94,7 +94,7 @@ sealed class RouteDetailsRowContext {
 
 @Composable
 fun RouteStopListView(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     context: RouteDetailsContext,
     globalData: GlobalResponse,
     onClick: (RouteDetailsRowContext) -> Unit,
@@ -161,7 +161,7 @@ fun LoadingRouteStopListView(
 ) {
     CompositionLocalProvider(IsLoadingSheetContents provides true) {
         val objects = ObjectCollectionBuilder()
-        val mockRoute = RouteCardData.LineOrRoute.Route(objects.route {})
+        val mockRoute = LineOrRoute.Route(objects.route {})
 
         RouteStopListView(
             lineOrRoute = mockRoute,
@@ -203,7 +203,7 @@ fun LoadingRouteStopListView(
 
 @Composable
 fun RouteStopListView(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     parameters: RouteDetailsStopList.RouteParameters,
     selectedDirection: Int,
     setDirection: (Int) -> Unit,
@@ -346,7 +346,7 @@ fun RouteStopListView(
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp).padding(top = 2.dp),
         )
 
-        if (lineOrRoute is RouteCardData.LineOrRoute.Line && routes.size > 1) {
+        if (lineOrRoute is LineOrRoute.Line && routes.size > 1) {
             LineRoutePicker(lineOrRoute.line, routes, selectedRouteId, selectedDirection) {
                 setRouteId(it)
             }
@@ -367,7 +367,7 @@ fun RouteStopListView(
 
 @Composable
 private fun RouteStops(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     stopList: RouteDetailsStopList?,
     selectedDirection: Int,
     context: RouteDetailsContext,
@@ -496,7 +496,7 @@ private fun LineRoutePicker(
 
 @Composable
 private fun LoadingRouteStops(
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     selectedDirection: Int,
     context: RouteDetailsContext,
     rightSideContent: @Composable RowScope.(RouteDetailsRowContext, Modifier) -> Unit,
@@ -533,7 +533,7 @@ private fun RouteStopsPreview() {
         modules(module { single<SettingsCache> { SettingsCache(MockSettingsRepository()) } })
     }
     RouteStops(
-        RouteCardData.LineOrRoute.Route(TestData.getRoute("Red")),
+        LineOrRoute.Route(TestData.getRoute("Red")),
         RouteDetailsStopList(
             0,
             listOf(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRow.kt
@@ -22,13 +22,13 @@ import com.mbta.tid.mbta_app.android.component.routeIcon
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath.Silver.routeType
 
 @Composable
-fun RoutePickerRootRow(route: RouteCardData.LineOrRoute, onTap: () -> Unit) {
+fun RoutePickerRootRow(route: LineOrRoute, onTap: () -> Unit) {
     val routeColor = Color.fromHex(route.backgroundColor)
     val textColor = Color.fromHex(route.textColor)
     RoutePickerRootRow(route.type, routeColor, textColor, onTap) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRow.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.RoutePill
 import com.mbta.tid.mbta_app.android.component.RoutePillType
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteType
 
 @Composable
-fun RoutePickerRow(route: RouteCardData.LineOrRoute, onTap: () -> Unit) {
+fun RoutePickerRow(route: LineOrRoute, onTap: () -> Unit) {
     Row(
         Modifier.fillMaxWidth().clickable { onTap() }.padding(horizontal = 8.dp, vertical = 12.dp),
         Arrangement.SpaceBetween,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -37,6 +37,7 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSignificance
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
@@ -113,11 +114,11 @@ fun StopDetailsFilteredDeparturesView(
         val routeIds: List<String>
 
         when (lineOrRoute) {
-            is RouteCardData.LineOrRoute.Line -> {
+            is LineOrRoute.Line -> {
                 lineId = lineOrRoute.id
                 routeIds = lineOrRoute.routes.map { it.id }
             }
-            is RouteCardData.LineOrRoute.Route -> {
+            is LineOrRoute.Route -> {
                 lineId = null
                 routeIds = listOf(lineOrRoute.id)
             }
@@ -283,7 +284,7 @@ fun StopDetailsFilteredDeparturesView(
 @Composable
 private fun DepartureTiles(
     tripFilter: TripDetailsFilter?,
-    lineOrRoute: RouteCardData.LineOrRoute,
+    lineOrRoute: LineOrRoute,
     stop: Stop,
     tiles: List<TileData>,
     alerts: List<Alert>,
@@ -326,7 +327,7 @@ private fun DepartureTiles(
                     coroutineScope.launch { bringIntoViewRequester.bringIntoView() }
                 },
                 modifier = Modifier.bringIntoViewRequester(bringIntoViewRequester),
-                showRoutePill = lineOrRoute is RouteCardData.LineOrRoute.Line,
+                showRoutePill = lineOrRoute is LineOrRoute.Line,
                 showHeadsign = true,
                 isSelected = tileData.isSelected(tripFilter),
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredPickerView.kt
@@ -30,6 +30,7 @@ import com.mbta.tid.mbta_app.android.component.SaveFavoritesFlow
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -92,7 +93,7 @@ fun StopDetailsFilteredPickerView(
         }
         StopDetailsFilteredHeader(
             lineOrRoute.sortRoute,
-            (lineOrRoute as? RouteCardData.LineOrRoute.Line)?.line,
+            (lineOrRoute as? LineOrRoute.Line)?.line,
             stop,
             isFavorite = isFavorite(rsd),
             onFavorite = { inSaveFavoritesFlow = true },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -31,6 +31,7 @@ import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCard
 import com.mbta.tid.mbta_app.android.util.SettingsCache
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Prediction
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -198,8 +199,8 @@ private fun StopDetailsRoutesViewPreview() {
 
     val globalData = GlobalResponse(objects)
 
-    val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-    val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
+    val lineOrRoute1 = LineOrRoute.Route(route1)
+    val lineOrRoute2 = LineOrRoute.Route(route2)
     val context = RouteCardData.Context.StopDetailsUnfiltered
     val routeCardData =
         listOf(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -12,6 +12,7 @@ import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.modifiers.loadingShimmer
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -68,8 +69,8 @@ fun StopDetailsUnfilteredView(
     ): List<PillFilter> =
         routeCardData.map {
             when (val lineOrRoute = it.lineOrRoute) {
-                is RouteCardData.LineOrRoute.Line -> PillFilter.ByLine(lineOrRoute.line)
-                is RouteCardData.LineOrRoute.Route ->
+                is LineOrRoute.Line -> PillFilter.ByLine(lineOrRoute.line)
+                is LineOrRoute.Route ->
                     PillFilter.ByRoute(lineOrRoute.route, global.getLine(lineOrRoute.route.lineId))
             }
         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/LineOrRouteExtension.kt
@@ -2,8 +2,8 @@ package com.mbta.tid.mbta_app.android.util
 
 import android.content.Context
 import com.mbta.tid.mbta_app.android.R
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteType
 
-fun RouteCardData.LineOrRoute.labelWithModeIfBus(context: Context): String =
+fun LineOrRoute.labelWithModeIfBus(context: Context): String =
     if (this.type == RouteType.BUS) context.getString(R.string.bus_label, this.name) else this.name

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/routeModeLabel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/routeModeLabel.kt
@@ -3,16 +3,13 @@ package com.mbta.tid.mbta_app.android.util
 import android.content.Context
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.utils.RouteModeLabelType
 
-fun routeModeLabel(
-    context: Context,
-    lineOrRoute: RouteCardData.LineOrRoute,
-    isOnly: Boolean = true,
-): String = routeModeLabel(context, lineOrRoute.name, lineOrRoute.type, isOnly)
+fun routeModeLabel(context: Context, lineOrRoute: LineOrRoute, isOnly: Boolean = true): String =
+    routeModeLabel(context, lineOrRoute.name, lineOrRoute.type, isOnly)
 
 fun routeModeLabel(context: Context, line: Line?, route: Route?, isOnly: Boolean = true): String =
     routeModeLabel(context, line?.longName ?: route?.label, route?.type, isOnly)

--- a/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
+++ b/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
@@ -17,7 +17,7 @@ enum SaveFavoritesContext {
 }
 
 struct SaveFavoritesFlow: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let stop: Stop
     let directions: [Direction]
     let selectedDirection: Int32
@@ -40,7 +40,7 @@ struct SaveFavoritesFlow: View {
     let inspection = Inspection<Self>()
 
     init(
-        lineOrRoute: RouteCardData.LineOrRoute, stop: Stop, directions: [Direction], selectedDirection: Int32,
+        lineOrRoute: LineOrRoute, stop: Stop, directions: [Direction], selectedDirection: Int32,
         context: SaveFavoritesContext, global: GlobalResponse?,
         isFavorite: @escaping (RouteStopDirection) -> Bool,
         updateFavorites: @escaping ([RouteStopDirection: Bool]) -> Void,
@@ -160,7 +160,7 @@ struct SaveFavoritesFlow: View {
 }
 
 struct FavoriteConfirmationDialog: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let stop: Stop
     let directions: [Direction]
     let selectedDirection: Int32
@@ -218,7 +218,7 @@ struct FavoriteConfirmationDialog: View {
 }
 
 struct FavoriteConfirmationDialogContents: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let stop: Stop
     let directions: [Direction]
     let selectedDirection: Int32
@@ -271,7 +271,7 @@ struct FavoriteConfirmationDialogContents: View {
 }
 
 struct DirectionButtons: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let favorites: [Direction: Bool]
     let updateLocalFavorite: (Direction, Bool) -> Void
 
@@ -327,7 +327,7 @@ struct DirectionButtons: View {
 }
 
 struct FavoriteConfirmationDialogActions: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let stop: Stop
     let favoritesToSave: [Direction: Bool]
     let updateFavorites: ([RouteStopDirection: Bool]) -> Void

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -10,7 +10,7 @@ import Shared
 import SwiftUI
 
 struct CollapsableStopList<RightSideContent: View>: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let segment: RouteDetailsStopList.Segment
     let onClick: (RouteDetailsStopList.Entry) -> Void
     let isFirstSegment: Bool
@@ -22,7 +22,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
     let inspection = Inspection<Self>()
 
     init(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         segment: RouteDetailsStopList.Segment,
         onClick: @escaping (RouteDetailsStopList.Entry) -> Void,
         isFirstSegment: Bool = false,

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -18,7 +18,7 @@ struct RouteDetailsView: View {
     let errorBannerVM: IErrorBannerViewModel
 
     @State var globalData: GlobalResponse?
-    @State private var lineOrRoute: RouteCardData.LineOrRoute?
+    @State private var lineOrRoute: LineOrRoute?
 
     var body: some View {
         ScrollView([]) {
@@ -51,7 +51,7 @@ struct RouteDetailsView: View {
 
     @ViewBuilder private func loadingBody() -> some View {
         let objects = ObjectCollectionBuilder()
-        let mockRoute = RouteCardData.LineOrRouteRoute(route: objects.route { _ in })
+        let mockRoute = LineOrRoute.route(objects.route { _ in })
         let mockGlobal = GlobalResponse(objects: objects)
         let toastVM = MockToastViewModel(initialState: ToastViewModel.StateHidden())
         RouteStopListContentView(

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -28,7 +28,7 @@ enum RouteDetailsRowContext: Equatable {
 }
 
 struct RouteStopListView<RightSideContent: View>: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let parameters: RouteDetailsStopList.RouteParameters
     let context: RouteDetailsContext
     let globalData: GlobalResponse
@@ -52,7 +52,7 @@ struct RouteStopListView<RightSideContent: View>: View {
     let inspection = Inspection<Self>()
 
     init(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         context: RouteDetailsContext,
         globalData: GlobalResponse,
         onClick: @escaping (RouteDetailsRowContext) -> Void,
@@ -183,7 +183,7 @@ struct RouteStopListView<RightSideContent: View>: View {
 }
 
 struct RouteStopListContentView<RightSideContent: View>: View {
-    let lineOrRoute: RouteCardData.LineOrRoute
+    let lineOrRoute: LineOrRoute
     let parameters: RouteDetailsStopList.RouteParameters
     let selectedDirection: Int32
     let setSelectedDirection: (Int32) -> Void
@@ -211,7 +211,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
     let inspection = Inspection<Self>()
 
     init(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         parameters: RouteDetailsStopList.RouteParameters,
         selectedDirection: Int32,
         setSelectedDirection: @escaping (Int32) -> Void,

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerRootRow.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerRootRow.swift
@@ -40,7 +40,7 @@ struct RoutePickerRootRow: View {
         )
     }
 
-    init(route: RouteCardData.LineOrRoute, onTap: @escaping () -> Void) {
+    init(route: LineOrRoute, onTap: @escaping () -> Void) {
         let routeColor = Color(hex: route.backgroundColor)
         let textColor = Color(hex: route.textColor)
         self.init(

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerRow.swift
@@ -10,7 +10,7 @@ import Shared
 import SwiftUI
 
 struct RoutePickerRow: View {
-    let route: RouteCardData.LineOrRoute
+    let route: LineOrRoute
     let onTap: () -> Void
 
     var body: some View {

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -22,8 +22,8 @@ struct RoutePickerView: View {
     let onBack: () -> Void
 
     @State var globalData: GlobalResponse?
-    @State var routes: [RouteCardData.LineOrRoute] = []
-    @State var routeSearchResults: [RouteCardData.LineOrRoute] = []
+    @State var routes: [LineOrRoute] = []
+    @State var routeSearchResults: [LineOrRoute] = []
 
     @State var searchVMState: SearchRoutesViewModel.State = SearchRoutesViewModel.StateUnfiltered()
     @StateObject var searchObserver = TextFieldObserver()
@@ -60,7 +60,7 @@ struct RoutePickerView: View {
     private var isRootPath: Bool { path is RoutePickerPath.Root }
 
     func routeSearchResultsForVMState(state: SearchRoutesViewModel.State,
-                                      routes: [RouteCardData.LineOrRoute]) -> [RouteCardData.LineOrRoute] {
+                                      routes: [LineOrRoute]) -> [LineOrRoute] {
         switch onEnum(of: state) {
         case .unfiltered, .error: routes
         case let .results(state):

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -108,7 +108,7 @@ struct DirectionPicker: View {
         pattern.directionId = 1
     }
 
-    let lineOrRoute = RouteCardData.LineOrRoute.route(route)
+    let lineOrRoute = LineOrRoute.route(route)
     let context = RouteCardData.Context.stopDetailsFiltered
     let leaf0 = RouteCardData.Leaf(
         lineOrRoute: lineOrRoute,

--- a/iosApp/iosApp/Utils/Extensions/LineOrRouteExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/LineOrRouteExtension.swift
@@ -9,13 +9,16 @@
 import Shared
 import SwiftUI
 
-extension RouteCardData.LineOrRoute {
-    static func route(_ route: Route) -> RouteCardData.LineOrRouteRoute {
-        RouteCardData.LineOrRouteRoute(route: route)
+typealias LineModel = Line
+typealias RouteModel = Route
+
+extension LineOrRoute {
+    static func route(_ route: RouteModel) -> LineOrRoute.Route {
+        LineOrRoute.Route(route: route)
     }
 
-    static func line(_ line: Line, _ routes: Set<Route>) -> RouteCardData.LineOrRouteLine {
-        RouteCardData.LineOrRouteLine(line: line, routes: routes)
+    static func line(_ line: LineModel, _ routes: Set<RouteModel>) -> LineOrRoute.Line {
+        LineOrRoute.Line(line: line, routes: routes)
     }
 
     var labelWithModeIfBus: String {

--- a/iosApp/iosApp/Utils/RouteModeLabel.swift
+++ b/iosApp/iosApp/Utils/RouteModeLabel.swift
@@ -9,7 +9,7 @@
 import Shared
 import SwiftUI
 
-func routeModeLabel(lineOrRoute: RouteCardData.LineOrRoute, isOnly: Bool = true) -> String {
+func routeModeLabel(lineOrRoute: LineOrRoute, isOnly: Bool = true) -> String {
     routeModeLabel(name: lineOrRoute.name, type: lineOrRoute.type, isOnly: isOnly)
 }
 

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -116,7 +116,7 @@ final class NearbyTransitViewTests: XCTestCase {
         let distantMinutes = 10
         let objects = TestData.clone()
 
-        let route: RouteCardData.LineOrRoute = .route(TestData.getRoute(id: "67"))
+        let route: LineOrRoute = .route(TestData.getRoute(id: "67"))
         let stop = objects.getStop(id: "141")
         let trip = objects.getTrip(id: "68596786")
         let prediction = objects.prediction { prediction in
@@ -455,7 +455,7 @@ final class NearbyTransitViewTests: XCTestCase {
         let nearbyVM = NearbyViewModel()
         nearbyVM.nearbyState = .init(loadedLocation: mockLocation, loading: false, stopIds: [])
 
-        let route: RouteCardData.LineOrRoute = .route(TestData.getRoute(id: "67"))
+        let route: LineOrRoute = .route(TestData.getRoute(id: "67"))
         let stop = objects.getStop(id: "141")
         nearbyVM.routeCardData = [.init(lineOrRoute: route,
                                         stopData: [.init(lineOrRoute: route,

--- a/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerRootRowTests.swift
+++ b/iosApp/iosAppTests/Pages/RoutePicker/RoutePickerRootRowTests.swift
@@ -20,7 +20,7 @@ final class RoutePickerRootRowTests: XCTestCase {
             route.type = RouteType.heavyRail
         }
 
-        let sut = RoutePickerRootRow(route: RouteCardData.LineOrRoute.route(route), onTap: {})
+        let sut = RoutePickerRootRow(route: LineOrRoute.route(route), onTap: {})
         XCTAssertNotNil(try sut.inspect().find(text: "Red Line"))
     }
 
@@ -30,7 +30,7 @@ final class RoutePickerRootRowTests: XCTestCase {
         let allRoutes = (objects.routes.allValues as? [Route]) ?? []
         let routes = Set(allRoutes.filter { $0.lineId == line.id })
 
-        let sut = RoutePickerRootRow(route: RouteCardData.LineOrRoute.line(line, routes), onTap: {})
+        let sut = RoutePickerRootRow(route: LineOrRoute.line(line, routes), onTap: {})
         XCTAssertNotNil(try sut.inspect().find(text: "Green Line"))
     }
 
@@ -45,7 +45,7 @@ final class RoutePickerRootRowTests: XCTestCase {
 
         var tapped = false
         let sut = RoutePickerRootRow(
-            route: RouteCardData.LineOrRoute.route(route),
+            route: LineOrRoute.route(route),
             onTap: { tapped = true }
         )
         try sut.inspect().find(button: "Blue Line").tap()

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -52,7 +52,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
     }
 
     func makeLeaf(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         stop: Stop? = nil,
         patterns: [RoutePattern]? = nil,
         upcomingTrips: [UpcomingTrip]? = nil,

--- a/iosApp/iosAppTests/Utils/RouteModeLabelTests.swift
+++ b/iosApp/iosAppTests/Utils/RouteModeLabelTests.swift
@@ -70,7 +70,7 @@ final class RouteModeLabelTests: XCTestCase {
             route.longName = "SL3"
             route.type = .bus
         }
-        let lineOrRoute = RouteCardData.LineOrRoute.line(line, [route])
+        let lineOrRoute = LineOrRoute.line(line, [route])
         XCTAssertEqual("Silver Line bus", routeModeLabel(lineOrRoute: lineOrRoute))
     }
 }

--- a/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
+++ b/iosApp/iosAppTests/Views/RouteCardDeparturesTests.swift
@@ -190,7 +190,7 @@ final class RouteCardDeparturesTests: XCTestCase {
             prediction.tripId = tripE1.id
         }
 
-        let lineOrRoute = RouteCardData.LineOrRoute.line(
+        let lineOrRoute = LineOrRoute.line(
             Green.shared.line,
             [Green.shared.routeB, Green.shared.routeC, Green.shared.routeE]
         )
@@ -280,7 +280,7 @@ final class RouteCardDeparturesTests: XCTestCase {
             prediction.departureTime = now.plus(minutes: 5)
         })
 
-        let lineOrRoute = RouteCardData.LineOrRoute.line(line, [route])
+        let lineOrRoute = LineOrRoute.line(line, [route])
 
         let context = RouteCardData.Context.nearbyTransit
         let stopData = RouteCardData.RouteStopData(
@@ -328,7 +328,7 @@ final class RouteCardDeparturesTests: XCTestCase {
             prediction.departureTime = now.plus(minutes: 5)
         })
 
-        let lineOrRoute = RouteCardData.LineOrRoute.line(line, [route])
+        let lineOrRoute = LineOrRoute.line(line, [route])
 
         let context = RouteCardData.Context.nearbyTransit
         let stopData = RouteCardData.RouteStopData(

--- a/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
+++ b/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
@@ -19,7 +19,7 @@ final class SaveFavoritesFlowTest: XCTestCase {
         executionTimeAllowance = 60
     }
 
-    let line = RouteCardData.LineOrRoute.line(
+    let line = LineOrRoute.line(
         TestData.getLine(id: "line-Green"),
         Set([
             TestData.getRoute(id: "Green-B"),
@@ -146,7 +146,7 @@ final class SaveFavoritesFlowTest: XCTestCase {
             route.type = RouteType.bus
         }
 
-        let sut = SaveFavoritesFlow(lineOrRoute: RouteCardData.LineOrRoute.route(route),
+        let sut = SaveFavoritesFlow(lineOrRoute: LineOrRoute.route(route),
                                     stop: stop,
                                     directions: [direction0],
                                     selectedDirection: 0,
@@ -170,7 +170,7 @@ final class SaveFavoritesFlowTest: XCTestCase {
             route.type = RouteType.bus
         }
 
-        let sut = SaveFavoritesFlow(lineOrRoute: RouteCardData.LineOrRoute.route(route),
+        let sut = SaveFavoritesFlow(lineOrRoute: LineOrRoute.route(route),
                                     stop: stop,
                                     directions: [direction0],
                                     selectedDirection: 0,
@@ -252,7 +252,7 @@ final class SaveFavoritesFlowTest: XCTestCase {
         }
 
         let sut = SaveFavoritesFlow(
-            lineOrRoute: RouteCardData.LineOrRoute.route(route),
+            lineOrRoute: LineOrRoute.route(route),
             stop: stop,
             directions: [direction0],
             selectedDirection: 0,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LineOrRoute.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LineOrRoute.kt
@@ -1,0 +1,90 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.map.style.Color
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+
+// These are used to disambiguate from LineOrRoute.Route and LineOrRoute.Line
+
+private typealias LineModel = Line
+
+private typealias RouteModel = Route
+
+public sealed class LineOrRoute {
+
+    public data class Line(val line: LineModel, val routes: Set<RouteModel>) : LineOrRoute()
+
+    public data class Route(val route: RouteModel) : LineOrRoute()
+
+    public val id: String
+        get() =
+            when (this) {
+                is Line -> this.line.id
+                is Route -> this.route.id
+            }
+
+    public val name: String
+        get() =
+            when (this) {
+                is Line -> this.line.longName
+                is Route -> this.route.label
+            }
+
+    public val type: RouteType
+        get() =
+            when (this) {
+                is Line -> this.sortRoute.type
+                is Route -> this.route.type
+            }
+
+    public val backgroundColor: Color
+        get() =
+            when (this) {
+                is Line -> this.line.color
+                is Route -> this.route.color
+            }
+
+    public val textColor: Color
+        get() =
+            when (this) {
+                is Line -> this.line.textColor
+                is Route -> this.route.textColor
+            }
+
+    internal val isSubway: Boolean
+        get() =
+            when (this) {
+                is Line -> this.routes.any { it.type.isSubway() }
+                is Route -> this.route.type.isSubway()
+            }
+
+    /** The route whose sortOrder to use when sorting a RouteCardData. */
+    public val sortRoute: RouteModel
+        get() =
+            when (this) {
+                is Route -> this.route
+                is Line -> this.routes.min()
+            }
+
+    public val allRoutes: Set<RouteModel>
+        get() =
+            when (this) {
+                is Route -> setOf(this.route)
+                is Line -> this.routes
+            }
+
+    public fun directions(
+        globalData: GlobalResponse,
+        stop: Stop,
+        patterns: List<RoutePattern>,
+    ): List<Direction> =
+        when (this) {
+            is Line -> Direction.getDirectionsForLine(globalData, stop, patterns)
+            is Route -> Direction.getDirections(globalData, stop, this.route, patterns)
+        }
+
+    public fun containsRoute(routeId: String?): Boolean =
+        when (this) {
+            is Line -> this.routes.any { it.id == routeId }
+            is Route -> this.id == routeId
+        }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LoadingPlaceholders.kt
@@ -54,7 +54,7 @@ public object LoadingPlaceholders {
             return UpcomingTrip(trip, prediction = prediction)
         }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
 
         val leaf1 =
             RouteCardData.Leaf(
@@ -98,10 +98,7 @@ public object LoadingPlaceholders {
         return routeData
     }
 
-    public fun routeDetailsStops(
-        lineOrRoute: RouteCardData.LineOrRoute,
-        directionId: Int,
-    ): RouteDetailsStopList {
+    public fun routeDetailsStops(lineOrRoute: LineOrRoute, directionId: Int): RouteDetailsStopList {
         val objects = ObjectCollectionBuilder()
         val fixedRand = Random("${lineOrRoute.id}-$directionId".hashCode())
         fun randString(from: Int, until: Int) =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.map.style.Color
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -16,12 +15,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-
-// These are used in LineOrRoute to disambiguate them from LineOrRoute.Route and LineOrRoute.Line
-
-private typealias LineModel = Line
-
-private typealias RouteModel = Route
 
 // type aliases can't be nested :(
 
@@ -545,86 +538,6 @@ public data class RouteCardData(
                 )
             }
         }
-    }
-
-    public sealed class LineOrRoute {
-
-        public data class Line(val line: LineModel, val routes: Set<RouteModel>) : LineOrRoute()
-
-        public data class Route(val route: RouteModel) : LineOrRoute()
-
-        public val id: String
-            get() =
-                when (this) {
-                    is Line -> this.line.id
-                    is Route -> this.route.id
-                }
-
-        public val name: String
-            get() =
-                when (this) {
-                    is Line -> this.line.longName
-                    is Route -> this.route.label
-                }
-
-        public val type: RouteType
-            get() =
-                when (this) {
-                    is Line -> this.sortRoute.type
-                    is Route -> this.route.type
-                }
-
-        public val backgroundColor: Color
-            get() =
-                when (this) {
-                    is Line -> this.line.color
-                    is Route -> this.route.color
-                }
-
-        public val textColor: Color
-            get() =
-                when (this) {
-                    is Line -> this.line.textColor
-                    is Route -> this.route.textColor
-                }
-
-        internal val isSubway: Boolean
-            get() =
-                when (this) {
-                    is Line -> this.routes.any { it.type.isSubway() }
-                    is Route -> this.route.type.isSubway()
-                }
-
-        /** The route whose sortOrder to use when sorting a RouteCardData. */
-        public val sortRoute: RouteModel
-            get() =
-                when (this) {
-                    is Route -> this.route
-                    is Line -> this.routes.min()
-                }
-
-        public val allRoutes: Set<RouteModel>
-            get() =
-                when (this) {
-                    is Route -> setOf(this.route)
-                    is Line -> this.routes
-                }
-
-        public fun directions(
-            globalData: GlobalResponse,
-            stop: Stop,
-            patterns: List<RoutePattern>,
-        ): List<Direction> =
-            when (this) {
-                is Line -> Direction.getDirectionsForLine(globalData, stop, patterns)
-                is Route -> Direction.getDirections(globalData, stop, this.route, patterns)
-            }
-
-        public fun containsRoute(routeId: String?): Boolean =
-            when (this) {
-                is Line -> this.routes.any { it.id == routeId }
-                is Route -> this.id == routeId
-            }
     }
 
     /** The distance from the given position to the first stop in this route card. */

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopList.kt
@@ -79,7 +79,7 @@ public data class RouteDetailsStopList(val directionId: Int, val segments: List<
         val directions: List<Direction>,
     ) {
         public constructor(
-            lineOrRoute: RouteCardData.LineOrRoute,
+            lineOrRoute: LineOrRoute,
             globalData: GlobalResponse,
         ) : this(
             globalData.routePatterns.values

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.model.RouteCardData.LineOrRoute
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -4,10 +4,10 @@ import com.mbta.tid.mbta_app.kdTree.KdTree
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
@@ -81,7 +81,7 @@ internal constructor(
 
     public fun getRoute(routeId: String?): Route? = routes[routeId]
 
-    public fun getRoutesForPicker(path: RoutePickerPath): List<RouteCardData.LineOrRoute> =
+    public fun getRoutesForPicker(path: RoutePickerPath): List<LineOrRoute> =
         routes.values
             .filter {
                 it.isListedRoute &&
@@ -107,13 +107,13 @@ internal constructor(
             .mapNotNull { route ->
                 if (route.id in greenRoutes) {
                     this.getLine(route.lineId)?.let { line ->
-                        RouteCardData.LineOrRoute.Line(
+                        LineOrRoute.Line(
                             line,
                             routes = routesByLineId[line.id]?.toSet() ?: emptySet(),
                         )
                     }
                 } else {
-                    RouteCardData.LineOrRoute.Route(route)
+                    LineOrRoute.Route(route)
                 }
             }
             .distinct()
@@ -127,14 +127,14 @@ internal constructor(
             null
         }
 
-    public fun getLineOrRoute(lineOrRouteId: String): RouteCardData.LineOrRoute? {
+    public fun getLineOrRoute(lineOrRouteId: String): LineOrRoute? {
         val route = this.getRoute(lineOrRouteId)
         val line = this.getLine(lineOrRouteId) ?: this.getLine(route?.lineId)
         return when {
             line != null && line.isGrouped ->
-                RouteCardData.LineOrRoute.Line(line, this.routesByLineId[line.id].orEmpty().toSet())
+                LineOrRoute.Line(line, this.routesByLineId[line.id].orEmpty().toSet())
 
-            route != null -> RouteCardData.LineOrRoute.Route(route)
+            route != null -> LineOrRoute.Route(route)
             else -> null
         }
     }
@@ -146,10 +146,7 @@ internal constructor(
         return patternIds.mapNotNull { routePatterns[it] }
     }
 
-    public fun getPatternsFor(
-        stopId: String,
-        lineOrRoute: RouteCardData.LineOrRoute,
-    ): List<RoutePattern> {
+    public fun getPatternsFor(stopId: String, lineOrRoute: LineOrRoute): List<RoutePattern> {
         val stop = stops[stopId] ?: return emptyList()
         val stopIds = stop.childStopIds + listOf(stopId)
         val patternIds = stopIds.flatMap { patternIdsByStop[it] ?: emptyList() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.utils
 
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Line
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -68,7 +69,7 @@ public open class RouteCardPreviewData {
     public val global: GlobalResponse = GlobalResponse(objects)
 
     private fun cardStop(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         stop: Stop,
         patterns: List<RoutePattern>,
         trips: List<UpcomingTrip>,
@@ -112,7 +113,7 @@ public open class RouteCardPreviewData {
         )
 
     private fun card(
-        lineOrRoute: RouteCardData.LineOrRoute,
+        lineOrRoute: LineOrRoute,
         stop: Stop,
         patterns: List<RoutePattern>,
         trips: List<UpcomingTrip>,
@@ -133,7 +134,7 @@ public open class RouteCardPreviewData {
         alertDownstream: Map<Int, Alert> = emptyMap(),
     ) =
         card(
-            RouteCardData.LineOrRoute.Route(route),
+            LineOrRoute.Route(route),
             stop,
             objects.routePatterns.values.filter { it.routeId == route.id },
             trips,
@@ -152,7 +153,7 @@ public open class RouteCardPreviewData {
         val routeIds = routes.map { it.id }
         val routePatterns = objects.routePatterns.values.filter { routeIds.contains(it.routeId) }
         return card(
-            RouteCardData.LineOrRoute.Line(line, routes),
+            LineOrRoute.Line(line, routes),
             stop,
             routePatterns,
             trips,
@@ -657,7 +658,7 @@ public open class RouteCardPreviewData {
 
     // "Next two trips go to the same destination" group = "6. Bus route single direction"
     public fun Bus1(): RouteCardData {
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
+        val lineOrRoute = LineOrRoute.Route(bus87)
         return RouteCardData(
             lineOrRoute,
             listOf(
@@ -716,7 +717,7 @@ public open class RouteCardPreviewData {
 
     // "Next two trips go to different destinations" group = "6. Bus route single direction"
     public fun Bus2(): RouteCardData {
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(bus87)
+        val lineOrRoute = LineOrRoute.Route(bus87)
         return RouteCardData(
             lineOrRoute,
             listOf(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -11,7 +11,7 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSignificance
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.Direction
-import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.discardTrackChangesAtCRCore
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -68,7 +68,7 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
                 val filter = filter
                 val allPatterns =
                     if (filter != null && global != null && route != null)
-                        global.getPatternsFor(filter.stopId, RouteCardData.LineOrRoute.Route(route))
+                        global.getPatternsFor(filter.stopId, LineOrRoute.Route(route))
                     else emptyList()
                 if (trip != null) allPatterns.filter { it.id == trip.routePatternId }
                 else if (filter != null) allPatterns.filter { it.directionId == filter.directionId }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -15,8 +15,8 @@ class PatternSortingTest {
 
     private fun singleLineOrRoute() =
         objects.lines.values.singleOrNull()?.let {
-            RouteCardData.LineOrRoute.Line(it, objects.routes.values.toSet())
-        } ?: objects.routes.values.single().let { RouteCardData.LineOrRoute.Route(it) }
+            LineOrRoute.Line(it, objects.routes.values.toSet())
+        } ?: objects.routes.values.single().let { LineOrRoute.Route(it) }
 
     private fun singleStop() = objects.stops.values.single()
 
@@ -43,7 +43,7 @@ class PatternSortingTest {
         )
 
     private fun leaf(
-        lineOrRoute: RouteCardData.LineOrRoute = singleLineOrRoute(),
+        lineOrRoute: LineOrRoute = singleLineOrRoute(),
         stop: Stop = singleStop(),
         pattern: RoutePattern,
         trips: Int = 0,
@@ -70,19 +70,14 @@ class PatternSortingTest {
     private fun stopData(stop: Stop, vararg leaf: RouteCardData.Leaf) =
         stopData(stop, singleLineOrRoute(), *leaf)
 
-    private fun stopData(
-        stop: Stop,
-        lineOrRoute: RouteCardData.LineOrRoute,
-        vararg leaf: RouteCardData.Leaf,
-    ) = RouteCardData.RouteStopData(lineOrRoute, stop, leaf.asList(), GlobalResponse(objects))
+    private fun stopData(stop: Stop, lineOrRoute: LineOrRoute, vararg leaf: RouteCardData.Leaf) =
+        RouteCardData.RouteStopData(lineOrRoute, stop, leaf.asList(), GlobalResponse(objects))
 
     private fun routeCard(route: Route, vararg stops: RouteCardData.RouteStopData) =
-        routeCard(RouteCardData.LineOrRoute.Route(route), *stops)
+        routeCard(LineOrRoute.Route(route), *stops)
 
-    private fun routeCard(
-        lineOrRoute: RouteCardData.LineOrRoute,
-        vararg stops: RouteCardData.RouteStopData,
-    ) = RouteCardData(lineOrRoute, stops.asList(), EasternTimeInstant.now())
+    private fun routeCard(lineOrRoute: LineOrRoute, vararg stops: RouteCardData.RouteStopData) =
+        RouteCardData(lineOrRoute, stops.asList(), EasternTimeInstant.now())
 
     @Test
     fun compareLeavesAtStop() {
@@ -190,13 +185,13 @@ class PatternSortingTest {
                     type = if (subway) RouteType.HEAVY_RAIL else RouteType.BUS
                     this.sortOrder = sortOrder
                 }
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             val stop = if (near) nearStop else farStop
             return routeCard(
                 route,
                 stopData(
                     stop,
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     leaf(
                         lineOrRoute,
                         stop,
@@ -255,13 +250,13 @@ class PatternSortingTest {
                     type = if (subway) RouteType.HEAVY_RAIL else RouteType.BUS
                     this.sortOrder = sortOrder
                 }
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             val stop = if (near) nearStop else farStop
             return routeCard(
                 route,
                 stopData(
                     stop,
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     leaf(
                         lineOrRoute,
                         stop,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -36,7 +36,7 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.Disruption(alert, "alert-large-red-suspension"),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -86,7 +86,7 @@ class RouteCardDataLeafTest {
                     ),
                 ),
                 RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route),
+                        LineOrRoute.Route(route),
                         objects.stop(),
                         0,
                         emptyList(),
@@ -131,7 +131,7 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.Disruption(alert, "alert-large-silver-suspension"),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -184,7 +184,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -241,7 +241,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -290,7 +290,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -339,7 +339,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -369,7 +369,7 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.ServiceEndedToday),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -404,7 +404,7 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -444,7 +444,7 @@ class RouteCardDataLeafTest {
                     UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable),
                 ),
                 RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route),
+                        LineOrRoute.Route(route),
                         objects.stop(),
                         0,
                         emptyList(),
@@ -470,7 +470,7 @@ class RouteCardDataLeafTest {
         assertEquals(
             LeafFormat.Single(route = null, headsign = null, UpcomingFormat.Loading),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     listOf(pattern),
@@ -525,7 +525,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -582,7 +582,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(subwayRoute),
+                    LineOrRoute.Route(subwayRoute),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -617,7 +617,7 @@ class RouteCardDataLeafTest {
                 ),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(busRoute),
+                    LineOrRoute.Route(busRoute),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -647,7 +647,7 @@ class RouteCardDataLeafTest {
                 UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.NoSchedulesToday),
             ),
             RouteCardData.Leaf(
-                    RouteCardData.LineOrRoute.Route(route),
+                    LineOrRoute.Route(route),
                     objects.stop(),
                     0,
                     emptyList(),
@@ -669,7 +669,7 @@ class RouteCardDataLeafTest {
         fun objects() = objects.clone()
 
         val route = objects.getRoute("Red")
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
 
         object jfkUmass {
             val itself = objects.getStop("place-jfk")
@@ -1142,7 +1142,7 @@ class RouteCardDataLeafTest {
         val d = objects.getRoute("Green-D")
         val e = objects.getRoute("Green-E")
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(b, c, d, e))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(b, c, d, e))
 
         val boylston = objects.getStop("place-boyls")
         val kenmore = objects.getStop("place-kencl")
@@ -1329,7 +1329,7 @@ class RouteCardDataLeafTest {
 
         val route = objects.getRoute("CR-Providence")
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
 
         val toWickford = objects.getRoutePattern("CR-Providence-9cf54fb3-0")
         val toStoughton = objects.getRoutePattern("CR-Providence-9515a09b-0")
@@ -1511,7 +1511,7 @@ class RouteCardDataLeafTest {
         fun objects() = objects.clone()
 
         val route = objects.getRoute("87")
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         val outboundTypical = objects.getRoutePattern("87-2-0")
         val outboundDeviation =
             objects.routePattern(route) {
@@ -2410,7 +2410,7 @@ class RouteCardDataLeafTest {
                     UpcomingFormat.Disruption(alert, MapStopRoute.matching(route)),
                 ),
                 RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route),
+                        LineOrRoute.Route(route),
                         stop1,
                         0,
                         listOf(rp1, rp2),
@@ -2446,7 +2446,7 @@ class RouteCardDataLeafTest {
             }
         val leaf =
             RouteCardData.Leaf(
-                RouteCardData.LineOrRoute.Route(route),
+                LineOrRoute.Route(route),
                 stop,
                 directionId = 0,
                 routePatterns = emptyList(),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -46,7 +46,7 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = EasternTimeInstant.now()
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
@@ -119,7 +119,7 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = EasternTimeInstant.now()
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
@@ -208,7 +208,7 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = EasternTimeInstant.now()
 
-        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+        val lineOrRoute1 = LineOrRoute.Route(route1)
         assertEquals(
             mapOf(
                 route1.id to
@@ -323,8 +323,8 @@ class RouteCardDataTest {
                 )
             val now = EasternTimeInstant.now()
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute2 = LineOrRoute.Route(route2)
             assertEquals(
                 mapOf(
                     route2.id to
@@ -459,8 +459,8 @@ class RouteCardDataTest {
                 )
             val now = EasternTimeInstant.now()
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute2 = LineOrRoute.Route(route2)
             assertEquals(
                 mapOf(
                     route1.id to
@@ -575,8 +575,8 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val now = EasternTimeInstant.now()
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute2 = LineOrRoute.Route(route2)
             assertEquals(
                 mapOf(
                     route1.id to
@@ -687,7 +687,7 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = EasternTimeInstant.now()
 
-        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+        val lineOrRoute1 = LineOrRoute.Route(route1)
         assertEquals(
             mapOf(
                 route1.id to
@@ -776,7 +776,7 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = EasternTimeInstant.now()
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         assertEquals(
             mapOf(
                 route.id to
@@ -865,8 +865,8 @@ class RouteCardDataTest {
             val westDir = Direction("West", "Boston College", 0)
             val eastDir = Direction("East", "Government Center", 1)
 
-            val railLineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(railRoute))
-            val shuttleLineOrRoute = RouteCardData.LineOrRoute.Route(shuttleRoute)
+            val railLineOrRoute = LineOrRoute.Line(line, setOf(railRoute))
+            val shuttleLineOrRoute = LineOrRoute.Route(shuttleRoute)
             assertEquals(
                 mapOf(
                     line.id to
@@ -996,7 +996,7 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val now = EasternTimeInstant.now()
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(bRoute, cRoute, dRoute))
         assertEquals(
             mapOf(
                 line.id to
@@ -1213,7 +1213,7 @@ class RouteCardDataTest {
             val westDir = Direction("West", "Copley & West", 0)
             val northDir = Direction("East", "North Station & North", 1)
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeD))
+            val lineOrRoute = LineOrRoute.Line(line, setOf(routeB, routeC, routeD))
             assertEquals(
                 mapOf(
                     line.id to
@@ -1342,7 +1342,7 @@ class RouteCardDataTest {
                     trip = trip3
                 }
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 mapOf(
                     route1.id to
@@ -1470,7 +1470,7 @@ class RouteCardDataTest {
             departureTime = now - 2.hours
         }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         assertEquals(
             mapOf(
                 route.id to
@@ -1626,7 +1626,7 @@ class RouteCardDataTest {
         val globalData = GlobalResponse(objects)
 
         val lineOrRoute =
-            RouteCardData.LineOrRoute.Line(
+            LineOrRoute.Line(
                 greenLine,
                 setOf(
                     greenB,
@@ -1736,8 +1736,8 @@ class RouteCardDataTest {
         val time = EasternTimeInstant(2024, Month.FEBRUARY, 22, 12, 8, 19)
         val context = RouteCardData.Context.NearbyTransit
 
-        val subwayLineOrRoute = RouteCardData.LineOrRoute.Route(subwayRoute)
-        val busLineOrRoute = RouteCardData.LineOrRoute.Route(busRoute)
+        val subwayLineOrRoute = LineOrRoute.Route(subwayRoute)
+        val busLineOrRoute = LineOrRoute.Route(busRoute)
         assertEquals(
             listOf(
                 RouteCardData(
@@ -1845,8 +1845,8 @@ class RouteCardDataTest {
             val context = RouteCardData.Context.NearbyTransit
             val time = EasternTimeInstant(2024, Month.FEBRUARY, 22, 12, 8, 19)
 
-            val subwayLineOrRoute1 = RouteCardData.LineOrRoute.Route(subwayRoute1)
-            val subwayLineOrRoute2 = RouteCardData.LineOrRoute.Route(subwayRoute2)
+            val subwayLineOrRoute1 = LineOrRoute.Route(subwayRoute1)
+            val subwayLineOrRoute2 = LineOrRoute.Route(subwayRoute2)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -2501,7 +2501,7 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationInbound.representativeTripId
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -2613,7 +2613,7 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationInboundTrip2.id
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -2736,7 +2736,7 @@ class RouteCardDataTest {
                     stopId = stop2.id
                     tripId = typicalOutbound.representativeTripId
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -2848,7 +2848,7 @@ class RouteCardDataTest {
                     stopId = stop2.id
                     tripId = deviationOutbound.representativeTripId
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3036,7 +3036,7 @@ class RouteCardDataTest {
                     stopId = stop2.id
                     tripId = trip4.id
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3139,7 +3139,7 @@ class RouteCardDataTest {
                     stopId = stop1.id
                     tripId = deviationOutbound.representativeTripId
                 }
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3340,8 +3340,8 @@ class RouteCardDataTest {
                     departureTime = time + 121.minutes
                 }
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-            val lineOrRoute3 = RouteCardData.LineOrRoute.Route(route3)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute3 = LineOrRoute.Route(route3)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3470,7 +3470,7 @@ class RouteCardDataTest {
         val context = RouteCardData.Context.NearbyTransit
         val time = EasternTimeInstant(2024, Month.FEBRUARY, 22, 12, 8, 19)
 
-        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+        val lineOrRoute1 = LineOrRoute.Route(route1)
         assertEquals(
             listOf(
                 RouteCardData(
@@ -3566,7 +3566,7 @@ class RouteCardDataTest {
                     tripId = deviationInbound.representativeTripId
                 }
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3671,7 +3671,7 @@ class RouteCardDataTest {
                     scheduleRelationship = Prediction.ScheduleRelationship.Cancelled
                 }
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3746,7 +3746,7 @@ class RouteCardDataTest {
                 tripId = pattern1.representativeTripId
             }
 
-        val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
+        val lineOrRoute1 = LineOrRoute.Route(route1)
         assertEquals(
             listOf(
                 RouteCardData(
@@ -3822,7 +3822,7 @@ class RouteCardDataTest {
         val pred1 = objects.prediction(sched1) { departureTime = time + 1.5.minutes }
         val pred2 = objects.prediction(sched2) { departureTime = null }
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+        val lineOrRoute = LineOrRoute.Route(route)
         assertEquals(
             listOf(
                 RouteCardData(
@@ -3901,7 +3901,7 @@ class RouteCardDataTest {
                     status = "foo"
                 }
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3977,7 +3977,7 @@ class RouteCardDataTest {
                     status = "foo"
                 }
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -4069,7 +4069,7 @@ class RouteCardDataTest {
                 departureTime = time - 2.hours
             }
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             val context = RouteCardData.Context.NearbyTransit
             assertEquals(
                 listOf(
@@ -4203,8 +4203,8 @@ class RouteCardDataTest {
             val pred2 = objects.prediction(sched2) { departureTime = time + 2.3.minutes }
             val pred3 = objects.prediction(sched3) { departureTime = time + 3.4.minutes }
 
-            val lineOrRoute1 = RouteCardData.LineOrRoute.Route(route1)
-            val lineOrRoute2 = RouteCardData.LineOrRoute.Route(route2)
+            val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute2 = LineOrRoute.Route(route2)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -4488,7 +4488,7 @@ class RouteCardDataTest {
             )
         val context = RouteCardData.Context.NearbyTransit
 
-        val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB, routeC, routeE))
+        val lineOrRoute = LineOrRoute.Line(line, setOf(routeB, routeC, routeE))
         val expected =
             listOf(
                 RouteCardData(
@@ -4662,7 +4662,7 @@ class RouteCardDataTest {
                 )
             val context = RouteCardData.Context.NearbyTransit
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Line(line, setOf(routeB))
+            val lineOrRoute = LineOrRoute.Line(line, setOf(routeB))
             val expected =
                 listOf(
                     RouteCardData(
@@ -4770,7 +4770,7 @@ class RouteCardDataTest {
                 )
             val context = RouteCardData.Context.NearbyTransit
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route1)
+            val lineOrRoute = LineOrRoute.Route(route1)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -5046,7 +5046,7 @@ class RouteCardDataTest {
         val global = GlobalResponse(objects)
         val context = RouteCardData.Context.NearbyTransit
 
-        val orangeLineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute)
+        val orangeLineOrRoute = LineOrRoute.Route(orangeRoute)
         assertEquals(
             listOf(
                 RouteCardData(
@@ -5199,7 +5199,7 @@ class RouteCardDataTest {
                     departureTime = null
                 }
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(orangeRoute)
+            val lineOrRoute = LineOrRoute.Route(orangeRoute)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -5320,7 +5320,7 @@ class RouteCardDataTest {
                     departureTime = time + 2.minutes
                 }
 
-            val ferryLineOrRoute = RouteCardData.LineOrRoute.Route(ferryRoute)
+            val ferryLineOrRoute = LineOrRoute.Route(ferryRoute)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -5490,7 +5490,7 @@ class RouteCardDataTest {
                     targetStopWithChildren = setOf(park.id),
                     tripsById = global.trips,
                 )
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -5609,7 +5609,7 @@ class RouteCardDataTest {
                     ),
                 )
 
-            val lineOrRoute = RouteCardData.LineOrRoute.Route(route)
+            val lineOrRoute = LineOrRoute.Route(route)
             assertEquals(
                 listOf(
                     RouteCardData(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteDetailsStopListTest.kt
@@ -25,24 +25,18 @@ class RouteDetailsStopListTest {
 
         assertEquals(
             listOf(0),
-            RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Route(route1),
-                    globalData,
-                )
+            RouteDetailsStopList.RouteParameters(LineOrRoute.Route(route1), globalData)
+                .availableDirections,
+        )
+        assertEquals(
+            listOf(0, 1),
+            RouteDetailsStopList.RouteParameters(LineOrRoute.Route(route2), globalData)
                 .availableDirections,
         )
         assertEquals(
             listOf(0, 1),
             RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Route(route2),
-                    globalData,
-                )
-                .availableDirections,
-        )
-        assertEquals(
-            listOf(0, 1),
-            RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+                    LineOrRoute.Line(line, setOf(route1, route2)),
                     globalData,
                 )
                 .availableDirections,
@@ -73,32 +67,20 @@ class RouteDetailsStopListTest {
 
         assertEquals(
             listOf(Direction("East", "Here", 0), Direction("West", "There", 1)),
-            RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Route(route1),
-                    globalData,
-                )
-                .directions,
+            RouteDetailsStopList.RouteParameters(LineOrRoute.Route(route1), globalData).directions,
         )
         assertEquals(
             listOf(Direction("East", "Here", 0), Direction("West", "Elsewhere", 1)),
-            RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Route(route2),
-                    globalData,
-                )
-                .directions,
+            RouteDetailsStopList.RouteParameters(LineOrRoute.Route(route2), globalData).directions,
         )
         assertEquals(
             listOf(Direction("North", "Somewhere", 0), Direction("South", "Wherever", 1)),
-            RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Route(route3),
-                    globalData,
-                )
-                .directions,
+            RouteDetailsStopList.RouteParameters(LineOrRoute.Route(route3), globalData).directions,
         )
         assertEquals(
             listOf(Direction("East", "Here", 0), Direction("West", null, 1)),
             RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+                    LineOrRoute.Line(line, setOf(route1, route2)),
                     globalData,
                 )
                 .directions,
@@ -106,7 +88,7 @@ class RouteDetailsStopListTest {
         assertEquals(
             listOf(Direction(null, null, 0), Direction(null, null, 1)),
             RouteDetailsStopList.RouteParameters(
-                    RouteCardData.LineOrRoute.Line(line, setOf(route1, route2, route3)),
+                    LineOrRoute.Line(line, setOf(route1, route2, route3)),
                     globalData,
                 )
                 .directions,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.model.RouteCardData.LineOrRoute
 import com.mbta.tid.mbta_app.model.RoutePattern.PatternsForStop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.test.Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
@@ -3,9 +3,9 @@ package com.mbta.tid.mbta_app.model.response
 import com.mbta.tid.mbta_app.map.MapTestDataHelper.global
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.GlobalMapData
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
@@ -464,9 +464,9 @@ class GlobalResponseTest {
         // Test data does not include mattapan trolley or blue line
         assertEquals(
             listOf(
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Red")),
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Orange")),
-                RouteCardData.LineOrRoute.Line(
+                LineOrRoute.Route(objects.getRoute("Red")),
+                LineOrRoute.Route(objects.getRoute("Orange")),
+                LineOrRoute.Line(
                     objects.getLine("line-Green"),
                     setOf(
                         objects.getRoute("Green-B"),
@@ -552,10 +552,7 @@ class GlobalResponseTest {
         val allPatternsForStop = global.getPatternsFor("place-haecl")
         assertTrue(allPatternsForStop.map { it.routeId }.any { it != "Orange" })
         val orangePatterns =
-            global.getPatternsFor(
-                "place-haecl",
-                RouteCardData.LineOrRoute.Route(objects.getRoute("Orange")),
-            )
+            global.getPatternsFor("place-haecl", LineOrRoute.Route(objects.getRoute("Orange")))
         assertFalse(orangePatterns.map { it.routeId }.any { it != "Orange" })
     }
 
@@ -568,7 +565,7 @@ class GlobalResponseTest {
         val greenPatterns =
             global.getPatternsFor(
                 "place-haecl",
-                RouteCardData.LineOrRoute.Line(
+                LineOrRoute.Line(
                     objects.getLine("line-Green"),
                     setOf(
                         objects.getRoute("Green-B"),
@@ -591,9 +588,9 @@ class GlobalResponseTest {
 
         val globalData = GlobalResponse(objects)
 
-        assertEquals(RouteCardData.LineOrRoute.Route(route1), globalData.getLineOrRoute(route1.id))
-        assertEquals(RouteCardData.LineOrRoute.Route(route2), globalData.getLineOrRoute(route2.id))
-        assertEquals(RouteCardData.LineOrRoute.Route(route3), globalData.getLineOrRoute(route3.id))
+        assertEquals(LineOrRoute.Route(route1), globalData.getLineOrRoute(route1.id))
+        assertEquals(LineOrRoute.Route(route2), globalData.getLineOrRoute(route2.id))
+        assertEquals(LineOrRoute.Route(route3), globalData.getLineOrRoute(route3.id))
     }
 
     @Test
@@ -612,7 +609,7 @@ class GlobalResponseTest {
         val globalData = GlobalResponse(objects)
 
         assertEquals(
-            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            LineOrRoute.Line(line, setOf(route1, route2)),
             globalData.getLineOrRoute(line.id),
         )
     }
@@ -627,11 +624,11 @@ class GlobalResponseTest {
         val globalData = GlobalResponse(objects)
 
         assertEquals(
-            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            LineOrRoute.Line(line, setOf(route1, route2)),
             globalData.getLineOrRoute(route1.id),
         )
         assertEquals(
-            RouteCardData.LineOrRoute.Line(line, setOf(route1, route2)),
+            LineOrRoute.Line(line, setOf(route1, route2)),
             globalData.getLineOrRoute(route2.id),
         )
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Favorites
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -242,14 +243,14 @@ internal class FavoritesViewModelTest : KoinTest {
         val expectedStaticData =
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route1),
+                    LineOrRoute.Route(route1),
                     listOf(
                         RouteCardData.RouteStopData(
                             route1,
                             stop1,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route1),
+                                    LineOrRoute.Route(route1),
                                     stop1,
                                     directionId = 0,
                                     listOf(patterns.getValue(route1).getValue(0)),
@@ -268,14 +269,14 @@ internal class FavoritesViewModelTest : KoinTest {
                     now,
                 ),
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route2),
+                    LineOrRoute.Route(route2),
                     listOf(
                         RouteCardData.RouteStopData(
                             route2,
                             stop2,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route2),
+                                    LineOrRoute.Route(route2),
                                     stop2,
                                     directionId = 1,
                                     listOf(patterns.getValue(route2).getValue(1)),
@@ -297,14 +298,14 @@ internal class FavoritesViewModelTest : KoinTest {
         val expectedRealtimeData =
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route1),
+                    LineOrRoute.Route(route1),
                     listOf(
                         RouteCardData.RouteStopData(
                             route1,
                             stop1,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route1),
+                                    LineOrRoute.Route(route1),
                                     stop1,
                                     directionId = 0,
                                     listOf(patterns.getValue(route1).getValue(0)),
@@ -331,14 +332,14 @@ internal class FavoritesViewModelTest : KoinTest {
                     now,
                 ),
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route2),
+                    LineOrRoute.Route(route2),
                     listOf(
                         RouteCardData.RouteStopData(
                             route2,
                             stop2,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route2),
+                                    LineOrRoute.Route(route2),
                                     stop2,
                                     directionId = 1,
                                     listOf(patterns.getValue(route2).getValue(1)),
@@ -424,14 +425,14 @@ internal class FavoritesViewModelTest : KoinTest {
         val expectedStaticDataBefore =
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route1),
+                    LineOrRoute.Route(route1),
                     listOf(
                         RouteCardData.RouteStopData(
                             route1,
                             stop1,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route1),
+                                    LineOrRoute.Route(route1),
                                     stop1,
                                     0,
                                     listOf(patterns.getValue(route1).getValue(0)),
@@ -453,14 +454,14 @@ internal class FavoritesViewModelTest : KoinTest {
         val expectedStaticDataAfter =
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route2),
+                    LineOrRoute.Route(route2),
                     listOf(
                         RouteCardData.RouteStopData(
                             route2,
                             stop2,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route2),
+                                    LineOrRoute.Route(route2),
                                     stop2,
                                     1,
                                     listOf(patterns.getValue(route2).getValue(1)),
@@ -546,14 +547,14 @@ internal class FavoritesViewModelTest : KoinTest {
         val expectedStaticDataBefore =
             listOf(
                 RouteCardData(
-                    RouteCardData.LineOrRoute.Route(route1),
+                    LineOrRoute.Route(route1),
                     listOf(
                         RouteCardData.RouteStopData(
                             route1,
                             stop1,
                             listOf(
                                 RouteCardData.Leaf(
-                                    RouteCardData.LineOrRoute.Route(route1),
+                                    LineOrRoute.Route(route1),
                                     stop1,
                                     0,
                                     listOf(patterns.getValue(route1).getValue(0)),
@@ -830,7 +831,7 @@ internal class FavoritesViewModelTest : KoinTest {
                 stop1,
                 listOf(
                     RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route1),
+                        LineOrRoute.Route(route1),
                         stop1,
                         0,
                         listOf(patterns.getValue(route1).getValue(0)),
@@ -852,7 +853,7 @@ internal class FavoritesViewModelTest : KoinTest {
                 stop2,
                 listOf(
                     RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route2),
+                        LineOrRoute.Route(route2),
                         stop2,
                         1,
                         listOf(patterns.getValue(route2).getValue(1)),
@@ -874,7 +875,7 @@ internal class FavoritesViewModelTest : KoinTest {
                 stop3,
                 listOf(
                     RouteCardData.Leaf(
-                        RouteCardData.LineOrRoute.Route(route2),
+                        LineOrRoute.Route(route2),
                         stop3,
                         1,
                         listOf(patterns.getValue(route2).getValue(1)),
@@ -889,15 +890,10 @@ internal class FavoritesViewModelTest : KoinTest {
                 ),
                 globalData,
             )
-        val routeCard1Data =
-            RouteCardData(RouteCardData.LineOrRoute.Route(route1), listOf(stop1Data), now)
+        val routeCard1Data = RouteCardData(LineOrRoute.Route(route1), listOf(stop1Data), now)
 
         val routeCard2Data =
-            RouteCardData(
-                RouteCardData.LineOrRoute.Route(route2),
-                listOf(stop3Data, stop2Data),
-                now,
-            )
+            RouteCardData(LineOrRoute.Route(route2), listOf(stop3Data, stop2Data), now)
 
         val expectedStaticDataBefore = listOf(routeCard2Data, routeCard1Data)
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, but prep for [Better types for route vs line IDs in page filters](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1211441999289923?focus=true)

This just moves the `LineOrRoute` class out into its own class, since there's no good reason it should live in `RouteCardData` when we now use it in a lot of different places unrelated to the route cards.

I thought I was going to do the above ticket before starting [🤖 | Notifications | Make favorites confirmation a sheet](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211291334100677?focus=true) to simplify some of the line or route handling, but after looking a bit closer I don't think it's actually worth doing now. But I got this far, so might as well just put this up now.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Existing tests pass