### PR TITLE
fix: clarify starting tomorrow recurring until further notice

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -13,7 +13,10 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.Month
+import kotlinx.datetime.plus
 import org.junit.Rule
 import org.junit.Test
 
@@ -450,5 +453,77 @@ class AlertDetailsTest {
         composeTestRule.onNodeWithText("Sunday, Friday").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
         composeTestRule.onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM"))).assertIsDisplayed()
+    }
+
+    @Test
+    fun testRecurringStartTomorrowEndUnknown() {
+        val objects = ObjectCollectionBuilder()
+        val now = EasternTimeInstant.now()
+        val tomorrow = now.serviceDate.plus(DatePeriod(days = 1))
+        val overmorrow = tomorrow.plus(DatePeriod(days = 1))
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StationClosure
+                activePeriod(
+                    EasternTimeInstant(tomorrow, LocalTime(3, 0)),
+                    EasternTimeInstant(tomorrow, LocalTime(9, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(overmorrow, LocalTime(3, 0)),
+                    EasternTimeInstant(overmorrow, LocalTime(9, 0)),
+                )
+                durationCertainty = Alert.DurationCertainty.Unknown
+            }
+
+        composeTestRule.setContent {
+            AlertDetails(
+                alert,
+                line = null,
+                routes = null,
+                stop = null,
+                affectedStops = emptyList(),
+                now = now,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Starting tomorrow until further notice").assertIsDisplayed()
+    }
+
+    @Test
+    fun testRecurringStartLaterTodayEndUnknown() {
+        val objects = ObjectCollectionBuilder()
+        val today = EasternTimeInstant.now().serviceDate
+        val now = EasternTimeInstant(today, LocalTime(18, 0))
+        val tomorrow = today.plus(DatePeriod(days = 1))
+        val overmorrow = tomorrow.plus(DatePeriod(days = 1))
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.StationClosure
+                activePeriod(
+                    EasternTimeInstant(today, LocalTime(20, 0)),
+                    EasternTimeInstant(tomorrow, LocalTime(3, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(tomorrow, LocalTime(20, 0)),
+                    EasternTimeInstant(overmorrow, LocalTime(3, 0)),
+                )
+                durationCertainty = Alert.DurationCertainty.Unknown
+            }
+
+        composeTestRule.setContent {
+            AlertDetails(
+                alert,
+                line = null,
+                routes = null,
+                stop = null,
+                affectedStops = emptyList(),
+                now = now,
+            )
+        }
+
+        composeTestRule
+            .onNodeWithText("Starting tomorrow until further notice")
+            .assertDoesNotExist()
+        composeTestRule.onNodeWithText("Until further notice").assertIsDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
@@ -103,7 +103,7 @@ fun AlertDetails(
     ) {
         AlertTitle(routeLabel, stopLabel, formattedAlert, elevatorSubtitle, isElevatorAlert)
         if (!isElevatorAlert) {
-            AlertPeriod(alert, currentPeriod ?: nextPeriod)
+            AlertPeriod(alert, currentPeriod, nextPeriod, now)
 
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 AffectedStopCollapsible(
@@ -121,7 +121,7 @@ fun AlertDetails(
         }
         AlertDescription(alert, affectedStopsKnown = affectedStops.isNotEmpty())
         if (isElevatorAlert) {
-            AlertPeriod(alert, currentPeriod ?: nextPeriod)
+            AlertPeriod(alert, currentPeriod, nextPeriod, now)
         }
         AlertFooter(alert.updatedAt)
     }
@@ -167,7 +167,12 @@ private fun AlertTitle(
 }
 
 @Composable
-private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
+private fun AlertPeriod(
+    alert: Alert,
+    currentPeriod: Alert.ActivePeriod?,
+    nextPeriod: Alert.ActivePeriod?,
+    now: EasternTimeInstant,
+) {
     // This is all because Jetpack Compose has no built in table layout, we need the "Start" and
     // "End" label texts to take up the same column width, but they can be variable widths in
     // different languages, so we can't use a fixed size, but we also need the label and formatted
@@ -191,6 +196,7 @@ private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
         }
     }
 
+    val relevantPeriod = currentPeriod ?: nextPeriod
     val recurrence = alert.recurrenceRange()
 
     if (recurrence != null) {
@@ -206,8 +212,17 @@ private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
             if (recurrence.toEndOfService) stringResource(R.string.end_of_service)
             else recurrence.end.formattedTime()
         val dateRange =
-            if (recurrence.endDayKnown) stringResource(R.string.en_dash_range, startDay, endDay)
-            else stringResource(R.string.until_further_notice)
+            when {
+                recurrence.endDayKnown -> stringResource(R.string.en_dash_range, startDay, endDay)
+                // if the alert isn’t active already but starts later today, the start time will
+                // make it clear, but if it starts tomorrow, the start time will have already
+                // elapsed today, so we need to disambiguate
+                currentPeriod == null &&
+                    nextPeriod != null &&
+                    nextPeriod.startServiceDate != now.serviceDate ->
+                    stringResource(R.string.starting_tomorrow_until_further_notice)
+                else -> stringResource(R.string.until_further_notice)
+            }
         Column(
             Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -240,7 +255,7 @@ private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
                 Text(stringResource(R.string.en_dash_range, startTime, endTime), style = style)
             }
         }
-    } else if (currentPeriod != null) {
+    } else if (relevantPeriod != null) {
         Column(
             Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(14.dp),
@@ -251,14 +266,14 @@ private fun AlertPeriod(alert: Alert, currentPeriod: Alert.ActivePeriod?) {
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(columnTexts[0], Modifier.width(columnWidth), style = style)
-                Text(currentPeriod.formatStart(LocalResources.current), style = style)
+                Text(relevantPeriod.formatStart(LocalResources.current), style = style)
             }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.Top,
             ) {
                 Text(columnTexts[1], Modifier.width(columnWidth), style = style)
-                Text(currentPeriod.formatEnd(LocalResources.current), style = style)
+                Text(relevantPeriod.formatEnd(LocalResources.current), style = style)
             }
         }
     } else {

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -398,6 +398,7 @@
     <string name="start_of_service">inicio del servicio</string>
     <string name="starting_later_today">\u0020comenzando &lt;b>%1$s&lt;/b> hoy</string>
     <string name="starting_tomorrow">\u0020a partir de mañana</string>
+    <string name="starting_tomorrow_until_further_notice">A partir de mañana y hasta nuevo aviso.</string>
     <string name="station_closed">Estación cerrada</string>
     <string name="station_closed_sentence_case">Estación cerrada</string>
     <string name="station_closure">Cierre de estación</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -398,6 +398,7 @@
     <string name="start_of_service">début du service</string>
     <string name="starting_later_today">\u0020à partir de &lt;b>%1$s&lt;/b> aujourd’hui</string>
     <string name="starting_tomorrow">\u0020à partir de demain</string>
+    <string name="starting_tomorrow_until_further_notice">À compter de demain et jusqu’à nouvel ordre</string>
     <string name="station_closed">Station fermée</string>
     <string name="station_closed_sentence_case">Station fermée</string>
     <string name="station_closure">Fermeture de la station</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -407,6 +407,7 @@
     <string name="start_of_service">kòmansman sèvis</string>
     <string name="starting_later_today">\u0020kòmanse &lt;b>%1$s&lt;/b> jodi a</string>
     <string name="starting_tomorrow">\u0020kòmanse demen</string>
+    <string name="starting_tomorrow_until_further_notice">Apati demen jiskaske nou jwenn plis avi</string>
     <string name="station_closed">Estasyon Fèmen</string>
     <string name="station_closed_sentence_case">Estasyon fèmen</string>
     <string name="station_closure">Estasyon Fèmen</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -398,6 +398,7 @@
     <string name="start_of_service">início do serviço</string>
     <string name="starting_later_today">\u0020começando &lt;b>%1$s&lt;/b> hoje</string>
     <string name="starting_tomorrow">\u0020a partir de amanhã</string>
+    <string name="starting_tomorrow_until_further_notice">A partir de amanhã, até novo aviso.</string>
     <string name="station_closed">Estação fechada</string>
     <string name="station_closed_sentence_case">Estação fechada</string>
     <string name="station_closure">Fechamento de estação</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -392,6 +392,7 @@
     <string name="start_of_service">bắt đầu dịch vụ</string>
     <string name="starting_later_today">\u0020bắt đầu từ &lt;b>%1$s&lt;/b> hôm nay</string>
     <string name="starting_tomorrow">\u0020bắt đầu từ ngày mai</string>
+    <string name="starting_tomorrow_until_further_notice">Bắt đầu từ ngày mai cho đến khi có thông báo mới.</string>
     <string name="station_closed">Nhà ga/trạm dừng đóng cửa</string>
     <string name="station_closed_sentence_case">Nhà ga/trạm dừng đóng cửa</string>
     <string name="station_closure">Đóng ga</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -392,6 +392,7 @@
     <string name="start_of_service">服务开始</string>
     <string name="starting_later_today">\u0020从今天&lt;b>%1$s&lt;/b>开始</string>
     <string name="starting_tomorrow">\u0020从明天开始</string>
+    <string name="starting_tomorrow_until_further_notice">从明天开始，直至另行通知。</string>
     <string name="station_closed">车站已关闭</string>
     <string name="station_closed_sentence_case">车站已关闭</string>
     <string name="station_closure">车站关闭</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -392,6 +392,7 @@
     <string name="start_of_service">服務開始</string>
     <string name="starting_later_today">\u0020從今天&lt;b>%1$s&lt;/b>開始</string>
     <string name="starting_tomorrow">\u0020從明天開始</string>
+    <string name="starting_tomorrow_until_further_notice">從明天開始，直至另行通知。</string>
     <string name="station_closed">車站已關閉</string>
     <string name="station_closed_sentence_case">車站已關閉</string>
     <string name="station_closure">車站關閉</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -398,6 +398,7 @@
     <string name="start_of_service">start of service</string>
     <string name="starting_later_today">\u0020starting &lt;b>%1$s&lt;/b> today</string>
     <string name="starting_tomorrow">\u0020starting tomorrow</string>
+    <string name="starting_tomorrow_until_further_notice">Starting tomorrow until further notice</string>
     <string name="station_closed">Station Closed</string>
     <string name="station_closed_sentence_case">Station closed</string>
     <string name="station_closure">Station Closure</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -21131,6 +21131,53 @@
         }
       }
     },
+    "Starting tomorrow until further notice" : {
+      "comment" : "Date range for a recurring alert which hasn’t started yet and has an unknown end date; may be shown next to “Daily” or a list of weekdays",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A partir de mañana y hasta nuevo aviso."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "À compter de demain et jusqu’à nouvel ordre"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Apati demen jiskaske nou jwenn plis avi"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "A partir de amanhã, até novo aviso."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Bắt đầu từ ngày mai cho đến khi có thông báo mới."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "从明天开始，直至另行通知。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "從明天開始，直至另行通知。"
+          }
+        }
+      }
+    },
     "Station Accessibility Info" : {
       "comment" : "A setting on the More page to toggle displaying station accessibility info",
       "localizations" : {

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -71,9 +71,9 @@ struct AlertDetails: View {
         }
     }
 
-    private var currentPeriod: Shared.Alert.ActivePeriod? {
-        alert.currentPeriod(time: now) ?? alert.nextPeriod(time: now)
-    }
+    private var currentPeriod: Shared.Alert.ActivePeriod? { alert.currentPeriod(time: now) }
+    private var nextPeriod: Shared.Alert.ActivePeriod? { alert.nextPeriod(time: now) }
+    private var relevantPeriod: Shared.Alert.ActivePeriod? { currentPeriod ?? nextPeriod }
 
     static var calendar: Calendar {
         var result = Calendar(identifier: .iso8601)
@@ -101,6 +101,14 @@ struct AlertDetails: View {
                 )
             let dateRange = if recurrence.endDayKnown {
                 Text("\(startDay) – \(endDay)").font(Typography.bodySemibold)
+            } else if currentPeriod == nil, let nextPeriod, nextPeriod.startServiceDate != now.serviceDate {
+                Text(
+                    "Starting tomorrow until further notice",
+                    comment: """
+                    Date range for a recurring alert which hasn’t started yet and has an unknown end date; \
+                    may be shown next to “Daily” or a list of weekdays
+                    """
+                ).font(Typography.bodySemibold)
             } else {
                 Text("Until further notice").font(Typography.bodySemibold)
             }

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
@@ -375,4 +375,52 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "From"))
         XCTAssertNotNil(try sut.inspect().find(text: "9:41\u{202F}AM – 11:41\u{202F}AM"))
     }
+
+    func testRecurringStartTomorrowEndUnknown() throws {
+        let objects = ObjectCollectionBuilder()
+        let now = EasternTimeInstant.now()
+        let tomorrow = now.serviceDate.plus(days: 1)
+        let overmorrow = tomorrow.plus(days: 1)
+        let alert = objects.alert { alert in
+            alert.effect = .stationClosure
+            alert.activePeriod(
+                start: .init(date: tomorrow, time: .init(hour: 3, minute: 0, second: 0, nanosecond: 0)),
+                end: .init(date: tomorrow, time: .init(hour: 9, minute: 0, second: 0, nanosecond: 0))
+            )
+            alert.activePeriod(
+                start: .init(date: overmorrow, time: .init(hour: 3, minute: 0, second: 0, nanosecond: 0)),
+                end: .init(date: overmorrow, time: .init(hour: 9, minute: 0, second: 0, nanosecond: 0))
+            )
+            alert.durationCertainty = .unknown
+        }
+
+        let sut = AlertDetails(alert: alert, affectedStops: [], now: now)
+
+        XCTAssertNotNil(try sut.inspect().find(text: "Starting tomorrow until further notice"))
+    }
+
+    func testRecurringStartLaterTodayEndUnknown() throws {
+        let objects = ObjectCollectionBuilder()
+        let today = EasternTimeInstant.now().serviceDate
+        let now = EasternTimeInstant(date: today, time: .init(hour: 18, minute: 0, second: 0, nanosecond: 0))
+        let tomorrow = today.plus(days: 1)
+        let overmorrow = tomorrow.plus(days: 1)
+        let alert = objects.alert { alert in
+            alert.effect = .stationClosure
+            alert.activePeriod(
+                start: .init(date: today, time: .init(hour: 20, minute: 0, second: 0, nanosecond: 0)),
+                end: .init(date: tomorrow, time: .init(hour: 3, minute: 0, second: 0, nanosecond: 0))
+            )
+            alert.activePeriod(
+                start: .init(date: tomorrow, time: .init(hour: 20, minute: 0, second: 0, nanosecond: 0)),
+                end: .init(date: overmorrow, time: .init(hour: 3, minute: 0, second: 0, nanosecond: 0))
+            )
+            alert.durationCertainty = .unknown
+        }
+
+        let sut = AlertDetails(alert: alert, affectedStops: [], now: now)
+
+        XCTAssertThrowsError(try sut.inspect().find(text: "Starting tomorrow until further notice"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Until further notice"))
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | fix presentation of future recurring alerts w/ indefinite end date](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131246)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This isn’t a very general fix, but I don’t think this case is going to come up very often, and I don’t think we’ll need to add similar cases later on.

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Added unit tests that were failing and now pass. (Checking that it works end-to-end is blocked because something’s gone funky with dev Keycloak, but I believe in these tests.)

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
