### PR TITLE
fix: request stop and trip maps only when actually needed

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -337,23 +337,41 @@ public class MapViewModel(
             }
         }
 
-        LaunchedEffect(
-            stopId,
-            stopFilter,
-            tripId,
-            allRailRouteShapes,
-            globalData,
-            globalMapData,
-            routeCardData.data,
-        ) {
-            if (tripId != null) {
-                val tripShapes =
+        var stopMapData: StopMapResponse? by remember { mutableStateOf(null) }
+        LaunchedEffect(stopId) {
+            stopMapData = if (stopId != null) getStopMapData(stopId = stopId) else null
+        }
+
+        var tripShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>? by remember {
+            mutableStateOf(null)
+        }
+        LaunchedEffect(tripId) {
+            tripShapes =
+                if (tripId != null) {
                     withContext(iOCoroutineDispatcher) {
                         when (val data = tripRepository.getTripShape(tripId)) {
                             is ApiResult.Ok -> data.data.routesWithSegmentedShapes
                             is ApiResult.Error -> null
                         }
                     }
+                } else {
+                    null
+                }
+        }
+
+        LaunchedEffect(
+            stopId,
+            stopMapData,
+            stopFilter,
+            tripId,
+            tripShapes,
+            allRailRouteShapes,
+            globalData,
+            globalMapData,
+            routeCardData.data,
+        ) {
+            if (tripId != null) {
+                val tripShapes = tripShapes
                 val resolvedGlobal = globalData
                 if (tripShapes != null && resolvedGlobal != null) {
                     routeSourceData =
@@ -372,6 +390,7 @@ public class MapViewModel(
                         globalResponse = globalData,
                         railRouteShapes = allRailRouteShapes,
                         stopId = stopId,
+                        stopMapData = stopMapData,
                         stopFilter = stopFilter,
                         globalMapData = globalMapData,
                         routeCardData = routeCardData.data,
@@ -609,6 +628,7 @@ public class MapViewModel(
         globalResponse: GlobalResponse?,
         railRouteShapes: MapFriendlyRouteResponse?,
         stopId: String,
+        stopMapData: StopMapResponse?,
         stopFilter: StopDetailsFilter?,
         globalMapData: GlobalMapData?,
         routeCardData: List<RouteCardData>?,
@@ -617,8 +637,13 @@ public class MapViewModel(
         List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
         StopLayerGenerator.State,
     >? {
-        if (globalResponse == null || railRouteShapes == null || globalMapData == null) return null
-        val stopMapData = getStopMapData(stopId = stopId) ?: return null
+        if (
+            globalResponse == null ||
+                railRouteShapes == null ||
+                globalMapData == null ||
+                stopMapData == null
+        )
+            return null
 
         val filteredRouteShapes =
             if (stopFilter != null) {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -5,7 +5,9 @@ import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
 import com.mbta.tid.mbta_app.dependencyInjection.repositoriesModule
 import com.mbta.tid.mbta_app.mocks.MockClock
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.SegmentAlertState
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -13,9 +15,12 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
+import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
+import com.mbta.tid.mbta_app.repositories.IStopRepository
 import com.mbta.tid.mbta_app.repositories.MockTripRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -37,8 +42,10 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.fail
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -618,5 +625,58 @@ internal class MapViewModelTests : KoinTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `does not fetch stop data again when route card data changes`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        setUpKoin(dispatcher)
+        val routeCardDataVM = MockRouteCardDataViewModel(RouteCardDataViewModel.State(emptyList()))
+        val stopRepo =
+            object : IStopRepository {
+                var callCount = 0
+
+                override suspend fun getStopMapData(stopId: String): ApiResult<StopMapResponse> {
+                    callCount++
+                    if (callCount > 1) {
+                        fail("Fetched stop map data more than once")
+                    }
+                    return ApiResult.Ok(StopMapResponse(emptyList(), emptyMap()))
+                }
+            }
+        val viewModel =
+            MapViewModel(
+                routeCardDataVM,
+                globalRepository = get(),
+                railRouteShapeRepository = get(),
+                sentryRepository = get(),
+                stopRepository = stopRepo,
+                tripRepository = get(),
+                clock = get(),
+                defaultCoroutineDispatcher = dispatcher,
+                iOCoroutineDispatcher = dispatcher,
+            )
+
+        viewModel.setViewportManager(MockViewportManager())
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+            viewModel.selectedStop(TestData.getStop("place-sstat"), null)
+            awaitItem()
+            routeCardDataVM.models.value =
+                RouteCardDataViewModel.State(
+                    listOf(
+                        RouteCardData(
+                            LineOrRoute.Route(TestData.getRoute("Red")),
+                            stopData = emptyList(),
+                            at = EasternTimeInstant.now(),
+                        )
+                    )
+                )
+            // there won’t be a new model, but we do want to give the LaunchedEffect time to run
+            delay(100.milliseconds)
+        }
+
+        assertEquals(1, stopRepo.callCount)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [reduce excessive calls to /api/trip/map-friendly, /api/stop/map ](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213993311573670?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

I’m glad this was such an easy fix.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked with the local backend that the data is no longer fetched more often than it needs to be. Added a unit test for the stop data specifically and confirmed that it fails on `main` but passes on this PR.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
