### PR TITLE
fix(RouteCardData): Treat trip-specific major as secondary in alert card

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -182,8 +182,10 @@ public data class RouteCardData(
 
         private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
-                it.significance(atTime) < AlertSignificance.Major &&
-                    it.significance(atTime) >= AlertSignificance.Secondary
+                (it.significance(atTime) < AlertSignificance.Major &&
+                    it.significance(atTime) >= AlertSignificance.Secondary) ||
+                    (it.significance(atTime) == AlertSignificance.Major &&
+                        !it.anyInformedEntitySatisfies { checkNullTrip() })
             } ?: alertsDownstream.firstOrNull()
 
         public fun alertsHere(tripId: String? = null): List<Alert> =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -165,14 +165,14 @@ class RouteCardDataLeafTest {
     }
 
     @Test
-    fun `formats as Some with major alert affecting only one trip`() = parametricTest {
+    fun `formats as Some with major alert affecting only one trip`() {
         val now = EasternTimeInstant.now()
 
         val objects = ObjectCollectionBuilder()
         val route =
             objects.route {
-                id = "741"
-                type = RouteType.BUS
+                id = "CR-Worcester"
+                type = RouteType.COMMUTER_RAIL
             }
 
         val trip = objects.trip()
@@ -208,11 +208,16 @@ class RouteCardDataLeafTest {
                             UpcomingFormat.Some.FormattedTrip(
                                 upcomingTrip,
                                 route.type,
-                                TripInstantDisplay.Minutes(minutes = 5, last = true),
+                                TripInstantDisplay.Time(
+                                    predictionTime = prediction.departureTime!!,
+                                    last = true,
+                                    headline = true,
+                                ),
                                 lastTrip = true,
                             )
                         ),
-                    secondaryAlert = null,
+                    secondaryAlert =
+                        UpcomingFormat.SecondaryAlert(StopAlertState.Issue, MapStopRoute.COMMUTER),
                 ),
             ),
             RouteCardData.Leaf(
@@ -227,7 +232,7 @@ class RouteCardDataLeafTest {
                     true,
                     null,
                     emptyList(),
-                    anyEnumValue(),
+                    RouteCardData.Context.NearbyTransit,
                 )
                 .format(now, GlobalResponse(objects)),
         )


### PR DESCRIPTION
### Summary

_Ticket:_ Follow-up on [Notifications QA | trip-specific suspensions alerts replace all departures](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213983085131248?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

It was a little strange to not see a trip-specific cancellation or suspension reflected in favorites or nearby transit when it was previously. This updates the secondary alert logic to include major trip-specific alerts. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Updated unit test, ran locally
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/bd2089ae-2943-4a9a-a8dd-6bbf262ece9c" />

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
