### PR TITLE
chore: lint on commented out toString

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,5 +1,6 @@
 import co.touchlab.skie.configuration.DefaultArgumentInterop
 import com.diffplug.spotless.FormatterFunc
+import com.diffplug.spotless.Lint
 import com.mbta.tid.mbta_app.gradle.CachedExecTask
 import com.mbta.tid.mbta_app.gradle.CycloneDxBomTransformTask
 import com.mbta.tid.mbta_app.gradle.DependencyCodegenTask
@@ -160,6 +161,23 @@ spotless {
                         }
                     }
                     return text
+                }
+            },
+        )
+        custom(
+            "ban commented out override fun toString",
+            object : Serializable, FormatterFunc {
+                private val badRegex = Regex("""//\s+override fun toString""")
+
+                override fun apply(p0: String) = p0
+
+                override fun lint(content: String, file: File): List<Lint> {
+                    return content.lines().withIndex().mapNotNull { line ->
+                        val match = badRegex.find(line.value)
+                        if (match != null) {
+                            Lint.atLine(line.index + 1, "", "")
+                        } else null
+                    }
                 }
             },
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [Prevent committing commented out toString fn](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1214098708693408?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This is nice and simple with the comparatively-recent Spotless lint API.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that a commented out toString will cause Spotless to fail.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
