### PR TITLE
refactor: secondaryAlert => warningAlert

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
@@ -41,7 +41,7 @@ class HeadsignRowViewTest {
                         true,
                     ),
                 ),
-                secondaryAlert = null,
+                warningAlert = null,
             ),
         )
 
@@ -63,7 +63,7 @@ class HeadsignRowViewTest {
                         true,
                     )
                 ),
-                secondaryAlert = null,
+                warningAlert = null,
             ),
         )
 
@@ -72,7 +72,7 @@ class HeadsignRowViewTest {
     }
 
     @Test
-    fun showsOnePredictionWithSecondaryAlert() {
+    fun showsOnePredictionWithWarningAlert() {
         init(
             "A Place",
             UpcomingFormat.Some(
@@ -84,7 +84,7 @@ class HeadsignRowViewTest {
                         true,
                     )
                 ),
-                secondaryAlert = UpcomingFormat.SecondaryAlert("alert-large-green-issue"),
+                warningAlert = UpcomingFormat.WarningAlert("alert-large-green-issue"),
             ),
         )
 
@@ -105,12 +105,12 @@ class HeadsignRowViewTest {
     }
 
     @Test
-    fun showsNoPredictionsWithSecondaryAlert() {
+    fun showsNoPredictionsWithWarningAlert() {
         init(
             "Somewhere",
             UpcomingFormat.NoTrips(
                 noTripsFormat = UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                secondaryAlert = UpcomingFormat.SecondaryAlert("alert-large-bus-issue"),
+                warningAlert = UpcomingFormat.WarningAlert("alert-large-bus-issue"),
             ),
         )
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -78,7 +78,7 @@ class AlertCardTests {
     }
 
     @Test
-    fun testSecondaryAlertCard() {
+    fun testWarningAlertCard() {
         val alert =
             ObjectCollectionBuilder.Single.alert {
                 header = "Alert header"
@@ -253,7 +253,7 @@ class AlertCardTests {
     }
 
     @Test
-    fun testSecondaryAlertCardSummary() {
+    fun testWarningAlertCardSummary() {
         val alert =
             ObjectCollectionBuilder.Single.alert {
                 header = "Alert header"

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
@@ -44,7 +44,7 @@ class DepartureTileTest {
                                     false,
                                 )
                             ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     upcoming,
                 ),
@@ -84,7 +84,7 @@ class DepartureTileTest {
                                     false,
                                 )
                             ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     upcoming,
                 ),
@@ -119,7 +119,7 @@ class DepartureTileTest {
                                     false,
                                 )
                             ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     upcoming,
                 ),
@@ -156,7 +156,7 @@ class DepartureTileTest {
                                     false,
                                 )
                             ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     upcoming,
                 ),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionRowView.kt
@@ -72,7 +72,7 @@ private fun DirectionRowViewPreview() {
                                     lastTrip = false,
                                 ),
                             ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
             )
             DirectionRowView(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/HeadsignRowView.kt
@@ -60,7 +60,7 @@ fun HeadsignRowViewPreview() {
                             null,
                         ),
                     ),
-                    secondaryAlert = null,
+                    warningAlert = null,
                 ),
             )
             HeadsignRowView(
@@ -82,7 +82,7 @@ fun HeadsignRowViewPreview() {
                             null,
                         ),
                     ),
-                    secondaryAlert = UpcomingFormat.SecondaryAlert("alert-large-bus-issue"),
+                    warningAlert = UpcomingFormat.WarningAlert("alert-large-bus-issue"),
                 ),
             )
             HeadsignRowView(
@@ -93,14 +93,14 @@ fun HeadsignRowViewPreview() {
                 "None with Alert",
                 UpcomingFormat.NoTrips(
                     UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                    secondaryAlert = UpcomingFormat.SecondaryAlert("alert-large-bus-issue"),
+                    warningAlert = UpcomingFormat.WarningAlert("alert-large-bus-issue"),
                 ),
             )
             HeadsignRowView(
                 "Decorated None with Alert",
                 UpcomingFormat.NoTrips(
                     UpcomingFormat.NoTripsFormat.PredictionsUnavailable,
-                    secondaryAlert = UpcomingFormat.SecondaryAlert("alert-large-green-issue"),
+                    warningAlert = UpcomingFormat.WarningAlert("alert-large-green-issue"),
                 ),
                 pillDecoration =
                     PillDecoration.OnRow(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/PredictionRowView.kt
@@ -61,13 +61,12 @@ fun PredictionRowView(
                 line = null,
                 RoutePillType.Flex,
                 modifier =
-                    if (predictions.secondaryAlert == null) Modifier.padding(end = 8.dp)
-                    else Modifier,
+                    if (predictions.warningAlert == null) Modifier.padding(end = 8.dp) else Modifier,
             )
         }
-        predictions.secondaryAlert?.let { secondaryAlert ->
+        predictions.warningAlert?.let { warningAlert ->
             Image(
-                painterResource(drawableByName(secondaryAlert.iconName)),
+                painterResource(drawableByName(warningAlert.iconName)),
                 stringResource(R.string.alert),
                 modifier = Modifier.placeholderIfLoading().padding(end = 8.dp),
             )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/Departures.kt
@@ -110,9 +110,9 @@ fun Departures(
                         }
                         formatted is LeafFormat.Branched -> {
                             Row(verticalAlignment = Alignment.CenterVertically) {
-                                formatted.secondaryAlert?.let { secondaryAlert ->
+                                formatted.warningAlert?.let { warningAlert ->
                                     Image(
-                                        painterResource(drawableByName(secondaryAlert.iconName)),
+                                        painterResource(drawableByName(warningAlert.iconName)),
                                         stringResource(R.string.alert),
                                         modifier =
                                             Modifier.placeholderIfLoading().padding(end = 8.dp),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTile.kt
@@ -153,7 +153,7 @@ private fun DepartureTilePreview() {
                                 null,
                             )
                         ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     objects.upcomingTrip(schedule1),
                 ),
@@ -175,7 +175,7 @@ private fun DepartureTilePreview() {
                                 null,
                             )
                         ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     objects.upcomingTrip(schedule1),
                 ),
@@ -201,7 +201,7 @@ private fun DepartureTilePreview() {
                                 null,
                             )
                         ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     objects.upcomingTrip(schedule1),
                 ),
@@ -222,7 +222,7 @@ private fun DepartureTilePreview() {
                                 null,
                             )
                         ),
-                        secondaryAlert = null,
+                        warningAlert = null,
                     ),
                     objects.upcomingTrip(schedule1),
                 ),

--- a/androidApp/src/test/java/com/mbta/tid/mbta_app/android/map/DrawableByNameTest.kt
+++ b/androidApp/src/test/java/com/mbta/tid/mbta_app/android/map/DrawableByNameTest.kt
@@ -30,7 +30,7 @@ class DrawableByNameTest {
         for (alertEffect in Alert.Effect.entries - Alert.Effect.ElevatorClosure) {
             val alert = alert { effect = alertEffect }
             for (route in MapStopRoute.entries + null) {
-                val icon = UpcomingFormat.SecondaryAlert(alert, route)
+                val icon = UpcomingFormat.WarningAlert(alert, route)
                 assertNotNull(drawableByName(icon.iconName))
             }
         }

--- a/iosApp/iosApp/ComponentViews/PredictionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/PredictionRowView.swift
@@ -32,8 +32,8 @@ struct PredictionRowView: View {
 
     var body: some View {
         HStack(spacing: 0) {
-            if let secondaryAlert = predictions.secondaryAlert {
-                Image(secondaryAlert.iconName)
+            if let warningAlert = predictions.warningAlert {
+                Image(warningAlert.iconName)
                     .accessibilityLabel("Alert")
                     .frame(width: 18, height: 18)
                     .padding(.trailing, 8)
@@ -106,7 +106,7 @@ struct PredictionRowView: View {
                     alert: nil
 
                 ),
-            ], secondaryAlert: nil),
+            ], warningAlert: nil),
             destination: { Text("Needham Heights") }
         )
 
@@ -119,7 +119,7 @@ struct PredictionRowView: View {
                     lastTrip: false,
                     alert: nil
                 ),
-                secondaryAlert: nil
+                warningAlert: nil
             ),
             destination: { Text("Longer Destination than That") }
         )
@@ -131,7 +131,7 @@ struct PredictionRowView: View {
                 format: .Overridden(text: "Stopped 10 stops away", last: false),
                 lastTrip: false,
                 alert: nil
-            ), secondaryAlert: nil),
+            ), warningAlert: nil),
             pillDecoration: .onRow(route: TestData.getRoute(id: "Green-B")),
             destination: { Text("Destination") }
         )
@@ -143,7 +143,7 @@ struct PredictionRowView: View {
                 format: .Overridden(text: "Stopped 10 stops away", last: false),
                 lastTrip: false,
                 alert: nil
-            ), secondaryAlert: nil),
+            ), warningAlert: nil),
             destination: { Text("Destination") }
         )
 
@@ -163,7 +163,7 @@ struct PredictionRowView: View {
                     lastTrip: false,
                     alert: nil
                 ),
-            ], secondaryAlert: nil),
+            ], warningAlert: nil),
             destination: { Text("Destination") }
         )
 

--- a/iosApp/iosApp/ComponentViews/RouteCard/DirectionRowView.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/DirectionRowView.swift
@@ -63,7 +63,7 @@ struct DirectionRowView_Previews: PreviewProvider {
                             now: now, context: .nearbyTransit,
                             lastTrip: false,
                         ),
-                    ], secondaryAlert: nil)
+                    ], warningAlert: nil)
                 )
                 DirectionRowView(
                     direction: Direction(name: "North", destination: "None", id: 0),

--- a/iosApp/iosApp/ComponentViews/RouteCard/HeadsignRowView.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/HeadsignRowView.swift
@@ -49,10 +49,10 @@ struct HeadsignRowView_Previews: PreviewProvider {
                 prediction.trip = trip2
                 prediction.departureTime = now.plus(minutes: 12)
             }
-            let secondaryAlert = UpcomingFormat.SecondaryAlert(
+            let warningAlert = UpcomingFormat.WarningAlert(
                 iconName: "alert-large-bus-issue"
             )
-            let greenLineEAlert = UpcomingFormat.SecondaryAlert(
+            let greenLineEAlert = UpcomingFormat.WarningAlert(
                 iconName: "alert-large-green-issue"
             )
             let greenLineERoute = objects.route { route in
@@ -80,7 +80,7 @@ struct HeadsignRowView_Previews: PreviewProvider {
                             now: now, context: .nearbyTransit,
                             lastTrip: false,
                         ),
-                    ], secondaryAlert: nil)
+                    ], warningAlert: nil)
                 )
                 HeadsignRowView(
                     headsign: "Some with Alert",
@@ -97,7 +97,7 @@ struct HeadsignRowView_Previews: PreviewProvider {
                             now: now, context: .nearbyTransit,
                             lastTrip: false,
                         ),
-                    ], secondaryAlert: secondaryAlert)
+                    ], warningAlert: warningAlert)
                 )
                 HeadsignRowView(
                     headsign: "None",
@@ -109,14 +109,14 @@ struct HeadsignRowView_Previews: PreviewProvider {
                     headsign: "None with Alert",
                     predictions: UpcomingFormat.NoTrips(
                         noTripsFormat: UpcomingFormat.NoTripsFormatPredictionsUnavailable(),
-                        secondaryAlert: secondaryAlert
+                        warningAlert: warningAlert
                     )
                 )
                 HeadsignRowView(
                     headsign: "Decorated None with Alert",
                     predictions: UpcomingFormat.NoTrips(
                         noTripsFormat: UpcomingFormat.NoTripsFormatPredictionsUnavailable(),
-                        secondaryAlert: greenLineEAlert
+                        warningAlert: greenLineEAlert
                     ),
                     pillDecoration: .onRow(route: greenLineERoute)
                 )

--- a/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
+++ b/iosApp/iosApp/ComponentViews/RouteCard/RouteCardDirection.swift
@@ -18,8 +18,8 @@ struct RouteCardDirection: View {
         case let .branched(branched):
             VStack(alignment: .leading, spacing: 6) {
                 HStack(alignment: .center) {
-                    if let secondaryAlert = branched.secondaryAlert {
-                        Image(secondaryAlert.iconName)
+                    if let warningAlert = branched.warningAlert {
+                        Image(warningAlert.iconName)
                             .accessibilityLabel("Alert")
                             .frame(width: 18, height: 18)
                     }

--- a/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DepartureTile.swift
@@ -130,7 +130,7 @@ struct DepartureTile: View {
                             lastTrip: false,
                             alert: nil
                         ),
-                    ], secondaryAlert: nil),
+                    ], warningAlert: nil),
                     upcoming: upcomingTrip
                 ),
                 onTap: {},
@@ -148,7 +148,7 @@ struct DepartureTile: View {
                             lastTrip: false,
                             alert: nil
                         ),
-                    ], secondaryAlert: nil),
+                    ], warningAlert: nil),
                     upcoming: upcomingTrip
                 ),
                 onTap: {},
@@ -173,7 +173,7 @@ struct DepartureTile: View {
                                 alert: nil
                             ),
                         ],
-                        secondaryAlert: nil
+                        warningAlert: nil
                     ),
                     upcoming: upcomingTrip
                 ),
@@ -191,7 +191,7 @@ struct DepartureTile: View {
                             lastTrip: false,
                             alert: nil
                         ),
-                    ], secondaryAlert: nil),
+                    ], warningAlert: nil),
                     upcoming: upcomingTrip
                 ),
                 onTap: {},

--- a/iosApp/iosAppTests/Pages/StopDetails/DepartureTileTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DepartureTileTests.swift
@@ -33,7 +33,7 @@ final class DepartureTileTests: XCTestCase {
                         lastTrip: false,
                         alert: nil
                     )],
-                    secondaryAlert: nil
+                    warningAlert: nil
                 ),
                 upcoming: upcomingTrip
             ),
@@ -61,7 +61,7 @@ final class DepartureTileTests: XCTestCase {
                         lastTrip: false,
                         alert: nil
                     )],
-                    secondaryAlert: nil
+                    warningAlert: nil
                 ),
                 upcoming: upcomingTrip
             ),
@@ -91,7 +91,7 @@ final class DepartureTileTests: XCTestCase {
                         lastTrip: false,
                         alert: nil
                     )],
-                    secondaryAlert: nil
+                    warningAlert: nil
                 ),
                 upcoming: upcomingTrip
             ),
@@ -119,7 +119,7 @@ final class DepartureTileTests: XCTestCase {
                     lastTrip: false,
                     alert: nil
                 )],
-                secondaryAlert: nil
+                warningAlert: nil
             ),
             upcoming: upcomingTrip
         )

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -181,7 +181,7 @@ final class AlertCardTests: XCTestCase {
             .find(text: "Shuttle buses from Start Stop to End Stop through 4:00\u{202F}PM"))
     }
 
-    func testSecondaryAlertCard() throws {
+    func testWarningAlertCard() throws {
         let now = EasternTimeInstant.now()
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
@@ -209,7 +209,7 @@ final class AlertCardTests: XCTestCase {
         wait(for: [exp], timeout: 1)
     }
 
-    func testSecondaryAlertCardSummary() throws {
+    func testWarningAlertCardSummary() throws {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .detour

--- a/iosApp/iosAppTests/Views/PredictionRowViewTests.swift
+++ b/iosApp/iosAppTests/Views/PredictionRowViewTests.swift
@@ -13,11 +13,11 @@ import ViewInspector
 import XCTest
 
 final class PredictionRowViewTests: XCTestCase {
-    func testSecondaryAlert() throws {
+    func testWarningAlert() throws {
         let sut = PredictionRowView(
             predictions: UpcomingFormat.NoTrips(
                 noTripsFormat: UpcomingFormat.NoTripsFormatPredictionsUnavailable(),
-                secondaryAlert: .init(iconName: "alert-large-bus-issue")
+                warningAlert: .init(iconName: "alert-large-bus-issue")
             ),
             pillDecoration: .none,
             destination: { EmptyView() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/LeafFormat.kt
@@ -37,7 +37,7 @@ public sealed class LeafFormat {
                     TileData(
                         route = route,
                         headsign = headsign.takeUnless { it == directionDestination },
-                        UpcomingFormat.Some(trip, format.secondaryAlert),
+                        UpcomingFormat.Some(trip, format.warningAlert),
                         trip.trip,
                     )
                 }
@@ -58,14 +58,14 @@ public sealed class LeafFormat {
      *   [branchRows] when it has upcoming service. When a branch has
      *   [UpcomingFormat.NoTripsFormat.PredictionsUnavailable] or [UpcomingFormat.Disruption], it
      *   should only appear once in [branchRows].
-     * @param secondaryAlert The [UpcomingFormat.SecondaryAlert] affecting this stop to to display
-     *   once for the entire direction. This may be a secondary alert at this stop, or a major alert
+     * @param warningAlert The [UpcomingFormat.WarningAlert] affecting this stop to to display once
+     *   for the entire direction. This may be a secondary alert at this stop, or a major alert
      *   affecting a stop downstream of this one on any of the route patterns it serves.
      */
     public data class Branched
     internal constructor(
         val branchRows: List<BranchRow>,
-        val secondaryAlert: UpcomingFormat.SecondaryAlert? = null,
+        val warningAlert: UpcomingFormat.WarningAlert? = null,
     ) : LeafFormat() {
         public data class BranchRow
         internal constructor(
@@ -93,7 +93,7 @@ public sealed class LeafFormat {
                     TileData(
                         branch.route,
                         branch.headsign,
-                        UpcomingFormat.Some(trip, branch.format.secondaryAlert),
+                        UpcomingFormat.Some(trip, branch.format.warningAlert),
                         trip.trip,
                     )
                 } else null
@@ -119,7 +119,7 @@ public sealed class LeafFormat {
 
     internal class BranchedBuilder {
         private val branchRows = mutableListOf<Branched.BranchRow>()
-        var secondaryAlert: UpcomingFormat.SecondaryAlert? = null
+        var warningAlert: UpcomingFormat.WarningAlert? = null
 
         fun branchRow(headsign: String, format: UpcomingFormat) = branchRow(null, headsign, format)
 
@@ -127,7 +127,7 @@ public sealed class LeafFormat {
             branchRows.add(Branched.BranchRow(route, headsign, format))
         }
 
-        internal fun built() = Branched(branchRows, secondaryAlert)
+        internal fun built() = Branched(branchRows, warningAlert)
     }
 
     internal companion object {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -180,7 +180,14 @@ public data class RouteCardData(
                         it.anyInformedEntitySatisfies { checkNullTrip() })
             }
 
-        private fun secondaryAlertToDisplay(atTime: EasternTimeInstant) =
+        /**
+         * A warning alert should be displayed without obstructing schedules + predictions. It is
+         * one of
+         * - a secondary alert for this stop/route/direction
+         * - a major alert that affects only some trip for this stop/route/direction
+         * - an alert downstream of this stop/route/direction
+         */
+        private fun warningAlertToDisplay(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
                 (it.significance(atTime) < AlertSignificance.Major &&
                     it.significance(atTime) >= AlertSignificance.Secondary) ||
@@ -338,7 +345,7 @@ public data class RouteCardData(
             potentialService: Set<PotentialService>,
             formattedTrips: List<UpcomingFormat.Some.FormattedTrip>,
             mapStopRoute: MapStopRoute?,
-            secondaryAlert: UpcomingFormat.SecondaryAlert?,
+            warningAlert: UpcomingFormat.WarningAlert?,
             globalData: GlobalResponse?,
             now: EasternTimeInstant,
         ): LeafFormat {
@@ -367,7 +374,7 @@ public data class RouteCardData(
                             UpcomingFormat.Some(format, null),
                         )
                     },
-                    secondaryAlert,
+                    warningAlert,
                 )
             }
 
@@ -461,7 +468,7 @@ public data class RouteCardData(
 
             return LeafFormat.Branched(
                 upcomingTripBranches + predictionsUnavailableBranches + disruptedHeadsignBranches,
-                secondaryAlert,
+                warningAlert,
             )
         }
 
@@ -474,7 +481,7 @@ public data class RouteCardData(
             headsign: String?,
             formattedTrips: List<UpcomingFormat.Some.FormattedTrip>,
             mapStopRoute: MapStopRoute?,
-            secondaryAlert: UpcomingFormat.SecondaryAlert?,
+            warningAlert: UpcomingFormat.WarningAlert?,
             now: EasternTimeInstant,
         ): LeafFormat.Single {
             val majorAlert = majorAlertAffectingAllTrips(now)
@@ -484,7 +491,7 @@ public data class RouteCardData(
                 if (majorAlert != null) {
                     UpcomingFormat.Disruption(majorAlert, mapStopRoute)
                 } else {
-                    UpcomingFormat.Some(formattedTrips, secondaryAlert)
+                    UpcomingFormat.Some(formattedTrips, warningAlert)
                 }
             return LeafFormat.Single(route, headsign, format)
         }
@@ -519,9 +526,9 @@ public data class RouteCardData(
 
             val mapStopRoute = MapStopRoute.matching(representativeRoute)
 
-            val secondaryAlert =
-                secondaryAlertToDisplay(now)?.let {
-                    UpcomingFormat.SecondaryAlert(StopAlertState.Issue, mapStopRoute)
+            val warningAlert =
+                warningAlertToDisplay(now)?.let {
+                    UpcomingFormat.WarningAlert(StopAlertState.Issue, mapStopRoute)
                 }
 
             if (majorAlertAffectingAllTrips(now) == null && tripsToShow.isEmpty()) {
@@ -543,7 +550,7 @@ public data class RouteCardData(
                                     now,
                                     subwayServiceStartTime,
                                 ),
-                                secondaryAlert,
+                                warningAlert,
                             ),
                         )
                 }
@@ -554,7 +561,7 @@ public data class RouteCardData(
                     potentialService,
                     tripsToShow,
                     mapStopRoute,
-                    secondaryAlert,
+                    warningAlert,
                     globalData,
                     now,
                 )
@@ -566,7 +573,7 @@ public data class RouteCardData(
                     potentialService.singleOrNull()?.headsign,
                     tripsToShow,
                     mapStopRoute,
-                    secondaryAlert,
+                    warningAlert,
                     now,
                 )
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -61,7 +61,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                 UpcomingTrip(trip, schedule, prediction, predictionStop, vehicle, disruption?.alert)
                     .format(now, route, TripInstantDisplay.Context.TripDetails, false)
                     ?: return null,
-                secondaryAlert = null,
+                warningAlert = null,
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingFormat.kt
@@ -53,9 +53,9 @@ public sealed class UpcomingFormat {
         }
     }
 
-    public abstract val secondaryAlert: SecondaryAlert?
+    public abstract val warningAlert: WarningAlert?
 
-    public data class SecondaryAlert(val iconName: String) {
+    public data class WarningAlert(val iconName: String) {
         public constructor(
             alert: Alert,
             mapStopRoute: MapStopRoute?,
@@ -68,12 +68,12 @@ public sealed class UpcomingFormat {
     }
 
     public data object Loading : UpcomingFormat() {
-        override val secondaryAlert: SecondaryAlert? = null
+        override val warningAlert: WarningAlert? = null
     }
 
     public data class Some(
         val trips: List<FormattedTrip>,
-        override val secondaryAlert: SecondaryAlert?,
+        override val warningAlert: WarningAlert?,
     ) : UpcomingFormat() {
         public data class FormattedTrip(
             internal val trip: UpcomingTrip,
@@ -98,19 +98,17 @@ public sealed class UpcomingFormat {
 
         public constructor(
             trip: FormattedTrip,
-            secondaryAlert: SecondaryAlert?,
-        ) : this(listOf(trip), secondaryAlert)
+            warningAlert: WarningAlert?,
+        ) : this(listOf(trip), warningAlert)
     }
 
     public data class NoTrips
     @DefaultArgumentInterop.Enabled
-    constructor(
-        val noTripsFormat: NoTripsFormat,
-        override val secondaryAlert: SecondaryAlert? = null,
-    ) : UpcomingFormat()
+    constructor(val noTripsFormat: NoTripsFormat, override val warningAlert: WarningAlert? = null) :
+        UpcomingFormat()
 
     public data class Disruption(val alert: Alert, val iconName: String) : UpcomingFormat() {
-        override val secondaryAlert: SecondaryAlert? = null
+        override val warningAlert: WarningAlert? = null
 
         public constructor(
             alert: Alert,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TileData.kt
@@ -32,10 +32,7 @@ public data class TileData(
                 )
             val formatted =
                 if (formattedUpcomingTrip != null) {
-                    UpcomingFormat.Some(
-                        trips = listOf(formattedUpcomingTrip),
-                        secondaryAlert = null,
-                    )
+                    UpcomingFormat.Some(trips = listOf(formattedUpcomingTrip), warningAlert = null)
                 } else {
                     return null
                 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -93,7 +93,7 @@ class RouteCardDataLeafTest {
                     headsign = null,
                     UpcomingFormat.NoTrips(
                         UpcomingFormat.NoTripsFormat.ServiceEndedToday,
-                        UpcomingFormat.SecondaryAlert(icon),
+                        UpcomingFormat.WarningAlert(icon),
                     ),
                 ),
                 RouteCardData.Leaf(
@@ -216,8 +216,8 @@ class RouteCardDataLeafTest {
                                 lastTrip = true,
                             )
                         ),
-                    secondaryAlert =
-                        UpcomingFormat.SecondaryAlert(StopAlertState.Issue, MapStopRoute.COMMUTER),
+                    warningAlert =
+                        UpcomingFormat.WarningAlert(StopAlertState.Issue, MapStopRoute.COMMUTER),
                 ),
             ),
             RouteCardData.Leaf(
@@ -273,7 +273,7 @@ class RouteCardDataLeafTest {
                             lastTrip = true,
                         )
                     ),
-                    secondaryAlert = null,
+                    warningAlert = null,
                 ),
             ),
             RouteCardData.Leaf(
@@ -333,7 +333,7 @@ class RouteCardDataLeafTest {
                             lastTrip = true,
                         )
                     ),
-                    secondaryAlert = null,
+                    warningAlert = null,
                 ),
             ),
             RouteCardData.Leaf(
@@ -388,7 +388,7 @@ class RouteCardDataLeafTest {
                             lastTrip = true,
                         )
                     ),
-                    UpcomingFormat.SecondaryAlert("alert-large-bus-issue"),
+                    UpcomingFormat.WarningAlert("alert-large-bus-issue"),
                 ),
             ),
             RouteCardData.Leaf(
@@ -439,7 +439,7 @@ class RouteCardDataLeafTest {
                             lastTrip = true,
                         )
                     ),
-                    UpcomingFormat.SecondaryAlert("alert-large-bus-issue"),
+                    UpcomingFormat.WarningAlert("alert-large-bus-issue"),
                 ),
             ),
             RouteCardData.Leaf(
@@ -973,8 +973,8 @@ class RouteCardDataLeafTest {
 
             assertEquals(
                 LeafFormat.branched {
-                    secondaryAlert =
-                        UpcomingFormat.SecondaryAlert(StopAlertState.Issue, MapStopRoute.RED)
+                    warningAlert =
+                        UpcomingFormat.WarningAlert(StopAlertState.Issue, MapStopRoute.RED)
                     branchRow(
                         "Ashmont",
                         UpcomingFormat.Some(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -1101,7 +1101,7 @@ class TripDetailsStopListTest {
                     TripInstantDisplay.Time(now, false),
                     false,
                 ),
-                secondaryAlert = null,
+                warningAlert = null,
             ),
             entry.format(trip, now, route),
         )
@@ -1137,7 +1137,7 @@ class TripDetailsStopListTest {
                     TripInstantDisplay.Time(now, false),
                     false,
                 ),
-                secondaryAlert = null,
+                warningAlert = null,
             ),
             entry.format(trip, now, route),
         )


### PR DESCRIPTION
### Summary

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Follow-up to https://github.com/mbta/mobile_app/pull/1676. SecondaryAlert now contains more alerts that just those with significance of secondary, so renaming to WarningAlert. Also adds doc for `warningAlertToDisplay` to describe what types of alerts are considered a warning alert.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
