### PR TITLE
fix: Replace notifications for the same alert

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/NotificationWorker.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/NotificationWorker.kt
@@ -16,6 +16,7 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.MainActivity
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.json
+import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.response.PushNotificationPayload
 import com.mbta.tid.mbta_app.model.response.fromWorkData
 import org.koin.core.component.KoinComponent
@@ -78,7 +79,12 @@ class NotificationWorker(appContext: Context, workerParams: WorkerParameters) :
         )
         notificationManager.createNotificationChannel(channel)
 
-        val notificationId = 0
+        val idSuffix =
+            when (payload.summary) {
+                is AlertSummary.AllClear -> "-all-clear"
+                else -> ""
+            }
+        val notificationId = (payload.alertId + idSuffix).hashCode()
         notificationManager.notify(notificationId, notificationBuilder.build())
         return Result.success()
     }

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -85,8 +85,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
                 PushNotificationPayload.companion.launchKey:
                     PushNotificationPayload.companion.serialize(payload: payload),
             ]
-            let uuidString = UUID().uuidString
-            let request = UNNotificationRequest(identifier: uuidString, content: content, trigger: nil)
+            content.sound = .default
+            let idSuffix = switch onEnum(of: payload.summary) {
+            case .allClear: "-all-clear"
+            default: ""
+            }
+            let notificationId = payload.alertId + idSuffix
+            let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: nil)
             let notificationCenter = UNUserNotificationCenter.current()
             notificationCenter.add(request, withCompletionHandler: { error in
                 if let error {
@@ -105,8 +110,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         FcmTokenContainer.shared.token = token
     }
 
-    func userNotificationCenter(_: UNUserNotificationCenter,
-                                willPresent notification: UNNotification) async -> UNNotificationPresentationOptions {
+    func userNotificationCenter(
+        _: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
         let userInfo = notification.request.content.userInfo
         Messaging.messaging().appDidReceiveMessage(userInfo)
         return [[.banner, .list, .sound]]


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | Don't overwrite existing notifications on Android unless they're updates for the same alert](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214048791658267?focus=true)

On Android, we were only ever displaying a single notification for the last alert that was received, and on iOS we were displaying every single alert separately, even if there were updates for an alert that was already displayed as one of the existing notifications.

These changes make it so that any notifications coming in for an alert that is already displayed (either a reminder, standard notification, or update) will replace that existing notification, but still cause a sound and bring the notification to the top of the stack. All clears for that same alert will show up as a separate notification alongside the original one.

I also noticed while testing that iOS was never playing a notification sound, so I added that too.

### Testing

Manually tested sending reminders, notifications, updates, and all clears on iOS and Android.