### PR TITLE
fix(iOS): Bold recurring date range

### DIFF
--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -100,9 +100,9 @@ struct AlertDetails: View {
                     time: .shortened
                 )
             let dateRange = if recurrence.endDayKnown {
-                Text("\(startDay) – \(endDay)")
+                Text("\(startDay) – \(endDay)").font(Typography.bodySemibold)
             } else {
-                Text("Until further notice")
+                Text("Until further notice").font(Typography.bodySemibold)
             }
             if recurrence.daily {
                 Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 14) {


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | iOS - Alert Details styling](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131241?focus=true)

It's bold now.

<img width="250" height="544" alt="Simulator Screenshot - iPhone 17 - 2026-04-09 at 16 39 25" src="https://github.com/user-attachments/assets/94362e14-d106-4f39-b681-b1efd0ef188b" />

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

I looked at it, and it was bold.