### PR TITLE
fix(Alert.recurrenceRange): count all days in active period

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -447,8 +447,12 @@ internal constructor(
         val days: Set<DayOfWeek>,
         val endDayKnown: Boolean,
     ) {
+        /**
+         * If the alert is for > 1 day and it is active for all days in the range, treat it as daily
+         */
         public val daily: Boolean =
-            days == (start.serviceDate..end.serviceDate).map { it.dayOfWeek }.toSet()
+            days == (start.serviceDate..end.serviceDate).map { it.dayOfWeek }.toSet() &&
+                days.size > 1
 
         public val fromStartOfService: Boolean = start.local.time == LocalTime(3, 0)
         public val toEndOfService: Boolean =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.time.Duration.Companion.hours
-import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
@@ -460,32 +459,22 @@ internal constructor(
         val firstPeriod = activePeriod.minBy { it.start }
         val lastPeriod = activePeriod.maxBy { it.end ?: return@recurrenceRange null }
         val lastPeriodEnd = lastPeriod.end ?: return null
-        val alertDays =
-            activePeriod.map {
-                if (
-                    it.startServiceDate == it.endServiceDate &&
-                        it.start.local.time == firstPeriod.start.local.time &&
-                        it.end?.local?.time == lastPeriodEnd.local.time
-                ) {
-                    it.startServiceDate
-                } else {
-                    return@recurrenceRange null
+        val daysOfWeek =
+            activePeriod
+                .flatMap {
+                    if (it.endServiceDate == null) {
+                        DayOfWeek.entries.toSet()
+                    } else {
+                        (it.startServiceDate..it.endServiceDate).map { it.dayOfWeek }.toSet()
+                    }
                 }
-            }
-        val allAlertDaysContiguous =
-            alertDays
-                .windowed(size = 2, step = 1) { (a, b) -> (b - a) == DatePeriod(days = 1) }
-                .all { it }
-        val days =
-            if (allAlertDaysContiguous) {
-                DayOfWeek.entries.toSet()
-            } else {
-                alertDays.map { it.dayOfWeek }.toSet()
-            }
+                .sorted()
+                .toSet()
+
         return RecurrenceInfo(
             firstPeriod.start,
             lastPeriodEnd,
-            days,
+            daysOfWeek,
             endDayKnown = durationCertainty == DurationCertainty.Known,
         )
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -447,7 +447,8 @@ internal constructor(
         val days: Set<DayOfWeek>,
         val endDayKnown: Boolean,
     ) {
-        public val daily: Boolean = days.size == 7
+        public val daily: Boolean =
+            days == (start.serviceDate..end.serviceDate).map { it.dayOfWeek }.toSet()
 
         public val fromStartOfService: Boolean = start.local.time == LocalTime(3, 0)
         public val toEndOfService: Boolean =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -458,6 +458,12 @@ internal constructor(
         if (activePeriod.size <= 1) return null
         val firstPeriod = activePeriod.minBy { it.start }
         val lastPeriod = activePeriod.maxBy { it.end ?: return@recurrenceRange null }
+        if (
+            lastPeriod.endServiceDate != null &&
+                firstPeriod.startServiceDate == lastPeriod.endServiceDate
+        ) {
+            return null
+        }
         val lastPeriodEnd = lastPeriod.end ?: return null
         val seenDaysOfWeek =
             activePeriod

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -447,12 +447,7 @@ internal constructor(
         val days: Set<DayOfWeek>,
         val endDayKnown: Boolean,
     ) {
-        /**
-         * If the alert is for > 1 day and it is active for all days in the range, treat it as daily
-         */
-        public val daily: Boolean =
-            days == (start.serviceDate..end.serviceDate).map { it.dayOfWeek }.toSet() &&
-                days.size > 1
+        public val daily: Boolean = days.size == 7
 
         public val fromStartOfService: Boolean = start.local.time == LocalTime(3, 0)
         public val toEndOfService: Boolean =
@@ -464,7 +459,7 @@ internal constructor(
         val firstPeriod = activePeriod.minBy { it.start }
         val lastPeriod = activePeriod.maxBy { it.end ?: return@recurrenceRange null }
         val lastPeriodEnd = lastPeriod.end ?: return null
-        val daysOfWeek =
+        val seenDaysOfWeek =
             activePeriod
                 .flatMap {
                     if (it.endServiceDate == null) {
@@ -475,6 +470,21 @@ internal constructor(
                 }
                 .sorted()
                 .toSet()
+
+        val allDaysInRangeSeen =
+            lastPeriod.endServiceDate != null &&
+                (firstPeriod.startServiceDate..lastPeriod.endServiceDate)
+                    .map { it.dayOfWeek }
+                    .toSet() == seenDaysOfWeek
+
+        // If all the days in the range have been seen, then include all days.
+        // This indicates that the alert is "daily".
+        val daysOfWeek =
+            if (allDaysInRangeSeen && seenDaysOfWeek.size > 1) {
+                DayOfWeek.entries.toSet()
+            } else {
+                seenDaysOfWeek
+            }
 
         return RecurrenceInfo(
             firstPeriod.start,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -11,6 +11,7 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.plus
 
@@ -133,7 +134,7 @@ class AlertTest {
         val endOfService = LocalTime(3, 0)
         val alert =
             ObjectCollectionBuilder.Single.alert {
-                for (daysForward in 0..5) {
+                for (daysForward in 0..6) {
                     activePeriod(
                         EasternTimeInstant(today.plus(DatePeriod(days = daysForward)), ninePM),
                         EasternTimeInstant(
@@ -147,7 +148,7 @@ class AlertTest {
         assertEquals(
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
-                EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
+                EasternTimeInstant(today.plus(DatePeriod(days = 7)), endOfService),
                 DayOfWeek.entries.toSet(),
                 endDayKnown = true,
             ),
@@ -163,7 +164,7 @@ class AlertTest {
         val alert =
             ObjectCollectionBuilder.Single.alert {
                 durationCertainty = Alert.DurationCertainty.Unknown
-                for (daysForward in 0..5) {
+                for (daysForward in 0..6) {
                     activePeriod(
                         EasternTimeInstant(today.plus(DatePeriod(days = daysForward)), ninePM),
                         EasternTimeInstant(
@@ -177,7 +178,7 @@ class AlertTest {
         assertEquals(
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
-                EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
+                EasternTimeInstant(today.plus(DatePeriod(days = 7)), endOfService),
                 DayOfWeek.entries.toSet(),
                 endDayKnown = false,
             ),
@@ -204,6 +205,39 @@ class AlertTest {
                         ),
                     )
                 }
+            }
+
+        assertEquals(
+            Alert.RecurrenceInfo(
+                alert.activePeriod.first().start,
+                alert.activePeriod.last().end!!,
+                selectedDays,
+                endDayKnown = true,
+            ),
+            alert.recurrenceRange(),
+        )
+    }
+
+    @Test
+    fun `recurrenceRange two sets of continuous week days `() {
+        val selectedDays =
+            setOf(
+                DayOfWeek.MONDAY,
+                DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY,
+            )
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, 4, 22), LocalTime(3, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, 4, 25), LocalTime(3, 0, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, 4, 27), LocalTime(3, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, 5, 1), LocalTime(3, 0, 0)),
+                )
             }
 
         assertEquals(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -134,7 +134,7 @@ class AlertTest {
         val endOfService = LocalTime(3, 0)
         val alert =
             ObjectCollectionBuilder.Single.alert {
-                for (daysForward in 0..6) {
+                for (daysForward in 0..5) {
                     activePeriod(
                         EasternTimeInstant(today.plus(DatePeriod(days = daysForward)), ninePM),
                         EasternTimeInstant(
@@ -148,7 +148,7 @@ class AlertTest {
         assertEquals(
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
-                EasternTimeInstant(today.plus(DatePeriod(days = 7)), endOfService),
+                EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
                 DayOfWeek.entries.toSet(),
                 endDayKnown = true,
             ),
@@ -164,7 +164,7 @@ class AlertTest {
         val alert =
             ObjectCollectionBuilder.Single.alert {
                 durationCertainty = Alert.DurationCertainty.Unknown
-                for (daysForward in 0..6) {
+                for (daysForward in 0..5) {
                     activePeriod(
                         EasternTimeInstant(today.plus(DatePeriod(days = daysForward)), ninePM),
                         EasternTimeInstant(
@@ -178,7 +178,7 @@ class AlertTest {
         assertEquals(
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
-                EasternTimeInstant(today.plus(DatePeriod(days = 7)), endOfService),
+                EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
                 DayOfWeek.entries.toSet(),
                 endDayKnown = false,
             ),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -239,16 +239,37 @@ class AlertTest {
                     EasternTimeInstant(LocalDate(2026, 5, 1), LocalTime(3, 0, 0)),
                 )
             }
-
-        assertEquals(
+        val expectedInfo =
             Alert.RecurrenceInfo(
                 alert.activePeriod.first().start,
                 alert.activePeriod.last().end!!,
                 selectedDays,
                 endDayKnown = true,
-            ),
-            alert.recurrenceRange(),
-        )
+            )
+        assertEquals(expectedInfo, alert.recurrenceRange())
+        assertFalse(expectedInfo.daily)
+    }
+
+    @Test
+    fun `recurrenceRange subset of continuous weekdays is still daily `() {
+
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, 4, 22), LocalTime(5, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, 4, 22), LocalTime(9, 0, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, 4, 23), LocalTime(5, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, 4, 23), LocalTime(9, 0, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, 4, 24), LocalTime(5, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, 4, 24), LocalTime(9, 0, 0)),
+                )
+            }
+
+        assertTrue(alert.recurrenceRange()!!.daily)
     }
 
     @Test


### PR DESCRIPTION
### Summary

_Ticket:_ [GL-B Alert recurrence display issue](https://github.com/mbta/mobile_app/pull/new/kb-recurrence-fix)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
We were incorrectly displaying a GL-B alert as ending on 4/24, because that is when the first active period ends. In reality, it is recurring weekdays over 2 disjoint periods. I think part of the issue was that [The backend](https://github.com/mbta/mobile_app_backend/blob/721639f298451e67fb66355fc6c1110ddc352ea4/lib/mbta_v3_api/alert.ex#L233) collapses consecutive periods together, whereas the frontend was expecting separate periods for each day. I'm concerned that there could be other ramifications of removing the backend collapsing logic (introduced [here](https://github.com/mbta/mobile_app_backend/pull/328) to address a different active period display issue), so this just makes the recurrence check handle cases where a period is > 1 day.

Backend PR: https://github.com/mbta/mobile_app_backend/pull/469

Note: [outstanding discussion](https://mbta.slack.com/archives/C082U4THN5A/p1776886055791379?thread_ts=1776858827.168749&cid=C082U4THN5A) as to whether we can get the data representation for a recurrence directly from Alerts
iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests
* Ran locally for alert w/ same dates as the affected GL-B alert & confirmed it displays as a recurrence.
<img width="45%"  alt="image" src="https://github.com/user-attachments/assets/4f19e3e7-de96-4a3c-ae45-72c419273e5a" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
