### PR TITLE
refactor: split test data into methods by object type

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/TestData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/TestData.kt
@@ -22,7 +22,15 @@ import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
  */
 public val TestData: ObjectCollectionBuilder by lazy {
     val objects = ObjectCollectionBuilder()
+    putLines(objects)
+    putRoutes(objects)
+    putRoutePatterns(objects)
+    putStops(objects)
+    putTrips(objects)
+    objects
+}
 
+private fun putLines(objects: ObjectCollectionBuilder) {
     objects.put(
         Line(
             id = "line-Green",
@@ -43,7 +51,9 @@ public val TestData: ObjectCollectionBuilder by lazy {
             textColor = "FFFFFF",
         )
     )
+}
 
+private fun putRoutes(objects: ObjectCollectionBuilder) {
     objects.put(
         Route(
             id = "Red",
@@ -334,7 +344,9 @@ public val TestData: ObjectCollectionBuilder by lazy {
             routePatternIds = null,
         )
     )
+}
 
+private fun putRoutePatterns(objects: ObjectCollectionBuilder) {
     objects.put(
         RoutePattern(
             id = "Red-3-0",
@@ -797,7 +809,9 @@ public val TestData: ObjectCollectionBuilder by lazy {
             routeId = "87",
         )
     )
+}
 
+private fun putStops(objects: ObjectCollectionBuilder) {
     objects.put(
         Stop(
             id = "121",
@@ -9408,7 +9422,9 @@ public val TestData: ObjectCollectionBuilder by lazy {
             wheelchairBoarding = WheelchairBoardingStatus.INACCESSIBLE,
         )
     )
+}
 
+private fun putTrips(objects: ObjectCollectionBuilder) {
     objects.put(
         Trip(
             id = "68166605",
@@ -10601,6 +10617,4 @@ public val TestData: ObjectCollectionBuilder by lazy {
                 ),
         )
     )
-
-    objects
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Notifications | Sheet favorite section UX changes](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1211291334100672?focus=true), tangentially

I tried to add all Orange Line stops to the test data, but then the Android Studio previews were failing because the method that builds the test data was too large.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the shared tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
