### PR TITLE
feat: "Trip Complete" card on trip details

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -45,7 +45,11 @@ class TripDetailsViewTest {
     val routePattern = objects.routePattern(route)
     val stop = objects.stop()
     val trip = objects.trip(routePattern)
-    val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.InTransitTo }
+    val vehicle =
+        objects.vehicle {
+            currentStatus = Vehicle.CurrentStatus.InTransitTo
+            tripId = trip.id
+        }
     val stopSequence = 10
 
     val downstreamStopSequence = 20
@@ -212,6 +216,7 @@ class TripDetailsViewTest {
             TripDetails(
                 trip = trip,
                 headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                tripData = tripData,
                 onHeaderTap = null,
                 onOpenAlertDetails = {},
                 onFollowTrip = { onFollowCalled = true },
@@ -240,6 +245,7 @@ class TripDetailsViewTest {
             TripDetails(
                 trip = trip,
                 headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                tripData = tripData,
                 onHeaderTap = null,
                 onOpenAlertDetails = {},
                 onFollowTrip = {},
@@ -268,6 +274,47 @@ class TripDetailsViewTest {
             TripDetails(
                 trip = trip,
                 headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                tripData = tripData,
+                onHeaderTap = null,
+                onOpenAlertDetails = {},
+                onFollowTrip = {},
+                onTapStop = {},
+                route = route,
+                tripFilter = tripFilter,
+                stopList = TripDetailsStopList(trip, emptyList()),
+                now = now,
+                isTripDetailsPage = true,
+                alertSummaries = emptyMap(),
+                globalResponse = GlobalResponse(objects),
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Follow").assertDoesNotExist()
+    }
+
+    @Test
+    fun testDisplaysTripCompleteCard() {
+        loadKoinMocks(objects) {
+            settings = MockSettingsRepository(mapOf(Settings.TrackThisTrip to true))
+        }
+
+        composeTestRule.setContent {
+            TripDetails(
+                trip = trip,
+                headerSpec = TripHeaderSpec.VehicleOnTrip(vehicle, stop, null, false),
+                tripData =
+                    TripData(
+                        tripFilter,
+                        trip,
+                        TripSchedulesResponse.Schedules(listOf(schedule)),
+                        PredictionsStreamDataResponse(objects),
+                        true,
+                        objects.vehicle {
+                            currentStatus = Vehicle.CurrentStatus.InTransitTo
+                            tripId = "other trip"
+                        },
+                    ),
                 onHeaderTap = null,
                 onOpenAlertDetails = {},
                 onFollowTrip = {},

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/tripDetails/TripCompleteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/tripDetails/TripCompleteCard.kt
@@ -1,0 +1,79 @@
+package com.mbta.tid.mbta_app.android.tripDetails
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.routeIcon
+import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
+import com.mbta.tid.mbta_app.android.util.typeText
+import com.mbta.tid.mbta_app.utils.TestData
+
+@Composable
+fun TripCompleteCard(routeAccents: TripRouteAccents, modifier: Modifier = Modifier) {
+    val iconSize = 48.dp
+
+    Column(
+        modifier = modifier.haloContainer(2.dp).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        horizontalAlignment = Alignment.Start,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier.size(iconSize).clip(CircleShape).background(routeAccents.color),
+                Alignment.Center,
+            ) {
+                val (painter, contentDescription) = routeIcon(routeAccents.type)
+                Icon(
+                    painter = painter,
+                    contentDescription = contentDescription,
+                    modifier = Modifier.size(iconSize),
+                    tint = routeAccents.textColor,
+                )
+            }
+            Text(
+                stringResource(R.string.trip_complete),
+                Modifier.weight(1f),
+                style = Typography.title2Bold,
+            )
+        }
+
+        HorizontalDivider(color = routeAccents.color.copy(alpha = 0.25f), thickness = 2.dp)
+        val vehicleType = routeAccents.type.typeText(LocalContext.current, true)
+        Text(stringResource(R.string.trip_complete_body, vehicleType), style = Typography.callout)
+    }
+}
+
+@Composable
+@Preview
+fun TripCompleteCardPreview() {
+    val testData = TestData.clone()
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        TripCompleteCard(TripRouteAccents(testData.getRoute("Red")))
+        TripCompleteCard(TripRouteAccents(testData.getRoute("Green-C")))
+        TripCompleteCard(TripRouteAccents(testData.getRoute("742")))
+        TripCompleteCard(TripRouteAccents(testData.getRoute("15")))
+        TripCompleteCard(TripRouteAccents(testData.getRoute("CR-Lowell")))
+    }
+}

--- a/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+es/strings_ios_converted.xml
@@ -387,6 +387,8 @@
     <string name="trains">trenes</string>
     <string name="trip_cancelled">Viaje cancelado</string>
     <string name="trip_cancelled_details">Este viaje ha sido cancelado. Lamentamos las molestias.</string>
+    <string name="trip_complete">Viaje completo</string>
+    <string name="trip_complete_body">Este %1$s ha llegado a su destino.</string>
     <string name="try_a_different_spelling_or_name">Pruebe con una ortografía o un nombre diferentes.</string>
     <string name="try_your_search_again">Busque de nuevo.</string>
     <string name="unable_to_connect">No se puede conectar</string>

--- a/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+fr/strings_ios_converted.xml
@@ -387,6 +387,8 @@
     <string name="trains">trains</string>
     <string name="trip_cancelled">Trajet annulé</string>
     <string name="trip_cancelled_details">Ce voyage a été annulé. Nous sommes désolés pour la gêne occasionnée.</string>
+    <string name="trip_complete">Voyage terminé</string>
+    <string name="trip_complete_body">Ce %1$s a atteint sa destination.</string>
     <string name="try_a_different_spelling_or_name">Essayez avec une autre orthographe ou un autre nom.</string>
     <string name="try_your_search_again">Réessayez votre recherche.</string>
     <string name="unable_to_connect">Impossible de se connecter</string>

--- a/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+ht/strings_ios_converted.xml
@@ -399,6 +399,8 @@
     <string name="trains">tren yo</string>
     <string name="trip_cancelled">Vwayaj la anile</string>
     <string name="trip_cancelled_details">Vwayaj sa a anile. Nou regrèt deranjman an.</string>
+    <string name="trip_complete">Vwayaj konplè</string>
+    <string name="trip_complete_body">%1$s sa a rive nan destinasyon li.</string>
     <string name="try_a_different_spelling_or_name">Eseye yon diferan òtograf oswa non.</string>
     <string name="try_your_search_again">Eseye rechèch ou a ankò.</string>
     <string name="unable_to_connect">Pa ka konekte</string>

--- a/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+pt+BR/strings_ios_converted.xml
@@ -387,6 +387,8 @@
     <string name="trains">trens</string>
     <string name="trip_cancelled">Viagem cancelada</string>
     <string name="trip_cancelled_details">Esta viagem foi cancelada. Lamentamos o inconveniente.</string>
+    <string name="trip_complete">Viagem concluída</string>
+    <string name="trip_complete_body">Este %1$s chegou ao seu destino.</string>
     <string name="try_a_different_spelling_or_name">Tente uma ortografia ou nome diferente.</string>
     <string name="try_your_search_again">Tente pesquisar novamente.</string>
     <string name="unable_to_connect">Impossível conectar</string>

--- a/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+vi/strings_ios_converted.xml
@@ -379,6 +379,8 @@
     <string name="trains">tàu</string>
     <string name="trip_cancelled">Chuyến đi đã bị hủy</string>
     <string name="trip_cancelled_details">Chuyến đi này đã bị hủy. Chúng tôi xin lỗi vì sự bất tiện này.</string>
+    <string name="trip_complete">Chuyến đi hoàn tất</string>
+    <string name="trip_complete_body">%1$s này đã đến đích.</string>
     <string name="try_a_different_spelling_or_name">Thử cách viết hoặc tên khác.</string>
     <string name="try_your_search_again">Thử tìm kiếm lại.</string>
     <string name="unable_to_connect">Không thể kết nối</string>

--- a/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hans+CN/strings_ios_converted.xml
@@ -379,6 +379,8 @@
     <string name="trains">列车</string>
     <string name="trip_cancelled">行程已取消</string>
     <string name="trip_cancelled_details">此行程已取消。我们对此造成的不便深表歉意。</string>
+    <string name="trip_complete">行程完成</string>
+    <string name="trip_complete_body">此 %1$s 已到达目的地。</string>
     <string name="try_a_different_spelling_or_name">尝试不同的拼写或名称。</string>
     <string name="try_your_search_again">再次尝试搜索。</string>
     <string name="unable_to_connect">无法连接</string>

--- a/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-b+zh+Hant+TW/strings_ios_converted.xml
@@ -379,6 +379,8 @@
     <string name="trains">列車</string>
     <string name="trip_cancelled">行程已取消</string>
     <string name="trip_cancelled_details">本行程已取消。對於造成您的不便，我們深表歉意。</string>
+    <string name="trip_complete">行程完成</string>
+    <string name="trip_complete_body">此 %1$s 已到達目的地。</string>
     <string name="try_a_different_spelling_or_name">嘗試不同的拼字或名稱。</string>
     <string name="try_your_search_again">再次嘗試搜尋。</string>
     <string name="unable_to_connect">無法連接</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="trains">trains</string>
     <string name="trip_cancelled">Trip cancelled</string>
     <string name="trip_cancelled_details">This trip has been cancelled. We’re sorry for the inconvenience.</string>
+    <string name="trip_complete">Trip complete</string>
+    <string name="trip_complete_body">This %1$s has reached its destination.</string>
     <string name="try_a_different_spelling_or_name">Try a different spelling or name.</string>
     <string name="try_your_search_again">Try your search again.</string>
     <string name="unable_to_connect">Unable to connect</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -19118,50 +19118,49 @@
         }
       }
     },
-    "This %1$@ has reached its destination." : {
-      "comment" : "Body text of a card on trip details telling the user that the vehicle they were following has completed its trip. Interpolated value can be \"bus\", \"train\", or \"ferry\"",
-      "extractionState" : "manual",
+    "This %@ has reached its destination." : {
+      "comment" : "Body text of a card on trip details telling the user that the vehicle they were following has completed its trip. Interpolated value can be \"bus\", \"train\", or \"ferry\".",
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Este %1$@ ha llegado a su destino."
+            "value" : "Este %@ ha llegado a su destino."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Ce %1$@ a atteint sa destination."
+            "value" : "Ce %@ a atteint sa destination."
           }
         },
         "ht" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "%1$@ sa a rive nan destinasyon li."
+            "value" : "%@ sa a rive nan destinasyon li."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Este %1$@ chegou ao seu destino."
+            "value" : "Este %@ chegou ao seu destino."
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "%1$@ này đã đến đích."
+            "value" : "%@ này đã đến đích."
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "此 %1$@ 已到达目的地。"
+            "value" : "此 %@ 已到达目的地。"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "此 %1$@ 已到達目的地。"
+            "value" : "此 %@ 已到達目的地。"
           }
         }
       }
@@ -20310,7 +20309,6 @@
     },
     "Trip complete" : {
       "comment" : "Header of a card on trip details telling the user that the vehicle they were following has completed its trip",
-      "extractionState" : "manual",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -19118,6 +19118,54 @@
         }
       }
     },
+    "This %1$@ has reached its destination." : {
+      "comment" : "Body text of a card on trip details telling the user that the vehicle they were following has completed its trip. Interpolated value can be \"bus\", \"train\", or \"ferry\"",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este %1$@ ha llegado a su destino."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ce %1$@ a atteint sa destination."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ sa a rive nan destinasyon li."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este %1$@ chegou ao seu destino."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ này đã đến đích."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此 %1$@ 已到达目的地。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "此 %1$@ 已到達目的地。"
+          }
+        }
+      }
+    },
     "This stop has %ld elevators closed" : {
       "comment" : "Describe an elevator outage at the stop in the list of all stops on the trip",
       "localizations" : {
@@ -20256,6 +20304,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "行程已取消"
+          }
+        }
+      }
+    },
+    "Trip complete" : {
+      "comment" : "Header of a card on trip details telling the user that the vehicle they were following has completed its trip",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Viaje completo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Voyage terminé"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Vwayaj konplè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Viagem concluída"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Chuyến đi hoàn tất"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行程完成"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "行程完成"
           }
         }
       }

--- a/iosApp/iosApp/Pages/TripDetails/TripCompleteCard.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripCompleteCard.swift
@@ -1,0 +1,54 @@
+//
+//  TripCompleteCard.swift
+//  iosApp
+//
+//  Created by esimon on 2025-09-29.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct TripCompleteCard: View {
+    let routeAccents: TripRouteAccents
+
+    @ScaledMetric var iconSize = 48
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 16) {
+                ZStack(alignment: .center) {
+                    Circle()
+                        .fill(routeAccents.color)
+                        .frame(width: iconSize, height: iconSize, alignment: .center)
+                    routeIcon(routeAccents.type)
+                        .resizable()
+                        .scaledToFit()
+                        .foregroundStyle(routeAccents.textColor)
+                        .frame(width: iconSize, height: iconSize, alignment: .center)
+                }
+                Text("Trip complete")
+                    .font(Typography.title2Bold)
+                    .multilineTextAlignment(.leading)
+            }
+            routeAccents.color.opacity(0.25).frame(height: 2)
+            Text("This \(routeAccents.type.typeText(isOnly: true)) has reached its destination.")
+                .font(Typography.callout)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background(Color.fill3)
+        .withRoundedBorder(width: 2)
+    }
+}
+
+#Preview {
+    let data = TestData.clone()
+    VStack(spacing: 16) {
+        TripCompleteCard(routeAccents: .init(route: data.getRoute(id: "Red")))
+        TripCompleteCard(routeAccents: .init(route: data.getRoute(id: "Green-C")))
+        TripCompleteCard(routeAccents: .init(route: data.getRoute(id: "742")))
+        TripCompleteCard(routeAccents: .init(route: data.getRoute(id: "15")))
+        TripCompleteCard(routeAccents: .init(route: data.getRoute(id: "CR-Lowell")))
+    }.padding(16).background(Color.fill2)
+}

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -520,4 +520,85 @@ final class TripDetailsViewTests: XCTestCase {
         ViewHosting.host(view: sut.withFixedSettings([.trackThisTrip: true]))
         wait(for: [exp], timeout: 1)
     }
+
+    @MainActor
+    func testDisplaysTripCompleteCard() throws {
+        let now = EasternTimeInstant.now()
+        let objects = ObjectCollectionBuilder()
+        let route = objects.route { _ in }
+        let pattern = objects.routePattern(route: route) { _ in }
+        let trip = objects.trip(routePattern: pattern)
+        let targetStop = objects.stop { _ in }
+        let vehicleStop = objects.stop { _ in }
+        let vehicle = objects.vehicle { vehicle in
+            vehicle.tripId = "different trip"
+            vehicle.routeId = route.id
+            vehicle.currentStatus = .inTransitTo
+            vehicle.stopId = vehicleStop.id
+        }
+
+        let schedule = objects.schedule { schedule in
+            schedule.routeId = route.id
+            schedule.stopId = targetStop.id
+            schedule.trip = trip
+        }
+        let prediction = objects.prediction(schedule: schedule) { prediction in
+            prediction.departureTime = now.plus(seconds: 5)
+            prediction.vehicleId = vehicle.id
+        }
+
+        loadKoinMocks(objects: objects)
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(objects: objects)
+
+        let tripFilter = TripDetailsPageFilter(
+            tripId: trip.id,
+            vehicleId: vehicle.id,
+            routeId: route.id,
+            directionId: 0,
+            stopId: targetStop.id,
+            stopSequence: nil
+        )
+        let tripDetailsVM = MockTripDetailsViewModel(initialState: .init(
+            tripData: .init(
+                tripFilter: tripFilter,
+                trip: trip,
+                tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
+                tripPredictions: .init(objects: objects),
+                tripPredictionsLoaded: true,
+                vehicle: vehicle
+            ),
+            stopList: .init(trip: trip, stops: [.init(
+                stop: targetStop,
+                stopSequence: 0,
+                disruption: nil,
+                schedule: schedule,
+                prediction: prediction,
+                predictionStop: targetStop,
+                vehicle: vehicle,
+                routes: [route]
+            )]),
+            context: .stopDetails,
+            awaitingPredictionsAfterBackground: false
+        ))
+
+        var sut = TripDetailsView(
+            tripFilter: tripFilter,
+            alertSummaries: [:],
+            isTripDetailsPage: true,
+            now: now,
+            onOpenAlertDetails: { _ in },
+            errorBannerVM: MockErrorBannerViewModel(),
+            nearbyVM: nearbyVM,
+            mapVM: MockMapViewModel(),
+            tripDetailsVM: tripDetailsVM,
+        )
+
+        let exp = sut.on(\.didLoadData) { view in
+            XCTAssertNotNil(try view.find(text: "Trip complete"))
+        }
+        ViewHosting.host(view: sut.withFixedSettings([.trackThisTrip: true]))
+        wait(for: [exp], timeout: 1)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -105,8 +105,8 @@ internal fun getTripData(
     vehicle =
         subscribeToVehicle(
             tripFilter?.vehicleId,
-            active,
             errorKey,
+            active,
             errorBannerRepository,
             vehicleRepository,
         )
@@ -122,11 +122,14 @@ internal fun getTripData(
         }
     }
 
-    LaunchedEffect(trip, tripSchedules, tripPredictions, vehicle, context) {
+    LaunchedEffect(tripFilter, trip, tripSchedules, tripPredictions, vehicle, context) {
         val resolvedTrip = trip
         result =
             if (
-                tripFilter != null && resolvedTrip != null && resolvedTrip.id == tripFilter.tripId
+                tripFilter != null &&
+                    resolvedTrip != null &&
+                    resolvedTrip.id == tripFilter.tripId &&
+                    (tripFilter.vehicleId == null || vehicle != null)
             ) {
                 TripData(tripFilter, resolvedTrip, tripSchedules, tripPredictions, true, vehicle)
             } else {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -16,8 +16,8 @@ import org.koin.compose.koinInject
 @Composable
 internal fun subscribeToVehicle(
     vehicleId: String?,
-    active: Boolean,
     errorKey: String,
+    active: Boolean,
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
 ): Vehicle? {


### PR DESCRIPTION
### Summary

_Ticket:_ [[QA & release track this trip]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211412336640357?focus=true)

When a trip finishes, show a card saying that the trip is done, rather than getting into a weird "completing another trip" route ladder state.

<img width="250" height="544" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-30 at 14 43 43" src="https://github.com/user-attachments/assets/b315eac9-d58c-4867-bb5b-f96e9bb716cb" /> <img width="250" height="500" alt="Screenshot_20250930_143958" src="https://github.com/user-attachments/assets/b1d91c54-654c-4a19-b86a-f3868bdfbb8d" />


iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests on both platforms