### PR TITLE
feat: store favorites in a separate JSON file

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepository.kt
@@ -2,11 +2,12 @@ package com.mbta.tid.mbta_app.repositories
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.fs.JsonPersistence
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.Favorites
+import com.mbta.tid.mbta_app.utils.SystemPaths
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import org.koin.core.component.KoinComponent
@@ -22,22 +23,34 @@ internal class FavoritesRepository : IFavoritesRepository, KoinComponent {
 
     private val dataStore: DataStore<Preferences> by inject()
 
+    private val jsonPersistence: JsonPersistence by inject()
+
     private val favoritesKey = stringPreferencesKey("favorites")
 
-    override suspend fun getFavorites(): Favorites {
+    private suspend fun getPreferencesFavorites(): Favorites? {
         val encoded = dataStore.data.map { it[favoritesKey] }.first()
         if (encoded.isNullOrBlank()) {
             return Favorites()
         }
         return try {
             json.decodeFromString(encoded)
-        } catch (e: Exception) {
-            Favorites()
+        } catch (_: Exception) {
+            null
         }
     }
 
+    override suspend fun getFavorites(): Favorites {
+        val favorites =
+            jsonPersistence.read<Favorites>(SystemPaths.Category.Data, null, favoritesKey.name)
+        if (favorites != null) return favorites
+        val preferencesFavorites = getPreferencesFavorites()
+        if (preferencesFavorites == null) return Favorites()
+        setFavorites(preferencesFavorites)
+        return preferencesFavorites
+    }
+
     override suspend fun setFavorites(favorites: Favorites) {
-        dataStore.edit { it[favoritesKey] = json.encodeToString(favorites) }
+        jsonPersistence.write(SystemPaths.Category.Data, null, favoritesKey.name, favorites)
     }
 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/FavoritesRepositoryTest.kt
@@ -1,0 +1,152 @@
+package com.mbta.tid.mbta_app.repositories
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.preferencesOf
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.mbta.tid.mbta_app.json
+import com.mbta.tid.mbta_app.mocks.MockDatastoreStorage
+import com.mbta.tid.mbta_app.mocks.mockJsonPersistence
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.utils.SystemPaths
+import com.mbta.tid.mbta_app.utils.buildFavorites
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalTime
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.putJsonArray
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+class FavoritesRepositoryTest {
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `migrates preferences to JSON file`() = runBlocking {
+        val favorites = buildFavorites {
+            routeStopDirection("route1", "stop1", 0) {
+                notifications {
+                    enabled = true
+                    window(LocalTime(8, 0), LocalTime(9, 0), setOf(DayOfWeek.FRIDAY))
+                }
+            }
+            routeStopDirection("route2", "stop2", 1)
+        }
+        val storage = MockDatastoreStorage()
+        storage.preferences =
+            preferencesOf(stringPreferencesKey("favorites") to json.encodeToString(favorites))
+        val dataStore = DataStoreFactory.create(storage)
+        val jsonPersistence = mockJsonPersistence()
+        startKoin {
+            modules(
+                module {
+                    single<DataStore<Preferences>> { dataStore }
+                    single { jsonPersistence }
+                }
+            )
+        }
+        val repo = FavoritesRepository()
+
+        assertEquals(favorites, repo.getFavorites())
+        assertEquals(
+            favorites,
+            jsonPersistence.read(SystemPaths.Category.Data, group = null, "favorites"),
+        )
+    }
+
+    @Test
+    fun `loads pre-notifications favorites from preferences`() = runBlocking {
+        val rsd1 = RouteStopDirection("route1", "stop1", 0)
+        val rsd2 = RouteStopDirection("route2", "stop2", 1)
+
+        val storage = MockDatastoreStorage()
+        storage.preferences =
+            preferencesOf(
+                stringPreferencesKey("favorites") to
+                    json.encodeToString(
+                        buildJsonObject {
+                            putJsonArray("routeStopDirection") {
+                                add(json.encodeToJsonElement(rsd1))
+                                add(json.encodeToJsonElement(rsd2))
+                            }
+                        }
+                    )
+            )
+
+        val dataStore = DataStoreFactory.create(storage)
+        val jsonPersistence = mockJsonPersistence()
+        startKoin {
+            modules(
+                module {
+                    single<DataStore<Preferences>> { dataStore }
+                    single { jsonPersistence }
+                }
+            )
+        }
+        val repo = FavoritesRepository()
+
+        assertEquals(
+            buildFavorites {
+                routeStopDirection(rsd1)
+                routeStopDirection(rsd2)
+            },
+            repo.getFavorites(),
+        )
+    }
+
+    @Test
+    fun `loads from JSON file`() = runBlocking {
+        val favorites = buildFavorites {
+            routeStopDirection("route1", "stop1", 0) {
+                notifications {
+                    enabled = true
+                    window(LocalTime(8, 0), LocalTime(9, 0), setOf(DayOfWeek.FRIDAY))
+                }
+            }
+            routeStopDirection("route2", "stop2", 1)
+        }
+        val jsonPersistence = mockJsonPersistence()
+        jsonPersistence.write(SystemPaths.Category.Data, group = null, "favorites", favorites)
+        startKoin { modules(module { single { jsonPersistence } }) }
+        val repo = FavoritesRepository()
+        assertEquals(favorites, repo.getFavorites())
+    }
+
+    @Test
+    fun `saves updated favorites`() = runBlocking {
+        val jsonPersistence = mockJsonPersistence()
+        startKoin {
+            modules(
+                module {
+                    single { DataStoreFactory.create(MockDatastoreStorage()) }
+                    single { jsonPersistence }
+                }
+            )
+        }
+        val repo = FavoritesRepository()
+        val favorites = buildFavorites {
+            routeStopDirection("route1", "stop1", 0) {
+                notifications {
+                    enabled = true
+                    window(LocalTime(8, 0), LocalTime(9, 0), setOf(DayOfWeek.FRIDAY))
+                }
+            }
+            routeStopDirection("route2", "stop2", 1)
+        }
+        repo.setFavorites(favorites)
+        assertEquals(favorites, repo.getFavorites())
+        assertEquals(
+            favorites,
+            jsonPersistence.read(SystemPaths.Category.Data, group = null, "favorites"),
+        )
+    }
+}


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Notifications | persist notification windows](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211295242617965?focus=true)

Nice and self-contained.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added new tests for the migration logic.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
