### PR TITLE
fix(StopDetailsFiltered): trip-only major alerts don't hide tiles

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -275,7 +275,7 @@ fun StopDetailsFilteredDeparturesView(
             }
         } else if (
             isAllServiceDisrupted ||
-                displayAlerts.highPriority.any {
+                displayAlerts.all.any {
                     it.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId) ==
                         AlertCardSpec.Takeover
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -180,7 +180,7 @@ fun StopDetailsFilteredDeparturesView(
 
     @Composable
     fun AlertCard(displayAlert: DisplayAlert, summary: AlertSummary?, modifier: Modifier) {
-        val spec = displayAlert.cardSpec(now, isAllServiceDisrupted)
+        val spec = displayAlert.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId)
 
         AlertCard(
             displayAlert.alert,
@@ -273,7 +273,13 @@ fun StopDetailsFilteredDeparturesView(
             ) {
                 WorldCupBlurb(leaf, routeAccents, offerDetails = true)
             }
-        } else if (isAllServiceDisrupted) {
+        } else if (
+            isAllServiceDisrupted ||
+                displayAlerts.highPriority.any {
+                    it.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId) ==
+                        AlertCardSpec.Takeover
+                }
+        ) {
             Box {}
         } else if (noPredictionsStatus != null) {
             Box(modifier = Modifier.padding(horizontal = 10.dp).padding(bottom = 12.dp)) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -275,10 +275,7 @@ fun StopDetailsFilteredDeparturesView(
             }
         } else if (
             isAllServiceDisrupted ||
-                displayAlerts.all.any {
-                    it.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId) ==
-                        AlertCardSpec.Takeover
-                }
+                displayAlerts.hasTakeover(now, isAllServiceDisrupted, tripFilter?.tripId)
         ) {
             Box {}
         } else if (noPredictionsStatus != null) {

--- a/iosApp/iosApp/ComponentViews/AlertListContainer.swift
+++ b/iosApp/iosApp/ComponentViews/AlertListContainer.swift
@@ -15,6 +15,7 @@ struct AlertListContainer: View {
     let alertSummaries: [String: AlertSummary?]
     let now: EasternTimeInstant
     let isAllServiceDisrupted: Bool
+    let tripId: String?
     let routeAccents: TripRouteAccents
     let onRowTap: (String, AlertCardSpec) -> Void
 
@@ -61,7 +62,7 @@ struct AlertListContainer: View {
     @ViewBuilder
     func alertCard(_ displayAlert: DisplayAlert) -> some View {
         let alert = displayAlert.alert
-        let spec = displayAlert.cardSpec(now: now, isAllServiceDisrupted: isAllServiceDisrupted)
+        let spec = displayAlert.cardSpec(now: now, isAllServiceDisrupted: isAllServiceDisrupted, tripId: tripId)
 
         if alertSummaries.keys.contains(displayAlert.id) {
             AlertCard(
@@ -99,6 +100,7 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }
             )
@@ -109,6 +111,7 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }
             )
@@ -119,6 +122,7 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }
             )

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -146,7 +146,11 @@ struct StopDetailsFilteredDepartureDetails: View {
                     .background(Color.fill3)
                     .withRoundedBorder()
                     .padding(.horizontal, 16)
-            } else if isAllServiceDisrupted {
+            } else if isAllServiceDisrupted || displayAlerts.all.contains(where: { $0.cardSpec(
+                now: now,
+                isAllServiceDisrupted: isAllServiceDisrupted,
+                tripId: tripFilter?.tripId
+            ) == AlertCardSpec.takeover }) {
                 EmptyView()
             } else if let noPredictionsStatus {
                 StopDetailsNoTripCard(
@@ -350,6 +354,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                                alertSummaries: alertSummaries,
                                now: now,
                                isAllServiceDisrupted: isAllServiceDisrupted,
+                               tripId: tripFilter?.tripId,
                                routeAccents: routeAccents,
                                onRowTap: { id, spec in getAlertDetailsHandler(id, spec: spec) })
 

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -146,11 +146,9 @@ struct StopDetailsFilteredDepartureDetails: View {
                     .background(Color.fill3)
                     .withRoundedBorder()
                     .padding(.horizontal, 16)
-            } else if isAllServiceDisrupted || displayAlerts.all.contains(where: { $0.cardSpec(
-                now: now,
-                isAllServiceDisrupted: isAllServiceDisrupted,
-                tripId: tripFilter?.tripId
-            ) == AlertCardSpec.takeover }) {
+            } else if isAllServiceDisrupted || displayAlerts.hasTakeover(now: now,
+                                                                         isAllServiceDisrupted: isAllServiceDisrupted,
+                                                                         tripId: tripFilter?.tripId) {
                 EmptyView()
             } else if let noPredictionsStatus {
                 StopDetailsNoTripCard(

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -130,6 +130,7 @@ struct StopDetailsUnfilteredView: View {
                                                        alertSummaries: summaries,
                                                        now: now,
                                                        isAllServiceDisrupted: false,
+                                                       tripId: nil,
                                                        routeAccents: .init(),
                                                        onRowTap: { id, _ in
                                                            nearbyVM.pushNavEntry(.alertDetails(

--- a/iosApp/iosAppTests/Views/AlertListContainerTests.swift
+++ b/iosApp/iosAppTests/Views/AlertListContainerTests.swift
@@ -52,6 +52,7 @@ final class AlertListContainerTests: XCTestCase {
                                      alertSummaries: [highAlert.id: highAlertSummary, downstreamAlert.id: nil],
                                      now: now,
                                      isAllServiceDisrupted: false,
+                                     tripId: nil,
                                      routeAccents: .init(),
                                      onRowTap: { _, _ in })
 
@@ -70,6 +71,7 @@ final class AlertListContainerTests: XCTestCase {
                                      alertSummaries: [:],
                                      now: now,
                                      isAllServiceDisrupted: false,
+                                     tripId: nil,
                                      routeAccents: .init(),
                                      onRowTap: { _, _ in })
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -364,6 +364,13 @@ internal constructor(
                 }
             }
 
+            fun checkTripStrict(tripId: String) {
+                if (!isSatisfied) return
+                if (this@InformedEntity.trip != tripId) {
+                    isSatisfied = false
+                }
+            }
+
             fun checkNullTrip() {
                 if (this@InformedEntity.trip != null) {
                     isSatisfied = false

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -372,6 +372,7 @@ internal constructor(
             }
 
             fun checkNullTrip() {
+                if (!isSatisfied) return
                 if (this@InformedEntity.trip != null) {
                     isSatisfied = false
                 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -363,6 +363,12 @@ internal constructor(
                     isSatisfied = false
                 }
             }
+
+            fun checkNullTrip() {
+                if (this@InformedEntity.trip != null) {
+                    isSatisfied = false
+                }
+            }
         }
 
         internal fun satisfies(block: PredicateBuilder.() -> Unit): Boolean {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -20,15 +20,20 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
         tripId: String?,
     ): AlertCardSpec {
 
-        val significance = alert.significance(now)
+        val significanceNow = alert.significance(now)
         return if (isDownstream) {
             AlertCardSpec.Downstream
         } else if (
-            significance == AlertSignificance.Major &&
-                ((isAllServiceDisrupted) || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+            significanceNow == AlertSignificance.Major && (isAllServiceDisrupted) ||
+                // May be looking at a trip in the future, so use the intrinsic significance instead
+                // of significance now.
+                (alert.anyInformedEntitySatisfies { checkTrip(tripId) } &&
+                    alert.significance(null) == AlertSignificance.Major)
         ) {
             AlertCardSpec.Takeover
-        } else if (significance == AlertSignificance.Minor && alert.effect == Alert.Effect.Delay) {
+        } else if (
+            significanceNow == AlertSignificance.Minor && alert.effect == Alert.Effect.Delay
+        ) {
             AlertCardSpec.Delay
         } else if (alert.effect == Alert.Effect.ElevatorClosure) {
             AlertCardSpec.Elevator

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -27,7 +27,8 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
             significanceNow == AlertSignificance.Major && (isAllServiceDisrupted) ||
                 // May be looking at a trip in the future, so use the intrinsic significance instead
                 // of significance now.
-                (alert.anyInformedEntitySatisfies { checkTrip(tripId) } &&
+                (tripId != null &&
+                    alert.anyInformedEntitySatisfies { checkTripStrict(tripId) } &&
                     alert.significance(null) == AlertSignificance.Major)
         ) {
             AlertCardSpec.Takeover

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlert.kt
@@ -14,12 +14,19 @@ public data class DisplayAlert(val alert: Alert, val isDownstream: Boolean = fal
 
     val id: String = alert.id
 
-    public fun cardSpec(now: EasternTimeInstant, isAllServiceDisrupted: Boolean): AlertCardSpec {
+    public fun cardSpec(
+        now: EasternTimeInstant,
+        isAllServiceDisrupted: Boolean,
+        tripId: String?,
+    ): AlertCardSpec {
 
         val significance = alert.significance(now)
         return if (isDownstream) {
             AlertCardSpec.Downstream
-        } else if (significance == AlertSignificance.Major && isAllServiceDisrupted) {
+        } else if (
+            significance == AlertSignificance.Major &&
+                ((isAllServiceDisrupted) || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+        ) {
             AlertCardSpec.Takeover
         } else if (significance == AlertSignificance.Minor && alert.effect == Alert.Effect.Delay) {
             AlertCardSpec.Delay

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
@@ -9,6 +9,7 @@ public data class DisplayAlerts(
     val lowPriority: List<DisplayAlert>,
 ) {
 
+    public val all: List<DisplayAlert> = highPriority + lowPriority
     public val allAlerts: List<Alert> = (highPriority + lowPriority).map { it.alert }
 
     public companion object {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/DisplayAlerts.kt
@@ -8,9 +8,17 @@ public data class DisplayAlerts(
     val highPriority: List<DisplayAlert>,
     val lowPriority: List<DisplayAlert>,
 ) {
-
-    public val all: List<DisplayAlert> = highPriority + lowPriority
     public val allAlerts: List<Alert> = (highPriority + lowPriority).map { it.alert }
+
+    public fun hasTakeover(
+        now: EasternTimeInstant,
+        isAllServiceDisrupted: Boolean,
+        tripId: String?,
+    ): Boolean {
+        return (highPriority + lowPriority).any {
+            it.cardSpec(now, isAllServiceDisrupted, tripId) == AlertCardSpec.Takeover
+        }
+    }
 
     public companion object {
         /**

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/PatternSorting.kt
@@ -15,7 +15,7 @@ internal object PatternSorting {
     private fun patternServiceBucket(leafData: RouteCardData.Leaf, now: EasternTimeInstant) =
         when {
             // showing either a trip or an alert (or World Cup service)
-            leafData.hasMajorAlerts(now) ||
+            leafData.hasMajorAlertsAffectingAllTrips(now) ||
                 leafData.upcomingTrips.isNotEmpty() ||
                 leafData.lineOrRoute.id == WorldCupService.route.id -> 1
             // service ended

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.model.Alert.Effect
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -171,11 +170,14 @@ public data class RouteCardData(
 
         internal val hasSchedulesToday: Boolean = hasSchedulesTodayByPattern.any { it.value }
 
-        internal fun hasMajorAlerts(atTime: EasternTimeInstant): Boolean =
-            this.alertsHere.any { alert -> alert.significance(atTime) == AlertSignificance.Major }
+        internal fun hasMajorAlertsAffectingAllTrips(atTime: EasternTimeInstant): Boolean =
+            majorAlertAffectingAllTrips(atTime) == null
 
-        private fun majorAlert(atTime: EasternTimeInstant) =
-            alertsHere.firstOrNull { it.significance(atTime) >= AlertSignificance.Major }
+        private fun majorAlertAffectingAllTrips(atTime: EasternTimeInstant) =
+            alertsHere.firstOrNull {
+                it.significance(atTime) >= AlertSignificance.Major &&
+                    it.anyInformedEntitySatisfies { checkNullTrip() }
+            } // && it.anyInformedEntitySatisfies { checkNullTrip() } }
 
         private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
@@ -472,7 +474,7 @@ public data class RouteCardData(
             secondaryAlert: UpcomingFormat.SecondaryAlert?,
             now: EasternTimeInstant,
         ): LeafFormat.Single {
-            val majorAlert = majorAlert(now)
+            val majorAlert = majorAlertAffectingAllTrips(now)
             val format =
                 if (majorAlert != null) {
                     UpcomingFormat.Disruption(majorAlert, mapStopRoute)
@@ -517,7 +519,7 @@ public data class RouteCardData(
                     UpcomingFormat.SecondaryAlert(StopAlertState.Issue, mapStopRoute)
                 }
 
-            if (majorAlert(now) == null && tripsToShow.isEmpty()) {
+            if (majorAlertAffectingAllTrips(now) == null && tripsToShow.isEmpty()) {
                 // base case is the same for branched & non-branched routes:
                 // if there is no alert & no trips to show, use the single format
                 val service = if (isBranching) null else potentialService.firstOrNull()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -171,7 +171,7 @@ public data class RouteCardData(
         internal val hasSchedulesToday: Boolean = hasSchedulesTodayByPattern.any { it.value }
 
         internal fun hasMajorAlertsAffectingAllTrips(atTime: EasternTimeInstant): Boolean =
-            majorAlertAffectingAllTrips(atTime) == null
+            majorAlertAffectingAllTrips(atTime) != null
 
         private fun majorAlertAffectingAllTrips(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -177,7 +177,7 @@ public data class RouteCardData(
             alertsHere.firstOrNull {
                 it.significance(atTime) >= AlertSignificance.Major &&
                     it.anyInformedEntitySatisfies { checkNullTrip() }
-            } // && it.anyInformedEntitySatisfies { checkNullTrip() } }
+            }
 
         private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -476,6 +476,8 @@ public data class RouteCardData(
         ): LeafFormat.Single {
             val majorAlert = majorAlertAffectingAllTrips(now)
             val format =
+                // Format as disrupted. Assume any upcoming trips that exist should not be shown
+                // and are in fact affected by the alert
                 if (majorAlert != null) {
                     UpcomingFormat.Disruption(majorAlert, mapStopRoute)
                 } else {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -176,7 +176,8 @@ public data class RouteCardData(
         private fun majorAlertAffectingAllTrips(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
                 it.significance(atTime) >= AlertSignificance.Major &&
-                    it.anyInformedEntitySatisfies { checkNullTrip() }
+                    (it.informedEntity.isEmpty() ||
+                        it.anyInformedEntitySatisfies { checkNullTrip() })
             }
 
         private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -93,7 +93,7 @@ public sealed class UpcomingFormat {
                 lastTrip: Boolean,
             ) : this(trip, routeType, trip.display(now, routeType, context, lastTrip), lastTrip)
 
-            override fun toString(): String = format.toString()
+            //     override fun toString(): String = format.toString()
         }
 
         public constructor(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -93,7 +93,7 @@ public sealed class UpcomingFormat {
                 lastTrip: Boolean,
             ) : this(trip, routeType, trip.display(now, routeType, context, lastTrip), lastTrip)
 
-            //     override fun toString(): String = format.toString()
+            override fun toString(): String = format.toString()
         }
 
         public constructor(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
@@ -5,6 +5,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.runBlocking
 
@@ -60,6 +61,29 @@ class DisplayAlertTest {
                 id = "hereForTargetTrip"
                 effect = Effect.Shuttle
                 activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            trip = "trip1",
+                            activities =
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride,
+                                ),
+                        )
+                    )
+            }
+        assertEquals(AlertCardSpec.Takeover, DisplayAlert(tripAlert).cardSpec(now, true, "trip1"))
+    }
+
+    @Test
+    fun `cardSpec major for selected trip with alert in  future is takeover`() = runBlocking {
+        val tripAlert =
+            objects.alert {
+                id = "hereForTargetTrip"
+                effect = Effect.Shuttle
+                activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(5.hours), null))
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
@@ -78,6 +78,32 @@ class DisplayAlertTest {
     }
 
     @Test
+    fun `cardSpec when alert is major but not trip-specific an not all service is disrupted`() =
+        runBlocking {
+            val majorAlert =
+                objects.alert {
+                    id = "hereForTargetTrip"
+                    effect = Effect.Shuttle
+                    activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
+                    informedEntity =
+                        mutableListOf(
+                            Alert.InformedEntity(
+                                activities =
+                                    listOf(
+                                        Alert.InformedEntity.Activity.Board,
+                                        Alert.InformedEntity.Activity.Exit,
+                                        Alert.InformedEntity.Activity.Ride,
+                                    )
+                            )
+                        )
+                }
+            assertEquals(
+                AlertCardSpec.Basic,
+                DisplayAlert(majorAlert).cardSpec(now, false, "trip1"),
+            )
+        }
+
+    @Test
     fun `cardSpec major for selected trip with alert in  future is takeover`() = runBlocking {
         val tripAlert =
             objects.alert {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
@@ -44,26 +44,49 @@ class DisplayAlertTest {
         }
 
     @Test
-    fun `cardSpec major with still some service is regular`() = runBlocking {
-        assertEquals(AlertCardSpec.Basic, DisplayAlert(hereMajorNow).cardSpec(now, false))
+    fun `cardSpec major with still some service somehow is regular`() = runBlocking {
+        assertEquals(AlertCardSpec.Basic, DisplayAlert(hereMajorNow).cardSpec(now, false, null))
     }
 
     @Test
-    fun `cardSpec major with no service somehow is takeover`() = runBlocking {
-        assertEquals(AlertCardSpec.Takeover, DisplayAlert(hereMajorNow).cardSpec(now, true))
+    fun `cardSpec major with no service is takeover`() = runBlocking {
+        assertEquals(AlertCardSpec.Takeover, DisplayAlert(hereMajorNow).cardSpec(now, true, null))
+    }
+
+    @Test
+    fun `cardSpec major for selected trip is takeover`() = runBlocking {
+        val tripAlert =
+            objects.alert {
+                id = "hereForTargetTrip"
+                effect = Effect.Shuttle
+                activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            trip = "trip1",
+                            activities =
+                                listOf(
+                                    Alert.InformedEntity.Activity.Board,
+                                    Alert.InformedEntity.Activity.Exit,
+                                    Alert.InformedEntity.Activity.Ride,
+                                ),
+                        )
+                    )
+            }
+        assertEquals(AlertCardSpec.Takeover, DisplayAlert(tripAlert).cardSpec(now, true, "trip1"))
     }
 
     @Test
     fun `cardSpec major downstream now is downstream`() = runBlocking {
         assertEquals(
             AlertCardSpec.Downstream,
-            DisplayAlert(downstreamMajorNow, true).cardSpec(now, false),
+            DisplayAlert(downstreamMajorNow, true).cardSpec(now, false, null),
         )
     }
 
     @Test
     fun `cardSpec major here later is regular`() = runBlocking {
-        assertEquals(AlertCardSpec.Basic, DisplayAlert(hereMajorLater).cardSpec(now, false))
+        assertEquals(AlertCardSpec.Basic, DisplayAlert(hereMajorLater).cardSpec(now, false, null))
     }
 
     @Test
@@ -73,11 +96,14 @@ class DisplayAlertTest {
             severity = 5
             cause = Alert.Cause.SingleTracking
         }
-        assertEquals(AlertCardSpec.Delay, DisplayAlert(minorDelay).cardSpec(now, false))
+        assertEquals(AlertCardSpec.Delay, DisplayAlert(minorDelay).cardSpec(now, false, null))
     }
 
     @Test
     fun `cardSpec elevator`() {
-        assertEquals(AlertCardSpec.Elevator, DisplayAlert(hereElevatorNow).cardSpec(now, false))
+        assertEquals(
+            AlertCardSpec.Elevator,
+            DisplayAlert(hereElevatorNow).cardSpec(now, false, null),
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertsTest.kt
@@ -88,87 +88,111 @@ class DisplayAlertsTest {
         }
 
     @Test
-    fun `Leaf alertsDisplayOrder sorts and splits alerts in expected order no elevator `() =
-        runBlocking {
-            val displayAlerts =
-                DisplayAlerts.forAlertsAtStop(
-                    listOf(
-                        hereMinorLater,
-                        hereMajorLater,
-                        hereElevatorLater,
-                        hereElevatorNow,
-                        hereMinorNow,
-                        hereMajorNow,
-                    ),
-                    listOf(
-                        downstreamMinorEvenLater,
-                        downstreamMinorLater,
-                        downstreamMajorLater,
-                        downstreamMinorNow,
-                        downstreamMajorNow,
-                    ),
-                    false,
-                    now,
-                )
-
-            assertEquals(
-                listOf(hereMajorNow, hereMinorNow),
-                displayAlerts.highPriority.map { it.alert },
-            )
-            assertEquals(
+    fun `forAlertsAtStop sorts and splits alerts in expected order no elevator `() = runBlocking {
+        val displayAlerts =
+            DisplayAlerts.forAlertsAtStop(
                 listOf(
-                    downstreamMajorNow,
-                    downstreamMinorNow,
-                    hereMajorLater,
                     hereMinorLater,
-                    downstreamMajorLater,
-                    downstreamMinorLater,
-                    downstreamMinorEvenLater,
+                    hereMajorLater,
+                    hereElevatorLater,
+                    hereElevatorNow,
+                    hereMinorNow,
+                    hereMajorNow,
                 ),
-                displayAlerts.lowPriority.map { it.alert },
+                listOf(
+                    downstreamMinorEvenLater,
+                    downstreamMinorLater,
+                    downstreamMajorLater,
+                    downstreamMinorNow,
+                    downstreamMajorNow,
+                ),
+                false,
+                now,
             )
-        }
+
+        assertEquals(
+            listOf(hereMajorNow, hereMinorNow),
+            displayAlerts.highPriority.map { it.alert },
+        )
+        assertEquals(
+            listOf(
+                downstreamMajorNow,
+                downstreamMinorNow,
+                hereMajorLater,
+                hereMinorLater,
+                downstreamMajorLater,
+                downstreamMinorLater,
+                downstreamMinorEvenLater,
+            ),
+            displayAlerts.lowPriority.map { it.alert },
+        )
+    }
 
     @Test
-    fun `Leaf alertsDisplayOrder sorts and splits alerts in expected order with elevator `() =
-        runBlocking {
-            val displayAlerts =
-                DisplayAlerts.forAlertsAtStop(
-                    listOf(
-                        hereMinorLater,
-                        hereMajorLater,
-                        hereElevatorLater,
-                        hereElevatorNow,
-                        hereMinorNow,
-                        hereMajorNow,
-                    ),
-                    listOf(
-                        downstreamMinorEvenLater,
-                        downstreamMinorLater,
-                        downstreamMajorLater,
-                        downstreamMinorNow,
-                        downstreamMajorNow,
-                    ),
-                    true,
-                    now,
-                )
-
-            assertEquals(
-                listOf(hereMajorNow, hereElevatorNow, hereMinorNow),
-                displayAlerts.highPriority.map { it.alert },
-            )
-            assertEquals(
+    fun `forAlertsAtStop sorts and splits alerts in expected order with elevator `() = runBlocking {
+        val displayAlerts =
+            DisplayAlerts.forAlertsAtStop(
                 listOf(
-                    Pair(downstreamMajorNow, true),
-                    Pair(downstreamMinorNow, true),
-                    Pair(hereMajorLater, false),
-                    Pair(hereElevatorLater, false),
-                    Pair(hereMinorLater, false),
-                    Pair(downstreamMajorLater, true),
-                    Pair(downstreamMinorLater, true),
-                    Pair(downstreamMinorEvenLater, true),
+                    hereMinorLater,
+                    hereMajorLater,
+                    hereElevatorLater,
+                    hereElevatorNow,
+                    hereMinorNow,
+                    hereMajorNow,
                 ),
-                displayAlerts.lowPriority.map { Pair(it.alert, it.isDownstream) },
+                listOf(
+                    downstreamMinorEvenLater,
+                    downstreamMinorLater,
+                    downstreamMajorLater,
+                    downstreamMinorNow,
+                    downstreamMajorNow,
+                ),
+                true,
+                now,
             )
-        }
+
+        assertEquals(
+            listOf(hereMajorNow, hereElevatorNow, hereMinorNow),
+            displayAlerts.highPriority.map { it.alert },
+        )
+        assertEquals(
+            listOf(
+                Pair(downstreamMajorNow, true),
+                Pair(downstreamMinorNow, true),
+                Pair(hereMajorLater, false),
+                Pair(hereElevatorLater, false),
+                Pair(hereMinorLater, false),
+                Pair(downstreamMajorLater, true),
+                Pair(downstreamMinorLater, true),
+                Pair(downstreamMinorEvenLater, true),
+            ),
+            displayAlerts.lowPriority.map { Pair(it.alert, it.isDownstream) },
+        )
+    }
+
+    @Test
+    fun `hasTakeover true when any takeover`() = runBlocking {
+        val displayAlerts =
+            DisplayAlerts.forAlertsAtStop(
+                listOf(hereMajorNow),
+                listOf(downstreamMinorEvenLater),
+                true,
+                now,
+            )
+
+        assertEquals(true, displayAlerts.hasTakeover(now, true, null))
+    }
+
+    @Test
+    fun `hasTakeover false when no takeover`() = runBlocking {
+        val displayAlerts =
+            DisplayAlerts.forAlertsAtStop(
+                listOf(hereMinorNow),
+                listOf(downstreamMinorEvenLater),
+                true,
+                now,
+            )
+
+        assertEquals(false, displayAlerts.hasTakeover(now, true, null))
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -165,6 +165,75 @@ class RouteCardDataLeafTest {
     }
 
     @Test
+    fun `formats as Some with major alert affecting only one trip`() = parametricTest {
+        val now = EasternTimeInstant.now()
+
+        val objects = ObjectCollectionBuilder()
+        val route =
+            objects.route {
+                id = "741"
+                type = RouteType.BUS
+            }
+
+        val trip = objects.trip()
+        val prediction =
+            objects.prediction {
+                this.trip = trip
+                departureTime = now + 5.minutes
+            }
+        val upcomingTrip = objects.upcomingTrip(prediction)
+
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
+                informedEntity =
+                    mutableListOf(
+                        Alert.InformedEntity(
+                            activities = listOf(Alert.InformedEntity.Activity.Board),
+                            directionId = trip.directionId,
+                            route = route.id,
+                            trip = trip.id,
+                        )
+                    )
+            }
+
+        assertEquals(
+            LeafFormat.Single(
+                route = null,
+                headsign = "",
+                UpcomingFormat.Some(
+                    trips =
+                        listOf(
+                            UpcomingFormat.Some.FormattedTrip(
+                                upcomingTrip,
+                                route.type,
+                                TripInstantDisplay.Minutes(minutes = 5, last = true),
+                                lastTrip = true,
+                            )
+                        ),
+                    secondaryAlert = null,
+                ),
+            ),
+            RouteCardData.Leaf(
+                    LineOrRoute.Route(route),
+                    objects.stop(),
+                    0,
+                    emptyList(),
+                    emptySet(),
+                    listOf(upcomingTrip),
+                    listOf(alert),
+                    true,
+                    true,
+                    null,
+                    emptyList(),
+                    anyEnumValue(),
+                )
+                .format(now, GlobalResponse(objects)),
+        )
+    }
+
+    @Test
     fun `formats CR as prediction in past with status`() {
         val now = EasternTimeInstant.now()
         val predictionTime = now - 2.minutes


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | trip-specific suspensions alerts replace all departures](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131248?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

If a major alert applies to one trip, we shouldn't format it as if there is a major alert affecting all trips.

Note: There are a few other things going on here (alert card text, alert not showing up at Boston Landing) that I'll look ito separately

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests
* Ran locally
<img width="45%"  alt="image" src="https://github.com/user-attachments/assets/7a3a1ec8-55c3-4eb3-ad00-51fa34a6bc61" s><img width="45%" alt="image" src="https://github.com/user-attachments/assets/5ced2b9f-34e7-4f2e-ae0a-606283ec2292" style="width: 50%; height: 50%"/>
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/9ec55375-10ee-46c0-a117-98ecf38d043e" /><img width="45%"  alt="image" src="https://github.com/user-attachments/assets/7855dddd-c490-4d56-b464-d639fd656ee6" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
