### PR TITLE
feat: Update trip summary behavior

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -350,6 +350,7 @@ class AlertCardTests {
                 TripSpecificAlertSummary(
                     TripSpecificAlertSummary.TripFrom(
                         EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
+                        RouteType.COMMUTER_RAIL,
                         "Ruggles",
                     ),
                     Alert.Effect.Cancellation,
@@ -365,7 +366,9 @@ class AlertCardTests {
         composeTestRule
             .onNode(
                 hasTextMatching(
-                    Regex("12:13\\sPM from Ruggles is cancelled today due to mechanical issue")
+                    Regex(
+                        "12:13\\sPM train from Ruggles is cancelled today due to mechanical issue"
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -406,6 +409,7 @@ class AlertCardTests {
                     TripShuttleAlertSummary.SingleTrip(
                         EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
                         RouteType.COMMUTER_RAIL,
+                        "Oak Grove",
                     ),
                     "Ruggles",
                     "Forest Hills",
@@ -421,8 +425,40 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "Shuttle buses replace the 12:13\\sPM train today from Ruggles to Forest Hills"
+                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills"
                     )
+                )
+            )
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun testThisTripShuttleAlertCard() {
+        val objects = ObjectCollectionBuilder()
+        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                TripShuttleAlertSummary(
+                    TripShuttleAlertSummary.SingleTrip(
+                        EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
+                        RouteType.COMMUTER_RAIL,
+                        null,
+                    ),
+                    "Ruggles",
+                    "Forest Hills",
+                ),
+                AlertCardSpec.Takeover,
+                routeAccents.copy(type = RouteType.COMMUTER_RAIL),
+                onViewDetails = {},
+            )
+        }
+        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+
+        composeTestRule
+            .onNode(
+                hasTextMatching(
+                    Regex("Shuttle buses replace the 12:13\\sPM train from Ruggles to Forest Hills")
                 )
             )
             .assertIsDisplayed()
@@ -438,6 +474,7 @@ class AlertCardTests {
                 TripSpecificAlertSummary(
                     TripSpecificAlertSummary.TripTo(
                         EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
+                        RouteType.COMMUTER_RAIL,
                         "Stoughton",
                     ),
                     Alert.Effect.StationClosure,
@@ -454,7 +491,9 @@ class AlertCardTests {
         composeTestRule
             .onNode(
                 hasTextMatching(
-                    Regex("12:13\\sPM to Stoughton will not stop at Back Bay and Ruggles today")
+                    Regex(
+                        "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today"
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -470,6 +509,7 @@ class AlertCardTests {
                 TripSpecificAlertSummary(
                     TripSpecificAlertSummary.TripFrom(
                         EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
+                        RouteType.COMMUTER_RAIL,
                         "Ruggles",
                     ),
                     Alert.Effect.Cancellation,
@@ -486,7 +526,9 @@ class AlertCardTests {
         composeTestRule
             .onNode(
                 hasTextMatching(
-                    Regex("12:13\\sPM from Ruggles is cancelled tomorrow due to mechanical issue")
+                    Regex(
+                        "12:13\\sPM train from Ruggles is cancelled tomorrow due to mechanical issue"
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -503,6 +545,7 @@ class AlertCardTests {
                     TripShuttleAlertSummary.SingleTrip(
                         EasternTimeInstant(2026, Month.MARCH, 9, 12, 13),
                         RouteType.COMMUTER_RAIL,
+                        "Oak Grove",
                     ),
                     "Ruggles",
                     "Forest Hills",
@@ -525,7 +568,44 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "Shuttle buses replace the 12:13\\sPM train today from Ruggles to Forest Hills daily until Thursday"
+                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills daily until Thursday"
+                    )
+                )
+            )
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun testThisTripShuttleRecurrence() {
+        val objects = ObjectCollectionBuilder()
+        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        composeTestRule.setContent {
+            AlertCard(
+                alert,
+                TripShuttleAlertSummary(
+                    TripShuttleAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
+                    "Ruggles",
+                    "Forest Hills",
+                    recurrence =
+                        AlertSummary.Recurrence.Daily(
+                            ending =
+                                AlertSummary.Timeframe.ThisWeek(
+                                    EasternTimeInstant(2026, Month.MARCH, 12, 9, 18)
+                                )
+                        ),
+                ),
+                AlertCardSpec.Takeover,
+                routeAccents.copy(type = RouteType.COMMUTER_RAIL),
+                onViewDetails = {},
+            )
+        }
+        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+
+        composeTestRule
+            .onNode(
+                hasTextMatching(
+                    Regex(
+                        "Shuttle buses replace this train from Ruggles to Forest Hills daily until Thursday"
                     )
                 )
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
@@ -1,0 +1,190 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
+import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.hours
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Month
+import org.junit.Rule
+import org.junit.Test
+
+class FormattedAlertTests {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testTripSpecificShuttle() = runTest {
+        val now = EasternTimeInstant(2026, Month.APRIL, 10, 15, 0, 0)
+        val summary =
+            TripShuttleAlertSummary(
+                TripShuttleAlertSummary.SingleTrip(
+                    now.plus(1.hours),
+                    RouteType.COMMUTER_RAIL,
+                    null,
+                ),
+                "Porter",
+                "North Station",
+            )
+        val format = FormattedAlert(null, summary)
+        val pattern = "Shuttle buses replace the 4:00\\sPM train from Porter to North Station"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assert(Regex(pattern).matches(summaryString))
+        }
+    }
+
+    @Test
+    fun testTripSpecificDownstreamShuttle() = runTest {
+        val now = EasternTimeInstant(2026, Month.APRIL, 10, 15, 0, 0)
+        val summary =
+            TripShuttleAlertSummary(
+                TripShuttleAlertSummary.SingleTrip(
+                    now.plus(1.hours),
+                    RouteType.COMMUTER_RAIL,
+                    "Concord",
+                ),
+                "Porter",
+                "North Station",
+            )
+        val format = FormattedAlert(null, summary)
+        val pattern =
+            "4:00\\sPM train from Concord is replaced by shuttle buses from Porter to North Station"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assert(Regex(pattern).matches(summaryString))
+        }
+    }
+
+    @Test
+    fun testThisTripSpecificShuttle() = runTest {
+        val summary =
+            TripShuttleAlertSummary(
+                TripShuttleAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
+                "Porter",
+                "North Station",
+            )
+        val format = FormattedAlert(null, summary)
+        val expected = "Shuttle buses replace this train from Porter to North Station"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assertEquals(expected, summaryString)
+        }
+    }
+
+    @Test
+    fun testTripSpecificSuspension() = runTest {
+        val now = EasternTimeInstant(2026, Month.APRIL, 10, 12, 13, 0)
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.TripFrom(now, RouteType.COMMUTER_RAIL, "Ruggles"),
+                Alert.Effect.Suspension,
+                null,
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val pattern = "12:13\\sPM train from Ruggles is suspended today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assert(Regex(pattern).matches(summaryString))
+        }
+    }
+
+    @Test
+    fun testTripSpecificDownstreamSuspension() = runTest {
+        val now = EasternTimeInstant(2026, Month.APRIL, 10, 11, 15, 0)
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.TripFrom(now, RouteType.COMMUTER_RAIL, "Concord"),
+                Alert.Effect.Suspension,
+                listOf("Porter"),
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val pattern = "11:15\\sAM train from Concord will terminate at Porter today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assert(Regex(pattern).matches(summaryString))
+        }
+    }
+
+    @Test
+    fun testThisTripSpecificSuspension() = runTest {
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
+                Alert.Effect.Suspension,
+                null,
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val expected = "This train is suspended today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assertEquals(expected, summaryString)
+        }
+    }
+
+    @Test
+    fun testThisTripSpecificDownstreamSuspension() = runTest {
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
+                Alert.Effect.Suspension,
+                listOf("Porter"),
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val expected = "This train will terminate at Porter today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assertEquals(expected, summaryString)
+        }
+    }
+
+    @Test
+    fun testTripSpecificDownstreamStopClosure() = runTest {
+        val now = EasternTimeInstant(2026, Month.APRIL, 10, 12, 13, 0)
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.TripTo(now, RouteType.COMMUTER_RAIL, "Stoughton"),
+                Alert.Effect.StopClosure,
+                listOf("Back Bay", "Ruggles"),
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val pattern =
+            "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assert(Regex(pattern).matches(summaryString))
+        }
+    }
+
+    @Test
+    fun testThisTripSpecificStopClosure() = runTest {
+        val summary =
+            TripSpecificAlertSummary(
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
+                Alert.Effect.StationClosure,
+                listOf("Porter"),
+                true,
+                Alert.Cause.Weather,
+            )
+        val format = FormattedAlert(null, summary)
+        val expected = "This train will not stop at Porter today due to weather"
+        composeTestRule.setContent {
+            val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
+            assertEquals(expected, summaryString)
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -218,6 +218,7 @@ fun AlertCardPreview() {
             TripSpecificAlertSummary(
                 TripSpecificAlertSummary.TripFrom(
                     EasternTimeInstant(2026, Month.MARCH, 10, 22, 17),
+                    RouteType.COMMUTER_RAIL,
                     "Mansfield",
                 ),
                 Alert.Effect.Cancellation,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -148,7 +148,7 @@ data class FormattedAlert(
             is TripShuttleAlertSummary -> {
                 val identity = alertSummary.tripIdentity
                 val identityString = summaryTripShuttleIdentity(identity, resources)
-                if (identity is TripShuttleAlertSummary.SingleTrip && identity.fromStop != null)
+                if (identity is TripShuttleAlertSummary.SingleTrip && identity.fromStopName != null)
                     AnnotatedString.fromHtml(
                         resources.getString(
                             R.string.alert_summary_trip_shuttle_downstream,
@@ -654,7 +654,7 @@ data class FormattedAlert(
         ) =
             when (tripIdentity) {
                 is TripShuttleAlertSummary.SingleTrip ->
-                    tripIdentity.fromStop?.let {
+                    tripIdentity.fromStopName?.let {
                         resources.getString(
                             R.string.trip_from,
                             tripIdentity.tripTime.formattedTime(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -145,18 +145,30 @@ data class FormattedAlert(
                         summaryRecurrence(alertSummary.recurrence, resources),
                     )
                 )
-            is TripShuttleAlertSummary ->
-                AnnotatedString.fromHtml(
-                    resources.getString(
-                        R.string.alert_summary_trip_shuttle,
-                        summaryTripShuttleIdentity(alertSummary.tripIdentity, resources),
-                        if (alertSummary.isToday) resources.getString(R.string.today)
-                        else resources.getString(R.string.tomorrow),
-                        alertSummary.currentStopName,
-                        alertSummary.endStopName,
-                        summaryRecurrence(alertSummary.recurrence, resources),
+            is TripShuttleAlertSummary -> {
+                val identity = alertSummary.tripIdentity
+                val identityString = summaryTripShuttleIdentity(identity, resources)
+                if (identity is TripShuttleAlertSummary.SingleTrip && identity.fromStop != null)
+                    AnnotatedString.fromHtml(
+                        resources.getString(
+                            R.string.alert_summary_trip_shuttle_downstream,
+                            identityString,
+                            alertSummary.startStopName,
+                            alertSummary.endStopName,
+                            summaryRecurrence(alertSummary.recurrence, resources),
+                        )
                     )
-                )
+                else
+                    AnnotatedString.fromHtml(
+                        resources.getString(
+                            R.string.alert_summary_trip_shuttle,
+                            identityString,
+                            alertSummary.startStopName,
+                            alertSummary.endStopName,
+                            summaryRecurrence(alertSummary.recurrence, resources),
+                        )
+                    )
+            }
             is AlertSummary.Unknown -> AnnotatedString(alertSummary.fallback)
             null -> null
         }
@@ -195,7 +207,9 @@ data class FormattedAlert(
 
                         Alert.Effect.Suspension -> R.string.train_suspended
 
-                        Alert.Effect.StationClosure -> R.string.stop_skipped
+                        Alert.Effect.StationClosure,
+                        Alert.Effect.StopClosure,
+                        Alert.Effect.DockClosure -> R.string.stop_skipped
 
                         else -> null
                     }?.let {
@@ -552,16 +566,23 @@ data class FormattedAlert(
             resources: Resources,
         ) =
             when (tripIdentity) {
+                is TripSpecificAlertSummary.ThisTrip ->
+                    resources.getString(
+                        R.string.this_vehicle,
+                        tripIdentity.routeType.typeText(resources, isOnly = true),
+                    )
                 is TripSpecificAlertSummary.TripFrom ->
                     resources.getString(
                         R.string.trip_from,
                         tripIdentity.tripTime.formattedTime(),
+                        tripIdentity.routeType.typeText(resources, true),
                         tripIdentity.stopName,
                     )
                 is TripSpecificAlertSummary.TripTo ->
                     resources.getString(
                         R.string.trip_to,
                         tripIdentity.tripTime.formattedTime(),
+                        tripIdentity.routeType.typeText(resources, true),
                         tripIdentity.headsign,
                     )
                 is TripSpecificAlertSummary.MultipleTrips ->
@@ -585,18 +606,21 @@ data class FormattedAlert(
                     else resources.getString(R.string.is_cancelled, day)
 
                 Alert.Effect.StationClosure if effectStops != null ->
-                    resources.getString(
-                        R.string.will_not_stop_at,
-                        effectStops
-                            .map { "<b>${it}</b>" }
-                            .reduce { l, r -> resources.getString(R.string.x_and_y, l, r) },
-                        day,
-                    )
+                    summaryTripWillNotStopAt(effectStops, day, resources)
+
+                Alert.Effect.DockClosure if effectStops != null ->
+                    summaryTripWillNotStopAt(effectStops, day, resources)
+
+                Alert.Effect.StopClosure if effectStops != null ->
+                    summaryTripWillNotStopAt(effectStops, day, resources)
 
                 Alert.Effect.Suspension ->
-                    if (tripIdentity == TripSpecificAlertSummary.MultipleTrips)
-                        resources.getString(R.string.are_suspended, day)
-                    else resources.getString(R.string.is_suspended, day)
+                    effectStops?.singleOrNull()?.let {
+                        resources.getString(R.string.will_terminate_at, it, day)
+                    }
+                        ?: if (tripIdentity == TripSpecificAlertSummary.MultipleTrips)
+                            resources.getString(R.string.are_suspended, day)
+                        else resources.getString(R.string.is_suspended, day)
                 else ->
                     resources.getString(
                         R.string.affected_by,
@@ -605,6 +629,19 @@ data class FormattedAlert(
                     )
             }
         }
+
+        private fun summaryTripWillNotStopAt(
+            effectStops: List<String>,
+            day: String,
+            resources: Resources,
+        ): String =
+            resources.getString(
+                R.string.will_not_stop_at,
+                effectStops
+                    .map { "<b>${it}</b>" }
+                    .reduce { l, r -> resources.getString(R.string.x_and_y, l, r) },
+                day,
+            )
 
         private fun summaryDueToCause(@StringRes dueToCauseRes: Int?, resources: Resources) =
             dueToCauseRes?.let {
@@ -617,9 +654,22 @@ data class FormattedAlert(
         ) =
             when (tripIdentity) {
                 is TripShuttleAlertSummary.SingleTrip ->
+                    tripIdentity.fromStop?.let {
+                        resources.getString(
+                            R.string.trip_from,
+                            tripIdentity.tripTime.formattedTime(),
+                            tripIdentity.routeType.typeText(resources, isOnly = true),
+                            it,
+                        )
+                    }
+                        ?: resources.getString(
+                            R.string.the_time_mode,
+                            tripIdentity.tripTime.formattedTime(),
+                            tripIdentity.routeType.typeText(resources, isOnly = true),
+                        )
+                is TripShuttleAlertSummary.ThisTrip ->
                     resources.getString(
-                        R.string.the_time_mode,
-                        tripIdentity.tripTime.formattedTime(),
+                        R.string.this_vehicle_shuttle,
                         tripIdentity.routeType.typeText(resources, isOnly = true),
                     )
                 TripShuttleAlertSummary.MultipleTrips ->

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -39,7 +39,6 @@
     <string name="alert_summary_timeframe_time">\u0020hasta las %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020hasta mañana</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020hasta nuevo aviso</string>
-    <string name="alert_summary_trip_shuttle">Los autobuses lanzadera reemplazan a %1$s %2$s desde &lt;b>%3$s&lt;/b> hasta &lt;b>%4$s&lt;/b>%5$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Actualización:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Camino alternativo</string>
@@ -464,10 +463,8 @@
     <string name="trip_cancelled_details">Este viaje ha sido cancelado. Lamentamos las molestias.</string>
     <string name="trip_complete">Viaje completado</string>
     <string name="trip_complete_body">Este %1$s ha llegado a su destino.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> de &lt;b>%2$s&lt;/b></string>
     <string name="trip_not_available">Viaje no disponible</string>
     <string name="trip_not_available_body">Este %1$s aún no está asignado a ningún viaje.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Pruebe con una ortografía o un nombre diferentes.</string>
     <string name="try_your_search_again">Busque de nuevo.</string>
     <string name="unable_to_connect">No se puede conectar</string>

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -39,6 +39,8 @@
     <string name="alert_summary_timeframe_time">\u0020hasta las %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020hasta mañana</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020hasta nuevo aviso</string>
+    <string name="alert_summary_trip_shuttle">Los autobuses lanzadera reemplazan a %1$s desde &lt;b>%2$s&lt;/b> hasta &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s se reemplaza por autobuses lanzadera desde &lt;b>%2$s&lt;/b> hasta &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Actualización:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Camino alternativo</string>
@@ -463,8 +465,10 @@
     <string name="trip_cancelled_details">Este viaje ha sido cancelado. Lamentamos las molestias.</string>
     <string name="trip_complete">Viaje completado</string>
     <string name="trip_complete_body">Este %1$s ha llegado a su destino.</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s de &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Viaje no disponible</string>
     <string name="trip_not_available_body">Este %1$s aún no está asignado a ningún viaje.</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s a &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Pruebe con una ortografía o un nombre diferentes.</string>
     <string name="try_your_search_again">Busque de nuevo.</string>
     <string name="unable_to_connect">No se puede conectar</string>
@@ -519,6 +523,7 @@
     <string name="weather_lowercase">clima</string>
     <string name="westbound">En dirección oeste</string>
     <string name="will_not_stop_at">no se detendrá en %1$s %2$s</string>
+    <string name="will_terminate_at">finalizará en %1$s %2$s</string>
     <string name="world_cup_service_inbound">Servicio desde el &lt;b>partido del Mundial&lt;/b> de hoy hasta la &lt;b>Estación Sur&lt;/b>.</string>
     <string name="world_cup_service_outbound">Servicio desde la &lt;b>Estación Sur&lt;/b> hasta el &lt;b>partido del Mundial&lt;/b> de hoy.</string>
     <string name="world_cup_ticket_required">Se requiere billete de tren para el estadio de Boston</string>

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -438,6 +438,8 @@
     <string name="technical_problem_lowercase">problema técnico</string>
     <string name="the_time_mode">el &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">Esta parada es solo para descenso</string>
+    <string name="this_vehicle">Este %1$s</string>
+    <string name="this_vehicle_shuttle">este %1$s</string>
     <string name="tie_replacement">Reemplazo de traviesas</string>
     <string name="tie_replacement_lowercase">reemplazo de traviesas</string>
     <string name="time_picker_type_toggle">Alternar tipo de selector de hora</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -39,6 +39,8 @@
     <string name="alert_summary_timeframe_time">\u0020jusqu’à %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020jusqu’à demain</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020jusqu’à nouvel ordre</string>
+    <string name="alert_summary_trip_shuttle">Des navettes remplacent %1$s de &lt;b>%2$s&lt;/b> à &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s est remplacé par des navettes entre &lt;b>%2$s&lt;/b> et &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Mise à jour :&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Trajet alternatif</string>
@@ -463,8 +465,10 @@
     <string name="trip_cancelled_details">Ce voyage a été annulé. Nous sommes désolés pour la gêne occasionnée.</string>
     <string name="trip_complete">Voyage terminé</string>
     <string name="trip_complete_body">Ce %1$s a atteint sa destination.</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s de &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Voyage non disponible</string>
     <string name="trip_not_available_body">Ce %1$s n’est pas encore affecté à un voyage.</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s à &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Essayez avec une autre orthographe ou un autre nom.</string>
     <string name="try_your_search_again">Réessayez votre recherche.</string>
     <string name="unable_to_connect">Impossible de se connecter</string>
@@ -519,6 +523,7 @@
     <string name="weather_lowercase">météo</string>
     <string name="westbound">En direction de l’ouest</string>
     <string name="will_not_stop_at">ne s’arrêtera pas à %1$s %2$s</string>
+    <string name="will_terminate_at">se terminera à %1$s %2$s</string>
     <string name="world_cup_service_inbound">Service depuis le match de la &lt;b>Coupe du Monde&lt;/b> d’aujourd’hui jusqu’à &lt;b>South Station&lt;/b></string>
     <string name="world_cup_service_outbound">Service de &lt;b>gare du Sud&lt;/b> pour le match de la &lt;b>Coupe du Monde&lt;/b> d’aujourd’hui</string>
     <string name="world_cup_ticket_required">Billet de train pour le stade de Boston requis</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -438,6 +438,8 @@
     <string name="technical_problem_lowercase">problème technique</string>
     <string name="the_time_mode">le &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">Cet arrêt est réservé à la descente uniquement</string>
+    <string name="this_vehicle">Ce %1$s</string>
+    <string name="this_vehicle_shuttle">ce %1$s</string>
     <string name="tie_replacement">Remplacement de traverses</string>
     <string name="tie_replacement_lowercase">remplacement de traverses</string>
     <string name="time_picker_type_toggle">bascule du type de sélecteur d’heure</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -39,7 +39,6 @@
     <string name="alert_summary_timeframe_time">\u0020jusqu’à %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020jusqu’à demain</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020jusqu’à nouvel ordre</string>
-    <string name="alert_summary_trip_shuttle">Des navettes remplacent %1$s %2$s de &lt;b>%3$s&lt;/b> à &lt;b>%4$s&lt;/b>%5$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Mise à jour :&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Trajet alternatif</string>
@@ -464,10 +463,8 @@
     <string name="trip_cancelled_details">Ce voyage a été annulé. Nous sommes désolés pour la gêne occasionnée.</string>
     <string name="trip_complete">Voyage terminé</string>
     <string name="trip_complete_body">Ce %1$s a atteint sa destination.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> de &lt;b>%2$s&lt;/b></string>
     <string name="trip_not_available">Voyage non disponible</string>
     <string name="trip_not_available_body">Ce %1$s n’est pas encore affecté à un voyage.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Essayez avec une autre orthographe ou un autre nom.</string>
     <string name="try_your_search_again">Réessayez votre recherche.</string>
     <string name="unable_to_connect">Impossible de se connecter</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -450,6 +450,8 @@
     <string name="technical_problem_lowercase">pwoblèm teknik</string>
     <string name="the_time_mode">&lt;b>%1$s&lt;/b> %2$s la</string>
     <string name="this_stop_is_drop_off_only">Arè sa a se pou depoze moun sèlman</string>
+    <string name="this_vehicle">Sa a %1$s</string>
+    <string name="this_vehicle_shuttle">sa a %1$s</string>
     <string name="tie_replacement">Ranplasman kòd</string>
     <string name="tie_replacement_lowercase">ranplasman mare</string>
     <string name="time_picker_type_toggle">Chanje/dezaktive kalite seleksyon tan an</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -42,7 +42,6 @@
     <string name="alert_summary_timeframe_time">\u0020jiska %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020jiska demen</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020jiskaske yo bay lòt avi</string>
-    <string name="alert_summary_trip_shuttle">Otobis navèt yo ranplase %1$s %2$s soti &lt;b>%3$s&lt;/b> pou rive &lt;b>%4$s&lt;/b>%5$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Mizajou:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Lòt chemen</string>
@@ -476,10 +475,8 @@
     <string name="trip_cancelled_details">Vwayaj sa a anile. Nou regrèt deranjman an.</string>
     <string name="trip_complete">Vwayaj konplè</string>
     <string name="trip_complete_body">%1$s sa a rive nan destinasyon li.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> soti nan &lt;b>%2$s&lt;/b></string>
     <string name="trip_not_available">Vwayaj pa disponib</string>
     <string name="trip_not_available_body">%1$s sa a poko resevwa yon vwayaj.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> pou rive nan &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Eseye yon diferan òtograf oswa non.</string>
     <string name="try_your_search_again">Eseye rechèch ou a ankò.</string>
     <string name="unable_to_connect">Pa ka konekte</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -42,6 +42,8 @@
     <string name="alert_summary_timeframe_time">\u0020jiska %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020jiska demen</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020jiskaske yo bay lòt avi</string>
+    <string name="alert_summary_trip_shuttle">Otobis navèt yo ranplase %1$s soti &lt;b>%2$s&lt;/b> pou rive &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">Yo ranplase %1$s ak bis navèt soti &lt;b>%2$s&lt;/b> pou rive &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Mizajou:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Lòt chemen</string>
@@ -475,8 +477,10 @@
     <string name="trip_cancelled_details">Vwayaj sa a anile. Nou regrèt deranjman an.</string>
     <string name="trip_complete">Vwayaj konplè</string>
     <string name="trip_complete_body">%1$s sa a rive nan destinasyon li.</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s soti nan &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Vwayaj pa disponib</string>
     <string name="trip_not_available_body">%1$s sa a poko resevwa yon vwayaj.</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s pou rive nan &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Eseye yon diferan òtograf oswa non.</string>
     <string name="try_your_search_again">Eseye rechèch ou a ankò.</string>
     <string name="unable_to_connect">Pa ka konekte</string>
@@ -534,6 +538,7 @@
     <string name="weather_lowercase">move tan</string>
     <string name="westbound">Pran direksyon lwès</string>
     <string name="will_not_stop_at">p ap rete nan %1$s %2$s</string>
+    <string name="will_terminate_at">ap fini nan %1$s %2$s</string>
     <string name="world_cup_service_inbound">Sèvis apati match &lt;b>Koup di Mond&lt;/b> jodi a pou rive nan &lt;b>Estasyon Sid&lt;/b></string>
     <string name="world_cup_service_outbound">Sèvis soti nan &lt;b>Estasyon Sid&lt;/b> pou rive nan &lt;b>match koup di mond&lt;/b> jodi a</string>
     <string name="world_cup_ticket_required">Tikè tren Boston Stadium obligatwa</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -39,7 +39,6 @@
     <string name="alert_summary_timeframe_time">\u0020até %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020até amanhã</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020até novo aviso</string>
-    <string name="alert_summary_trip_shuttle">Ônibus de transporte substituem %1$s %2$s de &lt;b>%3$s&lt;/b> a &lt;b>%4$s&lt;/b>%5$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Atualização:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Caminho alternativo</string>
@@ -464,10 +463,8 @@
     <string name="trip_cancelled_details">Esta viagem foi cancelada. Lamentamos o inconveniente.</string>
     <string name="trip_complete">Viagem concluída</string>
     <string name="trip_complete_body">%1$s chegou ao destino.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> de &lt;b>%2$s&lt;/b></string>
     <string name="trip_not_available">Viagem não disponível</string>
     <string name="trip_not_available_body">Este %1$s ainda não foi atribuído a uma viagem.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> para &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Tente uma ortografia ou nome diferente.</string>
     <string name="try_your_search_again">Tente pesquisar novamente.</string>
     <string name="unable_to_connect">Impossível conectar</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -438,6 +438,8 @@
     <string name="technical_problem_lowercase">problema técnico</string>
     <string name="the_time_mode">o &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">Esta parada é somente para desembarque</string>
+    <string name="this_vehicle">Este %1$s</string>
+    <string name="this_vehicle_shuttle">este %1$s</string>
     <string name="tie_replacement">Troca de pneu</string>
     <string name="tie_replacement_lowercase">substituição de dormentes</string>
     <string name="time_picker_type_toggle">Alternar tipo de seletor de tempo</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -39,6 +39,8 @@
     <string name="alert_summary_timeframe_time">\u0020até %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020até amanhã</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020até novo aviso</string>
+    <string name="alert_summary_trip_shuttle">Ônibus de transporte substituem %1$s de &lt;b>%2$s&lt;/b> a &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s é substituído por ônibus de transporte de &lt;b>%2$s&lt;/b> para &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Atualização:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Caminho alternativo</string>
@@ -463,8 +465,10 @@
     <string name="trip_cancelled_details">Esta viagem foi cancelada. Lamentamos o inconveniente.</string>
     <string name="trip_complete">Viagem concluída</string>
     <string name="trip_complete_body">%1$s chegou ao destino.</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s de &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Viagem não disponível</string>
     <string name="trip_not_available_body">Este %1$s ainda não foi atribuído a uma viagem.</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s para &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Tente uma ortografia ou nome diferente.</string>
     <string name="try_your_search_again">Tente pesquisar novamente.</string>
     <string name="unable_to_connect">Impossível conectar</string>
@@ -519,6 +523,7 @@
     <string name="weather_lowercase">clima</string>
     <string name="westbound">Sentido oeste</string>
     <string name="will_not_stop_at">não vai parar em %1$s %2$s</string>
+    <string name="will_terminate_at">será encerrado em %1$s %2$s</string>
     <string name="world_cup_service_inbound">Serviço de hoje para a &lt;b>Estação Sul&lt;/b>, partindo da &lt;b>partida da Copa do Mundo&lt;/b>.</string>
     <string name="world_cup_service_outbound">Serviço da &lt;b>Estação Sul&lt;/b> para o jogo da &lt;b>Copa do Mundo&lt;/b> de hoje.</string>
     <string name="world_cup_ticket_required">É necessário um bilhete de trem para o Estádio de Boston.</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -37,6 +37,8 @@
     <string name="alert_summary_timeframe_time">\u0020đến %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020đến ngày mai</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020cho đến khi có thông báo mới</string>
+    <string name="alert_summary_trip_shuttle">Xe buýt đưa đón thay thế %1$s từ &lt;b>%2$s&lt;/b> đến &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">Tuyến %1$s được thay thế bằng xe buýt đưa đón từ &lt;b>%2$s&lt;/b> đến &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Cập nhật:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Đường đi thay thế</string>
@@ -455,8 +457,10 @@
     <string name="trip_cancelled_details">Chuyến đi này đã bị hủy. Chúng tôi xin lỗi vì sự bất tiện này.</string>
     <string name="trip_complete">Chuyến đi hoàn tất</string>
     <string name="trip_complete_body">%1$s này đã đến đích.</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s từ &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Chuyến đi không khả dụng</string>
     <string name="trip_not_available_body">Mã %1$s này chưa được chỉ định cho chuyến đi nào.</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s đến &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Thử cách viết hoặc tên khác.</string>
     <string name="try_your_search_again">Thử tìm kiếm lại.</string>
     <string name="unable_to_connect">Không thể kết nối</string>
@@ -509,6 +513,7 @@
     <string name="weather_lowercase">thời tiết</string>
     <string name="westbound">Về hướng tây</string>
     <string name="will_not_stop_at">sẽ không dừng lại ở %1$s %2$s</string>
+    <string name="will_terminate_at">sẽ kết thúc tại %1$s %2$s</string>
     <string name="world_cup_service_inbound">Tuyến xe buýt từ &lt;b>trận đấu World Cup&lt;/b> hôm nay đến &lt;b>Ga phía Nam&lt;/b></string>
     <string name="world_cup_service_outbound">Tuyến xe buýt từ &lt;b>Ga Nam&lt;/b> đến &lt;b>trận đấu World Cup hôm nay&lt;/b></string>
     <string name="world_cup_ticket_required">Cần có vé tàu đến Sân vận động Boston.</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -37,7 +37,6 @@
     <string name="alert_summary_timeframe_time">\u0020đến %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020đến ngày mai</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020cho đến khi có thông báo mới</string>
-    <string name="alert_summary_trip_shuttle">Xe buýt đưa đón thay thế %1$s %2$s từ &lt;b>%3$s&lt;/b> đến &lt;b>%4$s&lt;/b>%5$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Cập nhật:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">Đường đi thay thế</string>
@@ -456,10 +455,8 @@
     <string name="trip_cancelled_details">Chuyến đi này đã bị hủy. Chúng tôi xin lỗi vì sự bất tiện này.</string>
     <string name="trip_complete">Chuyến đi hoàn tất</string>
     <string name="trip_complete_body">%1$s này đã đến đích.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> từ &lt;b>%2$s&lt;/b></string>
     <string name="trip_not_available">Chuyến đi không khả dụng</string>
     <string name="trip_not_available_body">Mã %1$s này chưa được chỉ định cho chuyến đi nào.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> đến &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Thử cách viết hoặc tên khác.</string>
     <string name="try_your_search_again">Thử tìm kiếm lại.</string>
     <string name="unable_to_connect">Không thể kết nối</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -430,6 +430,8 @@
     <string name="technical_problem_lowercase">vấn đề kỹ thuật</string>
     <string name="the_time_mode">cái &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">Điểm dừng này chỉ để trả khách</string>
+    <string name="this_vehicle">Cái này %1$s</string>
+    <string name="this_vehicle_shuttle">cái này %1$s</string>
     <string name="tie_replacement">Thay tà vẹt</string>
     <string name="tie_replacement_lowercase">thay tà vẹt</string>
     <string name="time_picker_type_toggle">công tắc chọn loại thời gian</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -37,6 +37,8 @@
     <string name="alert_summary_timeframe_time">\u0020至%1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020直至明天</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020等待进一步通知</string>
+    <string name="alert_summary_trip_shuttle">接驳巴士取代了从 &lt;b>%2$s&lt;/b> 到 &lt;b>%3$s&lt;/b>%4$s 的 %1$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s 由 &lt;b>%2$s&lt;/b> 到 &lt;b>%3$s&lt;/b>%4$s 的接驳巴士替代</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>更新：&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">备选路线</string>
@@ -455,8 +457,10 @@
     <string name="trip_cancelled_details">此行程已取消。我们对此造成的不便深表歉意。</string>
     <string name="trip_complete">行程结束</string>
     <string name="trip_complete_body">本%1$s已到达目的地。</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s 来自 &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">行程不可用</string>
     <string name="trip_not_available_body">此 %1$s 尚未分配给任何行程。</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s 至 &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">尝试不同的拼写或名称。</string>
     <string name="try_your_search_again">再次尝试搜索。</string>
     <string name="unable_to_connect">无法连接</string>
@@ -509,6 +513,7 @@
     <string name="weather_lowercase">天气</string>
     <string name="westbound">西行</string>
     <string name="will_not_stop_at">不会止步于 %1$s %2$s</string>
+    <string name="will_terminate_at">将在 %1$s %2$s 处终止</string>
     <string name="world_cup_service_inbound">从今天的&lt;b>世界杯比赛&lt;/b>到&lt;b>南站&lt;/b>的列车服务</string>
     <string name="world_cup_service_outbound">从&lt;b>南站&lt;/b>开往今日&lt;b>世界杯比赛&lt;/b>的列车服务</string>
     <string name="world_cup_ticket_required">需要波士顿体育场火车票</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -37,7 +37,6 @@
     <string name="alert_summary_timeframe_time">\u0020至%1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020直至明天</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020等待进一步通知</string>
-    <string name="alert_summary_trip_shuttle">接驳巴士取代了从&lt;b>%3$s&lt;/b>到&lt;b>%4$s&lt;/b>%5$s之间的%1$s %2$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>更新：&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">备选路线</string>
@@ -456,10 +455,8 @@
     <string name="trip_cancelled_details">此行程已取消。我们对此造成的不便深表歉意。</string>
     <string name="trip_complete">行程结束</string>
     <string name="trip_complete_body">本%1$s已到达目的地。</string>
-    <string name="trip_from">来自 &lt;b>%2$s&lt;/b> 的 &lt;b>%1$s&lt;/b></string>
     <string name="trip_not_available">行程不可用</string>
     <string name="trip_not_available_body">此 %1$s 尚未分配给任何行程。</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">尝试不同的拼写或名称。</string>
     <string name="try_your_search_again">再次尝试搜索。</string>
     <string name="unable_to_connect">无法连接</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -430,6 +430,8 @@
     <string name="technical_problem_lowercase">技术故障</string>
     <string name="the_time_mode">&lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">此站点仅供下客</string>
+    <string name="this_vehicle">这 %1$s</string>
+    <string name="this_vehicle_shuttle">这 %1$s</string>
     <string name="tie_replacement">更换轨枕</string>
     <string name="tie_replacement_lowercase">更换轨枕</string>
     <string name="time_picker_type_toggle">时间选择器类型切换</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -37,7 +37,6 @@
     <string name="alert_summary_timeframe_time">\u0020至%1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020直至明天</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020等待進一步通知</string>
-    <string name="alert_summary_trip_shuttle">接駁巴士取代了從&lt;b>%3$s&lt;/b>到&lt;b>%4$s&lt;/b>%5$s之間的%1$s %2$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>更新：&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">替代路徑</string>
@@ -456,10 +455,8 @@
     <string name="trip_cancelled_details">本行程已取消。對於造成您的不便，我們深表歉意。</string>
     <string name="trip_complete">行程結束</string>
     <string name="trip_complete_body">本%1$s已到達目的地。</string>
-    <string name="trip_from">來自 &lt;b>%2$s&lt;/b> 的 &lt;b>%1$s&lt;/b></string>
     <string name="trip_not_available">行程不可用</string>
     <string name="trip_not_available_body">此 %1$s 尚未分配給任何行程。</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> 到 &lt;b>%2$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">嘗試不同的拼字或名稱。</string>
     <string name="try_your_search_again">再次嘗試搜尋。</string>
     <string name="unable_to_connect">無法連接</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -430,6 +430,8 @@
     <string name="technical_problem_lowercase">技術故障</string>
     <string name="the_time_mode">&lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">此網站僅供下客</string>
+    <string name="this_vehicle">這 %1$s</string>
+    <string name="this_vehicle_shuttle">這 %1$s</string>
     <string name="tie_replacement">更換軌枕</string>
     <string name="tie_replacement_lowercase">更換軌枕</string>
     <string name="time_picker_type_toggle">時間選擇器類型切換</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -37,6 +37,8 @@
     <string name="alert_summary_timeframe_time">\u0020至%1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020直至明天</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020等待進一步通知</string>
+    <string name="alert_summary_trip_shuttle">接駁巴士取代了從 &lt;b>%2$s&lt;/b> 到 &lt;b>%3$s&lt;/b>%4$s 的 %1$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s 由 &lt;b>%2$s&lt;/b> 至 &lt;b>%3$s&lt;/b>%4$s 的接駁巴士取代</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>更新：&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alternative_path">替代路徑</string>
@@ -455,8 +457,10 @@
     <string name="trip_cancelled_details">本行程已取消。對於造成您的不便，我們深表歉意。</string>
     <string name="trip_complete">行程結束</string>
     <string name="trip_complete_body">本%1$s已到達目的地。</string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s 來自 &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">行程不可用</string>
     <string name="trip_not_available_body">此 %1$s 尚未分配給任何行程。</string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s 至 &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">嘗試不同的拼字或名稱。</string>
     <string name="try_your_search_again">再次嘗試搜尋。</string>
     <string name="unable_to_connect">無法連接</string>
@@ -509,6 +513,7 @@
     <string name="weather_lowercase">天氣</string>
     <string name="westbound">西行</string>
     <string name="will_not_stop_at">不會止步於 %1$s %2$s</string>
+    <string name="will_terminate_at">將在 %1$s %2$s 處終止</string>
     <string name="world_cup_service_inbound">從今天的&lt;b>世界盃比賽&lt;/b>到&lt;b>南站&lt;/b>的列車服務</string>
     <string name="world_cup_service_outbound">從&lt;b>南站&lt;/b>開往今日&lt;b>世界盃比賽&lt;/b>的列車服務</string>
     <string name="world_cup_ticket_required">需要波士頓球場火車票</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -38,7 +38,8 @@
     <string name="alert_summary_timeframe_time">\u0020through %1$s</string>
     <string name="alert_summary_timeframe_tomorrow">\u0020through tomorrow</string>
     <string name="alert_summary_timeframe_until_further_notice">\u0020until further notice</string>
-    <string name="alert_summary_trip_shuttle">Shuttle buses replace %1$s %2$s from &lt;b>%3$s&lt;/b> to &lt;b>%4$s&lt;/b>%5$s</string>
+    <string name="alert_summary_trip_shuttle">Shuttle buses replace %1$s from &lt;b>%2$s&lt;/b> to &lt;b>%3$s&lt;/b>%4$s</string>
+    <string name="alert_summary_trip_shuttle_downstream">%1$s is replaced by shuttle buses from &lt;b>%2$s&lt;/b> to &lt;b>%3$s&lt;/b>%4$s</string>
     <string name="alert_summary_trip_specific">%1$s %2$s%3$s%4$s</string>
     <string name="alert_summary_with_update">&lt;b>Update:&lt;/b> %1$s%2$s%3$s%4$s</string>
     <string name="alerts_channel" tools:ignore="MissingTranslation">Service Alerts</string>
@@ -436,6 +437,8 @@
     <string name="technical_problem_lowercase">technical problem</string>
     <string name="the_time_mode">the &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">This stop is drop-off only</string>
+    <string name="this_vehicle">This %1$s </string>
+    <string name="this_vehicle_shuttle">this %1$s </string>
     <string name="tie_replacement">Tie Replacement</string>
     <string name="tie_replacement_lowercase">tie replacement</string>
     <string name="time_picker_type_toggle">Time picker type toggle</string>
@@ -463,10 +466,10 @@
     <string name="trip_cancelled_details">This trip has been cancelled. We’re sorry for the inconvenience.</string>
     <string name="trip_complete">Trip complete</string>
     <string name="trip_complete_body">This %1$s has reached its destination.</string>
-    <string name="trip_from">&lt;b>%1$s&lt;/b> from &lt;b>%2$s&lt;/b></string>
+    <string name="trip_from">&lt;b>%1$s&lt;/b> %2$s from &lt;b>%3$s&lt;/b></string>
     <string name="trip_not_available">Trip not available</string>
     <string name="trip_not_available_body">This %1$s is not assigned to a trip yet.</string>
-    <string name="trip_to">&lt;b>%1$s&lt;/b> to &lt;b>%2$s&lt;/b></string>
+    <string name="trip_to">&lt;b>%1$s&lt;/b> %2$s to &lt;b>%3$s&lt;/b></string>
     <string name="try_a_different_spelling_or_name">Try a different spelling or name.</string>
     <string name="try_your_search_again">Try your search again.</string>
     <string name="unable_to_connect">Unable to connect</string>
@@ -520,6 +523,7 @@
     <string name="weather_lowercase">weather</string>
     <string name="westbound">Westbound</string>
     <string name="will_not_stop_at">will not stop at %1$s %2$s</string>
+    <string name="will_terminate_at">will terminate at %1$s %2$s</string>
     <string name="world_cup_service_inbound">Service from today’s &lt;b>World Cup match&lt;/b> to &lt;b>South Station&lt;/b></string>
     <string name="world_cup_service_outbound">Service from &lt;b>South Station&lt;/b> to today’s &lt;b>World Cup match&lt;/b></string>
     <string name="world_cup_ticket_required">Boston Stadium Train ticket required</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -437,8 +437,8 @@
     <string name="technical_problem_lowercase">technical problem</string>
     <string name="the_time_mode">the &lt;b>%1$s&lt;/b> %2$s</string>
     <string name="this_stop_is_drop_off_only">This stop is drop-off only</string>
-    <string name="this_vehicle">This %1$s </string>
-    <string name="this_vehicle_shuttle">this %1$s </string>
+    <string name="this_vehicle">This %1$s</string>
+    <string name="this_vehicle_shuttle">this %1$s</string>
     <string name="tie_replacement">Tie Replacement</string>
     <string name="tie_replacement_lowercase">tie replacement</string>
     <string name="time_picker_type_toggle">Time picker type toggle</string>

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -207,7 +207,10 @@ struct AlertCard: View {
                 alert: alert,
                 alertSummary: AlertSummary.Standard(
                     effect: .shuttle,
-                    location: .some(AlertSummary.LocationSuccessiveStops(startStopName: "Start", endStopName: "End")),
+                    location: .some(AlertSummary.LocationSuccessiveStops(
+                        startStopName: "Start",
+                        endStopName: "End"
+                    )),
                     timeframe: .some(AlertSummary.TimeframeTime(
                         time: .init(year: 2025, month: .april, day: 16, hour: 16, minute: 0, second: 0)
                     )),
@@ -253,6 +256,7 @@ struct AlertCard: View {
                 alertSummary: TripSpecificAlertSummary(
                     tripIdentity: TripSpecificAlertSummary.TripFrom(
                         tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
+                        routeType: .commuterRail,
                         stopName: "Ruggles"
                     ), effect: .cancellation, cause: .mechanicalIssue
                 ),

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -823,6 +823,17 @@
         }
       }
     },
+    "**%@** %@ from %@" : {
+      "comment" : "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "**%1$@** %2$@ from %3$@"
+          }
+        }
+      }
+    },
     "**%@** ahead" : {
       "comment" : "Label for an alert that exists on a future stop along the selected route,\nthe interpolated value can be any alert effect,\nex. \"[Detour] ahead\", \"[Shuttle buses] ahead\"",
       "localizations" : {
@@ -964,6 +975,12 @@
         }
       }
     },
+    "**%1$@** %2$@ from **%3$@**" : {
+      "comment" : "Trip identity in the form of ”[time] [vehicle type] from [stop]”, ex “[12:13 PM] [train] from [Ruggles]”"
+    },
+    "**%1$@** %2$@ to **%3$@**" : {
+      "comment" : "Trip identity in the form of ”[time] [vehicle type] to [headsign]”, ex “[12:13 PM] [train] to [Stoughton]”"
+    },
     "**%1$@** at **%2$@** added to Favorites" : {
       "comment" : "Favorite added toast text, the first value is the route name (Red Line, 1 bus),\nand the second is a stop name (Ruggles, Alewife).\nThe asterisks surround bolded text. ex. \"[Green Line] at [Arlington] added to Favorites\"",
       "localizations" : {
@@ -1013,6 +1030,7 @@
     },
     "**%1$@** from **%2$@**" : {
       "comment" : "Trip identity in the form of ”[time] from [stop]”, ex “[12:13 PM] from [Ruggles]”",
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -1060,6 +1078,7 @@
     },
     "**%1$@** to **%2$@**" : {
       "comment" : "Trip identity in the form of ”[time] to [headsign]”, ex “[12:13 PM] to [Stoughton]”",
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -3146,6 +3165,9 @@
           }
         }
       }
+    },
+    "%1$@ is replaced by shuttle buses from **%2$@** to **%3$@**%4$@" : {
+      "comment" : "Alert summary in the format of “[trip identity] is replaced by shuttle buses from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] from [Ruggles] to [Forest Hills][ some days until Friday]”"
     },
     "%1$@ to %2$@ has departed %3$@" : {
       "comment" : "Screen reader text that is announced when a trip disappears from the screen.,\nin the format \"[train/bus/ferry] to [destination] has departed [stop name]\",\nex. \"[train] to [Alewife] has departed [Central]\", \"[bus] to [Nubian] has departed [Harvard]\"",
@@ -20058,6 +20080,7 @@
     },
     "Shuttle buses replace %1$@ %2$@ from **%3$@** to **%4$@**%5$@" : {
       "comment" : "Alert summary in the format of “Shuttle buses replace [trip identity] [day] from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] [today] from [Ruggles] to [Forest Hills][ some days until Friday]”",
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {
@@ -20102,6 +20125,9 @@
           }
         }
       }
+    },
+    "Shuttle buses replace %1$@ from **%2$@** to **%3$@**%4$@" : {
+      "comment" : "Alert summary in the format of “Shuttle buses replace [trip identity] from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [this train] from [Ruggles] to [Forest Hills][ some days until Friday]”"
     },
     "Shuttle buses replace service" : {
       "comment" : "Shuttle alert VoiceOver text",
@@ -23023,6 +23049,12 @@
           }
         }
       }
+    },
+    "this %1$@" : {
+      "comment" : "Trip identity in the form of ”this [vehicle type]”, ex ”this [train]”"
+    },
+    "This %1$@" : {
+      "comment" : "Trip identity in the form of ”This [vehicle type]”, ex ”This [train]”"
     },
     "This stop has %ld elevators closed" : {
       "comment" : "Describe an elevator outage at the stop in the list of all stops on the trip",
@@ -26111,6 +26143,9 @@
           }
         }
       }
+    },
+    "will terminate at %1$@ %2$@" : {
+      "comment" : "Trip specific alert effect denoting suspension downstream, with interpolated stop name, ex: “will terminate at [Porter]“"
     },
     "You can always change location settings later in the Settings app." : {
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -823,17 +823,6 @@
         }
       }
     },
-    "**%@** %@ from %@" : {
-      "comment" : "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "**%1$@** %2$@ from %3$@"
-          }
-        }
-      }
-    },
     "**%@** ahead" : {
       "comment" : "Label for an alert that exists on a future stop along the selected route,\nthe interpolated value can be any alert effect,\nex. \"[Detour] ahead\", \"[Shuttle buses] ahead\"",
       "localizations" : {
@@ -976,10 +965,98 @@
       }
     },
     "**%1$@** %2$@ from **%3$@**" : {
-      "comment" : "Trip identity in the form of ”[time] [vehicle type] from [stop]”, ex “[12:13 PM] [train] from [Ruggles]”"
+      "comment" : "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]“",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ de **%3$@**"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ de **%3$@**"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ soti nan **%3$@**"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ de **%3$@**"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ từ **%3$@**"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ 来自 **%3$@**"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ 來自 **%3$@**"
+          }
+        }
+      }
     },
     "**%1$@** %2$@ to **%3$@**" : {
-      "comment" : "Trip identity in the form of ”[time] [vehicle type] to [headsign]”, ex “[12:13 PM] [train] to [Stoughton]”"
+      "comment" : "Trip identity in the form of ”[time] [vehicle type] to [headsign]”, ex “[12:13 PM] [train] to [Stoughton]”",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ a **%3$@**"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ à **%3$@**"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ pou rive nan **%3$@**"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ para **%3$@**"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ đến **%3$@**"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ 至 **%3$@**"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**%1$@** %2$@ 至 **%3$@**"
+          }
+        }
+      }
     },
     "**%1$@** at **%2$@** added to Favorites" : {
       "comment" : "Favorite added toast text, the first value is the route name (Red Line, 1 bus),\nand the second is a stop name (Ruggles, Alewife).\nThe asterisks surround bolded text. ex. \"[Green Line] at [Arlington] added to Favorites\"",
@@ -1024,102 +1101,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**%1$@**位於**%2$@**已新增到我的最愛"
-          }
-        }
-      }
-    },
-    "**%1$@** from **%2$@**" : {
-      "comment" : "Trip identity in the form of ”[time] from [stop]”, ex “[12:13 PM] from [Ruggles]”",
-      "extractionState" : "stale",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** de **%2$@**"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** de **%2$@**"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** soti nan **%2$@**"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** de **%2$@**"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** từ **%2$@**"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "来自 **%2$@** 的 **%1$@**"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "來自 **%2$@** 的 **%1$@**"
-          }
-        }
-      }
-    },
-    "**%1$@** to **%2$@**" : {
-      "comment" : "Trip identity in the form of ”[time] to [headsign]”, ex “[12:13 PM] to [Stoughton]”",
-      "extractionState" : "stale",
-      "localizations" : {
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** a **%2$@**"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** à **%2$@**"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** pou rive nan **%2$@**"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** para **%2$@**"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** đến **%2$@**"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** 到 **%2$@**"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**%1$@** 到 **%2$@**"
           }
         }
       }
@@ -3167,7 +3148,51 @@
       }
     },
     "%1$@ is replaced by shuttle buses from **%2$@** to **%3$@**%4$@" : {
-      "comment" : "Alert summary in the format of “[trip identity] is replaced by shuttle buses from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] from [Ruggles] to [Forest Hills][ some days until Friday]”"
+      "comment" : "Alert summary in the format of “[trip identity] is replaced by shuttle buses from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] from [Ruggles] to [Forest Hills][ some days until Friday]”",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ se reemplaza por autobuses lanzadera desde **%2$@** hasta **%3$@**%4$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ est remplacé par des navettes entre **%2$@** et **%3$@**%4$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Yo ranplase %1$@ ak bis navèt soti **%2$@** pou rive **%3$@**%4$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ é substituído por ônibus de transporte de **%2$@** para **%3$@**%4$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tuyến %1$@ được thay thế bằng xe buýt đưa đón từ **%2$@** đến **%3$@**%4$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ 由 **%2$@** 到 **%3$@**%4$@ 的接驳巴士替代"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "%1$@ 由 **%2$@** 至 **%3$@**%4$@ 的接駁巴士取代"
+          }
+        }
+      }
     },
     "%1$@ to %2$@ has departed %3$@" : {
       "comment" : "Screen reader text that is announced when a trip disappears from the screen.,\nin the format \"[train/bus/ferry] to [destination] has departed [stop name]\",\nex. \"[train] to [Alewife] has departed [Central]\", \"[bus] to [Nubian] has departed [Harvard]\"",
@@ -20078,56 +20103,52 @@
         }
       }
     },
-    "Shuttle buses replace %1$@ %2$@ from **%3$@** to **%4$@**%5$@" : {
-      "comment" : "Alert summary in the format of “Shuttle buses replace [trip identity] [day] from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] [today] from [Ruggles] to [Forest Hills][ some days until Friday]”",
-      "extractionState" : "stale",
+    "Shuttle buses replace %1$@ from **%2$@** to **%3$@**%4$@" : {
+      "comment" : "Alert summary in the format of “Shuttle buses replace [trip identity] from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [this train] from [Ruggles] to [Forest Hills][ some days until Friday]”",
       "localizations" : {
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Los autobuses lanzadera reemplazan a %1$@ %2$@ desde **%3$@** hasta **%4$@**%5$@"
+            "value" : "Los autobuses lanzadera reemplazan a %1$@ desde **%2$@** hasta **%3$@**%4$@"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Des navettes remplacent %1$@ %2$@ de **%3$@** à **%4$@**%5$@"
+            "value" : "Des navettes remplacent %1$@ de **%2$@** à **%3$@**%4$@"
           }
         },
         "ht" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Otobis navèt yo ranplase %1$@ %2$@ soti **%3$@** pou rive **%4$@**%5$@"
+            "value" : "Otobis navèt yo ranplase %1$@ soti **%2$@** pou rive **%3$@**%4$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Ônibus de transporte substituem %1$@ %2$@ de **%3$@** a **%4$@**%5$@"
+            "value" : "Ônibus de transporte substituem %1$@ de **%2$@** a **%3$@**%4$@"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "Xe buýt đưa đón thay thế %1$@ %2$@ từ **%3$@** đến **%4$@**%5$@"
+            "value" : "Xe buýt đưa đón thay thế %1$@ từ **%2$@** đến **%3$@**%4$@"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "接驳巴士取代了从**%3$@**到**%4$@**%5$@之间的%1$@ %2$@"
+            "value" : "接驳巴士取代了从 **%2$@** 到 **%3$@**%4$@ 的 %1$@"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "接駁巴士取代了從**%3$@**到**%4$@**%5$@之間的%1$@ %2$@"
+            "value" : "接駁巴士取代了從 **%2$@** 到 **%3$@**%4$@ 的 %1$@"
           }
         }
       }
-    },
-    "Shuttle buses replace %1$@ from **%2$@** to **%3$@**%4$@" : {
-      "comment" : "Alert summary in the format of “Shuttle buses replace [trip identity] from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [this train] from [Ruggles] to [Forest Hills][ some days until Friday]”"
     },
     "Shuttle buses replace service" : {
       "comment" : "Shuttle alert VoiceOver text",
@@ -23051,10 +23072,98 @@
       }
     },
     "this %1$@" : {
-      "comment" : "Trip identity in the form of ”this [vehicle type]”, ex ”this [train]”"
+      "comment" : "Trip identity in the form of ”this [vehicle type]”, ex ”this [train]”",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "este %1$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ce %1$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sa a %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "este %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "cái này %1$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "这 %1$@"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "這 %1$@"
+          }
+        }
+      }
     },
     "This %1$@" : {
-      "comment" : "Trip identity in the form of ”This [vehicle type]”, ex ”This [train]”"
+      "comment" : "Trip identity in the form of ”This [vehicle type]”, ex ”This [train]”",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este %1$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ce %1$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Sa a %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Este %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cái này %1$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "这 %1$@"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "這 %1$@"
+          }
+        }
+      }
     },
     "This stop has %ld elevators closed" : {
       "comment" : "Describe an elevator outage at the stop in the list of all stops on the trip",
@@ -26145,7 +26254,51 @@
       }
     },
     "will terminate at %1$@ %2$@" : {
-      "comment" : "Trip specific alert effect denoting suspension downstream, with interpolated stop name, ex: “will terminate at [Porter]“"
+      "comment" : "Trip specific alert effect denoting suspension downstream, with interpolated stop name, ex: “will terminate at [Porter]“",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "finalizará en %1$@ %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "se terminera à %1$@ %2$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "ap fini nan %1$@ %2$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "será encerrado em %1$@ %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "sẽ kết thúc tại %1$@ %2$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "将在 %1$@ %2$@ 处终止"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "將在 %1$@ %2$@ 處終止"
+          }
+        }
+      }
     },
     "You can always change location settings later in the Settings app." : {
       "localizations" : {

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -344,113 +344,6 @@ struct FormattedAlert: Equatable {
         }
     }
 
-    static func summaryTripIdentity(tripIdentity: TripSpecificAlertSummaryTripIdentity) -> String {
-        switch onEnum(of: tripIdentity) {
-        case let .tripFrom(tripIdentity): String(
-                format: NSLocalizedString(
-                    "**%1$@** from **%2$@**",
-                    comment: "Trip identity in the form of ”[time] from [stop]”, ex “[12:13 PM] from [Ruggles]”"
-                ),
-                tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
-                tripIdentity.stopName
-            )
-        case let .tripTo(tripIdentity): String(
-                format: NSLocalizedString(
-                    "**%1$@** to **%2$@**",
-                    comment: "Trip identity in the form of ”[time] to [headsign]”, ex “[12:13 PM] to [Stoughton]”"
-                ),
-                tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
-                tripIdentity.headsign
-            )
-        case .multipleTrips: NSLocalizedString(
-                "Multiple trips",
-                comment: "Trip identity referring to more than one specific trip"
-            )
-        }
-    }
-
-    static func summaryTripEffect(
-        tripIdentity: TripSpecificAlertSummaryTripIdentity,
-        effect: Alert.Effect,
-        effectStops: [String]?,
-        isToday: Bool,
-    ) -> String {
-        let day = isToday ? NSLocalizedString("today", comment: "") : NSLocalizedString("tomorrow", comment: "")
-        let isPlural = tripIdentity is TripSpecificAlertSummary.MultipleTrips
-        switch effect {
-        case .cancellation where isPlural: return String(format: NSLocalizedString(
-                "are cancelled %@",
-                comment: "Multiple trip specific alert effect denoting cancellation, will specify “today” or “tomorrow”"
-            ), day)
-        case .cancellation: return String(format: NSLocalizedString(
-                "is cancelled %@",
-                comment: "Trip specific alert effect denoting cancellation, will specify “today” or “tomorrow”"
-            ), day)
-        case .stationClosure: if let effectStops {
-                return String(
-                    format: NSLocalizedString(
-                        "will not stop at %@ %@",
-                        comment: "Trip specific alert effect denoting station bypass, ex “will not stop at [Back Bay and Ruggles] [today]”"
-                    ),
-                    effectStops.map { "**\($0)**" }.reduce(nil) { lhs, rhs in
-                        if let lhs { String(
-                            format: NSLocalizedString(
-                                "%1$@ and %2$@",
-                                comment: "Joins two stops into a list, ex “[Back Bay] and [Ruggles]”"
-                            ),
-                            lhs,
-                            rhs
-                        ) } else { rhs }
-                    } ?? "",
-                    day
-                )
-            }
-        case .suspension where isPlural: return String(format: NSLocalizedString(
-                "are suspended %@",
-                comment: "Multiple trip specific alert effect denoting suspension, will specify “today” or “tomorrow”"
-            ), day)
-        case .suspension: return String(format: NSLocalizedString(
-                "is suspended %@",
-                comment: "Trip specific alert effect denoting suspension, will specify “today” or “tomorrow”"
-            ), day)
-        default:
-            break
-        }
-        return String(
-            format: NSLocalizedString(
-                "affected by %@ %@",
-                comment: "Trip specific alert effect fallback, ex “affected by [snow route] [today]”"
-            ),
-            effect.effectSentenceCaseString,
-            day
-        )
-    }
-
-    var summaryTripCause: String {
-        if let dueToCause {
-            String(format: NSLocalizedString(" due to %@", comment: ""), dueToCause)
-        } else {
-            ""
-        }
-    }
-
-    static func summaryTripShuttleIdentity(tripIdentity: TripShuttleAlertSummaryTripIdentity) -> String {
-        switch onEnum(of: tripIdentity) {
-        case let .singleTrip(tripIdentity): String(
-                format: NSLocalizedString(
-                    "the **%@** %@",
-                    comment: "Trip identity in the format of “the [time] [vehicle]”, ex “the [12:13 PM] [train]"
-                ),
-                tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
-                tripIdentity.routeType.typeText(isOnly: true)
-            )
-        case .multipleTrips: NSLocalizedString(
-                "multiple trips",
-                comment: "Trip identity referring to more than one specific trip"
-            )
-        }
-    }
-
     var summary: AttributedString? {
         summary(alertSummary: alertSummary)
     }
@@ -494,43 +387,8 @@ struct FormattedAlert: Equatable {
                         """
                     ), args.map { $0 as CVarArg }))
             }
-        case let .tripSpecificAlertSummary(alertSummary): return AttributedString.tryMarkdown(String(
-                format: NSLocalizedString(
-                    "%1$@ %2$@%3$@%4$@",
-                    comment: """
-                    Alert summary in the format of “[trip identity] [is affected][due to cause][until recurrence]”, \
-                    ex “[12:13 PM from Ruggles] [is cancelled today][ due to a mechanical issue][ \
-                    some days until Wednesday]” or “[Multiple trips] [are suspended today][][]”
-                    """
-                ),
-                Self.summaryTripIdentity(tripIdentity: alertSummary.tripIdentity),
-                Self.summaryTripEffect(
-                    tripIdentity: alertSummary.tripIdentity,
-                    effect: alertSummary.effect,
-                    effectStops: alertSummary.effectStops,
-                    isToday: alertSummary.isToday
-                ),
-                summaryTripCause,
-                Self.summaryRecurrence(recurrence: alertSummary.recurrence)
-            ))
-        case let .tripShuttleAlertSummary(alertSummary): return AttributedString.tryMarkdown(String(
-                format: NSLocalizedString(
-                    "Shuttle buses replace %1$@ %2$@ from **%3$@** to **%4$@**%5$@",
-                    comment: """
-                    Alert summary in the format of “Shuttle buses replace [trip identity] [day] \
-                    from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] \
-                    [today] from [Ruggles] to [Forest Hills][ some days until Friday]”
-                    """
-                ),
-                Self.summaryTripShuttleIdentity(tripIdentity: alertSummary.tripIdentity),
-                alertSummary.isToday ? NSLocalizedString("today", comment: "") : NSLocalizedString(
-                    "tomorrow",
-                    comment: ""
-                ),
-                alertSummary.currentStopName,
-                alertSummary.endStopName,
-                Self.summaryRecurrence(recurrence: alertSummary.recurrence)
-            ))
+        case let .tripSpecificAlertSummary(alertSummary): return tripSpecificAlertSummary(alertSummary: alertSummary)
+        case let .tripShuttleAlertSummary(alertSummary): return tripShuttleAlertSummary(alertSummary: alertSummary)
         case let .unknown(alertSummary): return AttributedString(alertSummary.fallback)
         case nil: return nil
         }
@@ -597,7 +455,9 @@ struct FormattedAlert: Equatable {
                 AttributedString(NSLocalizedString("Ferry suspended", comment: ""))
             case (_, .suspension) where alertSummary is TripSpecificAlertSummary:
                 AttributedString(NSLocalizedString("Train suspended", comment: ""))
-            case (_, .stationClosure) where alertSummary is TripSpecificAlertSummary:
+            case (_, .stationClosure) where alertSummary is TripSpecificAlertSummary,
+                 (_, .stopClosure) where alertSummary is TripSpecificAlertSummary,
+                 (_, .dockClosure) where alertSummary is TripSpecificAlertSummary:
                 AttributedString(NSLocalizedString("Stop skipped", comment: ""))
             default: AttributedString.tryMarkdown(effect)
             }

--- a/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
+++ b/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
@@ -13,7 +13,7 @@ extension FormattedAlert {
     static func summaryTripShuttleIdentity(tripIdentity: TripShuttleAlertSummaryTripIdentity) -> String {
         switch onEnum(of: tripIdentity) {
         case let .singleTrip(tripIdentity):
-            if let fromStop = tripIdentity.fromStop {
+            if let fromStop = tripIdentity.fromStopName {
                 String(
                     format: NSLocalizedString(
                         "**%1$@** %2$@ from **%3$@**",
@@ -52,7 +52,7 @@ extension FormattedAlert {
         let identity = alertSummary.tripIdentity
         let identityString = Self.summaryTripShuttleIdentity(tripIdentity: identity)
 
-        return if case let .singleTrip(singleTrip) = onEnum(of: identity), singleTrip.fromStop != nil {
+        return if case let .singleTrip(singleTrip) = onEnum(of: identity), singleTrip.fromStopName != nil {
             AttributedString.tryMarkdown(String(
                 format: NSLocalizedString(
                     "%1$@ is replaced by shuttle buses from **%2$@** to **%3$@**%4$@",

--- a/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
+++ b/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
@@ -16,8 +16,8 @@ extension FormattedAlert {
             if let fromStop = tripIdentity.fromStop {
                 String(
                     format: NSLocalizedString(
-                        "**%@** %@ from %@",
-                        comment: "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]"
+                        "**%1$@** %2$@ from **%3$@**",
+                        comment: "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]“"
                     ),
                     tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
                     tripIdentity.routeType.typeText(isOnly: true),

--- a/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
+++ b/iosApp/iosApp/Utils/FormattedAlertTripShuttleExtension.swift
@@ -1,0 +1,87 @@
+//
+//  FormattedAlertTripShuttleExtension.swift
+//  iosApp
+//
+//  Created by esimon on 4/17/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Foundation
+import Shared
+
+extension FormattedAlert {
+    static func summaryTripShuttleIdentity(tripIdentity: TripShuttleAlertSummaryTripIdentity) -> String {
+        switch onEnum(of: tripIdentity) {
+        case let .singleTrip(tripIdentity):
+            if let fromStop = tripIdentity.fromStop {
+                String(
+                    format: NSLocalizedString(
+                        "**%@** %@ from %@",
+                        comment: "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]"
+                    ),
+                    tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
+                    tripIdentity.routeType.typeText(isOnly: true),
+                    fromStop
+                )
+            } else {
+                String(
+                    format: NSLocalizedString(
+                        "the **%@** %@",
+                        comment: "Trip identity in the format of “the [time] [vehicle]”, ex “the [12:13 PM] [train]"
+                    ),
+                    tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
+                    tripIdentity.routeType.typeText(isOnly: true)
+                )
+            }
+
+        case let .thisTrip(tripIdentity): String(
+                format: NSLocalizedString(
+                    "this %1$@",
+                    comment: "Trip identity in the form of ”this [vehicle type]”, ex ”this [train]”"
+                ), tripIdentity.routeType.typeText(isOnly: true)
+            )
+
+        case .multipleTrips: NSLocalizedString(
+                "multiple trips",
+                comment: "Trip identity referring to more than one specific trip"
+            )
+        }
+    }
+
+    func tripShuttleAlertSummary(alertSummary: TripShuttleAlertSummary) -> AttributedString {
+        let identity = alertSummary.tripIdentity
+        let identityString = Self.summaryTripShuttleIdentity(tripIdentity: identity)
+
+        return if case let .singleTrip(singleTrip) = onEnum(of: identity), singleTrip.fromStop != nil {
+            AttributedString.tryMarkdown(String(
+                format: NSLocalizedString(
+                    "%1$@ is replaced by shuttle buses from **%2$@** to **%3$@**%4$@",
+                    comment: """
+                    Alert summary in the format of “[trip identity] is replaced by shuttle buses \
+                    from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [the 12:13 PM train] \
+                    from [Ruggles] to [Forest Hills][ some days until Friday]”
+                    """
+                ),
+                identityString,
+                alertSummary.startStopName,
+                alertSummary.endStopName,
+                Self.summaryRecurrence(recurrence: alertSummary.recurrence)
+            ))
+        } else {
+            AttributedString.tryMarkdown(String(
+                format: NSLocalizedString(
+                    "Shuttle buses replace %1$@ from **%2$@** to **%3$@**%4$@",
+                    comment: """
+                    Alert summary in the format of “Shuttle buses replace [trip identity] \
+                    from [stop] to [stop][until recurrence]”, ex “Shuttle buses replace [this train] \
+                    from [Ruggles] to [Forest Hills][ some days until Friday]”
+                    """
+                ),
+                identityString,
+                alertSummary.startStopName,
+                alertSummary.endStopName,
+                Self.summaryRecurrence(recurrence: alertSummary.recurrence)
+            ))
+        }
+    }
+}

--- a/iosApp/iosApp/Utils/FormattedAlertTripSpecificExtension.swift
+++ b/iosApp/iosApp/Utils/FormattedAlertTripSpecificExtension.swift
@@ -1,0 +1,139 @@
+//
+//  FormattedAlertTripSpecificExtension.swift
+//  iosApp
+//
+//  Created by esimon on 4/17/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Foundation
+import Shared
+
+extension FormattedAlert {
+    static func summaryTripIdentity(tripIdentity: TripSpecificAlertSummaryTripIdentity) -> String {
+        switch onEnum(of: tripIdentity) {
+        case let .thisTrip(tripIdentity): String(
+                format: NSLocalizedString(
+                    "This %1$@",
+                    comment: "Trip identity in the form of ”This [vehicle type]”, ex ”This [train]”"
+                ), tripIdentity.routeType.typeText(isOnly: true)
+            )
+        case let .tripFrom(tripIdentity): String(
+                format: NSLocalizedString(
+                    "**%1$@** %2$@ from **%3$@**",
+                    comment: "Trip identity in the form of ”[time] [vehicle type] from [stop]”, ex “[12:13 PM] [train] from [Ruggles]”"
+                ),
+                tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
+                tripIdentity.routeType.typeText(isOnly: true),
+                tripIdentity.stopName
+            )
+        case let .tripTo(tripIdentity): String(
+                format: NSLocalizedString(
+                    "**%1$@** %2$@ to **%3$@**",
+                    comment: "Trip identity in the form of ”[time] [vehicle type] to [headsign]”, ex “[12:13 PM] [train] to [Stoughton]”"
+                ),
+                tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
+                tripIdentity.routeType.typeText(isOnly: true),
+                tripIdentity.headsign
+            )
+        case .multipleTrips: NSLocalizedString(
+                "Multiple trips",
+                comment: "Trip identity referring to more than one specific trip"
+            )
+        }
+    }
+
+    static func summaryTripEffect(
+        tripIdentity: TripSpecificAlertSummaryTripIdentity,
+        effect: Alert.Effect,
+        effectStops: [String]?,
+        isToday: Bool
+    ) -> String {
+        let day = isToday ? NSLocalizedString("today", comment: "") : NSLocalizedString("tomorrow", comment: "")
+        let isPlural = tripIdentity is TripSpecificAlertSummary.MultipleTrips
+        switch effect {
+        case .cancellation where isPlural: return String(format: NSLocalizedString(
+                "are cancelled %@",
+                comment: "Multiple trip specific alert effect denoting cancellation, will specify “today” or “tomorrow”"
+            ), day)
+        case .cancellation: return String(format: NSLocalizedString(
+                "is cancelled %@",
+                comment: "Trip specific alert effect denoting cancellation, will specify “today” or “tomorrow”"
+            ), day)
+        case .stationClosure, .stopClosure, .dockClosure: if let effectStops {
+                return String(
+                    format: NSLocalizedString(
+                        "will not stop at %@ %@",
+                        comment: "Trip specific alert effect denoting station bypass, ex “will not stop at [Back Bay and Ruggles] [today]”"
+                    ),
+                    effectStops.map { "**\($0)**" }.reduce(nil) { lhs, rhs in
+                        if let lhs { String(
+                            format: NSLocalizedString(
+                                "%1$@ and %2$@",
+                                comment: "Joins two stops into a list, ex “[Back Bay] and [Ruggles]”"
+                            ),
+                            lhs,
+                            rhs
+                        ) } else { rhs }
+                    } ?? "",
+                    day
+                )
+            }
+        case .suspension:
+            if let terminatingStop = effectStops?.first {
+                return String(format: NSLocalizedString(
+                    "will terminate at %1$@ %2$@",
+                    comment: "Trip specific alert effect denoting suspension downstream, with interpolated stop name, ex: “will terminate at [Porter]“"
+                ), terminatingStop, day)
+            } else if isPlural {
+                return String(format: NSLocalizedString(
+                    "are suspended %@",
+                    comment: "Multiple trip specific alert effect denoting suspension, will specify “today” or “tomorrow”"
+                ), day)
+            } else {
+                return String(format: NSLocalizedString(
+                    "is suspended %@",
+                    comment: "Trip specific alert effect denoting suspension, will specify “today” or “tomorrow”"
+                ), day)
+            }
+        default:
+            break
+        }
+        return String(
+            format: NSLocalizedString(
+                "affected by %@ %@",
+                comment: "Trip specific alert effect fallback, ex “affected by [snow route] [today]”"
+            ),
+            effect.effectSentenceCaseString,
+            day
+        )
+    }
+
+    func tripSpecificAlertSummary(alertSummary: TripSpecificAlertSummary) -> AttributedString {
+        var summaryTripCause =
+            if let dueToCause {
+                String(format: NSLocalizedString(" due to %@", comment: ""), dueToCause)
+            } else {
+                ""
+            }
+        return AttributedString.tryMarkdown(String(
+            format: NSLocalizedString(
+                "%1$@ %2$@%3$@%4$@",
+                comment: """
+                Alert summary in the format of “[trip identity] [is affected][due to cause][until recurrence]”, \
+                ex “[12:13 PM from Ruggles] [is cancelled today][ due to a mechanical issue][ \
+                some days until Wednesday]” or “[Multiple trips] [are suspended today][][]”
+                """
+            ),
+            Self.summaryTripIdentity(tripIdentity: alertSummary.tripIdentity),
+            Self.summaryTripEffect(
+                tripIdentity: alertSummary.tripIdentity,
+                effect: alertSummary.effect,
+                effectStops: alertSummary.effectStops,
+                isToday: alertSummary.isToday
+            ),
+            summaryTripCause,
+            Self.summaryRecurrence(recurrence: alertSummary.recurrence)
+        ))
+    }
+}

--- a/iosApp/iosApp/Utils/FormattedAlertTripSpecificExtension.swift
+++ b/iosApp/iosApp/Utils/FormattedAlertTripSpecificExtension.swift
@@ -21,7 +21,7 @@ extension FormattedAlert {
         case let .tripFrom(tripIdentity): String(
                 format: NSLocalizedString(
                     "**%1$@** %2$@ from **%3$@**",
-                    comment: "Trip identity in the form of ”[time] [vehicle type] from [stop]”, ex “[12:13 PM] [train] from [Ruggles]”"
+                    comment: "Trip identity in the format of “[time] [vehicle] from [stop]”, ex “[12:13 PM] [train] from [South Station]“"
                 ),
                 tripIdentity.tripTime.formatted(date: .omitted, time: .shortened),
                 tripIdentity.routeType.typeText(isOnly: true),

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
@@ -48,8 +48,8 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: stop2.name))
         XCTAssertNotNil(try sut.inspect().find(text: stop3.name))
         XCTAssertNotNil(try sut.inspect().find(text: "Full Description"))
-        XCTAssertNotNil(try sut.inspect().find(text: alert.description_!))
-        XCTAssertNotNil(try sut.inspect().find(text: alert.header!))
+        XCTAssertNotNil(try sut.inspect().find(text: XCTUnwrap(alert.description_)))
+        XCTAssertNotNil(try sut.inspect().find(text: XCTUnwrap(alert.header)))
         XCTAssertNotNil(try sut.inspect().find(text: "Updated: 7/28/2025, 3:30\u{202F}PM"))
     }
 
@@ -115,7 +115,7 @@ final class AlertDetailsTests: XCTestCase {
         try XCTAssertNotNil(sut.inspect().find(text: "Tuesday, Jul 29, later today"))
     }
 
-    func testNoCurrentActivePeriod() throws {
+    func testNoCurrentActivePeriod() {
         let objects = ObjectCollectionBuilder()
 
         let now = EasternTimeInstant.now()
@@ -137,7 +137,7 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNil(try? sut.inspect().find(text: "Start"))
     }
 
-    func testNoDescription() throws {
+    func testNoDescription() {
         let objects = ObjectCollectionBuilder()
 
         let now = EasternTimeInstant.now()
@@ -158,7 +158,7 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNil(try? sut.inspect().find(text: "Full Description"))
     }
 
-    func testStopsInDescription() throws {
+    func testStopsInDescription() {
         let objects = ObjectCollectionBuilder()
 
         let now = EasternTimeInstant.now()
@@ -185,7 +185,6 @@ final class AlertDetailsTests: XCTestCase {
             affectedStops: [], now: now
         )
 
-        try print(sutWithoutStops.inspect().findAll(ViewType.Text.self).map { text in try text.string() })
         XCTAssertNil(try? sutWithoutStops.inspect().find(text: "3 affected stops"))
         XCTAssertNotNil(try? sutWithoutStops.inspect().find(text: "Alert description"))
         XCTAssertNotNil(try? sutWithoutStops.inspect().find(text: "Affected stops:\nStop 1\nStop 2\nStop 3"))

--- a/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
+++ b/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
@@ -1,0 +1,297 @@
+//
+//  FormattedAlertTests.swift
+//  iosApp
+//
+//  Created by esimon on 4/21/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@testable import iosApp
+
+final class FormattedAlertTests: XCTestCase {
+    func testTripShuttle() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripShuttleAlertSummary(
+                tripIdentity: TripShuttleAlertSummary.SingleTrip(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    fromStop: nil
+                ),
+                startStopName: "Oak Grove",
+                endStopName: "Forest Hills",
+                recurrence: nil
+            )
+        )
+        XCTAssertEqual(
+            "Shuttle buses replace the 12:13\u{202F}PM train from Oak Grove to Forest Hills",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testDownstreamTripShuttle() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripShuttleAlertSummary(
+                tripIdentity: TripShuttleAlertSummary.SingleTrip(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    fromStop: "Oak Grove"
+                ),
+                startStopName: "Ruggles",
+                endStopName: "Forest Hills",
+                recurrence: nil
+            )
+        )
+        XCTAssertEqual(
+            "12:13\u{202F}PM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testThisTripShuttle() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripShuttleAlertSummary(
+                tripIdentity: TripShuttleAlertSummary.ThisTrip(
+                    routeType: .commuterRail
+                ),
+                startStopName: "Porter",
+                endStopName: "North Station",
+                recurrence: nil
+            )
+        )
+        XCTAssertEqual(
+            "Shuttle buses replace this train from Porter to North Station",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testDownstreamTripShuttleRecurrence() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripShuttleAlertSummary(
+                tripIdentity: TripShuttleAlertSummary.SingleTrip(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    fromStop: "Oak Grove"
+                ),
+                startStopName: "Ruggles",
+                endStopName: "Forest Hills",
+                recurrence: AlertSummary.RecurrenceDaily(
+                    ending: AlertSummary.TimeframeThisWeek(
+                        time: .init(
+                            year: 2026,
+                            month: .march,
+                            day: 12,
+                            hour: 9,
+                            minute: 6,
+                            second: 0
+                        )
+                    )
+                )
+            )
+        )
+        XCTAssertEqual(
+            "12:13\u{202F}PM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills daily until Thursday",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testThisTripShuttleRecurrence() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripShuttleAlertSummary(
+                tripIdentity: TripShuttleAlertSummary.ThisTrip(
+                    routeType: .commuterRail
+                ),
+                startStopName: "Porter",
+                endStopName: "North Station",
+                recurrence: AlertSummary.RecurrenceDaily(
+                    ending: AlertSummary.TimeframeThisWeek(
+                        time: .init(
+                            year: 2026,
+                            month: .march,
+                            day: 12,
+                            hour: 9,
+                            minute: 6,
+                            second: 0
+                        )
+                    )
+                )
+            )
+        )
+        XCTAssertEqual(
+            "Shuttle buses replace this train from Porter to North Station daily until Thursday",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testTripSuspension() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.TripFrom(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    stopName: "Ruggles"
+                ),
+                effect: .suspension,
+                effectStops: nil,
+                isToday: true,
+                cause: .weather
+            )
+        )
+        XCTAssertEqual(
+            "12:13\u{202F}PM train from Ruggles is suspended today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testThisTripSuspension() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.ThisTrip(
+                    routeType: .commuterRail
+                ),
+                effect: .suspension,
+                effectStops: nil,
+                isToday: true,
+                cause: .weather
+            )
+        )
+        XCTAssertEqual(
+            "This train is suspended today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testDownstreamTripSuspension() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.TripFrom(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    stopName: "Ruggles"
+                ),
+                effect: .suspension,
+                effectStops: ["South Station"],
+                isToday: true,
+                cause: .weather
+            )
+        )
+        XCTAssertEqual(
+            "12:13\u{202F}PM train from Ruggles will terminate at South Station today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testThisDownstreamTripSuspension() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.ThisTrip(
+                    routeType: .commuterRail
+                ),
+                effect: .suspension,
+                effectStops: ["South Station"],
+                isToday: true,
+                cause: .weather
+            )
+        )
+        XCTAssertEqual(
+            "This train will terminate at South Station today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testTripStopSkipped() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.TripTo(
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    headsign: "South Station"
+                ),
+                effect: .stationClosure,
+                effectStops: ["Back Bay", "Ruggles"],
+                isToday: true,
+                cause: .weather
+            )
+        )
+        XCTAssertEqual(
+            "12:13\u{202F}PM train to South Station will not stop at Back Bay and Ruggles today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+
+    func testThisTripStopSkipped() throws {
+        let formatted = FormattedAlert(
+            alert: nil,
+            alertSummary: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.ThisTrip(
+                    routeType: .ferry
+                ),
+                effect: .dockClosure,
+                effectStops: ["Rowes Wharf"],
+                isToday: true,
+                cause: .weather
+            )
+        )
+
+        XCTAssertEqual(
+            "This ferry will not stop at Rowes Wharf today due to weather",
+            String(formatted.alertCardMajorBody.characters[...])
+        )
+    }
+}

--- a/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
+++ b/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
@@ -28,7 +28,7 @@ final class FormattedAlertTests: XCTestCase {
                         second: 0
                     ),
                     routeType: .commuterRail,
-                    fromStop: nil
+                    fromStopName: nil
                 ),
                 startStopName: "Oak Grove",
                 endStopName: "Forest Hills",
@@ -55,7 +55,7 @@ final class FormattedAlertTests: XCTestCase {
                         second: 0
                     ),
                     routeType: .commuterRail,
-                    fromStop: "Oak Grove"
+                    fromStopName: "Oak Grove"
                 ),
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills",
@@ -100,7 +100,7 @@ final class FormattedAlertTests: XCTestCase {
                         second: 0
                     ),
                     routeType: .commuterRail,
-                    fromStop: "Oak Grove"
+                    fromStopName: "Oak Grove"
                 ),
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills",

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -686,7 +686,7 @@ final class AlertCardTests: XCTestCase {
                         second: 0
                     ),
                     routeType: .commuterRail,
-                    fromStop: "Oak Grove"
+                    fromStopName: "Oak Grove"
                 ),
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills"
@@ -816,7 +816,7 @@ final class AlertCardTests: XCTestCase {
                         second: 0
                     ),
                     routeType: .commuterRail,
-                    fromStop: "Oak Grove"
+                    fromStopName: "Oak Grove"
                 ),
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills",

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -6,11 +6,12 @@
 //  Copyright © 2025 MBTA. All rights reserved.
 //
 
-@testable import iosApp
 import Shared
 import SwiftUI
 import ViewInspector
 import XCTest
+
+@testable import iosApp
 
 final class AlertCardTests: XCTestCase {
     override func setUp() {
@@ -40,8 +41,12 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Station Closure"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-suspension"))
-        XCTAssertThrowsError(try sut.inspect().find(imageName: "fa-chevron-right"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-suspension")
+        )
+        XCTAssertThrowsError(
+            try sut.inspect().find(imageName: "fa-chevron-right")
+        )
         try sut.inspect().find(button: "View details").tap()
         wait(for: [exp], timeout: 1)
     }
@@ -55,19 +60,28 @@ final class AlertCardTests: XCTestCase {
 
         let sut = AlertCard(
             alert: alert,
-            alertSummary: AlertSummary.Standard(effect: .shuttle,
-                                                location: .some(AlertSummary.LocationSuccessiveStops(
-                                                    startStopName: "Start Stop",
-                                                    endStopName: "End Stop"
-                                                )),
-                                                timeframe: .some(AlertSummary.TimeframeTomorrow()),
-                                                recurrence: nil,
-                                                isUpdate: false),
+            alertSummary: AlertSummary.Standard(
+                effect: .shuttle,
+                location: .some(
+                    AlertSummary.LocationSuccessiveStops(
+                        startStopName: "Start Stop",
+                        endStopName: "End Stop"
+                    )
+                ),
+                timeframe: .some(AlertSummary.TimeframeTomorrow()),
+                recurrence: nil,
+                isUpdate: false
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
         )
-        XCTAssertNotNil(try sut.inspect().find(text: "Shuttle buses from Start Stop to End Stop through tomorrow"))
+        XCTAssertNotNil(
+            try sut.inspect().find(
+                text:
+                "Shuttle buses from Start Stop to End Stop through tomorrow"
+            )
+        )
     }
 
     func testMajorAlertCardSummaryThroughEndOfService() throws {
@@ -79,17 +93,25 @@ final class AlertCardTests: XCTestCase {
 
         let sut = AlertCard(
             alert: alert,
-            alertSummary: AlertSummary.Standard(effect: .stopClosure,
-                                                location: .some(AlertSummary
-                                                    .LocationSingleStop(stopName: "Single Stop")),
-                                                timeframe: .some(AlertSummary.TimeframeEndOfService()),
-                                                recurrence: nil,
-                                                isUpdate: false),
+            alertSummary: AlertSummary.Standard(
+                effect: .stopClosure,
+                location: .some(
+                    AlertSummary
+                        .LocationSingleStop(stopName: "Single Stop")
+                ),
+                timeframe: .some(AlertSummary.TimeframeEndOfService()),
+                recurrence: nil,
+                isUpdate: false
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
         )
-        XCTAssertNotNil(try sut.inspect().find(text: "Stop closed at Single Stop through end of service"))
+        XCTAssertNotNil(
+            try sut.inspect().find(
+                text: "Stop closed at Single Stop through end of service"
+            )
+        )
     }
 
     func testMajorAlertCardSummaryThroughLaterDate() throws {
@@ -104,13 +126,28 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: AlertSummary.Standard(
                 effect: .shuttle,
-                location: .some(AlertSummary.LocationStopToDirection(
-                    startStopName: "Start Stop",
-                    direction: Direction(name: "West", destination: "Destination", id: 0)
-                )),
-                timeframe: .some(AlertSummary.TimeframeLaterDate(
-                    time: EasternTimeInstant(year: 2025, month: .april, day: 16, hour: 16, minute: 0, second: 0)
-                )),
+                location: .some(
+                    AlertSummary.LocationStopToDirection(
+                        startStopName: "Start Stop",
+                        direction: Direction(
+                            name: "West",
+                            destination: "Destination",
+                            id: 0
+                        )
+                    )
+                ),
+                timeframe: .some(
+                    AlertSummary.TimeframeLaterDate(
+                        time: EasternTimeInstant(
+                            year: 2025,
+                            month: .april,
+                            day: 16,
+                            hour: 16,
+                            minute: 0,
+                            second: 0
+                        )
+                    )
+                ),
                 recurrence: nil,
                 isUpdate: false
             ),
@@ -119,7 +156,12 @@ final class AlertCardTests: XCTestCase {
             onViewDetails: {}
         )
 
-        XCTAssertNotNil(try sut.inspect().find(text: "Shuttle buses from Start Stop to Westbound stops through Apr 16"))
+        XCTAssertNotNil(
+            try sut.inspect().find(
+                text:
+                "Shuttle buses from Start Stop to Westbound stops through Apr 16"
+            )
+        )
     }
 
     func testMajorAlertCardSummaryThroughThisWeek() throws {
@@ -133,13 +175,28 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: AlertSummary.Standard(
                 effect: .shuttle,
-                location: .some(AlertSummary.LocationDirectionToStop(
-                    direction: Direction(name: "West", destination: "Destination", id: 0),
-                    endStopName: "End Stop"
-                )),
-                timeframe: .some(AlertSummary.TimeframeThisWeek(
-                    time: EasternTimeInstant(year: 2025, month: .april, day: 16, hour: 16, minute: 0, second: 0)
-                )),
+                location: .some(
+                    AlertSummary.LocationDirectionToStop(
+                        direction: Direction(
+                            name: "West",
+                            destination: "Destination",
+                            id: 0
+                        ),
+                        endStopName: "End Stop"
+                    )
+                ),
+                timeframe: .some(
+                    AlertSummary.TimeframeThisWeek(
+                        time: EasternTimeInstant(
+                            year: 2025,
+                            month: .april,
+                            day: 16,
+                            hour: 16,
+                            minute: 0,
+                            second: 0
+                        )
+                    )
+                ),
                 recurrence: nil,
                 isUpdate: false
             ),
@@ -147,8 +204,13 @@ final class AlertCardTests: XCTestCase {
             routeAccents: .init(),
             onViewDetails: {}
         )
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Shuttle buses from Westbound stops to End Stop through Wednesday"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "Shuttle buses from Westbound stops to End Stop through Wednesday"
+                )
+        )
     }
 
     func testMajorAlertCardSummaryThroughTime() throws {
@@ -158,16 +220,25 @@ final class AlertCardTests: XCTestCase {
             alert.header = "Test header"
         }
 
-        let time = EasternTimeInstant(year: 2025, month: .april, day: 16, hour: 16, minute: 0, second: 0)
+        let time = EasternTimeInstant(
+            year: 2025,
+            month: .april,
+            day: 16,
+            hour: 16,
+            minute: 0,
+            second: 0
+        )
 
         let sut = AlertCard(
             alert: alert,
             alertSummary: AlertSummary.Standard(
                 effect: .shuttle,
-                location: .some(AlertSummary.LocationSuccessiveStops(
-                    startStopName: "Start Stop",
-                    endStopName: "End Stop"
-                )),
+                location: .some(
+                    AlertSummary.LocationSuccessiveStops(
+                        startStopName: "Start Stop",
+                        endStopName: "End Stop"
+                    )
+                ),
                 timeframe: .some(AlertSummary.TimeframeTime(time: time)),
                 recurrence: nil,
                 isUpdate: false
@@ -177,8 +248,13 @@ final class AlertCardTests: XCTestCase {
             onViewDetails: {}
         )
 
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Shuttle buses from Start Stop to End Stop through 4:00\u{202F}PM"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "Shuttle buses from Start Stop to End Stop through 4:00\u{202F}PM"
+                )
+        )
     }
 
     func testWarningAlertCard() throws {
@@ -203,7 +279,9 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Detour"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-issue"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-issue")
+        )
         XCTAssertNotNil(try sut.inspect().find(imageName: "fa-chevron-right"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
@@ -253,7 +331,9 @@ final class AlertCardTests: XCTestCase {
             }
         )
         XCTAssertNotNil(try sut.inspect().find(text: "Service change ahead"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-issue"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-issue")
+        )
         XCTAssertNotNil(try sut.inspect().find(imageName: "fa-chevron-right"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
@@ -281,8 +361,10 @@ final class AlertCardTests: XCTestCase {
                 exp.fulfill()
             }
         )
-        XCTAssertNotNil(try sut.inspect().find(text: alert.header!))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "accessibility-icon-alert"))
+        XCTAssertNotNil(try sut.inspect().find(text: XCTUnwrap(alert.header)))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "accessibility-icon-alert")
+        )
         XCTAssertNotNil(try sut.inspect().find(imageName: "fa-chevron-right"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
@@ -298,7 +380,10 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .elevatorClosure
             alert.header = "Elevator header"
-            alert.informedEntity(activities: [.usingWheelchair], facility: facility.id)
+            alert.informedEntity(
+                activities: [.usingWheelchair],
+                facility: facility.id
+            )
             alert.facilities = [facility.id: facility]
             alert.activePeriod(
                 start: now.minus(hours: 3 * 24),
@@ -316,8 +401,12 @@ final class AlertCardTests: XCTestCase {
                 exp.fulfill()
             }
         )
-        XCTAssertNotNil(try sut.inspect().find(text: "Elevator closure (Elevator name)"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "accessibility-icon-alert"))
+        XCTAssertNotNil(
+            try sut.inspect().find(text: "Elevator closure (Elevator name)")
+        )
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "accessibility-icon-alert")
+        )
         XCTAssertNotNil(try sut.inspect().find(imageName: "fa-chevron-right"))
         try sut.inspect().implicitAnyView().button().tap()
         wait(for: [exp], timeout: 1)
@@ -338,7 +427,9 @@ final class AlertCardTests: XCTestCase {
             routeAccents: .init(),
             onViewDetails: {}
         )
-        XCTAssertNotNil(try sut.inspect().find(text: "Delays due to heavy ridership"))
+        XCTAssertNotNil(
+            try sut.inspect().find(text: "Delays due to heavy ridership")
+        )
 
         XCTAssertNotNil(try sut.inspect().find(imageName: "fa-chevron-right"))
     }
@@ -351,13 +442,23 @@ final class AlertCardTests: XCTestCase {
             alert.header = "Test header"
         }
 
-        let time = EasternTimeInstant(year: 2025, month: .april, day: 16, hour: 21, minute: 0, second: 0)
+        let time = EasternTimeInstant(
+            year: 2025,
+            month: .april,
+            day: 16,
+            hour: 21,
+            minute: 0,
+            second: 0
+        )
 
         let sut = AlertCard(
             alert: alert,
             alertSummary: AlertSummary.Standard(
                 effect: .delay,
-                location: AlertSummary.LocationWholeRoute(routeLabel: "Red Line", routeType: .heavyRail),
+                location: AlertSummary.LocationWholeRoute(
+                    routeLabel: "Red Line",
+                    routeType: .heavyRail
+                ),
                 timeframe: AlertSummary.TimeframeStartingLaterToday(time: time),
                 recurrence: nil,
                 isUpdate: false
@@ -367,8 +468,10 @@ final class AlertCardTests: XCTestCase {
             onViewDetails: {}
         )
 
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Delay on Red Line starting 9:00\u{202F}PM today"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(text: "Delay on Red Line starting 9:00\u{202F}PM today")
+        )
     }
 
     func testDelayAlertCardUnknownCause() throws {
@@ -426,10 +529,12 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: AlertSummary.AllClear(
-                location: .some(AlertSummary.LocationSuccessiveStops(
-                    startStopName: "Start Stop",
-                    endStopName: "End Stop"
-                )),
+                location: .some(
+                    AlertSummary.LocationSuccessiveStops(
+                        startStopName: "Start Stop",
+                        endStopName: "End Stop"
+                    )
+                )
             ),
             spec: .takeover,
             routeAccents: .init(),
@@ -438,9 +543,16 @@ final class AlertCardTests: XCTestCase {
             }
         )
 
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "All clear: Regular service from Start Stop to End Stop"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-allclear"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "All clear: Regular service from Start Stop to End Stop"
+                )
+        )
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-allclear")
+        )
     }
 
     func testUpdateAlertCard() throws {
@@ -458,10 +570,12 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: AlertSummary.Standard(
                 effect: .shuttle,
-                location: .some(AlertSummary.LocationSuccessiveStops(
-                    startStopName: "Start Stop",
-                    endStopName: "End Stop"
-                )),
+                location: .some(
+                    AlertSummary.LocationSuccessiveStops(
+                        startStopName: "Start Stop",
+                        endStopName: "End Stop"
+                    )
+                ),
                 timeframe: AlertSummary.TimeframeTomorrow(),
                 recurrence: nil,
                 isUpdate: true
@@ -473,9 +587,16 @@ final class AlertCardTests: XCTestCase {
             }
         )
 
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Update: Shuttle buses from Start Stop to End Stop through tomorrow"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-shuttle"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "Update: Shuttle buses from Start Stop to End Stop through tomorrow"
+                )
+        )
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-shuttle")
+        )
     }
 
     func testTripCancellationAlertCard() throws {
@@ -488,9 +609,19 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripFrom(
-                    tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
                     stopName: "Ruggles"
-                ), effect: .cancellation, cause: .mechanicalIssue
+                ),
+                effect: .cancellation,
+                cause: .mechanicalIssue
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -499,8 +630,13 @@ final class AlertCardTests: XCTestCase {
 
         XCTAssertNotNil(try sut.inspect().find(text: "Train cancelled"))
         XCTAssertNotNil(try sut.inspect().find(imageName: "mode-cr-slash"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "12:13\u{202F}PM from Ruggles is cancelled today due to mechanical issue"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "12:13\u{202F}PM train from Ruggles is cancelled today due to mechanical issue"
+                )
+        )
     }
 
     func testMultipleTripSuspensionAlertCard() throws {
@@ -512,7 +648,9 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: TripSpecificAlertSummary(
-                tripIdentity: TripSpecificAlertSummary.MultipleTrips.shared, effect: .suspension, cause: .holiday
+                tripIdentity: TripSpecificAlertSummary.MultipleTrips.shared,
+                effect: .suspension,
+                cause: .holiday
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -520,9 +658,13 @@ final class AlertCardTests: XCTestCase {
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Train suspended"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-suspension"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Multiple trips are suspended today due to holiday"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-suspension")
+        )
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(text: "Multiple trips are suspended today due to holiday")
+        )
     }
 
     func testTripShuttleAlertCard() throws {
@@ -535,9 +677,19 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.SingleTrip(
-                    tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
-                    routeType: .commuterRail
-                ), currentStopName: "Ruggles", endStopName: "Forest Hills"
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    fromStop: "Oak Grove"
+                ),
+                startStopName: "Ruggles",
+                endStopName: "Forest Hills"
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -545,9 +697,21 @@ final class AlertCardTests: XCTestCase {
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Shuttle bus"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-shuttle"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "Shuttle buses replace the 12:13\u{202F}PM train today from Ruggles to Forest Hills"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-shuttle")
+        )
+        try print(
+            sut.inspect().findAll(ViewType.Text.self).map { text in
+                try text.string()
+            }
+        )
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "12:13\u{202F}PM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills"
+                )
+        )
     }
 
     func testTripStationBypassAlertCard() throws {
@@ -560,9 +724,19 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripTo(
-                    tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
                     headsign: "Stoughton"
-                ), effect: .stationClosure, effectStops: ["Back Bay", "Ruggles"]
+                ),
+                effect: .stationClosure,
+                effectStops: ["Back Bay", "Ruggles"]
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -570,9 +744,16 @@ final class AlertCardTests: XCTestCase {
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Stop skipped"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-suspension"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "12:13\u{202F}PM to Stoughton will not stop at Back Bay and Ruggles today"))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-suspension")
+        )
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "12:13\u{202F}PM train to Stoughton will not stop at Back Bay and Ruggles today"
+                )
+        )
     }
 
     func testTripSpecificReminder() throws {
@@ -585,9 +766,20 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripFrom(
-                    tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
                     stopName: "Ruggles"
-                ), effect: .cancellation, isToday: false, cause: .mechanicalIssue
+                ),
+                effect: .cancellation,
+                isToday: false,
+                cause: .mechanicalIssue
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -596,8 +788,13 @@ final class AlertCardTests: XCTestCase {
 
         XCTAssertNotNil(try sut.inspect().find(text: "Train cancelled"))
         XCTAssertNotNil(try sut.inspect().find(imageName: "mode-cr-slash"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(text: "12:13\u{202F}PM from Ruggles is cancelled tomorrow due to mechanical issue"))
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text:
+                    "12:13\u{202F}PM train from Ruggles is cancelled tomorrow due to mechanical issue"
+                )
+        )
     }
 
     func testTripShuttleRecurrence() throws {
@@ -610,30 +807,49 @@ final class AlertCardTests: XCTestCase {
             alert: alert,
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.SingleTrip(
-                    tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),
-                    routeType: .commuterRail
-                ), currentStopName: "Ruggles", endStopName: "Forest Hills",
-                recurrence: AlertSummary.RecurrenceDaily(ending: AlertSummary.TimeframeThisWeek(time: .init(
-                    year: 2026,
-                    month: .march,
-                    day: 12,
-                    hour: 9,
-                    minute: 6,
-                    second: 0
-                )))
+                    tripTime: .init(
+                        year: 2026,
+                        month: .march,
+                        day: 9,
+                        hour: 12,
+                        minute: 13,
+                        second: 0
+                    ),
+                    routeType: .commuterRail,
+                    fromStop: "Oak Grove"
+                ),
+                startStopName: "Ruggles",
+                endStopName: "Forest Hills",
+                recurrence: AlertSummary.RecurrenceDaily(
+                    ending: AlertSummary.TimeframeThisWeek(
+                        time: .init(
+                            year: 2026,
+                            month: .march,
+                            day: 12,
+                            hour: 9,
+                            minute: 6,
+                            second: 0
+                        )
+                    )
+                )
             ),
+
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
             onViewDetails: {}
         )
 
         XCTAssertNotNil(try sut.inspect().find(text: "Shuttle bus"))
-        XCTAssertNotNil(try sut.inspect().find(imageName: "alert-borderless-shuttle"))
-        XCTAssertNotNil(try sut.inspect()
-            .find(
-                text: """
-                Shuttle buses replace the 12:13\u{202F}PM train today from Ruggles to Forest Hills daily until Thursday
-                """
-            ))
+        XCTAssertNotNil(
+            try sut.inspect().find(imageName: "alert-borderless-shuttle")
+        )
+        XCTAssertNotNil(
+            try sut.inspect()
+                .find(
+                    text: """
+                    12:13\u{202F}PM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills daily until Thursday
+                    """
+                )
+        )
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.collections.filter
@@ -46,27 +47,41 @@ public sealed class AlertSummary {
     public sealed class Location {
         @Serializable
         @SerialName("direction_to_stop")
-        public data class DirectionToStop(
+        public data class DirectionToStop
+        @DefaultArgumentInterop.Enabled
+        constructor(
             val direction: Direction,
             @SerialName("end_stop_name") val endStopName: String,
+            val downstream: Boolean? = null,
         ) : Location()
 
         @Serializable
         @SerialName("single_stop")
-        public data class SingleStop(@SerialName("stop_name") val stopName: String) : Location()
+        public data class SingleStop
+        @DefaultArgumentInterop.Enabled
+        constructor(
+            @SerialName("stop_name") val stopName: String,
+            val downstream: Boolean? = null,
+        ) : Location()
 
         @Serializable
         @SerialName("stop_to_direction")
-        public data class StopToDirection(
+        public data class StopToDirection
+        @DefaultArgumentInterop.Enabled
+        constructor(
             @SerialName("start_stop_name") val startStopName: String,
             val direction: Direction,
+            val downstream: Boolean? = null,
         ) : Location()
 
         @Serializable
         @SerialName("successive_stops")
-        public data class SuccessiveStops(
+        public data class SuccessiveStops
+        @DefaultArgumentInterop.Enabled
+        constructor(
             @SerialName("start_stop_name") val startStopName: String,
             @SerialName("end_stop_name") val endStopName: String,
+            @SerialName("downstream") val downstream: Boolean? = null,
         ) : Location()
 
         @Serializable
@@ -321,9 +336,14 @@ public sealed class AlertSummary {
             // same disrupted stops, or if multiple branches are disrupted
             val firstStops = affectedPatternStops.values.firstOrNull { it.size > 1 } ?: return null
             val orderedStops = firstStops.mapNotNull { global.stops[it] }
+            val downstream = affectedPatternStops.values.all { !it.contains(stopId) }
 
             if (affectedPatternStops.all { it.value.toSet() == firstStops.toSet() }) {
-                return Location.SuccessiveStops(orderedStops.first().name, orderedStops.last().name)
+                return Location.SuccessiveStops(
+                    orderedStops.first().name,
+                    orderedStops.last().name,
+                    downstream,
+                )
             }
 
             // Determine if every effected stop list starts or ends at the same stop, if they do,
@@ -341,9 +361,9 @@ public sealed class AlertSummary {
                     } else return null
 
                 return if (first) {
-                    Location.StopToDirection(stopName, direction)
+                    Location.StopToDirection(stopName, direction, downstream)
                 } else {
-                    Location.DirectionToStop(direction, stopName)
+                    Location.DirectionToStop(direction, stopName, downstream)
                 }
             }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
@@ -12,9 +12,8 @@ public data class TripShuttleAlertSummary
 @DefaultArgumentInterop.Enabled
 constructor(
     @SerialName("trip_identity") val tripIdentity: TripIdentity,
-    @SerialName("current_stop_name") val currentStopName: String,
+    @SerialName("start_stop_name") val startStopName: String,
     @SerialName("end_stop_name") val endStopName: String,
-    @SerialName("is_today") val isToday: Boolean = true,
     override val recurrence: Recurrence? = null,
 ) : AlertSummary() {
     override val effect: Alert.Effect = Alert.Effect.Shuttle
@@ -26,7 +25,12 @@ constructor(
     public data class SingleTrip(
         @SerialName("trip_time") val tripTime: EasternTimeInstant,
         @SerialName("route_type") val routeType: RouteType,
+        @SerialName("from_stop") val fromStop: String?,
     ) : TripIdentity
+
+    @Serializable
+    @SerialName("this_trip")
+    public data class ThisTrip(@SerialName("route_type") val routeType: RouteType) : TripIdentity
 
     @Serializable @SerialName("multiple_trips") public data object MultipleTrips : TripIdentity
 
@@ -36,13 +40,11 @@ constructor(
             stopId: String,
             directionId: Int,
             patterns: List<RoutePattern>,
-            atTime: EasternTimeInstant,
             informedTrips: List<UpcomingTrip>,
             global: GlobalResponse,
             recurrence: Recurrence?,
         ): TripShuttleAlertSummary? {
-            val (tripIdentity, isToday) =
-                tripIdentityIsToday(patterns, atTime, informedTrips, global) ?: return null
+            val tripIdentity = tripIdentity(patterns, informedTrips, global) ?: return null
             val currentStopName = global.getStop(stopId)?.name
             val location =
                 alertLocation(
@@ -57,9 +59,8 @@ constructor(
             return if (currentStopName != null && location is Location.SuccessiveStops) {
                 TripShuttleAlertSummary(
                     tripIdentity,
-                    currentStopName,
+                    if (location.downstream == false) currentStopName else location.startStopName,
                     location.endStopName,
-                    isToday,
                     recurrence,
                 )
             } else {
@@ -67,35 +68,20 @@ constructor(
             }
         }
 
-        private fun tripIdentityIsToday(
+        private fun tripIdentity(
             patterns: List<RoutePattern>,
-            atTime: EasternTimeInstant,
             informedTrips: List<UpcomingTrip>,
             global: GlobalResponse,
-        ): Pair<TripIdentity, Boolean>? {
-            return when (val informedTrip = informedTrips.singleOrNull()) {
+        ): TripIdentity? {
+            return when (informedTrips.singleOrNull()) {
                 null if informedTrips.isEmpty() -> null
-                null ->
-                    Pair(
-                        MultipleTrips,
-                        informedTrips.any {
-                            (it.schedule?.departureTime ?: it.schedule?.arrivalTime)?.serviceDate ==
-                                atTime.serviceDate
-                        },
-                    )
+                null -> MultipleTrips
 
                 else -> {
-                    val tripTime =
-                        informedTrip.schedule?.departureTime
-                            ?: informedTrip.schedule?.arrivalTime
-                            ?: return null
                     val routeType =
                         patterns.firstNotNullOfOrNull { global.getRoute(it.routeId)?.type }
                             ?: return null
-                    Pair(
-                        SingleTrip(tripTime, routeType),
-                        tripTime.serviceDate == atTime.serviceDate,
-                    )
+                    ThisTrip(routeType)
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
@@ -25,7 +25,7 @@ constructor(
     public data class SingleTrip(
         @SerialName("trip_time") val tripTime: EasternTimeInstant,
         @SerialName("route_type") val routeType: RouteType,
-        @SerialName("from_stop") val fromStop: String?,
+        @SerialName("from_stop_name") val fromStopName: String?,
     ) : TripIdentity
 
     @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
@@ -71,7 +71,9 @@ constructor(
                         recurrence,
                     )
                 }
-                Alert.Effect.StationClosure -> {
+                Alert.Effect.StationClosure,
+                Alert.Effect.StopClosure,
+                Alert.Effect.DockClosure -> {
                     val routeType =
                         patterns.firstNotNullOfOrNull { global.getRoute(it.routeId)?.type }
                             ?: return null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
@@ -21,9 +21,14 @@ constructor(
     @Serializable public sealed interface TripIdentity
 
     @Serializable
+    @SerialName("this_trip")
+    public data class ThisTrip(@SerialName("route_type") val routeType: RouteType) : TripIdentity
+
+    @Serializable
     @SerialName("trip_from")
     public data class TripFrom(
         @SerialName("trip_time") val tripTime: EasternTimeInstant,
+        @SerialName("route_type") val routeType: RouteType,
         @SerialName("stop_name") val stopName: String,
     ) : TripIdentity
 
@@ -31,6 +36,7 @@ constructor(
     @SerialName("trip_to")
     public data class TripTo(
         @SerialName("trip_time") val tripTime: EasternTimeInstant,
+        @SerialName("route_type") val routeType: RouteType,
         val headsign: String,
     ) : TripIdentity
 
@@ -60,20 +66,23 @@ constructor(
                         stopId,
                         directionId,
                         patterns,
-                        atTime,
                         informedTrips,
                         global,
                         recurrence,
                     )
                 }
                 Alert.Effect.StationClosure -> {
+                    val routeType =
+                        patterns.firstNotNullOfOrNull { global.getRoute(it.routeId)?.type }
+                            ?: return null
                     val (rawTripIdentity, isToday) =
-                        tripIdentityIsToday(stopId, atTime, informedTrips, global) ?: return null
+                        tripIdentityIsToday(atTime, routeType, informedTrips) ?: return null
                     val tripIdentity =
                         when (rawTripIdentity) {
                             is TripFrom ->
                                 TripTo(
                                     rawTripIdentity.tripTime,
+                                    routeType,
                                     informedTrip?.headsign ?: return null,
                                 )
                             else -> rawTripIdentity
@@ -94,12 +103,31 @@ constructor(
                     )
                 }
                 else -> {
+                    val routeType =
+                        patterns.firstNotNullOfOrNull { global.getRoute(it.routeId)?.type }
+                            ?: return null
                     val (tripIdentity, isToday) =
-                        tripIdentityIsToday(stopId, atTime, informedTrips, global) ?: return null
+                        tripIdentityIsToday(atTime, routeType, informedTrips) ?: return null
+                    val suspensionEffectStops =
+                        if (alert.effect == Alert.Effect.Suspension) {
+                            val location =
+                                alertLocation(alert, stopId, directionId, patterns, global)
+                            when (location) {
+                                is Location.SingleStop ->
+                                    if (location.downstream == true) location.stopName else null
+                                is Location.SuccessiveStops ->
+                                    if (location.downstream == true) location.startStopName
+                                    else null
+                                is Location.StopToDirection ->
+                                    if (location.downstream == true) location.startStopName
+                                    else null
+                                else -> null
+                            }?.let { listOf(it) }
+                        } else null
                     TripSpecificAlertSummary(
                         tripIdentity,
                         alert.effect,
-                        null,
+                        suspensionEffectStops,
                         isToday,
                         alert.cause,
                         recurrence,
@@ -109,10 +137,9 @@ constructor(
         }
 
         private fun tripIdentityIsToday(
-            stopId: String,
             atTime: EasternTimeInstant,
+            routeType: RouteType,
             informedTrips: List<UpcomingTrip>,
-            global: GlobalResponse,
         ): Pair<TripIdentity, Boolean>? {
             return when (val informedTrip = informedTrips.singleOrNull()) {
                 null if informedTrips.isEmpty() -> null
@@ -130,10 +157,7 @@ constructor(
                         informedTrip.schedule?.departureTime
                             ?: informedTrip.schedule?.arrivalTime
                             ?: return null
-                    Pair(
-                        TripFrom(tripTime, global.getStop(stopId)?.name ?: return null),
-                        tripTime.serviceDate == atTime.serviceDate,
-                    )
+                    Pair(ThisTrip(routeType), tripTime.serviceDate == atTime.serviceDate)
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PushNotificationPayload.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PushNotificationPayload.kt
@@ -73,6 +73,7 @@ public data class PushNotificationPayload(
             is AlertSummary.AllClear -> return StillActive.AllClear
             is TripSpecificAlertSummary ->
                 when (summary.tripIdentity) {
+                    is TripSpecificAlertSummary.ThisTrip -> {}
                     is TripSpecificAlertSummary.TripFrom ->
                         if (now < summary.tripIdentity.tripTime) return StillActive.Yes
                     is TripSpecificAlertSummary.TripTo ->
@@ -81,6 +82,7 @@ public data class PushNotificationPayload(
                 }
             is TripShuttleAlertSummary ->
                 when (summary.tripIdentity) {
+                    is TripShuttleAlertSummary.ThisTrip -> {}
                     is TripShuttleAlertSummary.SingleTrip ->
                         if (now < summary.tripIdentity.tripTime) return StillActive.Yes
                     TripShuttleAlertSummary.MultipleTrips -> {}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -130,7 +130,7 @@ class AlertSummaryTest {
                 put("type", "single_trip")
                 put("trip_time", "2026-03-06T15:21:00-05:00")
                 put("route_type", "commuter_rail")
-                put("from_stop", "Oak Grove")
+                put("from_stop_name", "Oak Grove")
             }
             put("start_stop_name", "Ruggles")
             put("end_stop_name", "Forest Hills")

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -86,6 +86,7 @@ class AlertSummaryTest {
             putJsonObject("trip_identity") {
                 put("type", "trip_from")
                 put("trip_time", "2026-03-06T15:19:00-05:00")
+                put("route_type", "heavy_rail")
                 put("stop_name", "North Station")
             }
             put("effect", "suspension")
@@ -102,6 +103,7 @@ class AlertSummaryTest {
             TripSpecificAlertSummary(
                 TripSpecificAlertSummary.TripFrom(
                     EasternTimeInstant(2026, Month.MARCH, 6, 15, 19),
+                    RouteType.HEAVY_RAIL,
                     "North Station",
                 ),
                 Alert.Effect.Suspension,
@@ -128,8 +130,9 @@ class AlertSummaryTest {
                 put("type", "single_trip")
                 put("trip_time", "2026-03-06T15:21:00-05:00")
                 put("route_type", "commuter_rail")
+                put("from_stop", "Oak Grove")
             }
-            put("current_stop_name", "Ruggles")
+            put("start_stop_name", "Ruggles")
             put("end_stop_name", "Forest Hills")
         }
         val summary: AlertSummary =
@@ -137,10 +140,10 @@ class AlertSummaryTest {
                 TripShuttleAlertSummary.SingleTrip(
                     EasternTimeInstant(2026, Month.MARCH, 6, 15, 21),
                     RouteType.COMMUTER_RAIL,
+                    "Oak Grove",
                 ),
                 "Ruggles",
                 "Forest Hills",
-                isToday = true,
                 recurrence = null,
             )
         assertEquals(jsonObject, json.encodeToJsonElement(summary))
@@ -315,22 +318,26 @@ class AlertSummaryTest {
         performCheck(
             TripSpecificAlertSummary.TripFrom(
                 EasternTimeInstant(2026, Month.MARCH, 6, 15, 25),
+                RouteType.COMMUTER_RAIL,
                 "Ruggles",
             )
         ) {
             put("type", "trip_from")
             put("trip_time", "2026-03-06T15:25:00-05:00")
+            put("route_type", "commuter_rail")
             put("stop_name", "Ruggles")
         }
 
         performCheck(
             TripSpecificAlertSummary.TripTo(
                 EasternTimeInstant(2026, Month.MARCH, 6, 15, 25),
+                RouteType.COMMUTER_RAIL,
                 "South Station",
             )
         ) {
             put("type", "trip_to")
             put("trip_time", "2026-03-06T15:25:00-05:00")
+            put("route_type", "commuter_rail")
             put("headsign", "South Station")
         }
 
@@ -679,6 +686,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.SuccessiveStops(
                     successiveStops.first().name,
                     successiveStops.last().name,
+                    true,
                 ),
                 null,
             ),
@@ -793,6 +801,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.StopToDirection(
                     firstStop.name,
                     Direction(route.directionNames[0]!!, route.directionDestinations[0]!!, 0),
+                    true,
                 ),
                 null,
             ),
@@ -865,6 +874,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.DirectionToStop(
                     Direction(route.directionNames[1]!!, route.directionDestinations[1]!!, 1),
                     lastStop.name,
+                    true,
                 ),
                 null,
             ),
@@ -937,6 +947,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.StopToDirection(
                     firstStop.name,
                     Direction(route.directionNames[0]!!, route.directionDestinations[0]!!, 0),
+                    false,
                 ),
                 null,
             ),
@@ -1008,7 +1019,7 @@ class AlertSummaryTest {
         assertEquals(
             AlertSummary.Standard(
                 alert.effect,
-                AlertSummary.Location.SuccessiveStops(cBranchStop.name, trunkStop.name),
+                AlertSummary.Location.SuccessiveStops(cBranchStop.name, trunkStop.name, false),
                 null,
             ),
             alertSummary,
@@ -1102,6 +1113,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.StopToDirection(
                     trunkAlertingStop.name,
                     Direction(route.directionNames[0]!!, route.directionDestinations[0]!!, 0),
+                    true,
                 ),
                 null,
             ),
@@ -1313,6 +1325,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.SuccessiveStops(
                     successiveStops.first().name,
                     successiveStops.last().name,
+                    true,
                 ),
                 null,
                 null,
@@ -1365,6 +1378,7 @@ class AlertSummaryTest {
                 AlertSummary.Location.SuccessiveStops(
                     successiveStops.first().name,
                     successiveStops.last().name,
+                    true,
                 )
             ),
             alertSummary,
@@ -1622,7 +1636,7 @@ class AlertSummaryTest {
         val now = EasternTimeInstant(today, LocalTime(12, 0))
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Ruggles" }
-        val route = objects.route {}
+        val route = objects.route { type = RouteType.COMMUTER_RAIL }
         val pattern = objects.routePattern(route) {}
         val trip = objects.trip(pattern) {}
         val alert =
@@ -1650,10 +1664,7 @@ class AlertSummaryTest {
 
         assertEquals(
             TripSpecificAlertSummary(
-                TripSpecificAlertSummary.TripFrom(
-                    EasternTimeInstant(today, LocalTime(12, 13)),
-                    "Ruggles",
-                ),
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
                 Alert.Effect.Suspension,
                 cause = Alert.Cause.Weather,
             ),
@@ -1748,10 +1759,7 @@ class AlertSummaryTest {
 
         assertEquals(
             TripShuttleAlertSummary(
-                TripShuttleAlertSummary.SingleTrip(
-                    EasternTimeInstant(today, LocalTime(12, 13)),
-                    RouteType.COMMUTER_RAIL,
-                ),
+                TripShuttleAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
                 "Ruggles",
                 "Forest Hills",
             ),
@@ -1766,7 +1774,7 @@ class AlertSummaryTest {
         val objects = ObjectCollectionBuilder()
         val stop1 = objects.stop { name = "Ruggles" }
         val stop2 = objects.stop { name = "Back Bay" }
-        val route = objects.route {}
+        val route = objects.route { type = RouteType.COMMUTER_RAIL }
         val pattern = objects.routePattern(route) {}
         val trip = objects.trip(pattern) { headsign = "Stoughton" }
         val alert =
@@ -1795,10 +1803,7 @@ class AlertSummaryTest {
 
         assertEquals(
             TripSpecificAlertSummary(
-                TripSpecificAlertSummary.TripTo(
-                    EasternTimeInstant(today, LocalTime(12, 13)),
-                    trip.headsign,
-                ),
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
                 Alert.Effect.StationClosure,
                 listOf("Back Bay", "Ruggles"),
                 cause = Alert.Cause.UnknownCause,
@@ -1813,7 +1818,7 @@ class AlertSummaryTest {
         val now = EasternTimeInstant(today, LocalTime(12, 0))
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop { name = "Ruggles" }
-        val route = objects.route {}
+        val route = objects.route { type = RouteType.COMMUTER_RAIL }
         val pattern = objects.routePattern(route) {}
         val trip = objects.trip(pattern) {}
         val alert =
@@ -1841,10 +1846,7 @@ class AlertSummaryTest {
 
         assertEquals(
             TripSpecificAlertSummary(
-                TripSpecificAlertSummary.TripFrom(
-                    EasternTimeInstant(today.plus(DatePeriod(days = 1)), LocalTime(12, 13)),
-                    "Ruggles",
-                ),
+                TripSpecificAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
                 Alert.Effect.Suspension,
                 isToday = false,
             ),
@@ -1906,10 +1908,7 @@ class AlertSummaryTest {
 
         assertEquals(
             TripShuttleAlertSummary(
-                TripShuttleAlertSummary.SingleTrip(
-                    EasternTimeInstant(monday, onePM),
-                    RouteType.COMMUTER_RAIL,
-                ),
+                TripShuttleAlertSummary.ThisTrip(RouteType.COMMUTER_RAIL),
                 "Ruggles",
                 "Forest Hills",
                 recurrence =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PushNotificationPayloadTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/PushNotificationPayloadTest.kt
@@ -4,6 +4,7 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
 import com.mbta.tid.mbta_app.routes.DeepLinkState
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -453,7 +454,7 @@ class PushNotificationPayloadTest {
             PushNotificationPayload(
                 PushNotificationPayload.Title.BareLabel("Some Line"),
                 TripSpecificAlertSummary(
-                    TripSpecificAlertSummary.TripFrom(tripTime, "Here"),
+                    TripSpecificAlertSummary.TripFrom(tripTime, RouteType.COMMUTER_RAIL, "Here"),
                     Alert.Effect.Cancellation,
                 ),
                 "alert",

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
@@ -359,6 +359,7 @@ class TripDetailsPageViewModelTest : KoinTest {
                                         AlertSummary.Location.SuccessiveStops(
                                             "North Quincy",
                                             "Braintree",
+                                            downstream = true,
                                         ),
                                     timeframe = AlertSummary.Timeframe.EndOfService,
                                 )


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications QA | Trip specific suspension and shuttle alert summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214072175090608?focus=true)
Backend PR: https://github.com/mbta/mobile_app_backend/pull/470

⚠️ Don't merge before the associated backend PR is ready

Fix a few edge cases with trip specific shuttle, suspension, and stop closure legibility, and added a new "this trip" identity.

<table>
  <tr>
    <td><img width="250" height="542" alt="Screenshot_20260421_151559" src="https://github.com/user-attachments/assets/16aea365-ed94-4cfe-a282-5e25d31124dc" /></td>
    <td><img width="250" height="542" alt="Screenshot_20260421_151635" src="https://github.com/user-attachments/assets/23de4418-7d09-4276-b7b2-20c9486c279e" /></td>
  </tr>
</table>

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added unit tests for new "this trip" identity, and the updated notification trip time identity. We didn't have tests for `FormattedAlert` directly on either platform and were using `AlertCardTests` to test them indirectly. I added some tests for the new text on alert cards, but also added some tests directly for `FormattedAlert`, just to simplify things. However, I just added tests for the new updated trip summary cases, I didn't go back and add tests for all the other existing behavior already covered by `AlertCardTests`.