### PR TITLE
fix(iOS): Track this trip iOS QA

### DIFF
--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -174,7 +174,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                                     HStack {}
                                         .accessibilityLabel(Text("This stop is not accessible"))
                                 }
-                            }.padding(.trailing, 8)
+                            }.padding(.trailing, 6)
                             if let connectingRoutes, !connectingRoutes.isEmpty {
                                 scrollRoutes
                                     .accessibilityElement()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -261,12 +261,14 @@ public class MapViewModel(
                 }
                 is Event.MapStyleLoaded -> {
                     layerManager?.run {
-                        addLayers(
-                            allRailRouteShapes ?: return@run,
-                            stopLayerGeneratorState,
-                            globalData ?: return@run,
-                            if (isDarkMode) ColorPalette.dark else ColorPalette.light,
-                        )
+                        val state = stopLayerGeneratorState
+                        val globalResponse = globalData ?: return@run
+                        val colorPalette = if (isDarkMode) ColorPalette.dark else ColorPalette.light
+                        routeShapes?.let { addLayers(it, state, globalResponse, colorPalette) }
+                            ?: allRailRouteShapes?.let {
+                                addLayers(it, state, globalResponse, colorPalette)
+                            }
+                            ?: return@run
                         resetPuckPosition()
                     }
                 }


### PR DESCRIPTION
### Summary

_Ticket:_ [[QA & release track this trip]](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211412336640357?focus=true)

Address the actionable changes from iOS QA.
* Minor padding tweak on trip details stop rows
* Address an issue caused by `MapStyleLoaded` being called more frequently by mapbox on iOS, it was always using the set of rail routes even when called on trip or stop details where it should have a more specific filtered list

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified that the padding was correct by measuring screenshots, and that the selected route exclusively stays visible on trip details