### PR TITLE
fix: make read-only copies of ObjectCollectionBuilder object maps in models

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 public data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
-    public constructor(objects: ObjectCollectionBuilder) : this(objects.alerts)
+    public constructor(objects: ObjectCollectionBuilder) : this(objects.alerts.toMap())
 
     public fun getAlert(alertId: String): Alert? = alerts[alertId]
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -35,8 +35,8 @@ internal constructor(
     public constructor(
         objects: ObjectCollectionBuilder
     ) : this(
-        objects.facilities,
-        objects.lines,
+        objects.facilities.toMap(),
+        objects.lines.toMap(),
         objects.routePatterns
             .flatMap {
                 objects.trips[it.value.representativeTripId]?.stopIds?.map { stopId ->
@@ -44,23 +44,23 @@ internal constructor(
                 } ?: emptyList()
             }
             .groupBy({ it.first }, { it.second }),
-        objects.routes,
-        objects.routePatterns,
-        objects.stops,
-        objects.trips,
+        objects.routes.toMap(),
+        objects.routePatterns.toMap(),
+        objects.stops.toMap(),
+        objects.trips.toMap(),
     )
 
     public constructor(
         objects: ObjectCollectionBuilder,
         patternIdsByStop: Map<String, List<String>>,
     ) : this(
-        objects.facilities,
-        objects.lines,
-        patternIdsByStop,
-        objects.routes,
-        objects.routePatterns,
-        objects.stops,
-        objects.trips,
+        objects.facilities.toMap(),
+        objects.lines.toMap(),
+        patternIdsByStop.toMap(),
+        objects.routes.toMap(),
+        objects.routePatterns.toMap(),
+        objects.stops.toMap(),
+        objects.trips.toMap(),
     )
 
     public fun withWorldCupService(today: LocalDate): GlobalResponse =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopJoinResponse.kt
@@ -21,8 +21,8 @@ public data class PredictionsByStopJoinResponse(
         objects.predictions.values
             .groupBy { it.stopId }
             .mapValues { predictions -> predictions.value.associateBy { it.id } },
-        objects.trips,
-        objects.vehicles,
+        objects.trips.toMap(),
+        objects.vehicles.toMap(),
     )
 
     public constructor(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsByStopMessageResponse.kt
@@ -20,7 +20,7 @@ internal constructor(
     internal constructor(
         objects: ObjectCollectionBuilder,
         stopId: String = objects.stops.keys.single(),
-    ) : this(stopId, objects.predictions, objects.trips, objects.vehicles)
+    ) : this(stopId, objects.predictions.toMap(), objects.trips.toMap(), objects.vehicles.toMap())
 
     override fun toString(): String = "[PredictionsByStopMessageResponse]"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/PredictionsStreamDataResponse.kt
@@ -14,7 +14,7 @@ public data class PredictionsStreamDataResponse(
 ) {
     public constructor(
         objects: ObjectCollectionBuilder
-    ) : this(objects.predictions, objects.trips, objects.vehicles)
+    ) : this(objects.predictions.toMap(), objects.trips.toMap(), objects.vehicles.toMap())
 
     public fun predictionQuantity(): Int = predictions.size
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/ScheduleResponse.kt
@@ -12,7 +12,7 @@ public data class ScheduleResponse(
 ) {
     public constructor(
         objects: ObjectCollectionBuilder
-    ) : this(objects.schedules.values.toList(), objects.trips)
+    ) : this(objects.schedules.values.toList(), objects.trips.toMap())
 
     internal fun getSchedulesTodayByPattern(): Map<String, Boolean> {
         val scheduledTrips = this.trips

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
@@ -93,7 +93,7 @@ constructor(
 
     internal constructor(
         objects: ObjectCollectionBuilder
-    ) : this(response = VehiclesStreamDataResponse(objects.vehicles))
+    ) : this(response = VehiclesStreamDataResponse(objects.vehicles.toMap()))
 
     override fun connect(
         routeId: LineOrRoute.Id,


### PR DESCRIPTION
### Summary

_Ticket:_ [iOS: Fix flaky shared tests](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213997621491057)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

The test that was failing sometimes was creating new objects while a background task was iterating over existing objects, so the ConcurrentModificationException was real, although it would only be possible in tests. This could have been fixed by rearranging the test, but then a later test would accidentally do the same thing and create a similar race condition; the more robust fix is to make immutable copies when creating (for example) an `AlertsStreamDataResponse` out of an `ObjectCollectionBuilder` so that no test can exhibit a race condition like this again. (I wish I were writing Rust, where accidentally cascading mutability like this is really difficult to do.)

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Ran the iOS shared tests quite a few times locally and did not see any failures.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
