### PR TITLE
fix: Trip-specific suspension & cancellation alerts take over just the affected trip

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,16 +29,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.DebugView
 import com.mbta.tid.mbta_app.android.component.routeCard.WorldCupBlurb
-import com.mbta.tid.mbta_app.android.component.routeSlashIcon
 import com.mbta.tid.mbta_app.android.state.getGlobalData
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.Alert
@@ -111,11 +107,6 @@ fun StopDetailsFilteredDeparturesView(
         )
 
     val downstreamAlerts: List<Alert> = leaf.alertsDownstream(tripId = tripFilter?.tripId)
-
-    val selectedTripIsCancelled =
-        if (tripFilter != null)
-            leaf.upcomingTrips.any { it.trip.id == tripFilter.tripId && it.isCancelled }
-        else false
 
     val routeAccents = TripRouteAccents(lineOrRoute.sortRoute)
 
@@ -274,7 +265,12 @@ fun StopDetailsFilteredDeparturesView(
             ) {
                 WorldCupBlurb(leaf, routeAccents, offerDetails = true)
             }
-        } else if (isAllServiceDisrupted) {
+        } else if (
+            isAllServiceDisrupted ||
+                (displayAlerts.highPriority + displayAlerts.lowPriority).any {
+                    it.cardSpec(isAllServiceDisrupted, tripFilter?.tripId) == AlertCardSpec.Takeover
+                }
+        ) {
             Box {}
         } else if (noPredictionsStatus != null) {
             Box(modifier = Modifier.padding(horizontal = 10.dp).padding(bottom = 12.dp)) {
@@ -305,23 +301,6 @@ fun StopDetailsFilteredDeparturesView(
                     routeType = routeAccents.type,
                     now = now,
                     nextScheduleResponse = nextScheduleResponse,
-                )
-            }
-        } else if (selectedTripIsCancelled) {
-            Box(modifier = Modifier.padding(horizontal = 10.dp, vertical = 16.dp)) {
-                StopDetailsIconCard(
-                    routeAccents.color,
-                    details = { Text(stringResource(R.string.trip_cancelled_details)) },
-                    header = { modifier ->
-                        Text(stringResource(R.string.trip_cancelled), modifier = modifier)
-                    },
-                    icon = { modifier ->
-                        Icon(
-                            painter = routeSlashIcon(routeType = routeAccents.type),
-                            contentDescription = null,
-                            modifier = modifier.testTag("route_slash_icon"),
-                        )
-                    },
                 )
             }
         } else {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -106,6 +106,7 @@ fun StopDetailsFilteredDeparturesView(
             leaf.alertsHere(tripFilter?.tripId),
             leaf.alertsDownstream(tripFilter?.tripId),
             showStationAccessibility,
+            tripFilter?.tripId,
             now,
         )
 
@@ -180,7 +181,7 @@ fun StopDetailsFilteredDeparturesView(
 
     @Composable
     fun AlertCard(displayAlert: DisplayAlert, summary: AlertSummary?, modifier: Modifier) {
-        val spec = displayAlert.cardSpec(now, isAllServiceDisrupted)
+        val spec = displayAlert.cardSpec(isAllServiceDisrupted, tripFilter?.tripId)
 
         AlertCard(
             displayAlert.alert,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -172,7 +172,7 @@ fun StopDetailsFilteredDeparturesView(
 
     @Composable
     fun AlertCard(displayAlert: DisplayAlert, summary: AlertSummary?, modifier: Modifier) {
-        val spec = displayAlert.cardSpec(isAllServiceDisrupted, tripFilter?.tripId)
+        val spec = displayAlert.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId)
 
         AlertCard(
             displayAlert.alert,
@@ -268,7 +268,8 @@ fun StopDetailsFilteredDeparturesView(
         } else if (
             isAllServiceDisrupted ||
                 (displayAlerts.highPriority + displayAlerts.lowPriority).any {
-                    it.cardSpec(isAllServiceDisrupted, tripFilter?.tripId) == AlertCardSpec.Takeover
+                    it.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId) ==
+                        AlertCardSpec.Takeover
                 }
         ) {
             Box {}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -54,7 +54,10 @@ internal constructor(
     public fun allClear(atTime: EasternTimeInstant): Boolean =
         activePeriod.all { it.end != null && it.end < atTime }
 
-    public fun significance(atTime: EasternTimeInstant?): AlertSignificance {
+    public fun significance(
+        atTime: EasternTimeInstant?,
+        tripId: String? = null,
+    ): AlertSignificance {
         val intrinsicSignificance =
             when (effect) {
                 // suspensions or shuttles can reasonably apply to an entire route
@@ -73,7 +76,10 @@ internal constructor(
                 Effect.TrackChange -> AlertSignificance.Minor
                 // cancellation is major for the specific trip but minor for the
                 // route/stop/direction
-                Effect.Cancellation -> AlertSignificance.Minor
+                Effect.Cancellation ->
+                    if (tripId != null && this.anyInformedEntitySatisfies { checkTrip(tripId) })
+                        AlertSignificance.Major
+                    else AlertSignificance.Minor
                 Effect.Delay ->
                     if (
                         (severity >= 3 && informedEntity.any { it.routeType !== RouteType.BUS }) ||

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -14,7 +14,7 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
 
     public fun cardSpec(isAllServiceDisrupted: Boolean, tripId: String? = null): AlertCardSpec {
 
-        val significance = alert.significance(null)
+        val significance = alert.significance(null, tripId = tripId)
         return if (isDownstream) {
             AlertCardSpec.Downstream
         } else if (

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -1,5 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+
 public enum class AlertCardSpec {
     Delay,
     Downstream,
@@ -12,9 +14,13 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
 
     val id: String = alert.id
 
-    public fun cardSpec(isAllServiceDisrupted: Boolean, tripId: String? = null): AlertCardSpec {
+    public fun cardSpec(
+        now: EasternTimeInstant,
+        isAllServiceDisrupted: Boolean,
+        tripId: String? = null,
+    ): AlertCardSpec {
 
-        val significance = alert.significance(null, tripId = tripId)
+        val significance = alert.significance(now, tripId = tripId)
         return if (isDownstream) {
             AlertCardSpec.Downstream
         } else if (

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -1,7 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-
 public enum class AlertCardSpec {
     Delay,
     Downstream,
@@ -14,12 +12,15 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
 
     val id: String = alert.id
 
-    public fun cardSpec(now: EasternTimeInstant, isAllServiceDisrupted: Boolean): AlertCardSpec {
+    public fun cardSpec(isAllServiceDisrupted: Boolean, tripId: String? = null): AlertCardSpec {
 
-        val significance = alert.significance(now)
+        val significance = alert.significance(null)
         return if (isDownstream) {
             AlertCardSpec.Downstream
-        } else if (significance == AlertSignificance.Major && isAllServiceDisrupted) {
+        } else if (
+            significance == AlertSignificance.Major &&
+                (isAllServiceDisrupted || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+        ) {
             AlertCardSpec.Takeover
         } else if (significance == AlertSignificance.Minor && alert.effect == Alert.Effect.Delay) {
             AlertCardSpec.Delay

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
@@ -28,6 +28,7 @@ public data class DisplayAlerts(
             alertsHere: List<Alert>,
             alertsDownstream: List<Alert>,
             includeElevatorAlerts: Boolean = false,
+            tripId: String? = null,
             now: EasternTimeInstant,
         ): DisplayAlerts {
             val idsHere = alertsHere.map { it.id }.toSet()
@@ -42,7 +43,11 @@ public data class DisplayAlerts(
                             .thenBy { it.currentOrNextPeriod(now)?.start?.instant }
                     )
                     .map { DisplayAlert(it, !idsHere.contains(it.id)) }
-                    .partition { it.alert.isActive(now) && !it.isDownstream }
+                    .partition {
+                        (it.alert.isActive(now) ||
+                            it.alert.anyInformedEntitySatisfies { checkTrip(tripId) }) &&
+                            !it.isDownstream
+                    }
 
             return DisplayAlerts(tier1, tier2)
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.model.Alert.Effect
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
@@ -64,7 +65,47 @@ internal class AlertsRepository(
                     return
                 }
             println("Received ${newAlerts.alerts.size} alerts")
-            onReceive(ApiResult.Ok(newAlerts))
+            onReceive(
+                ApiResult.Ok(
+                    AlertsStreamDataResponse(
+                        newAlerts.alerts.mapValues {
+                            if (it.key == "1000129") {
+
+                                it.value.copy(
+                                    informedEntity =
+                                        it.value.informedEntity.map { ie ->
+                                            if (
+                                                ie.stop == "WML-0025-07" ||
+                                                    ie.stop == "place-WML-0025"
+                                            ) {
+                                                ie.copy(
+                                                    activities =
+                                                        listOf(
+                                                            Alert.InformedEntity.Activity.Board,
+                                                            Alert.InformedEntity.Activity.Ride,
+                                                        )
+                                                )
+                                            } else if (
+                                                ie.stop == "WML-0102-02" ||
+                                                    ie.stop == "place-WML-0102"
+                                            ) {
+                                                ie.copy(
+                                                    activities =
+                                                        listOf(
+                                                            Alert.InformedEntity.Activity.Exit,
+                                                            Alert.InformedEntity.Activity.Ride,
+                                                        )
+                                                )
+                                            } else ie
+                                        }
+                                )
+                            } else {
+                                it.value
+                            }
+                        }
+                    )
+                )
+            )
         } else {
             println("No jsonPayload found for message ${message.body}")
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | trip-specific suspensions alerts replace all departures](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131248?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

WIP - getting closer, but need to block trip details 
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/25d4bb66-41ce-4c51-95cd-0ac93a76fa82" />





iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
