### PR TITLE
refactor(Alert): Separate intrinsicSignificance from significanceAtTime, new significanceForTrip

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStops.kt
@@ -107,7 +107,7 @@ fun TripStops(
                                 .lastOrNull()
                                 ?.disruption
                                 ?.alert
-                                ?.significance(now) == AlertSignificance.Major
+                                ?.significanceAtTime(now) == AlertSignificance.Major
                         )
                             4.dp
                         else 0.dp

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -54,46 +54,50 @@ internal constructor(
     public fun allClear(atTime: EasternTimeInstant): Boolean =
         activePeriod.all { it.end != null && it.end < atTime }
 
-    public fun significance(atTime: EasternTimeInstant?): AlertSignificance {
-        val intrinsicSignificance =
-            when (effect) {
-                // suspensions or shuttles can reasonably apply to an entire route
-                in setOf(Effect.Shuttle, Effect.Suspension) -> AlertSignificance.Major
-                // detours and closures are only major if they specify stops
-                in setOf(
-                    Effect.StationClosure,
-                    Effect.StopClosure,
-                    Effect.DockClosure,
-                    Effect.Detour,
-                    Effect.SnowRoute,
-                ) -> if (hasStopsSpecified) AlertSignificance.Major else AlertSignificance.Secondary
-                // service changes are always secondary
-                Effect.ServiceChange -> AlertSignificance.Secondary
-                Effect.ElevatorClosure -> AlertSignificance.Accessibility
-                Effect.TrackChange -> AlertSignificance.Minor
-                // cancellation is major for the specific trip but minor for the
-                // route/stop/direction
-                Effect.Cancellation -> AlertSignificance.Minor
-                Effect.Delay ->
-                    if (
-                        (severity >= 3 && informedEntity.any { it.routeType !== RouteType.BUS }) ||
-                            cause == Cause.SingleTracking
-                    ) {
-                        AlertSignificance.Minor
-                    } else {
-                        AlertSignificance.None
-                    }
-                else -> AlertSignificance.None
-            }
+    /** The significance that this alert will have when it is active. */
+    public val intrinsicSignificance: AlertSignificance =
+        when (effect) {
+            // suspensions or shuttles can reasonably apply to an entire route
+            in setOf(Effect.Shuttle, Effect.Suspension) -> AlertSignificance.Major
+            // detours and closures are only major if they specify stops
+            in setOf(
+                Effect.StationClosure,
+                Effect.StopClosure,
+                Effect.DockClosure,
+                Effect.Detour,
+                Effect.SnowRoute,
+            ) -> if (hasStopsSpecified) AlertSignificance.Major else AlertSignificance.Secondary
+            // service changes are always secondary
+            Effect.ServiceChange -> AlertSignificance.Secondary
+            Effect.ElevatorClosure -> AlertSignificance.Accessibility
+            Effect.TrackChange -> AlertSignificance.Minor
+            // cancellation is major for the specific trip but minor for the
+            // route/stop/direction
+            Effect.Cancellation -> AlertSignificance.Minor
+            Effect.Delay ->
+                if (
+                    (severity >= 3 && informedEntity.any { it.routeType !== RouteType.BUS }) ||
+                        cause == Cause.SingleTracking
+                ) {
+                    AlertSignificance.Minor
+                } else {
+                    AlertSignificance.None
+                }
+            else -> AlertSignificance.None
+        }
+
+    /**
+     * The significance that this alert has at the given time. An alert that isn't active now but
+     * will be in the next day has a max of secondary. Any alert beyond that has a significance of
+     * none, as it should be completely hidden.
+     */
+    public fun significanceAtTime(atTime: EasternTimeInstant): AlertSignificance {
+
         val maxSignificance =
             when {
-                // active now or checking intrinsic significance, use intrinsic
-                atTime == null || isActive(atTime) -> AlertSignificance.Major
-                // upcoming, show as secondary if will be major later
+                isActive(atTime) -> AlertSignificance.Major
                 willBeActiveSoon(atTime) -> AlertSignificance.Secondary
-                // all clear
                 allClear(atTime) -> AlertSignificance.Major
-                // will be active later but not soon enough to show yet, hide completely
                 else -> AlertSignificance.None
             }
         return minOf(intrinsicSignificance, maxSignificance)
@@ -526,7 +530,8 @@ internal constructor(
 
             val alerts =
                 alerts.filter {
-                    it.hasStopsSpecified && it.significance(null) >= AlertSignificance.Accessibility
+                    it.hasStopsSpecified &&
+                        it.intrinsicSignificance >= AlertSignificance.Accessibility
                 }
 
             val targetStopAlertIds =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -103,6 +103,16 @@ internal constructor(
         return minOf(intrinsicSignificance, maxSignificance)
     }
 
+    public fun significanceForTrip(tripId: String): AlertSignificance {
+
+        if (anyInformedEntitySatisfies { checkTrip(tripId) }) {
+            if (effect == Effect.Cancellation) {
+                return AlertSignificance.Major
+            }
+        }
+        return intrinsicSignificance
+    }
+
     val hasNoThroughService: Boolean = effect in setOf(Effect.Shuttle, Effect.Suspension)
 
     public suspend fun summary(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
@@ -102,7 +102,7 @@ private fun entityMatcher(
 private fun getServiceAlerts(alerts: List<Alert>, atTime: EasternTimeInstant): List<Alert> {
     // In practice, AlertAssociatedStop is only used for the map, where only Major alerts are shown.
     return alerts.filter { alert ->
-        alert.significance(atTime) >= AlertSignificance.Major &&
+        alert.significanceAtTime(atTime) >= AlertSignificance.Major &&
             // Alerts that only affect certain trips shouldn't reflect on the map
             !alert.informedEntity.any { it.trip != null }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -171,7 +171,8 @@ public sealed class AlertSummary {
             global: GlobalResponse,
         ): AlertSummary? {
             return withContext(Dispatchers.Default) {
-                if (alert.significance(atTime) < AlertSignificance.Minor) return@withContext null
+                if (alert.significanceAtTime(atTime) < AlertSignificance.Minor)
+                    return@withContext null
 
                 val location by lazy { alertLocation(alert, stopId, directionId, patterns, global) }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -16,7 +16,7 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
 
     public fun cardSpec(now: EasternTimeInstant, isAllServiceDisrupted: Boolean): AlertCardSpec {
 
-        val significance = alert.significance(now)
+        val significance = alert.significanceAtTime(now)
         return if (isDownstream) {
             AlertCardSpec.Downstream
         } else if (significance == AlertSignificance.Major && isAllServiceDisrupted) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
@@ -38,7 +38,7 @@ public data class DisplayAlerts(
                     .sortedWith(
                         compareByDescending<Alert> { it.isActive(now) }
                             .thenByDescending { idsHere.contains(it.id) }
-                            .thenByDescending { it.significance(null) }
+                            .thenByDescending { it.intrinsicSignificance }
                             .thenBy { it.currentOrNextPeriod(now)?.start?.instant }
                     )
                     .map { DisplayAlert(it, !idsHere.contains(it.id)) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.model.Alert.Effect
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -172,15 +171,17 @@ public data class RouteCardData(
         internal val hasSchedulesToday: Boolean = hasSchedulesTodayByPattern.any { it.value }
 
         internal fun hasMajorAlerts(atTime: EasternTimeInstant): Boolean =
-            this.alertsHere.any { alert -> alert.significance(atTime) == AlertSignificance.Major }
+            this.alertsHere.any { alert ->
+                alert.significanceAtTime(atTime) == AlertSignificance.Major
+            }
 
         private fun majorAlert(atTime: EasternTimeInstant) =
-            alertsHere.firstOrNull { it.significance(atTime) >= AlertSignificance.Major }
+            alertsHere.firstOrNull { it.significanceAtTime(atTime) >= AlertSignificance.Major }
 
         private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
-                it.significance(atTime) < AlertSignificance.Major &&
-                    it.significance(atTime) >= AlertSignificance.Secondary
+                it.significanceAtTime(atTime) < AlertSignificance.Major &&
+                    it.significanceAtTime(atTime) >= AlertSignificance.Secondary
             } ?: alertsDownstream.firstOrNull()
 
         public fun alertsHere(tripId: String? = null): List<Alert> =
@@ -297,7 +298,9 @@ public data class RouteCardData(
                         .orEmpty()
                 val majorAlert =
                     Alert.applicableAlerts(
-                        alertsHere.filter { it.significance(atTime) >= AlertSignificance.Major },
+                        alertsHere.filter {
+                            it.significanceAtTime(atTime) >= AlertSignificance.Major
+                        },
                         directionId,
                         routePatterns.map { it.routeId },
                         stopIds,
@@ -981,7 +984,7 @@ public data class RouteCardData(
         ): List<Alert> =
             alerts?.alerts?.values?.filter {
                 (it.isActive(filterAtTime) || it.willBeActiveSoon(filterAtTime)) &&
-                    it.significance(filterAtTime) >=
+                    it.significanceAtTime(filterAtTime) >=
                         if (includeMinorAlerts) AlertSignificance.Minor
                         else AlertSignificance.Accessibility
             } ?: emptyList()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -497,7 +497,8 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                             )
                         } &&
                         // there's no UI yet for secondary alerts in trip details
-                        alert.significanceAtTime(entryTime) >= AlertSignificance.Major
+                        (entryTime?.let { alert.significanceAtTime(it) }
+                            ?: alert.intrinsicSignificance) >= AlertSignificance.Major
                 }
             if (alert == null) return null
             return UpcomingFormat.Disruption(alert, route?.let { MapStopRoute.matching(it) })

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -497,7 +497,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                             )
                         } &&
                         // there's no UI yet for secondary alerts in trip details
-                        alert.significance(entryTime) >= AlertSignificance.Major
+                        alert.significanceAtTime(entryTime) >= AlertSignificance.Major
                 }
             if (alert == null) return null
             return UpcomingFormat.Disruption(alert, route?.let { MapStopRoute.matching(it) })

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -105,7 +105,7 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
                     val activeRelevantAlerts =
                         alerts.alerts.values.filter {
                             (it.isActive(time = now) || it.willBeActiveSoon(time = now)) &&
-                                it.significance(now) >= AlertSignificance.Minor
+                                it.significanceAtTime(now) >= AlertSignificance.Minor
                         }
                     val isCRCore = stop?.isCRCore ?: false
                     Alert.applicableAlerts(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -75,7 +75,7 @@ class AlertTest {
     }
 
     @Test
-    fun `alert significance for delay alerts`() {
+    fun `alert intrinsicSignificance for delay alerts`() {
         val subwayDelaySevere =
             ObjectCollectionBuilder.Single.alert {
                 effect = Alert.Effect.Delay
@@ -218,7 +218,7 @@ class AlertTest {
     }
 
     @Test
-    fun `alert significance limited for upcoming and past alerts`() {
+    fun `alert significanceAtTime limited for upcoming and past alerts`() {
         val objects = ObjectCollectionBuilder()
         val alertStart = EasternTimeInstant.now()
         val alertEnd = alertStart + 2.hours
@@ -241,6 +241,46 @@ class AlertTest {
             AlertSignificance.Major,
             alert.significanceAtTime(atTime = alertEnd + 1.minutes),
         )
+    }
+
+    @Test
+    fun `alert significanceForTrip major for cancellation of matching trip`() {
+        val objects = ObjectCollectionBuilder()
+        val now = EasternTimeInstant.now()
+        val alertStart = now + 1.hours
+        val alertEnd = alertStart + 2.hours
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Cancellation
+                activePeriod(alertStart, alertEnd)
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
+                    stop = "stop",
+                    trip = "targetTrip",
+                )
+            }
+
+        assertEquals(AlertSignificance.Major, alert.significanceForTrip("targetTrip"))
+        assertEquals(AlertSignificance.Minor, alert.significanceForTrip("otherTrip"))
+    }
+
+    @Test
+    fun `alert significanceForTrip is intrinsic for non-cancellations`() {
+        val objects = ObjectCollectionBuilder()
+        val now = EasternTimeInstant.now()
+        val alertStart = now + 1.hours
+        val alertEnd = alertStart + 2.hours
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.ServiceChange
+                activePeriod(alertStart, alertEnd)
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
+                    stop = "stop",
+                )
+            }
+
+        assertEquals(AlertSignificance.Secondary, alert.significanceForTrip("targetTrip"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -30,7 +30,7 @@ class AlertTest {
     }
 
     @Test
-    fun `alert significance is set properly`() {
+    fun `alert intrinsicSignificance is set properly`() {
         for (effect in Alert.Effect.entries) {
             val inherentlyStopSpecific =
                 when (effect) {
@@ -67,7 +67,7 @@ class AlertTest {
                     }
                 assertEquals(
                     expectedSignificance,
-                    alert.significance(null),
+                    alert.intrinsicSignificance,
                     "significance for effect $effect with${if (specifiedStops) "" else "out"} specified stops",
                 )
             }
@@ -118,12 +118,12 @@ class AlertTest {
                 cause = Alert.Cause.SingleTracking
             }
 
-        assertEquals(subwayDelaySevere.significance(null), AlertSignificance.Minor)
-        assertEquals(crDelaySevere.significance(null), AlertSignificance.Minor)
-        assertEquals(ferryDelaySevere.significance(null), AlertSignificance.Minor)
-        assertEquals(singleTrackingDelayInfo.significance(null), AlertSignificance.Minor)
-        assertEquals(subwayDelayNotSevere.significance(null), AlertSignificance.None)
-        assertEquals(busDelaySevere.significance(null), AlertSignificance.None)
+        assertEquals(subwayDelaySevere.intrinsicSignificance, AlertSignificance.Minor)
+        assertEquals(crDelaySevere.intrinsicSignificance, AlertSignificance.Minor)
+        assertEquals(ferryDelaySevere.intrinsicSignificance, AlertSignificance.Minor)
+        assertEquals(singleTrackingDelayInfo.intrinsicSignificance, AlertSignificance.Minor)
+        assertEquals(subwayDelayNotSevere.intrinsicSignificance, AlertSignificance.None)
+        assertEquals(busDelaySevere.intrinsicSignificance, AlertSignificance.None)
     }
 
     @Test
@@ -228,14 +228,19 @@ class AlertTest {
                 activePeriod(alertStart, alertEnd)
             }
 
-        assertEquals(AlertSignificance.Major, alert.significance(atTime = null))
-        assertEquals(AlertSignificance.None, alert.significance(atTime = alertStart - 25.hours))
+        assertEquals(
+            AlertSignificance.None,
+            alert.significanceAtTime(atTime = alertStart - 25.hours),
+        )
         assertEquals(
             AlertSignificance.Secondary,
-            alert.significance(atTime = alertStart - 12.hours),
+            alert.significanceAtTime(atTime = alertStart - 12.hours),
         )
-        assertEquals(AlertSignificance.Major, alert.significance(atTime = alertStart))
-        assertEquals(AlertSignificance.Major, alert.significance(atTime = alertEnd + 1.minutes))
+        assertEquals(AlertSignificance.Major, alert.significanceAtTime(atTime = alertStart))
+        assertEquals(
+            AlertSignificance.Major,
+            alert.significanceAtTime(atTime = alertEnd + 1.minutes),
+        )
     }
 
     @Test


### PR DESCRIPTION
### Summary



<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
In service of https://github.com/mbta/mobile_app/pull/1659

While working on that PR, I was tempted to add a new `tripId` param to the existing `significance(atTime: EasternTimeInstant?)` fun. That didn't feel quite right to me though - depending on the call site, we want either: 
1. significance independent of the current time
2. significance considering the current time
3. significance considering the currently selected trip


This PR makes those 3 separate functions. Now that I've split it all out, I could see merging 1&2 back into a `significanceAtTime` fun that takes an optional time, but I think it is a bit clearer and perhaps easier to choose which one you really want in a particular place with the separate names

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests for the new fun

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
