### PR TITLE
fix(ios.NotificationsSettingsWidget): Prevent 0 minute window

### DIFF
--- a/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
@@ -165,20 +165,14 @@ struct NotificationSettingsWidget: View {
                         minimumTime: nil
                     )
                     .onChange(of: window.startTime) { startTime in
-                        if startTime.hour! > window.endTime.hour! ||
-                            (startTime.hour! == window.endTime.hour! && startTime.minute! > window.endTime.minute!) {
-                            if startTime.hour! < 23 {
-                                window.endTime = .init(hour: startTime.hour! + 1, minute: startTime.minute!, second: 0)
-                            } else {
-                                window.endTime = .init(hour: 23, minute: 59, second: 0)
-                            }
-                        }
+                        window.setSafeEndTime(startTime: startTime)
+                        print("SAFE END TIME \(window.endTime)")
                     }
                     HaloSeparator()
                     LabeledTimeInput(
                         label: Text("To"),
                         time: $window.endTime,
-                        minimumTime: window.startTime
+                        minimumTime: .init(hour: window.startTime.hour, minute: (window.startTime.minute ?? 0) + 1)
                     )
                     DaysOfWeekInput(daysOfWeek: $window.daysOfWeek)
                 }

--- a/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
@@ -166,7 +166,6 @@ struct NotificationSettingsWidget: View {
                     )
                     .onChange(of: window.startTime) { startTime in
                         window.setSafeEndTime(startTime: startTime)
-                        print("SAFE END TIME \(window.endTime)")
                     }
                     HaloSeparator()
                     LabeledTimeInput(

--- a/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
@@ -171,7 +171,7 @@ struct NotificationSettingsWidget: View {
                     LabeledTimeInput(
                         label: Text("To"),
                         time: $window.endTime,
-                        minimumTime: .init(hour: window.startTime.hour, minute: (window.startTime.minute ?? 0) + 1)
+                        minimumTime: window.minimumEndTime()
                     )
                     DaysOfWeekInput(daysOfWeek: $window.daysOfWeek)
                 }

--- a/iosApp/iosApp/Utils/MutableFavoriteSettings.swift
+++ b/iosApp/iosApp/Utils/MutableFavoriteSettings.swift
@@ -101,11 +101,33 @@ class MutableFavoriteSettings: ObservableObject, Equatable, CustomDebugStringCon
                 )
             }
 
+            /**
+             The earliest possible end time for a given start time - one minute after start.
+             */
+            func minimumEndTime() -> DateComponents {
+                if let startHour = startTime.hour, let startMinute = startTime.minute {
+                    if startHour == 23, startMinute == 59 {
+                        return startTime
+                    }
+
+                    if startMinute < 59 {
+                        return .init(hour: startHour, minute: startMinute + 1, second: 0)
+                    }
+                    return .init(hour: startHour + 1, minute: 0, second: 0)
+                }
+                return .init(hour: 0, minute: 0, second: 0)
+            }
+
+            /**
+             Based on the new startTime, update the end time to be safely after the start.
+             If the new startTime is after endTime, push endTime to one hour after the start.
+             */
             func setSafeEndTime(startTime: DateComponents) {
-                if startTime.hour! > endTime.hour! ||
-                    (startTime.hour! == endTime.hour! && startTime.minute! >= endTime.minute!) {
-                    if startTime.hour! < 23 {
-                        endTime = .init(hour: startTime.hour! + 1, minute: startTime.minute!, second: 0)
+                if let startHour = startTime.hour, let endHour = endTime.hour,
+                   let startMinute = startTime.minute, let endMinute = endTime.minute, startHour > endHour
+                   || (startHour == endHour && startMinute >= endMinute) {
+                    if startHour < 23 {
+                        endTime = .init(hour: startHour + 1, minute: startMinute, second: 0)
                     } else {
                         endTime = .init(hour: 23, minute: 59, second: 0)
                     }

--- a/iosApp/iosApp/Utils/MutableFavoriteSettings.swift
+++ b/iosApp/iosApp/Utils/MutableFavoriteSettings.swift
@@ -101,6 +101,17 @@ class MutableFavoriteSettings: ObservableObject, Equatable, CustomDebugStringCon
                 )
             }
 
+            func setSafeEndTime(startTime: DateComponents) {
+                if startTime.hour! > endTime.hour! ||
+                    (startTime.hour! == endTime.hour! && startTime.minute! >= endTime.minute!) {
+                    if startTime.hour! < 23 {
+                        endTime = .init(hour: startTime.hour! + 1, minute: startTime.minute!, second: 0)
+                    } else {
+                        endTime = .init(hour: 23, minute: 59, second: 0)
+                    }
+                }
+            }
+
             var debugDescription: String {
                 "Window(startTime: \(startTime), endTime: \(endTime), daysOfWeek: \(daysOfWeek))"
             }

--- a/iosApp/iosAppTests/Utils/MutableFavoriteSettingsTest.swift
+++ b/iosApp/iosAppTests/Utils/MutableFavoriteSettingsTest.swift
@@ -1,0 +1,69 @@
+//
+//  MutableFavoriteSettingsTest.swift
+//  iosApp
+//
+//  Created by Kayla Brady on 4/8/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+@testable import iosApp
+import Shared
+import XCTest
+
+final class MutableFavoriteSettingsTest: XCTestCase {
+    func testWindowEndUnchangedWhenStillAfterStart() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
+        let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        window.setSafeEndTime(startTime: .init(hour: 0, minute: 5, second: 6))
+
+        XCTAssertEqual(window.endTime, initialEnd)
+    }
+
+    func testWindowPushedBackWhenBeforeNewStart() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
+        let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        window.setSafeEndTime(startTime: .init(hour: 4, minute: 5, second: 6))
+
+        XCTAssertEqual(window.endTime, .init(hour: 5, minute: 5, second: 0))
+    }
+
+    func testWindowPushedHourBackWhenEqualsNewStart() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
+        let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        window.setSafeEndTime(startTime: initialEnd)
+
+        XCTAssertEqual(window.endTime, .init(hour: 3, minute: 3, second: 0))
+    }
+
+    func testWindowPushedBackToEoDWhenEqualsNewStart() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
+        let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        window.setSafeEndTime(startTime: .init(hour: 23, minute: 0, second: 1))
+
+        XCTAssertEqual(window.endTime, .init(hour: 23, minute: 59, second: 0))
+    }
+}

--- a/iosApp/iosAppTests/Utils/MutableFavoriteSettingsTest.swift
+++ b/iosApp/iosAppTests/Utils/MutableFavoriteSettingsTest.swift
@@ -11,7 +11,7 @@ import Shared
 import XCTest
 
 final class MutableFavoriteSettingsTest: XCTestCase {
-    func testWindowEndUnchangedWhenStillAfterStart() {
+    func testSafeEndWindowEndUnchangedWhenStillAfterStart() {
         let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
         let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
         let window = MutableFavoriteSettings.Notifications.Window(
@@ -25,7 +25,7 @@ final class MutableFavoriteSettingsTest: XCTestCase {
         XCTAssertEqual(window.endTime, initialEnd)
     }
 
-    func testWindowPushedBackWhenBeforeNewStart() {
+    func testSafeEndWindowPushedBackWhenBeforeNewStart() {
         let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
         let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
         let window = MutableFavoriteSettings.Notifications.Window(
@@ -39,7 +39,7 @@ final class MutableFavoriteSettingsTest: XCTestCase {
         XCTAssertEqual(window.endTime, .init(hour: 5, minute: 5, second: 0))
     }
 
-    func testWindowPushedHourBackWhenEqualsNewStart() {
+    func testSafeEndWindowPushedHourBackWhenEqualsNewStart() {
         let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
         let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
         let window = MutableFavoriteSettings.Notifications.Window(
@@ -53,7 +53,7 @@ final class MutableFavoriteSettingsTest: XCTestCase {
         XCTAssertEqual(window.endTime, .init(hour: 3, minute: 3, second: 0))
     }
 
-    func testWindowPushedBackToEoDWhenEqualsNewStart() {
+    func testSafeEndWindowPushedBackToEoDWhenEqualsNewStart() {
         let initialStart: DateComponents = .init(hour: 0, minute: 1, second: 3)
         let initialEnd: DateComponents = .init(hour: 2, minute: 3, second: 4)
         let window = MutableFavoriteSettings.Notifications.Window(
@@ -65,5 +65,41 @@ final class MutableFavoriteSettingsTest: XCTestCase {
         window.setSafeEndTime(startTime: .init(hour: 23, minute: 0, second: 1))
 
         XCTAssertEqual(window.endTime, .init(hour: 23, minute: 59, second: 0))
+    }
+
+    func testMinEndMidHour() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 0, second: 0)
+        let initialEnd: DateComponents = .init(hour: 1, minute: 0, second: 0)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        XCTAssertEqual(window.minimumEndTime(), .init(hour: 0, minute: 1, second: 0))
+    }
+
+    func testMinEndAt59() {
+        let initialStart: DateComponents = .init(hour: 0, minute: 59, second: 0)
+        let initialEnd: DateComponents = .init(hour: 2, minute: 0, second: 0)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        XCTAssertEqual(window.minimumEndTime(), .init(hour: 1, minute: 0, second: 0))
+    }
+
+    func testMinEndAtEOD() {
+        let initialStart: DateComponents = .init(hour: 23, minute: 59, second: 0)
+        let initialEnd: DateComponents = .init(hour: 23, minute: 59, second: 0)
+        let window = MutableFavoriteSettings.Notifications.Window(
+            startTime: initialStart,
+            endTime: initialEnd,
+            daysOfWeek: [.monday]
+        )
+
+        XCTAssertEqual(window.minimumEndTime(), .init(hour: 23, minute: 59, second: 0))
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | iOS - Ensure windows are at least 1 minute long](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213954129675641?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Ensures that start time can't be changed to match end time, and end time can't be changed to match start time.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests
* Ran locally

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
