### PR TITLE
chore: delete unused AlertsRepository.getSnapshot

### DIFF
--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -319,11 +319,6 @@ final class ContentViewTests: XCTestCase {
             connectExp?.fulfill()
         }
 
-        func __getSnapshot() async throws -> ApiResult<AlertsStreamDataResponse> {
-            XCTFail()
-            return ApiResultError(code: nil, message: "")
-        }
-
         func disconnect() {
             disconnectExp?.fulfill()
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
@@ -32,9 +32,7 @@ public fun makeNativeModule(
         single<ICurrentAppVersionRepository> { currentAppVersion }
         single<INetworkConnectivityMonitor> { networkConnectivityMonitor }
         single<PhoenixSocket> { socket }
-        factory<IAlertsRepository> {
-            AlertsRepository(get(), get(), get(named("coroutineDispatcherIO")))
-        }
+        factory<IAlertsRepository> { AlertsRepository(get(), get(named("coroutineDispatcherIO"))) }
         factory<IPredictionsRepository> {
             PredictionsRepository(get(), get(named("coroutineDispatcherIO")))
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -4,31 +4,22 @@ import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.network.MobileBackendClient
 import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.AlertsChannel
 import com.mbta.tid.mbta_app.phoenix.ChannelOwner
-import io.ktor.client.call.body
-import io.ktor.http.path
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
 
 public interface IAlertsRepository {
     public fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit)
 
-    public suspend fun getSnapshot(): ApiResult<AlertsStreamDataResponse>
-
     public fun disconnect()
 }
 
-internal class AlertsRepository(
-    socket: PhoenixSocket,
-    private val mobileBackendClient: MobileBackendClient,
-    private val ioDispatcher: CoroutineDispatcher,
-) : IAlertsRepository, KoinComponent {
+internal class AlertsRepository(socket: PhoenixSocket, ioDispatcher: CoroutineDispatcher) :
+    IAlertsRepository, KoinComponent {
     private val channelOwner = ChannelOwner(socket, ioDispatcher)
     internal var channel: PhoenixChannel? by channelOwner::channel
 
@@ -39,11 +30,6 @@ internal class AlertsRepository(
             handleError = { onReceive(ApiResult.Error(message = it)) },
         )
     }
-
-    override suspend fun getSnapshot(): ApiResult<AlertsStreamDataResponse> =
-        withContext(ioDispatcher) {
-            ApiResult.runCatching { mobileBackendClient.get { url { path("api/alerts") } }.body() }
-        }
 
     override fun disconnect() {
         channelOwner.disconnect()
@@ -91,10 +77,6 @@ internal constructor(
         receiveCallback = onReceive
         onConnect()
         onReceive(result)
-    }
-
-    override suspend fun getSnapshot(): ApiResult<AlertsStreamDataResponse> {
-        return result
     }
 
     override fun disconnect() {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
@@ -1,31 +1,20 @@
 package com.mbta.tid.mbta_app.repositories
 
-import com.mbta.tid.mbta_app.AppVariant
 import com.mbta.tid.mbta_app.mocks.MockMessage
-import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.SocketError
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
-import com.mbta.tid.mbta_app.network.MobileBackendClient
 import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixPush
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.phoenix.AlertsChannel
-import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import dev.mokkery.MockMode
 import dev.mokkery.answering.returns
 import dev.mokkery.every
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.verify
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.engine.mock.respondBadRequest
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.fullPath
-import io.ktor.http.headersOf
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -34,24 +23,18 @@ import kotlin.test.assertNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.IO
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Month
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AlertsRepositoryTests {
-    private val emptyBackendClient =
-        MobileBackendClient(MockEngine { respondBadRequest() }, AppVariant.Staging)
-
     @Test
     fun testChannelSetOnRun() = runTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
-        val alertsRepo =
-            AlertsRepository(socket, emptyBackendClient, StandardTestDispatcher(testScheduler))
+        val alertsRepo = AlertsRepository(socket, StandardTestDispatcher(testScheduler))
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -66,8 +49,7 @@ class AlertsRepositoryTests {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
-        val alertsRepo =
-            AlertsRepository(socket, emptyBackendClient, StandardTestDispatcher(testScheduler))
+        val alertsRepo = AlertsRepository(socket, StandardTestDispatcher(testScheduler))
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -80,7 +62,7 @@ class AlertsRepositoryTests {
     @Test
     fun testChannelClearedOnLeave() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
-        val alertsRepo = AlertsRepository(socket, emptyBackendClient, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, Dispatchers.IO)
         every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
         alertsRepo.channel = socket.getChannel(topic = AlertsChannel.topic, params = emptyMap())
         assertNotNull(alertsRepo.channel)
@@ -92,7 +74,7 @@ class AlertsRepositoryTests {
     @Test
     fun testSetsAlertsWhenMessageReceived() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
-        val alertsRepo = AlertsRepository(socket, emptyBackendClient, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {
@@ -131,7 +113,7 @@ class AlertsRepositoryTests {
     @Test
     fun testSetsErrorWhenErrorReceived() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
-        val alertsRepo = AlertsRepository(socket, emptyBackendClient, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {
@@ -162,61 +144,6 @@ class AlertsRepositoryTests {
                 assertNotNull(outcome.message)
                 assertEquals(outcome.message, SocketError.FAILURE)
             }
-        )
-    }
-
-    @Test
-    fun testGetsSnapshot() = runBlocking {
-        val mockEngine = MockEngine { request ->
-            assertEquals("/api/alerts", request.url.fullPath)
-            respond(
-                """
-                {
-                    "alerts": {
-                        "3": {
-                            "id": "3",
-                            "active_period": [],
-                            "description": null,
-                            "effect_name": null,
-                            "header": null,
-                            "informed_entity": [],
-                            "lifecycle": "new",
-                            "severity": 5,
-                            "updated_at": "2025-10-30T15:05:00-04:00"
-                        }
-                    }
-                }
-                """
-                    .trimIndent(),
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, "application/json"),
-            )
-        }
-        val alertsRepo =
-            AlertsRepository(
-                mock(),
-                MobileBackendClient(mockEngine, AppVariant.Staging),
-                Dispatchers.IO,
-            )
-        assertEquals(
-            AlertsStreamDataResponse(
-                mapOf(
-                    "3" to
-                        Alert(
-                            id = "3",
-                            activePeriod = emptyList(),
-                            description = null,
-                            effectName = null,
-                            header = null,
-                            informedEntity = emptyList(),
-                            lifecycle = Alert.Lifecycle.New,
-                            severity = 5,
-                            updatedAt = EasternTimeInstant(2025, Month.OCTOBER, 30, 15, 5),
-                            facilities = null,
-                        )
-                )
-            ),
-            alertsRepo.getSnapshot().dataOrThrow(),
         )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [remove unused alerts controller & client references](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214110029669181)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This API endpoint client was added in https://github.com/mbta/mobile_app/pull/1396 but stopped being used in https://github.com/mbta/mobile_app/pull/1509.

Pairs with https://github.com/mbta/mobile_app_backend/pull/466.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the tests still compile on both Android and iOS.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
