### PR TITLE
fix(iOS): correctly add/remove favorites in new format

### DIFF
--- a/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
+++ b/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
@@ -24,7 +24,7 @@ struct SaveFavoritesFlow: View {
     let context: SaveFavoritesContext
     let global: GlobalResponse?
     let isFavorite: (RouteStopDirection) -> Bool
-    let updateFavorites: ([RouteStopDirection: Bool]) -> Void
+    let updateFavorites: ([RouteStopDirection: FavoriteSettings?]) -> Void
     let onClose: () -> Void
     let toastVM: IToastViewModel
 
@@ -43,7 +43,7 @@ struct SaveFavoritesFlow: View {
         lineOrRoute: LineOrRoute, stop: Stop, directions: [Direction], selectedDirection: Int32,
         context: SaveFavoritesContext, global: GlobalResponse?,
         isFavorite: @escaping (RouteStopDirection) -> Bool,
-        updateFavorites: @escaping ([RouteStopDirection: Bool]) -> Void,
+        updateFavorites: @escaping ([RouteStopDirection: FavoriteSettings?]) -> Void,
         onClose: @escaping () -> Void,
         toastVM: IToastViewModel = ViewModelDI().toast
     ) {
@@ -59,9 +59,9 @@ struct SaveFavoritesFlow: View {
         self.toastVM = toastVM
     }
 
-    func proposedFavorites() -> [Int32: Bool] {
+    func proposedFavorites() -> [Int32: FavoriteSettings?] {
         directions
-            .reduce(into: [Int32: Bool]()) { acc, direction in
+            .reduce(into: [Int32: FavoriteSettings?]()) { acc, direction in
                 // if selectedDirection and already a favorite, then removing favorite.
                 // if this is not the selected direction and already a favorite, then keep it.
                 let isFavorite = ((direction.id == selectedDirection) !=
@@ -72,14 +72,14 @@ struct SaveFavoritesFlow: View {
                     ))) ||
                     // If the only direction is the opposite one, mark it as favorite whether or not it already is
                     (directions.count == 1 && direction.id != selectedDirection)
-                acc[direction.id] = isFavorite
+                acc[direction.id] = isFavorite ? .init() : nil
             }
     }
 
-    func updateAndToast(_ update: [RouteStopDirection: Bool]) {
+    func updateAndToast(_ update: [RouteStopDirection: FavoriteSettings?]) {
         updateFavorites(update)
 
-        let favorited = update.filter(\.value)
+        let favorited = update.filter { $0.value != nil }
         let firstFavorite = favorited.first
         let labels = firstFavorite?.key.getLabels(global)
         var toastText: String? = nil
@@ -140,7 +140,7 @@ struct SaveFavoritesFlow: View {
                 VStack {}
                     .onAppear {
                         let rsd = RouteStopDirection(route: lineOrRoute.id, stop: stop.id, direction: selectedDirection)
-                        updateAndToast([rsd: !isFavorite(rsd)])
+                        updateAndToast([rsd: isFavorite(rsd) ? nil : .init()])
 
                         onClose()
                     }
@@ -165,19 +165,18 @@ struct FavoriteConfirmationDialog: View {
     let directions: [Direction]
     let selectedDirection: Int32
     let context: SaveFavoritesContext
-    let proposedFavorites: [Int32: Bool]
-    let updateFavorites: ([RouteStopDirection: Bool]) -> Void
+    let proposedFavorites: [Int32: FavoriteSettings?]
+    let updateFavorites: ([RouteStopDirection: FavoriteSettings?]) -> Void
     let onClose: () -> Void
 
     @State var showDialog = false
-    @State var favoritesToSave: [Direction: Bool] = [:]
+    @State var favoritesToSave: [Direction: FavoriteSettings?] = [:]
 
     var body: some View {
         VStack {}
             .onAppear {
-                favoritesToSave = directions.reduce(into: [Direction: Bool]()) { acc, direction in
-                    acc[direction] = proposedFavorites[direction.id] ?? false
-                }
+                favoritesToSave = Dictionary(uniqueKeysWithValues: directions
+                    .map { ($0, proposedFavorites[$0.id] ?? nil) })
                 showDialog = true
             }
             .customAlert(
@@ -223,8 +222,8 @@ struct FavoriteConfirmationDialogContents: View {
     let directions: [Direction]
     let selectedDirection: Int32
     let context: SaveFavoritesContext
-    let favoritesToSave: [Direction: Bool]
-    let updateLocalFavorite: (Direction, Bool) -> Void
+    let favoritesToSave: [Direction: FavoriteSettings?]
+    let updateLocalFavorite: (Direction, FavoriteSettings?) -> Void
 
     var body: some View {
         let headerText = if context == SaveFavoritesContext.favorites {
@@ -272,8 +271,8 @@ struct FavoriteConfirmationDialogContents: View {
 
 struct DirectionButtons: View {
     let lineOrRoute: LineOrRoute
-    let favorites: [Direction: Bool]
-    let updateLocalFavorite: (Direction, Bool) -> Void
+    let favorites: [Direction: FavoriteSettings?]
+    let updateLocalFavorite: (Direction, FavoriteSettings?) -> Void
 
     /**
      Convenience struct to support iterating through the map of favoritesToSave entries via `ForEach`.
@@ -281,12 +280,12 @@ struct DirectionButtons: View {
      */
     struct DirectionFavorite: Hashable {
         let direction: Direction
-        let isFavorite: Bool
+        let settings: FavoriteSettings?
     }
 
     var directionValues: [DirectionFavorite] {
         favorites
-            .map { DirectionFavorite(direction: $0.key, isFavorite: $0.value) }
+            .map { DirectionFavorite(direction: $0.key, settings: $0.value) }
             .sorted(by: { $0.direction.id < $1.direction.id })
     }
 
@@ -299,14 +298,17 @@ struct DirectionButtons: View {
                 id: \.element.direction
             ) { index, directionValue in
                 Button(action: {
-                    updateLocalFavorite(directionValue.direction, !directionValue.isFavorite)
+                    updateLocalFavorite(directionValue.direction, directionValue.settings != nil ? nil : .init())
                 }) {
                     VStack(spacing: 0) {
                         HStack(spacing: 0) {
                             DirectionLabel(direction: directionValue.direction)
                                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                             Spacer()
-                            StarIcon(starred: directionValue.isFavorite, color: .init(hex: lineOrRoute.backgroundColor))
+                            StarIcon(
+                                starred: directionValue.settings != nil,
+                                color: .init(hex: lineOrRoute.backgroundColor)
+                            )
                         }
                         .fixedSize(horizontal: false, vertical: true)
                         .padding(.horizontal, 16)
@@ -316,7 +318,7 @@ struct DirectionButtons: View {
                         }
                     }
                 }
-                .accessibilityAddTraits(directionValue.isFavorite ? [.isSelected] : [])
+                .accessibilityAddTraits(directionValue.settings != nil ? [.isSelected] : [])
                 .fullFocusSize()
                 .background(Color.fill3)
             }
@@ -329,8 +331,8 @@ struct DirectionButtons: View {
 struct FavoriteConfirmationDialogActions: View {
     let lineOrRoute: LineOrRoute
     let stop: Stop
-    let favoritesToSave: [Direction: Bool]
-    let updateFavorites: ([RouteStopDirection: Bool]) -> Void
+    let favoritesToSave: [Direction: FavoriteSettings?]
+    let updateFavorites: ([RouteStopDirection: FavoriteSettings?]) -> Void
     let onClose: () -> Void
 
     var body: some View {
@@ -342,7 +344,7 @@ struct FavoriteConfirmationDialogActions: View {
 
         Button {
             updateFavorites(favoritesToSave
-                .reduce(into: [RouteStopDirection: Bool]()) { partialResult, entry in
+                .reduce(into: [RouteStopDirection: FavoriteSettings?]()) { partialResult, entry in
                     partialResult[RouteStopDirection(
                         route: lineOrRoute.id,
                         stop: stop.id,
@@ -352,6 +354,6 @@ struct FavoriteConfirmationDialogActions: View {
             onClose()
         } label: {
             Text("Add")
-        }.disabled(favoritesToSave.values.allSatisfy { $0 == false })
+        }.disabled(favoritesToSave.values.allSatisfy { $0 == nil })
     }
 }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -470,7 +470,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
         )
     }
 
-    private func confirmFavorites(updatedValues: [RouteStopDirection: Bool]) {
+    private func confirmFavorites(updatedValues: [RouteStopDirection: FavoriteSettings?]) {
         Task {
             let editContext = switch onEnum(of: context) {
             case .favorites: EditFavoritesContext.favorites
@@ -478,7 +478,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
             }
 
             try? await favoritesUsecases.updateRouteStopDirections(
-                newValues: updatedValues.mapValues { KotlinBoolean(bool: $0) },
+                newValues: updatedValues,
                 context: editContext, defaultDirection: selectedDirection
             )
             loadFavorites()

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -145,7 +145,7 @@ struct StopDetailsFilteredView: View {
                     updateFavorites: { updatedValues in
                         Task {
                             try? await favoritesUsecases.updateRouteStopDirections(
-                                newValues: updatedValues.mapValues { KotlinBoolean(bool: $0) },
+                                newValues: updatedValues,
                                 context: .stopDetails, defaultDirection: routeStopDirection.direction
                             )
                             onUpdateFavorites()

--- a/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
@@ -1,0 +1,23 @@
+//
+//  FavoritesUsecasesExtension.swift
+//  iosApp
+//
+//  Created by Melody Horn on 10/2/25.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+
+extension FavoritesUsecases {
+    func updateRouteStopDirections(
+        newValues: [RouteStopDirection: FavoriteSettings?],
+        context: EditFavoritesContext,
+        defaultDirection: Int32,
+    ) async throws {
+        try await __updateRouteStopDirections(
+            newValues: newValues as [RouteStopDirection: Any],
+            context: context,
+            defaultDirection: defaultDirection
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
@@ -4,6 +4,8 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.ShouldRefineInSwift
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +25,8 @@ public class FavoritesUsecases(
         return storedFavorites.routeStopDirection
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @ShouldRefineInSwift
     public suspend fun updateRouteStopDirections(
         newValues: Map<RouteStopDirection, FavoriteSettings?>,
         context: EditFavoritesContext,


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C05QMG9GS9M/p1759327107052499)

I hate Objective-C.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that this fix works and that the iOS tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
