### PR TITLE
feat(MorePage.SendAppFeedback): Collect user settings

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,8 +50,10 @@ import com.mbta.tid.mbta_app.android.util.key
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.Dependency
 import com.mbta.tid.mbta_app.model.getAllDependencies
+import com.mbta.tid.mbta_app.model.morePage.MoreSection
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.viewModel.MoreViewModel
+import kotlin.collections.orEmpty
 import org.koin.compose.koinInject
 
 @SuppressLint("LocalContextConfigurationRead")
@@ -73,11 +76,17 @@ fun MorePage(bottomBar: @Composable () -> Unit, viewModel: MoreViewModel = koinI
 
     val navController = rememberNavController()
 
-    val sections = remember {
-        viewModel.getSections(translation, BuildConfig.VERSION_NAME) {
+    val settings = SettingsCache.getNullable()
+
+    fun getSections(): List<MoreSection> {
+        return viewModel.getSections(translation, BuildConfig.VERSION_NAME, settings.orEmpty()) {
             navController.navigate("licenses")
         }
     }
+    var sections = remember { getSections() }
+
+    LaunchedEffect(settings) { sections = getSections() }
+
     val dependencies = Dependency.getAllDependencies()
     var showingBuildNumber by remember { mutableStateOf(false) }
     val notificationsEnabled = SettingsCache.get(Settings.Notifications)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SettingsCache.kt
@@ -51,6 +51,19 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
      */
     @Composable
     fun getNullable(setting: Settings): Boolean? {
+        val cachedData = getNullable()
+        return cachedData?.get(setting)
+    }
+
+    /**
+     * Retrieves the value of all [Settings], updating automatically when this cache is updated, and
+     * loading in the background if the cache is empty.
+     *
+     * Will not automatically see changes made directly to the [settingsRepository]; make sure all
+     * changes are made via [set].
+     */
+    @Composable
+    fun getNullable(): Map<Settings, Boolean>? {
         val cachedData by cache.collectAsState()
 
         LaunchedEffect(cachedData == null) {
@@ -59,7 +72,7 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
             }
         }
 
-        return cachedData?.get(setting)
+        return cachedData
     }
 
     companion object {
@@ -72,5 +85,11 @@ class SettingsCache(private val settingsRepository: ISettingsRepository) : KoinC
          */
         @Composable
         fun getNullable(setting: Settings) = koinInject<SettingsCache>().getNullable(setting)
+
+        /**
+         * Gets the value of all settings from the current Koin context’s [SettingsCache]. Returns
+         * null if not yet loaded
+         */
+        @Composable fun getNullable() = koinInject<SettingsCache>().getNullable()
     }
 }

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -28,6 +28,7 @@ struct MorePage: View {
         viewModel.getSections(
             translation: translation,
             version: version,
+            settings: settingsCache.cache?.mapValues { KotlinBoolean(bool: $0) } ?? [:],
             licensesCallback: {
                 path.append(MoreNavTarget.licenses)
             }

--- a/shared/src/androidUnitTest/kotlin/com/mbta/tid/mbta_app/MoreViewModelTests.kt
+++ b/shared/src/androidUnitTest/kotlin/com/mbta/tid/mbta_app/MoreViewModelTests.kt
@@ -13,7 +13,7 @@ class MoreViewModelTests {
     @Test
     fun testLocalizedFeedbackLink() {
         val vm = MoreViewModel(Dispatchers.Default, MockSubscriptionsRepository())
-        val sections = vm.getSections("es", "1.2.3", {})
+        val sections = vm.getSections("es", "1.2.3", mapOf(), {})
 
         assertEquals(
             "https://mbta.com/androidappfeedback?language=es&version=1.2.3&platform=Android",
@@ -29,7 +29,7 @@ class MoreViewModelTests {
     @Test
     fun testMTicketURL() {
         val vm = MoreViewModel(Dispatchers.Default, MockSubscriptionsRepository())
-        val sections = vm.getSections("", "", {})
+        val sections = vm.getSections("", "", mapOf(), {})
         assertEquals(
             "https://play.google.com/store/apps/details?id=com.mbta.mobileapp",
             sections

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/morePage/feedbackFormUrl.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model.morePage
 
 import com.mbta.tid.mbta_app.PlatformType
+import com.mbta.tid.mbta_app.repositories.Settings
 import io.ktor.http.URLBuilder
 import io.ktor.util.appendAll
 
@@ -9,6 +10,7 @@ public fun feedbackFormUrl(
     translation: String,
     version: String?,
     platform: PlatformType,
+    settings: Map<Settings, Boolean>,
 ): String {
     val builder = URLBuilder(baseUrl)
     builder.parameters
@@ -25,6 +27,7 @@ public fun feedbackFormUrl(
                 ),
             )
         )
+        .appendAll(settings.entries.associate { it.key.name to it.value.toString() })
         .build()
 
     return builder.build().toString()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
@@ -20,28 +20,19 @@ public class MoreViewModel(
     public fun getSections(
         translation: String,
         version: String?,
+        settings: Map<Settings, Boolean>,
         licensesCallback: () -> Unit,
     ): List<MoreSection> {
         val platform = getPlatform()
-        val feedbackFormUrl =
+        val baseUrl =
             when (platform.type) {
-                PlatformType.iOS ->
-                    feedbackFormUrl(
-                        "https://mbta.com/appfeedback",
-                        translation,
-                        version,
-                        platform.type,
-                    )
-
+                PlatformType.iOS -> "https://mbta.com/appfeedback"
                 PlatformType.Android,
-                PlatformType.JVM ->
-                    feedbackFormUrl(
-                        "https://mbta.com/androidappfeedback",
-                        translation,
-                        version,
-                        platform.type,
-                    )
+                PlatformType.JVM -> "https://mbta.com/androidappfeedback"
             }
+        val feedbackFormUrl =
+            feedbackFormUrl(baseUrl, translation, version, platform.type, settings)
+
         val mTicketURL =
             when (platform.type) {
                 PlatformType.iOS -> "https://apps.apple.com/us/app/mbta-mticket/id560487958"

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/morePage/FeedbackFormUrlTest.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model.morePage
 
 import com.mbta.tid.mbta_app.PlatformType
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -8,8 +9,14 @@ class FeedbackFormUrlTest {
     @Test
     fun testParams() {
         assertEquals(
-            "https://example.com?language=en&version=1.2.3&platform=iOS",
-            feedbackFormUrl("https://example.com", "en", "1.2.3", PlatformType.iOS),
+            "https://example.com?language=en&version=1.2.3&platform=iOS&Notifications=true&HideMaps=false",
+            feedbackFormUrl(
+                "https://example.com",
+                "en",
+                "1.2.3",
+                PlatformType.iOS,
+                mapOf(Settings.Notifications to true, Settings.HideMaps to false),
+            ),
         )
     }
 
@@ -17,7 +24,7 @@ class FeedbackFormUrlTest {
     fun testAndroid() {
         assertEquals(
             "https://example.com?language=es&version=0.0.0&platform=Android",
-            feedbackFormUrl("https://example.com", "es", "0.0.0", PlatformType.Android),
+            feedbackFormUrl("https://example.com", "es", "0.0.0", PlatformType.Android, emptyMap()),
         )
     }
 
@@ -25,7 +32,7 @@ class FeedbackFormUrlTest {
     fun testNullVersion() {
         assertEquals(
             "https://example.com?language=ht&version=null&platform=Android",
-            feedbackFormUrl("https://example.com", "ht", null, PlatformType.JVM),
+            feedbackFormUrl("https://example.com", "ht", null, PlatformType.JVM, emptyMap()),
         )
     }
 }

--- a/shared/src/iosTest/kotlin/com/mbta/tid/mbta_app/MoreViewModelTests.kt
+++ b/shared/src/iosTest/kotlin/com/mbta/tid/mbta_app/MoreViewModelTests.kt
@@ -13,7 +13,7 @@ class MoreViewModelTests {
     @Test
     fun testLocalizedFeedbackLink() {
         val vm = MoreViewModel(Dispatchers.Default, MockSubscriptionsRepository())
-        val sections = vm.getSections("es", "1.2.3", {})
+        val sections = vm.getSections("es", "1.2.3", mapOf(), {})
         assertEquals(
             "https://mbta.com/appfeedback?language=es&version=1.2.3&platform=iOS",
             sections
@@ -28,7 +28,7 @@ class MoreViewModelTests {
     @Test
     fun testMTicketURL() {
         val vm = MoreViewModel(Dispatchers.Default, MockSubscriptionsRepository())
-        val sections = vm.getSections("", "", {})
+        val sections = vm.getSections("", "", mapOf(), {})
         assertEquals(
             "https://apps.apple.com/us/app/mbta-mticket/id560487958",
             sections


### PR DESCRIPTION
### Summary

_Ticket:_ [Collect settings with feedback form submission](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1212696633143161?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
* Records user settings as feedback form url params to add context for understanding feedback

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests
* Ran locally on iOS & android, confirmed in Splunk logs that I see the expected params
<img width="777" height="132" alt="image" src="https://github.com/user-attachments/assets/8c1fcffd-457d-469f-92c5-bb37850808ae" />
<img width="772" height="128" alt="image" src="https://github.com/user-attachments/assets/440d8404-8eac-4d56-9b92-43eeee20d4d9" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
