### PR TITLE
refactor(Alert.RecurrenceInfo): Calculate daily based on set of days in range

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -458,7 +458,13 @@ internal constructor(
         val days: Set<DayOfWeek>,
         val endDayKnown: Boolean,
     ) {
-        public val daily: Boolean = days.size == 7
+        public val daily: Boolean =
+            days ==
+                (start.serviceDate..end.serviceDate(
+                            EasternTimeInstant.ServiceDateRounding.BACKWARDS
+                        ))
+                    .map { it.dayOfWeek }
+                    .toSet() && days.count() > 1
 
         public val fromStartOfService: Boolean = start.local.time == LocalTime(3, 0)
         public val toEndOfService: Boolean =
@@ -488,25 +494,10 @@ internal constructor(
                 .sorted()
                 .toSet()
 
-        val allDaysInRangeSeen =
-            lastPeriod.endServiceDate != null &&
-                (firstPeriod.startServiceDate..lastPeriod.endServiceDate)
-                    .map { it.dayOfWeek }
-                    .toSet() == seenDaysOfWeek
-
-        // If all the days in the range have been seen, then include all days.
-        // This indicates that the alert is "daily".
-        val daysOfWeek =
-            if (allDaysInRangeSeen && seenDaysOfWeek.size > 1) {
-                DayOfWeek.entries.toSet()
-            } else {
-                seenDaysOfWeek
-            }
-
         return RecurrenceInfo(
             firstPeriod.start,
             lastPeriodEnd,
-            daysOfWeek,
+            seenDaysOfWeek,
             endDayKnown = durationCertainty == DurationCertainty.Known,
         )
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -129,7 +129,7 @@ class AlertTest {
 
     @Test
     fun `recurrenceRange daily on all days`() {
-        val today = EasternTimeInstant.now().serviceDate
+        val today = EasternTimeInstant(LocalDate(2026, 4, 13), LocalTime(3, 0, 0)).serviceDate
         val ninePM = LocalTime(21, 0)
         val endOfService = LocalTime(3, 0)
         val alert =
@@ -145,20 +145,28 @@ class AlertTest {
                 }
             }
 
-        assertEquals(
+        val recurrence =
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
                 EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
-                DayOfWeek.entries.toSet(),
+                setOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                    DayOfWeek.SATURDAY,
+                ),
                 endDayKnown = true,
-            ),
-            alert.recurrenceRange(),
-        )
+            )
+
+        assertEquals(recurrence, alert.recurrenceRange())
+        assertTrue(recurrence.daily)
     }
 
     @Test
     fun `recurrenceRange end unknown`() {
-        val today = EasternTimeInstant.now().serviceDate
+        val today = EasternTimeInstant(LocalDate(2026, 4, 13), LocalTime(3, 0, 0)).serviceDate
         val ninePM = LocalTime(21, 0)
         val endOfService = LocalTime(3, 0)
         val alert =
@@ -175,15 +183,22 @@ class AlertTest {
                 }
             }
 
-        assertEquals(
+        val recurrence =
             Alert.RecurrenceInfo(
                 EasternTimeInstant(today, ninePM),
                 EasternTimeInstant(today.plus(DatePeriod(days = 6)), endOfService),
-                DayOfWeek.entries.toSet(),
+                setOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                    DayOfWeek.SATURDAY,
+                ),
                 endDayKnown = false,
-            ),
-            alert.recurrenceRange(),
-        )
+            )
+        assertEquals(recurrence, alert.recurrenceRange())
+        assertTrue(recurrence.daily)
     }
 
     @Test
@@ -207,15 +222,15 @@ class AlertTest {
                 }
             }
 
-        assertEquals(
+        val recurrence =
             Alert.RecurrenceInfo(
                 alert.activePeriod.first().start,
                 alert.activePeriod.last().end!!,
                 selectedDays,
                 endDayKnown = true,
-            ),
-            alert.recurrenceRange(),
-        )
+            )
+        assertEquals(recurrence, alert.recurrenceRange())
+        assertFalse(recurrence.daily)
     }
 
     @Test


### PR DESCRIPTION
### Summary

_Ticket:_ [Name](URL)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
A follow up to https://github.com/mbta/mobile_app/pull/1689. Updating the recurrence logic involved rewriting how we check in `recurrenceRange` if the range is continuous. Including all days seemed a bit confusing for cases where an alert would recur daily for only 3 days. Now, `RecurrenceInfo.days` includes only the actual days in the range, and `RecurrenceInfo.daily` is true if all days within that range are seen.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Updated & added unit tests
* Ran locally with a daily alert for 3 days, confirmed it is still displayed as daily
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/003bb77b-d8a0-44bf-9679-fb05b334f444" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
