### PR TITLE
fix(Android): Properly round alert end dates backwards

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -235,7 +235,7 @@ class AlertCardTests {
             }
 
         // Fixed time so we can have a specific day of the week (sat)
-        val endTime = EasternTimeInstant(2025, Month.APRIL, 5, 3, 0)
+        val endTime = EasternTimeInstant(2025, Month.APRIL, 6, 3, 0)
         composeTestRule.setContent {
             AlertCard(
                 alert,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtensionTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtensionTests.kt
@@ -1,0 +1,90 @@
+package com.mbta.tid.mbta_app.android.util
+
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.datetime.Month
+import org.junit.Test
+
+class EasternTimeInstantExtensionTests {
+
+    @Test
+    fun testFormattedTime() {
+        val instant = EasternTimeInstant(2026, Month.APRIL, 9, 23, 30)
+        assertTrue(Regex("11:30\\sPM").matches(instant.formattedTime()))
+    }
+
+    @Test
+    fun testFormattedShortDateShortTime() {
+        val instant = EasternTimeInstant(2026, Month.APRIL, 9, 23, 30)
+        assertTrue(Regex("4/9/26, 11:30\\sPM").matches(instant.formattedShortDateShortTime()))
+    }
+
+    @Test
+    fun testFormattedServiceDay() {
+        val middayInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 11, 27)
+        assertEquals("Sunday", middayInstant.formattedServiceDay())
+
+        val pastMidnightInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 1, 23)
+        assertEquals("Saturday", pastMidnightInstant.formattedServiceDay())
+
+        val serviceThreshold = EasternTimeInstant(2026, Month.JANUARY, 11, 3, 0)
+        assertEquals("Sunday", serviceThreshold.formattedServiceDay())
+        assertEquals(
+            "Saturday",
+            serviceThreshold.formattedServiceDay(EasternTimeInstant.ServiceDateRounding.BACKWARDS),
+        )
+    }
+
+    @Test
+    fun testFormattedServiceDayAndDate() {
+        val middayInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 11, 27)
+        assertEquals("Sunday, Jan 11", middayInstant.formattedServiceDayAndDate())
+
+        val pastMidnightInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 1, 23)
+        assertEquals("Saturday, Jan 10", pastMidnightInstant.formattedServiceDayAndDate())
+
+        val serviceThreshold = EasternTimeInstant(2026, Month.JANUARY, 11, 3, 0)
+        assertEquals("Sunday, Jan 11", serviceThreshold.formattedServiceDayAndDate())
+        assertEquals(
+            "Saturday, Jan 10",
+            serviceThreshold.formattedServiceDayAndDate(
+                EasternTimeInstant.ServiceDateRounding.BACKWARDS
+            ),
+        )
+    }
+
+    @Test
+    fun testFormattedShortServiceDayAndDate() {
+        val middayInstant = EasternTimeInstant(2025, Month.OCTOBER, 4, 4, 12)
+        assertEquals("Sat, Oct 4", middayInstant.formattedShortServiceDayAndDate())
+
+        val pastMidnightInstant = EasternTimeInstant(2025, Month.OCTOBER, 4, 1, 23)
+        assertEquals("Fri, Oct 3", pastMidnightInstant.formattedShortServiceDayAndDate())
+
+        val serviceThreshold = EasternTimeInstant(2025, Month.OCTOBER, 4, 3, 0)
+        assertEquals("Sat, Oct 4", serviceThreshold.formattedShortServiceDayAndDate())
+        assertEquals(
+            "Fri, Oct 3",
+            serviceThreshold.formattedShortServiceDayAndDate(
+                EasternTimeInstant.ServiceDateRounding.BACKWARDS
+            ),
+        )
+    }
+
+    @Test
+    fun testFormattedServiceDate() {
+        val middayInstant = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 20, 20)
+        assertEquals("September 16", middayInstant.formattedServiceDate())
+
+        val pastMidnightInstant = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 2, 20)
+        assertEquals("September 15", pastMidnightInstant.formattedServiceDate())
+
+        val serviceThreshold = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 3, 0)
+        assertEquals("September 16", serviceThreshold.formattedServiceDate())
+        assertEquals(
+            "September 15",
+            serviceThreshold.formattedServiceDate(EasternTimeInstant.ServiceDateRounding.BACKWARDS),
+        )
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertActivePeriodFormatting.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertActivePeriodFormatting.kt
@@ -10,6 +10,7 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.formattedServiceDayAndDate
 import com.mbta.tid.mbta_app.android.util.formattedTime
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
 /**
  * Return a localized string containing the date and time of an alert. This includes special
@@ -36,7 +37,11 @@ private fun format(
                     SpanStyle(fontWeight = FontWeight.Bold),
                 )
 
-    val formattedDate = instant.formattedServiceDayAndDate()
+    val formattedDate =
+        instant.formattedServiceDayAndDate(
+            if (isStart) EasternTimeInstant.ServiceDateRounding.FORWARDS
+            else EasternTimeInstant.ServiceDateRounding.BACKWARDS
+        )
     var formattedTime = instant.formattedTime()
 
     if (isStart && period.fromStartOfService) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
@@ -197,11 +197,8 @@ private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
         val dateFormat =
             if (recurrence.daily) EasternTimeInstant::formattedShortServiceDayAndDate
             else EasternTimeInstant::formattedServiceDate
-        val startDay = recurrence.start.dateFormat()
-        val endDay =
-            recurrence.end
-                .coerceInServiceDay(EasternTimeInstant.ServiceDateRounding.BACKWARDS)
-                .dateFormat()
+        val startDay = recurrence.start.dateFormat(EasternTimeInstant.ServiceDateRounding.FORWARDS)
+        val endDay = recurrence.end.dateFormat(EasternTimeInstant.ServiceDateRounding.BACKWARDS)
         val startTime =
             if (recurrence.fromStartOfService) stringResource(R.string.start_of_service)
             else recurrence.start.formattedTime()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtension.kt
@@ -54,24 +54,32 @@ fun EasternTimeInstant.formattedShortDateShortTime(): String =
     this.formatWith(formatShortDateShortTime)
 
 /** Converts the [EasternTimeInstant] to its service day and formats it in the form of "Monday" */
-fun EasternTimeInstant.formattedServiceDay(): String =
-    this.coerceInServiceDay().formatWith(formatWeekday)
+fun EasternTimeInstant.formattedServiceDay(
+    rounding: EasternTimeInstant.ServiceDateRounding =
+        EasternTimeInstant.ServiceDateRounding.FORWARDS
+): String = this.coerceInServiceDay(rounding).formatWith(formatWeekday)
 
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "Monday, Jan
  * 1"
  */
-fun EasternTimeInstant.formattedServiceDayAndDate(): String =
-    this.coerceInServiceDay().formatWith(formatWeekdayAndDate)
+fun EasternTimeInstant.formattedServiceDayAndDate(
+    rounding: EasternTimeInstant.ServiceDateRounding =
+        EasternTimeInstant.ServiceDateRounding.FORWARDS
+): String = this.coerceInServiceDay(rounding).formatWith(formatWeekdayAndDate)
 
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "Mon, Jan 1"
  */
-fun EasternTimeInstant.formattedShortServiceDayAndDate(): String =
-    this.coerceInServiceDay().formatWith(formatShortWeekdayAndDate)
+fun EasternTimeInstant.formattedShortServiceDayAndDate(
+    rounding: EasternTimeInstant.ServiceDateRounding =
+        EasternTimeInstant.ServiceDateRounding.FORWARDS
+): String = this.coerceInServiceDay(rounding).formatWith(formatShortWeekdayAndDate)
 
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "January 1"
  */
-fun EasternTimeInstant.formattedServiceDate(): String =
-    this.coerceInServiceDay().formatWith(formatMonthDay)
+fun EasternTimeInstant.formattedServiceDate(
+    rounding: EasternTimeInstant.ServiceDateRounding =
+        EasternTimeInstant.ServiceDateRounding.FORWARDS
+): String = this.coerceInServiceDay(rounding).formatWith(formatMonthDay)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtension.kt
@@ -53,7 +53,13 @@ fun EasternTimeInstant.formattedTime(): String = this.formatWith(formatHourMinut
 fun EasternTimeInstant.formattedShortDateShortTime(): String =
     this.formatWith(formatShortDateShortTime)
 
-/** Converts the [EasternTimeInstant] to its service day and formats it in the form of "Monday" */
+/**
+ * Converts the [EasternTimeInstant] to its service day and formats it in the form of "Monday"
+ *
+ * @param rounding If the instant is exactly on the service date threshold (3:00AM), this will
+ *   determine which date is returned. Backwards will return the prior service day and forwards will
+ *   return the upcoming service day.
+ */
 fun EasternTimeInstant.formattedServiceDay(
     rounding: EasternTimeInstant.ServiceDateRounding =
         EasternTimeInstant.ServiceDateRounding.FORWARDS
@@ -62,6 +68,10 @@ fun EasternTimeInstant.formattedServiceDay(
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "Monday, Jan
  * 1"
+ *
+ * @param rounding If the instant is exactly on the service date threshold (3:00AM), this will
+ *   determine which date is returned. Backwards will return the prior service day and forwards will
+ *   return the upcoming service day.
  */
 fun EasternTimeInstant.formattedServiceDayAndDate(
     rounding: EasternTimeInstant.ServiceDateRounding =
@@ -70,6 +80,10 @@ fun EasternTimeInstant.formattedServiceDayAndDate(
 
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "Mon, Jan 1"
+ *
+ * @param rounding If the instant is exactly on the service date threshold (3:00AM), this will
+ *   determine which date is returned. Backwards will return the prior service day and forwards will
+ *   return the upcoming service day.
  */
 fun EasternTimeInstant.formattedShortServiceDayAndDate(
     rounding: EasternTimeInstant.ServiceDateRounding =
@@ -78,6 +92,10 @@ fun EasternTimeInstant.formattedShortServiceDayAndDate(
 
 /**
  * Converts the [EasternTimeInstant] to its service day and formats it in the form of "January 1"
+ *
+ * @param rounding If the instant is exactly on the service date threshold (3:00AM), this will
+ *   determine which date is returned. Backwards will return the prior service day and forwards will
+ *   return the upcoming service day.
  */
 fun EasternTimeInstant.formattedServiceDate(
     rounding: EasternTimeInstant.ServiceDateRounding =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
 import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
 data class FormattedAlert(
     val alert: Alert?,
@@ -499,12 +500,16 @@ data class FormattedAlert(
                 is AlertSummary.Timeframe.LaterDate ->
                     resources.getString(
                         R.string.alert_summary_timeframe_later_date,
-                        timeframe.time.formattedServiceDate(),
+                        timeframe.time.formattedServiceDate(
+                            EasternTimeInstant.ServiceDateRounding.BACKWARDS
+                        ),
                     )
                 is AlertSummary.Timeframe.ThisWeek ->
                     resources.getString(
                         R.string.alert_summary_timeframe_this_week,
-                        timeframe.time.formattedServiceDay(),
+                        timeframe.time.formattedServiceDay(
+                            EasternTimeInstant.ServiceDateRounding.BACKWARDS
+                        ),
                     )
                 is AlertSummary.Timeframe.Time ->
                     resources.getString(
@@ -638,12 +643,16 @@ data class FormattedAlert(
                 is AlertSummary.Timeframe.ThisWeek ->
                     resources.getString(
                         R.string.alert_summary_recurrence_end_day_this_week,
-                        endDay.time.formattedServiceDay(),
+                        endDay.time.formattedServiceDay(
+                            EasternTimeInstant.ServiceDateRounding.BACKWARDS
+                        ),
                     )
                 is AlertSummary.Timeframe.LaterDate ->
                     resources.getString(
                         R.string.alert_summary_recurrence_end_day_later_date,
-                        endDay.time.formattedServiceDate(),
+                        endDay.time.formattedServiceDate(
+                            EasternTimeInstant.ServiceDateRounding.BACKWARDS
+                        ),
                     )
                 AlertSummary.Timeframe.Unknown -> ""
             }

--- a/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertActivePeriodFormattingExtension.swift
@@ -35,8 +35,7 @@ extension Shared.Alert.ActivePeriod {
                 "end of service",
                 comment: "Used when an alert ends at the end of a service day"
             )
-            let previousDate = instant.minus(hours: 24)
-            formattedDate = previousDate.formatted(dateFormat)
+            formattedDate = instant.coerceInServiceDay(rounding: .backwards).formatted(dateFormat)
         } else if !isStart, endingLaterToday {
             formattedTime = NSLocalizedString(
                 "later today",


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | Android - end date should use service day, not calendar day](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131234?focus=true)

Alert end dates with a service day end time should always be rounded backwards rather than forwards. It seems like this has been an issue basically forever, I'm a little surprised we haven't caught it before now.

I also checked on all the equivalent calls on iOS and they seem to be properly rounding to the previous day for all end dates, but I did update one spot to use the shared `coerceInServiceDay` helper rather than subtracting 24 hours on its own.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Update a test that wasn't properly setting the end of service, all other existing tests still pass, manually checked that the alert end date shows up properly