### PR TITLE
refactor: encapsulate JSON I/O

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,6 +84,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+kotlinx-serialization-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "kotlinxSerialization" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -82,6 +82,7 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serialization.json)
+                implementation(libs.kotlinx.serialization.json.okio)
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.encoding)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.dependencyInjection
 
 import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.fs.JsonPersistence
 import com.mbta.tid.mbta_app.network.MobileBackendClient
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
@@ -46,7 +47,10 @@ import org.koin.dsl.module
 internal fun appModule(appVariant: AppVariant) = module {
     includes(
         module { single { MobileBackendClient(appVariant) } },
-        module { single { FileSystem.SYSTEM } },
+        module {
+            single { FileSystem.SYSTEM }
+            single { JsonPersistence(get(), get(), get(named("coroutineDispatcherIO"))) }
+        },
         module {
             single<CoroutineDispatcher>(named("coroutineDispatcherDefault")) { Dispatchers.Default }
         },

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/fs/JsonPersistence.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/fs/JsonPersistence.kt
@@ -1,0 +1,81 @@
+package com.mbta.tid.mbta_app.fs
+
+import com.mbta.tid.mbta_app.json
+import com.mbta.tid.mbta_app.utils.SystemPaths
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.json.okio.decodeFromBufferedSource
+import kotlinx.serialization.json.okio.encodeToBufferedSink
+import kotlinx.serialization.serializer
+import okio.BufferedSink
+import okio.FileSystem
+import okio.Path
+import org.koin.core.component.KoinComponent
+
+@OptIn(ExperimentalSerializationApi::class)
+internal class JsonPersistence(
+    private val fileSystem: FileSystem,
+    private val systemPaths: SystemPaths,
+    private val ioDispatcher: CoroutineDispatcher,
+) : KoinComponent {
+    private fun dir(category: SystemPaths.Category, group: String?): Path {
+        val categoryDir = systemPaths[category]
+        return if (group != null) categoryDir / group else categoryDir
+    }
+
+    suspend fun write(category: SystemPaths.Category, group: String?, name: String, data: String) =
+        write(category, group, name) { writeUtf8(data) }
+
+    suspend inline fun <reified T> write(
+        category: SystemPaths.Category,
+        group: String?,
+        name: String,
+        data: T,
+    ) = write(category, group, name) { json.encodeToBufferedSink(data, this) }
+
+    suspend fun <T> write(
+        category: SystemPaths.Category,
+        group: String?,
+        name: String,
+        serializer: SerializationStrategy<T>,
+        data: T,
+    ) = write(category, group, name) { json.encodeToBufferedSink(serializer, data, this) }
+
+    private suspend fun write(
+        category: SystemPaths.Category,
+        group: String?,
+        name: String,
+        writerAction: BufferedSink.() -> Unit,
+    ) =
+        withContext(ioDispatcher) {
+            val dir = dir(category, group)
+            fileSystem.createDirectories(dir)
+            val path = dir / "$name.json"
+            fileSystem.write(path, writerAction = writerAction)
+        }
+
+    suspend inline fun <reified T> read(
+        category: SystemPaths.Category,
+        group: String?,
+        name: String,
+    ): T? = read(category, group, name, json.serializersModule.serializer<T>())
+
+    suspend fun <T> read(
+        category: SystemPaths.Category,
+        group: String?,
+        name: String,
+        deserializer: DeserializationStrategy<T>,
+    ): T? =
+        withContext(ioDispatcher) {
+            val dir = dir(category, group)
+            val path = dir / "$name.json"
+            try {
+                fileSystem.read(path) { json.decodeFromBufferedSource(deserializer, this) }
+            } catch (_: Exception) {
+                null
+            }
+        }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SystemPaths.kt
@@ -6,8 +6,22 @@ import okio.Path.Companion.toPath
 internal interface SystemPaths {
     val data: Path
     val cache: Path
+
+    enum class Category {
+        Data,
+        Cache,
+    }
+
+    operator fun get(category: Category): Path =
+        when (category) {
+            Category.Data -> data
+            Category.Cache -> cache
+        }
 }
 
 internal class MockSystemPaths(override val data: Path, override val cache: Path) : SystemPaths {
-    constructor(data: String, cache: String) : this(data.toPath(), cache.toPath())
+    constructor(
+        data: String = "data",
+        cache: String = "cache",
+    ) : this(data.toPath(), cache.toPath())
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/fs/JsonPersistenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/fs/JsonPersistenceTest.kt
@@ -1,0 +1,59 @@
+package com.mbta.tid.mbta_app.fs
+
+import com.mbta.tid.mbta_app.utils.MockSystemPaths
+import com.mbta.tid.mbta_app.utils.SystemPaths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import okio.fakefilesystem.FakeFileSystem
+
+class JsonPersistenceTest {
+    @Test
+    fun `can write text`() = runBlocking {
+        val fs = FakeFileSystem()
+        val paths = MockSystemPaths()
+        val json = JsonPersistence(fs, paths, Dispatchers.IO)
+        json.write(SystemPaths.Category.Data, "foo", "bar", "baz")
+        assertEquals("baz", fs.read(paths.data / "foo" / "bar.json") { readUtf8() })
+    }
+
+    @Test
+    fun `can write JSON`() = runBlocking {
+        val fs = FakeFileSystem()
+        val paths = MockSystemPaths()
+        val json = JsonPersistence(fs, paths, Dispatchers.IO)
+        json.write(
+            SystemPaths.Category.Data,
+            group = null,
+            "test",
+            buildJsonArray {
+                add(false)
+                add(true)
+                add(false)
+            },
+        )
+        assertEquals("[false,true,false]", fs.read(paths.data / "test.json") { readUtf8() })
+    }
+
+    @Test
+    fun `can read JSON`() = runBlocking {
+        val fs = FakeFileSystem()
+        val paths = MockSystemPaths()
+        fs.createDirectories(paths.data)
+        fs.write(paths.data / "test.json") { writeUtf8("[false,true,false]") }
+        val json = JsonPersistence(fs, paths, Dispatchers.IO)
+        assertEquals(
+            buildJsonArray {
+                add(false)
+                add(true)
+                add(false)
+            },
+            json.read<JsonArray>(SystemPaths.Category.Data, group = null, "test"),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/mocks/MockJsonPersistence.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/mocks/MockJsonPersistence.kt
@@ -1,0 +1,10 @@
+package com.mbta.tid.mbta_app.mocks
+
+import com.mbta.tid.mbta_app.fs.JsonPersistence
+import com.mbta.tid.mbta_app.utils.MockSystemPaths
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import okio.fakefilesystem.FakeFileSystem
+
+internal fun mockJsonPersistence() =
+    JsonPersistence(FakeFileSystem(), MockSystemPaths(), Dispatchers.IO)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.mocks.mockJsonPersistence
 import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LocationType
@@ -12,8 +13,6 @@ import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
-import com.mbta.tid.mbta_app.utils.MockSystemPaths
-import com.mbta.tid.mbta_app.utils.SystemPaths
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -25,8 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
-import okio.FileSystem
-import okio.fakefilesystem.FakeFileSystem
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
@@ -142,8 +139,7 @@ class GlobalRepositoryTest : KoinTest {
             modules(
                 module {
                     single { MobileBackendClient(mockEngine, AppVariant.Staging) }
-                    single<SystemPaths> { MockSystemPaths(data = "data", cache = "cache") }
-                    single<FileSystem> { FakeFileSystem() }
+                    single { mockJsonPersistence() }
                 }
             )
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/RailRouteShapeRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.AppVariant
+import com.mbta.tid.mbta_app.mocks.mockJsonPersistence
 import com.mbta.tid.mbta_app.model.RoutePatternKey
 import com.mbta.tid.mbta_app.model.RouteSegment
 import com.mbta.tid.mbta_app.model.SegmentedRouteShape
@@ -8,8 +9,6 @@ import com.mbta.tid.mbta_app.model.Shape
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
-import com.mbta.tid.mbta_app.utils.MockSystemPaths
-import com.mbta.tid.mbta_app.utils.SystemPaths
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -21,8 +20,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.runBlocking
-import okio.FileSystem
-import okio.fakefilesystem.FakeFileSystem
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
@@ -137,8 +134,7 @@ class RailRouteShapeRepositoryTest : KoinTest {
             modules(
                 module {
                     single { MobileBackendClient(mockEngine, AppVariant.Staging) }
-                    single<SystemPaths> { MockSystemPaths(data = "data", cache = "cache") }
-                    single<FileSystem> { FakeFileSystem() }
+                    single { mockJsonPersistence() }
                 }
             )
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Notifications | persist notification windows](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211295242617965?focus=true)

This will simplify moving the favorites storage from preferences to a dedicated JSON file.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the existing tests pass. Added new tests for the new abstraction.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
