### PR TITLE
fix(Android): use fixed pill in FavoriteStopCard

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCardTest.kt
@@ -75,4 +75,22 @@ class FavoriteStopCardTest {
 
         composeTestRule.onNodeWithText("Only Southbound to").assertIsDisplayed()
     }
+
+    @Test
+    fun testCommuterRailPill() {
+        val objects = TestData.clone()
+        val providence = objects.getRoute("CR-Providence")
+        val backBay = objects.getStop("place-bbsta")
+        composeTestRule.setContent {
+            FavoriteStopCard(
+                backBay,
+                LineOrRoute.Route(providence),
+                Direction(0, providence, backBay),
+                toggleDirection = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Providence/Stoughton").assertDoesNotExist()
+        composeTestRule.onNodeWithText("CR").assertIsDisplayed()
+    }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCard.kt
@@ -47,7 +47,7 @@ fun FavoriteStopCard(
             RoutePill(
                 (route as? LineOrRoute.Route)?.route,
                 (route as? LineOrRoute.Line)?.line,
-                type = RoutePillType.Flex,
+                type = RoutePillType.Fixed,
             )
             DirectionLabel(
                 direction,
@@ -134,6 +134,7 @@ private fun FavoriteStopCardPreview() {
                 objects.getRoute("Green-E"),
             ),
         )
+    val providence = objects.getRoute("CR-Providence")
     val olSouthbound = Direction(0, ol.route, wellington)
     val blWestbound = Direction(0, bl.route, wonderland)
     val bus66Inbound = Direction(1, bus66.route, harvardStadiumGate2Inbound)
@@ -160,6 +161,12 @@ private fun FavoriteStopCardPreview() {
                 onlyServingOppositeDirection = true,
             )
             FavoriteStopCard(boylston, gl, glWestbound, toggleDirection = {})
+            FavoriteStopCard(
+                objects.getStop("place-bbsta"),
+                LineOrRoute.Route(providence),
+                Direction(0, providence),
+                toggleDirection = {},
+            )
         }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | CR route pills in add favorites flow](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214006391557166)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Conveniently, we’re already doing the right thing on iOS.

|Before|After|
|------|-----|
|<img width="1080" height="2400" alt="Screenshot_20260410_162954" src="https://github.com/user-attachments/assets/0f9f81e8-ea5f-4062-9677-571423911926" />|<img width="1080" height="2400" alt="Screenshot_20260410_163037" src="https://github.com/user-attachments/assets/093f937b-6350-4277-9c00-6c982a493260" />|

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added a unit test and manually checked that behavior is now correct.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
