### PR TITLE
feat: correctly display multi-route trips on each route

### DIFF
--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -124,7 +124,7 @@ extension HomeMapView {
             .flatMap(\.upcomingTrips)
             .first { upcoming in upcoming.trip.id == tripId }
         let stopSequence = upcoming?.stopSequence ?? tripFilter?.stopSequence
-        let routeId = upcoming?.trip.routeId ?? vehicle.routeId ?? routeCard?.lineOrRoute.id ?? stopFilter.routeId
+        let routeId = upcoming?.routeId ?? vehicle.routeId ?? routeCard?.lineOrRoute.id ?? stopFilter.routeId
 
         analytics.tappedVehicle(routeId: routeId)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -213,6 +213,7 @@ private constructor(
         public var trip: Trip
             get() = checkNotNull(trips[tripId])
             set(trip) {
+                routeId = trip.routeId.idText
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it.idText }
                 tripId = trip.id
                 directionId = trip.directionId
@@ -342,6 +343,7 @@ private constructor(
         public var trip: Trip
             get() = checkNotNull(trips[tripId])
             set(trip) {
+                routeId = trip.routeId.idText
                 routePatterns[trip.routePatternId]?.routeId?.let { routeId = it.idText }
                 tripId = trip.id
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -236,7 +236,7 @@ public data class RouteCardData(
                 val trip = formattedTrip.trip
                 if (context.isStopDetails() || trip.isUpcoming()) {
                     val existingPatterns =
-                        potentialService.getOrPut(Pair(trip.trip.routeId, trip.headsign)) {
+                        potentialService.getOrPut(Pair(trip.routeId, trip.headsign)) {
                             mutableSetOf()
                         }
                     if (trip.trip.routePatternId != null) {
@@ -366,8 +366,7 @@ public data class RouteCardData(
                     formattedTrips.map { format ->
                         val trip = format.trip
                         val route =
-                            if (shouldIncludeRoute) globalData?.getRoute(trip.trip.routeId)
-                            else null
+                            if (shouldIncludeRoute) globalData?.getRoute(trip.routeId) else null
                         LeafFormat.Branched.BranchRow(
                             route,
                             trip.headsign,
@@ -421,8 +420,7 @@ public data class RouteCardData(
                 formattedTrips.take(remainingRowsToShow).map { formatted ->
                     val upcomingTrip = formatted.trip
                     val route =
-                        if (shouldIncludeRoute) globalData?.getRoute(upcomingTrip.trip.routeId)
-                        else null
+                        if (shouldIncludeRoute) globalData?.getRoute(upcomingTrip.routeId) else null
                     LeafFormat.Branched.BranchRow(
                         route,
                         upcomingTrip.trip.headsign,
@@ -584,7 +582,7 @@ public data class RouteCardData(
     internal fun distanceFrom(position: Position): Length =
         this.stopData.first().stop.distanceFrom(position)
 
-    override fun toString(): String = "[RouteCardData]"
+    //    override fun toString(): String = "[RouteCardData]"
 
     public companion object {
         // For regular non-branching service, we always show up to 2 departure rows for each leaf
@@ -858,7 +856,7 @@ public data class RouteCardData(
             for (upcomingTrip in upcomingTrips) {
                 val parentStopId =
                     upcomingTrip.stopId?.let { parentStop(globalData, it)?.id } ?: continue
-                val lineOrRouteId = lineOrRouteId(globalData, upcomingTrip.trip.routeId) ?: continue
+                val lineOrRouteId = lineOrRouteId(globalData, upcomingTrip.routeId) ?: continue
                 upcomingTripsBySlot
                     .getOrPut(
                         HierarchyPath(lineOrRouteId, parentStopId, upcomingTrip.trip.directionId),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -582,7 +582,7 @@ public data class RouteCardData(
     internal fun distanceFrom(position: Position): Length =
         this.stopData.first().stop.distanceFrom(position)
 
-    //    override fun toString(): String = "[RouteCardData]"
+    override fun toString(): String = "[RouteCardData]"
 
     public companion object {
         // For regular non-branching service, we always show up to 2 departure rows for each leaf

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopDetailsUtils.kt
@@ -110,7 +110,7 @@ public object StopDetailsUtils {
                 .flatMap { it.stopData }
                 .flatMap { it.data }
                 .flatMap { it.upcomingTrips }
-                .map { it.trip.routeId }
+                .map { it.routeId }
                 .toSet()
         val filtered = vehicles.vehicles.filter { routeIds.contains(it.value.routeId) }
         return filtered

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -35,6 +35,12 @@ constructor(
 
     val id: String = "${trip.id}-${prediction?.stopSequence ?: schedule?.stopSequence}"
 
+    /**
+     * The effective route ID of this [UpcomingTrip].
+     *
+     * Multi-route trips are an MBTA GTFS extension; as implemented right now, we make extra copies
+     * of predictions and schedules that are rewritten to have the added route IDs.
+     */
     public val routeId: Route.Id = prediction?.routeId ?: schedule?.routeId ?: trip.routeId
 
     internal val time =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -35,6 +35,8 @@ constructor(
 
     val id: String = "${trip.id}-${prediction?.stopSequence ?: schedule?.stopSequence}"
 
+    public val routeId: Route.Id = prediction?.routeId ?: schedule?.routeId ?: trip.routeId
+
     internal val time =
         if (
             prediction != null &&
@@ -175,6 +177,7 @@ constructor(
             alerts: Map<String, Alert>,
         ): List<UpcomingTrip> {
             data class UpcomingTripKey(
+                val routeId: Route.Id,
                 val tripId: String,
                 val rootStopId: String?,
                 val stopSequence: Int?,
@@ -182,6 +185,7 @@ constructor(
                 constructor(
                     schedule: Schedule
                 ) : this(
+                    schedule.routeId,
                     schedule.tripId,
                     stops.resolveParentId(schedule.stopId),
                     schedule.stopSequence,
@@ -190,6 +194,7 @@ constructor(
                 constructor(
                     prediction: Prediction
                 ) : this(
+                    prediction.routeId,
                     prediction.tripId,
                     stops.resolveParentId(prediction.stopId),
                     prediction.stopSequence,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -573,6 +573,35 @@ class UpcomingTripTest {
     }
 
     @Test
+    fun `tripsFromData preserves multi-route trips on each route`() {
+        val objects = ObjectCollectionBuilder()
+        val route1 = objects.route()
+        val route2 = objects.route()
+        val trip = objects.trip { routeId = route1.id.idText }
+        val sched1 = objects.schedule { this.trip = trip }
+        val sched2 =
+            objects.schedule {
+                this.trip = trip
+                routeId = route2.id.idText
+            }
+        val pred1 = objects.prediction(sched1)
+        val pred2 = objects.prediction(sched2)
+
+        assertEquals(
+            listOf(UpcomingTrip(trip, sched1, pred1), UpcomingTrip(trip, sched2, pred2)),
+            UpcomingTrip.tripsFromData(
+                objects.stops,
+                listOf(sched1, sched2),
+                listOf(pred1, pred2),
+                objects.trips,
+                emptyMap(),
+                EasternTimeInstant.now(),
+                objects.alerts,
+            ),
+        )
+    }
+
+    @Test
     fun `time uses schedule time if there's no prediction`() {
         val now = EasternTimeInstant.now()
         val trip = trip()
@@ -799,5 +828,20 @@ class UpcomingTripTest {
         val trip = trip()
 
         assertNull(UpcomingTrip(trip, null, null, null).stopSequence)
+    }
+
+    @Test
+    fun `routeId prioritizes prediction then schedule then trip`() {
+        val objects = ObjectCollectionBuilder()
+        val trip = objects.trip { routeId = "route3" }
+        val schedule = objects.schedule { routeId = "route2" }
+        val prediction = objects.prediction { routeId = "route1" }
+        assertEquals(
+            Route.Id("route3"),
+            UpcomingTrip(trip, schedule = null, prediction = null).routeId,
+        )
+        assertEquals(Route.Id("route1"), UpcomingTrip(trip, schedule = null, prediction).routeId)
+        assertEquals(Route.Id("route2"), UpcomingTrip(trip, schedule, prediction = null).routeId)
+        assertEquals(Route.Id("route1"), UpcomingTrip(trip, schedule, prediction).routeId)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Ensure multi-route schedules and predictions are correctly displayed](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213913595242981?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Consumes https://github.com/mbta/mobile_app_backend/pull/461 and preserves the multiple routes that a trip is scheduled/predicted on.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that a trip with an added route will show on both its route and its added route at its scheduled time. Added unit tests to ensure that objects that would previously have been lost as duplicates are now preserved.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
