### PR TITLE
fix(RouteCardData): Include both directions at all temporary terminals

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1207,17 +1207,8 @@ public data class RouteCardData(
             // If we don’t have any upcoming trips to tell us whether or not service is
             // arrival-only, trust the typical-last-stop-on-route-pattern state.
             val shouldBeFilteredAsArrivalOnly =
-                if (isSubway) {
-                    // On subway, only filter out arrival only patterns at the typical last stop.
-                    // This way, during a scheduled disruption we still show arrival-only
-                    // headsign(s) at
-                    // a temporary terminal to acknowledge the missing typical service.
-                    this.isTypicalLastStopOnRoutePattern(stop, globalData) &&
-                        (this.upcomingTrips?.isArrivalOnly() ?: true)
-                } else {
-                    this.upcomingTrips?.isArrivalOnly()
-                        ?: this.isTypicalLastStopOnRoutePattern(stop, globalData)
-                }
+                this.isTypicalLastStopOnRoutePattern(stop, globalData) &&
+                    (this.upcomingTrips?.isArrivalOnly() ?: true)
 
             val hasUnseenTypicalPattern =
                 routePatterns?.any {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -5427,121 +5427,119 @@ class RouteCardDataTest {
         }
 
     @Test
-    fun `RouteCardData routeCardsForStopList filters out any arrival only for non-subway routes`() =
-        runBlocking {
-            val objects = ObjectCollectionBuilder()
+    fun `RouteCardData routeCardsForStopList filters out any arrival only`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
 
-            val longWharf = objects.stop { id = "Boat-Long" }
+        val longWharf = objects.stop { id = "Boat-Long" }
 
-            val ferryRoute =
-                objects.route {
-                    id = "Boat-F1"
-                    type = RouteType.FERRY
-                }
-            val ferryInboundToLongWharf =
-                objects.routePattern(ferryRoute) {
-                    id = "Boat-F1-3-1"
-                    routeId = ferryRoute.id.idText
-                    typicality = RoutePattern.Typicality.Typical
+        val ferryRoute =
+            objects.route {
+                id = "Boat-F1"
+                type = RouteType.FERRY
+            }
+        val ferryInboundToLongWharf =
+            objects.routePattern(ferryRoute) {
+                id = "Boat-F1-3-1"
+                routeId = ferryRoute.id.idText
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 1
+                representativeTrip {
+                    id = "Boat-F1-0730-Hull-BF2H-01-Weekday-Fall-24"
+                    headsign = "Long Wharf"
                     directionId = 1
-                    representativeTrip {
-                        id = "Boat-F1-0730-Hull-BF2H-01-Weekday-Fall-24"
-                        headsign = "Long Wharf"
-                        directionId = 1
-                        stopIds = listOf("Boat-Hull", "Boat-Long")
-                    }
+                    stopIds = listOf("Boat-Hull", "Boat-Long")
                 }
+            }
 
-            val ferryOutboundToHingham =
-                objects.routePattern(ferryRoute) {
-                    id = "Boat-F1-0-0"
-                    routeId = ferryRoute.id.idText
-                    typicality = RoutePattern.Typicality.Typical
+        val ferryOutboundToHingham =
+            objects.routePattern(ferryRoute) {
+                id = "Boat-F1-0-0"
+                routeId = ferryRoute.id.idText
+                typicality = RoutePattern.Typicality.Typical
+                directionId = 0
+                representativeTrip {
+                    id = "Boat-F1-1100-Long-BF2H-01-Weekday-Fall-24"
+                    headsign = "Hingham"
                     directionId = 0
-                    representativeTrip {
-                        id = "Boat-F1-1100-Long-BF2H-01-Weekday-Fall-24"
-                        headsign = "Hingham"
-                        directionId = 0
-                        stopIds = listOf("Boat-Long", "Boat-Logan", "Boat-Hull", "Boat-Hingham")
-                    }
+                    stopIds = listOf("Boat-Long", "Boat-Logan", "Boat-Hull", "Boat-Hingham")
                 }
+            }
 
-            val global =
-                GlobalResponse(
-                    objects,
-                    patternIdsByStop =
-                        mapOf(
-                            longWharf.id to
-                                listOf(ferryInboundToLongWharf.id, ferryOutboundToHingham.id)
-                        ),
-                )
-            val context = RouteCardData.Context.NearbyTransit
-            val time = EasternTimeInstant(2024, Month.OCTOBER, 30, 16, 40)
-
-            val ferryInboundTrip = objects.trip(ferryInboundToLongWharf)
-            val ferryOutboundTrip = objects.trip(ferryOutboundToHingham)
-
-            val schedInbound =
-                objects.schedule {
-                    trip = ferryInboundTrip
-                    stopId = longWharf.id
-                    stopSequence = 90
-                    arrivalTime = time + 2.minutes
-                    departureTime = null
-                }
-            val schedOutbound =
-                objects.schedule {
-                    trip = ferryOutboundTrip
-                    stopId = longWharf.id
-                    stopSequence = 90
-                    departureTime = time + 2.minutes
-                }
-
-            val ferryLineOrRoute = LineOrRoute.Route(ferryRoute)
-            assertEquals(
-                listOf(
-                    RouteCardData(
-                        lineOrRoute = ferryLineOrRoute,
-                        stopData =
-                            listOf(
-                                RouteCardData.RouteStopData(
-                                    ferryRoute,
-                                    longWharf,
-                                    listOf(
-                                        RouteCardData.Leaf(
-                                            lineOrRoute = ferryLineOrRoute,
-                                            stop = longWharf,
-                                            directionId = 0,
-                                            routePatterns = listOf(ferryOutboundToHingham),
-                                            stopIds = setOf(longWharf.id),
-                                            upcomingTrips =
-                                                listOf(objects.upcomingTrip(schedOutbound)),
-                                            alertsHere = emptyList(),
-                                            allDataLoaded = true,
-                                            hasSchedulesToday = true,
-                                            subwayServiceStartTime = null,
-                                            alertsDownstream = emptyList(),
-                                            context = context,
-                                        )
-                                    ),
-                                    global,
-                                )
-                            ),
-                        time,
-                    )
-                ),
-                RouteCardData.routeCardsForStopList(
-                    stopIds = listOf(longWharf.id),
-                    globalData = global,
-                    sortByDistanceFrom = longWharf.position,
-                    schedules = ScheduleResponse(objects),
-                    predictions = PredictionsStreamDataResponse(objects),
-                    alerts = AlertsStreamDataResponse(emptyMap()),
-                    now = time,
-                    context = context,
-                ),
+        val global =
+            GlobalResponse(
+                objects,
+                patternIdsByStop =
+                    mapOf(
+                        longWharf.id to
+                            listOf(ferryInboundToLongWharf.id, ferryOutboundToHingham.id)
+                    ),
             )
-        }
+        val context = RouteCardData.Context.NearbyTransit
+        val time = EasternTimeInstant(2024, Month.OCTOBER, 30, 16, 40)
+
+        val ferryInboundTrip = objects.trip(ferryInboundToLongWharf)
+        val ferryOutboundTrip = objects.trip(ferryOutboundToHingham)
+
+        val schedInbound =
+            objects.schedule {
+                trip = ferryInboundTrip
+                stopId = longWharf.id
+                stopSequence = 90
+                arrivalTime = time + 2.minutes
+                departureTime = null
+            }
+        val schedOutbound =
+            objects.schedule {
+                trip = ferryOutboundTrip
+                stopId = longWharf.id
+                stopSequence = 90
+                departureTime = time + 2.minutes
+            }
+
+        val ferryLineOrRoute = LineOrRoute.Route(ferryRoute)
+        assertEquals(
+            listOf(
+                RouteCardData(
+                    lineOrRoute = ferryLineOrRoute,
+                    stopData =
+                        listOf(
+                            RouteCardData.RouteStopData(
+                                ferryRoute,
+                                longWharf,
+                                listOf(
+                                    RouteCardData.Leaf(
+                                        lineOrRoute = ferryLineOrRoute,
+                                        stop = longWharf,
+                                        directionId = 0,
+                                        routePatterns = listOf(ferryOutboundToHingham),
+                                        stopIds = setOf(longWharf.id),
+                                        upcomingTrips = listOf(objects.upcomingTrip(schedOutbound)),
+                                        alertsHere = emptyList(),
+                                        allDataLoaded = true,
+                                        hasSchedulesToday = true,
+                                        subwayServiceStartTime = null,
+                                        alertsDownstream = emptyList(),
+                                        context = context,
+                                    )
+                                ),
+                                global,
+                            )
+                        ),
+                    time,
+                )
+            ),
+            RouteCardData.routeCardsForStopList(
+                stopIds = listOf(longWharf.id),
+                globalData = global,
+                sortByDistanceFrom = longWharf.position,
+                schedules = ScheduleResponse(objects),
+                predictions = PredictionsStreamDataResponse(objects),
+                alerts = AlertsStreamDataResponse(emptyMap()),
+                now = time,
+                context = context,
+            ),
+        )
+    }
 
     @Test
     fun `RouteCardData routeCardsForStopList returns alertsHere and downstream alerts`() =


### PR DESCRIPTION
### Summary

No ticket, noticed while looking into [Notifications QA | trip-specific suspensions alerts replace all departures](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131248?focus=true) while a planned CR disruption is taking place.

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Currently, a planned CR disruption is ~omitted from the app for the first affected stop - not shown in stop details, favorites, or nearby transit. 

This was due to subway-only temporary terminal logic applied in https://github.com/mbta/mobile_app/pull/739. That subway-only condition was added because at the time, not all routes had typical patterns, and we were seeing arrival-only directions displayed at regular ferry & bus terminals. Now, all routes have a typical pattern, so we don't need to special-case subway anymore. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
| Before | After |
|--------|--------|
|<img width="335" height="726" alt="image" src="https://github.com/user-attachments/assets/c79c38f3-1624-4133-959d-ef8f73d618c6" /> | <img width="335" height="2340" alt="image" src="https://github.com/user-attachments/assets/1d9e4299-7e3b-4d1c-bfda-351459ff86ce" /> |

* Also confirmed that for the ferry & bus routes included in the old PR, the arrival-only direction is still omitted. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
