### PR TITLE
build: skip JVM unit tests in Android CI

### DIFF
--- a/.github/workflows/test-android.yaml
+++ b/.github/workflows/test-android.yaml
@@ -25,7 +25,7 @@ jobs:
       - run: ./gradlew spotlessCheck
         if: ${{ !inputs.skip-everything }}
       - name: shared checks & unit tests
-        run: ./gradlew shared:check
+        run: ./gradlew shared:check --exclude-task shared:jvmTest
         if: ${{ !inputs.skip-everything }}
       - uses: actions/upload-artifact@v7
         if: failure() && !inputs.skip-everything


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS: Fix flaky shared tests](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213997621491057), honorarily

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

The only context in which the JVM tests are even applicable is the `ProjectUtils` that owns the test data, and anything that’s broken in some subtle way will either never matter or only matter when we need to change what test data we have.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked locally that this Gradle flag skips the JVM tests but still runs everything else.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
