### PR TITLE
fix: simplify weekdays / weekends in recurring alert display

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.DatePeriod
@@ -453,6 +454,75 @@ class AlertDetailsTest {
         composeTestRule.onNodeWithText("Sunday, Friday").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
         composeTestRule.onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM"))).assertIsDisplayed()
+    }
+
+    @Test
+    fun testRecurringWeekdays() {
+        val objects = ObjectCollectionBuilder()
+
+        val now = EasternTimeInstant(2026, Month.MAY, 4, 14, 38)
+
+        val route = objects.route()
+        val stop = objects.stop { name = "Park Street" }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                activePeriod(now - 1.hours, now + 1.hours)
+                activePeriod(now + 1.days - 1.hours, now + 1.days + 1.hours)
+                activePeriod(now + 2.days - 1.hours, now + 2.days + 1.hours)
+                activePeriod(now + 3.days - 1.hours, now + 3.days + 1.hours)
+                activePeriod(now + 4.days - 1.hours, now + 4.days + 1.hours)
+                activePeriod(now + 7.days - 1.hours, now + 7.days + 1.hours)
+            }
+
+        composeTestRule.setContent {
+            AlertDetails(
+                alert,
+                line = null,
+                routes = listOf(route),
+                stop = stop,
+                affectedStops = listOf(stop),
+                now = now,
+            )
+        }
+
+        composeTestRule.onNodeWithText("May 4 – May 11").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Weekdays").assertIsDisplayed()
+        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+        composeTestRule.onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM"))).assertIsDisplayed()
+    }
+
+    @Test
+    fun testRecurringWeekends() {
+        val objects = ObjectCollectionBuilder()
+
+        val now = EasternTimeInstant(2026, Month.MAY, 3, 14, 38)
+
+        val route = objects.route()
+        val stop = objects.stop { name = "Park Street" }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                activePeriod(now - 1.hours, now + 1.hours)
+                activePeriod(now + 6.days - 1.hours, now + 6.days + 1.hours)
+                activePeriod(now + 7.days - 1.hours, now + 7.days + 1.hours)
+            }
+
+        composeTestRule.setContent {
+            AlertDetails(
+                alert,
+                line = null,
+                routes = listOf(route),
+                stop = stop,
+                affectedStops = listOf(stop),
+                now = now,
+            )
+        }
+
+        composeTestRule.onNodeWithText("May 3 – May 10").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Weekends").assertIsDisplayed()
+        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+        composeTestRule.onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM"))).assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
@@ -238,14 +238,18 @@ private fun AlertPeriod(
                 }
             } else {
                 Text(dateRange, style = Typography.bodySemibold)
-                Text(
-                    recurrence.days
-                        .sortedBy { it.numberSundayFirst }
-                        .joinToString(separator = stringResource(R.string.list_join)) {
-                            it.formattedFull()
-                        },
-                    style = Typography.bodySemibold,
-                )
+                val daysOfWeek =
+                    when {
+                        recurrence.isWeekdays -> stringResource(R.string.weekdays)
+                        recurrence.isWeekends -> stringResource(R.string.weekends)
+                        else ->
+                            recurrence.days
+                                .sortedBy { it.numberSundayFirst }
+                                .joinToString(separator = stringResource(R.string.list_join)) {
+                                    it.formattedFull()
+                                }
+                    }
+                Text(daysOfWeek, style = Typography.bodySemibold)
             }
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -535,6 +535,8 @@
     <string name="waiting_to_depart">Esperando para partir</string>
     <string name="weather">Clima</string>
     <string name="weather_lowercase">clima</string>
+    <string name="weekdays">días laborables</string>
+    <string name="weekends">fines de semana</string>
     <string name="westbound">En dirección oeste</string>
     <string name="will_not_stop_at">no se detendrá en %1$s %2$s</string>
     <string name="will_terminate_at">finalizará en %1$s %2$s</string>

--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -535,8 +535,8 @@
     <string name="waiting_to_depart">Esperando para partir</string>
     <string name="weather">Clima</string>
     <string name="weather_lowercase">clima</string>
-    <string name="weekdays">días laborables</string>
-    <string name="weekends">fines de semana</string>
+    <string name="weekdays">Días laborables</string>
+    <string name="weekends">Fines de semana</string>
     <string name="westbound">En dirección oeste</string>
     <string name="will_not_stop_at">no se detendrá en %1$s %2$s</string>
     <string name="will_terminate_at">finalizará en %1$s %2$s</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -535,6 +535,8 @@
     <string name="waiting_to_depart">En attente de départ</string>
     <string name="weather">Météo</string>
     <string name="weather_lowercase">météo</string>
+    <string name="weekdays">Jours de la semaine</string>
+    <string name="weekends">Week-ends</string>
     <string name="westbound">En direction de l’ouest</string>
     <string name="will_not_stop_at">ne s’arrêtera pas à %1$s %2$s</string>
     <string name="will_terminate_at">se terminera à %1$s %2$s</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -550,6 +550,8 @@
     <string name="waiting_to_depart">Ap tann pou yo ale</string>
     <string name="weather">Tan</string>
     <string name="weather_lowercase">move tan</string>
+    <string name="weekdays">Jou lasemèn</string>
+    <string name="weekends">wikenn yo</string>
     <string name="westbound">Pran direksyon lwès</string>
     <string name="will_not_stop_at">p ap rete nan %1$s %2$s</string>
     <string name="will_terminate_at">ap fini nan %1$s %2$s</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -551,7 +551,7 @@
     <string name="weather">Tan</string>
     <string name="weather_lowercase">move tan</string>
     <string name="weekdays">Jou lasemèn</string>
-    <string name="weekends">wikenn yo</string>
+    <string name="weekends">Wikenn yo</string>
     <string name="westbound">Pran direksyon lwès</string>
     <string name="will_not_stop_at">p ap rete nan %1$s %2$s</string>
     <string name="will_terminate_at">ap fini nan %1$s %2$s</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -535,6 +535,8 @@
     <string name="waiting_to_depart">Esperando para partir</string>
     <string name="weather">Clima</string>
     <string name="weather_lowercase">clima</string>
+    <string name="weekdays">Dias úteis</string>
+    <string name="weekends">Fins de semana</string>
     <string name="westbound">Sentido oeste</string>
     <string name="will_not_stop_at">não vai parar em %1$s %2$s</string>
     <string name="will_terminate_at">será encerrado em %1$s %2$s</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -525,6 +525,8 @@
     <string name="waiting_to_depart">Đang chờ khởi hành</string>
     <string name="weather">Thời tiết</string>
     <string name="weather_lowercase">thời tiết</string>
+    <string name="weekdays">Các ngày trong tuần</string>
+    <string name="weekends">Cuối tuần</string>
     <string name="westbound">Về hướng tây</string>
     <string name="will_not_stop_at">sẽ không dừng lại ở %1$s %2$s</string>
     <string name="will_terminate_at">sẽ kết thúc tại %1$s %2$s</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -525,6 +525,8 @@
     <string name="waiting_to_depart">等待出发</string>
     <string name="weather">天气</string>
     <string name="weather_lowercase">天气</string>
+    <string name="weekdays">工作日</string>
+    <string name="weekends">周末</string>
     <string name="westbound">西行</string>
     <string name="will_not_stop_at">不会止步于 %1$s %2$s</string>
     <string name="will_terminate_at">将在 %1$s %2$s 处终止</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -525,6 +525,8 @@
     <string name="waiting_to_depart">等待離開</string>
     <string name="weather">天氣</string>
     <string name="weather_lowercase">天氣</string>
+    <string name="weekdays">工作日</string>
+    <string name="weekends">週末</string>
     <string name="westbound">西行</string>
     <string name="will_not_stop_at">不會止步於 %1$s %2$s</string>
     <string name="will_terminate_at">將在 %1$s %2$s 處終止</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -533,6 +533,8 @@
     <string name="waiting_to_depart">Waiting to depart</string>
     <string name="weather">Weather</string>
     <string name="weather_lowercase">weather</string>
+    <string name="weekdays">Weekdays</string>
+    <string name="weekends">Weekends</string>
     <string name="westbound">Westbound</string>
     <string name="will_not_stop_at">will not stop at %1$s %2$s</string>
     <string name="will_terminate_at">will terminate at %1$s %2$s</string>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -26965,7 +26965,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "días laborables"
+            "value" : "Días laborables"
           }
         },
         "fr" : {
@@ -27012,7 +27012,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "fines de semana"
+            "value" : "Fines de semana"
           }
         },
         "fr" : {
@@ -27024,7 +27024,7 @@
         "ht" : {
           "stringUnit" : {
             "state" : "needs_review",
-            "value" : "wikenn yo"
+            "value" : "Wikenn yo"
           }
         },
         "pt-BR" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -26959,6 +26959,100 @@
         }
       }
     },
+    "Weekdays" : {
+      "comment" : "Mondays through Fridays",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "días laborables"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jours de la semaine"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Jou lasemèn"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Dias úteis"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Các ngày trong tuần"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作日"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "工作日"
+          }
+        }
+      }
+    },
+    "Weekends" : {
+      "comment" : "Saturdays and Sundays",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "fines de semana"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Week-ends"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "wikenn yo"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Fins de semana"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Cuối tuần"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "周末"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "週末"
+          }
+        }
+      }
+    },
     "Westbound" : {
       "comment" : "A route direction label",
       "localizations" : {

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -129,12 +129,19 @@ struct AlertDetails: View {
                 VStack(alignment: .leading, spacing: 14) {
                     dateRange
                     let calendar = Self.calendar
-                    Text(recurrence.days.sorted(by: { $0.indexSundayFirst < $1.indexSundayFirst })
-                        .map { calendar.standaloneWeekdaySymbols[$0.indexSundayFirst] }
-                        .joined(separator: NSLocalizedString(
-                            ", ",
-                            comment: "Separator between elements in a list, e.g. “Monday[, ]Wednesday[, ]Friday"
-                        )))
+                    let daysOfWeek = if recurrence.isWeekdays {
+                        NSLocalizedString("Weekdays", comment: "Mondays through Fridays")
+                    } else if recurrence.isWeekends {
+                        NSLocalizedString("Weekends", comment: "Saturdays and Sundays")
+                    } else {
+                        recurrence.days.sorted(by: { $0.indexSundayFirst < $1.indexSundayFirst })
+                            .map { calendar.standaloneWeekdaySymbols[$0.indexSundayFirst] }
+                            .joined(separator: NSLocalizedString(
+                                ", ",
+                                comment: "Separator between elements in a list, e.g. “Monday[, ]Wednesday[, ]Friday"
+                            ))
+                    }
+                    Text(daysOfWeek)
                         .font(Typography.bodySemibold)
                     HStack(spacing: 8) {
                         Text("From", comment: "Label for the times of a recurring alert")

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
@@ -348,6 +348,80 @@ final class AlertDetailsTests: XCTestCase {
         XCTAssertNotNil(try sut.inspect().find(text: "9:41\u{202F}AM – 11:41\u{202F}AM"))
     }
 
+    func testRecurringWeekdays() throws {
+        let objects = ObjectCollectionBuilder()
+
+        let now = EasternTimeInstant(year: 2026, month: .may, day: 4, hour: 14, minute: 38, second: 0)
+
+        let route = objects.route { _ in }
+        let stop = objects.stop { $0.name = "Park Street" }
+        let alert = objects.alert { alert in
+            alert.effect = .suspension
+            alert.activePeriod(
+                start: now.minus(hours: 1),
+                end: now.plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 24).minus(hours: 1),
+                end: now.plus(hours: 24).plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 2 * 24).minus(hours: 1),
+                end: now.plus(hours: 2 * 24).plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 3 * 24).minus(hours: 1),
+                end: now.plus(hours: 3 * 24).plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 4 * 24).minus(hours: 1),
+                end: now.plus(hours: 4 * 24).plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 7 * 24).minus(hours: 1),
+                end: now.plus(hours: 7 * 24).plus(hours: 1)
+            )
+        }
+
+        let sut = AlertDetails(alert: alert, line: nil, routes: [route], stop: stop, affectedStops: [stop], now: now)
+
+        XCTAssertNotNil(try sut.inspect().find(text: "May 4 – May 11"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Weekdays"))
+        XCTAssertNotNil(try sut.inspect().find(text: "From"))
+        XCTAssertNotNil(try sut.inspect().find(text: "1:38\u{202F}PM – 3:38\u{202F}PM"))
+    }
+
+    func testRecurringWeekends() throws {
+        let objects = ObjectCollectionBuilder()
+
+        let now = EasternTimeInstant(year: 2026, month: .may, day: 3, hour: 14, minute: 38, second: 0)
+
+        let route = objects.route { _ in }
+        let stop = objects.stop { $0.name = "Park Street" }
+        let alert = objects.alert { alert in
+            alert.effect = .suspension
+            alert.activePeriod(
+                start: now.minus(hours: 1),
+                end: now.plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 6 * 24).minus(hours: 1),
+                end: now.plus(hours: 6 * 24).plus(hours: 1)
+            )
+            alert.activePeriod(
+                start: now.plus(hours: 7 * 24).minus(hours: 1),
+                end: now.plus(hours: 7 * 24).plus(hours: 1)
+            )
+        }
+
+        let sut = AlertDetails(alert: alert, line: nil, routes: [route], stop: stop, affectedStops: [stop], now: now)
+
+        XCTAssertNotNil(try sut.inspect().find(text: "May 3 – May 10"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Weekends"))
+        XCTAssertNotNil(try sut.inspect().find(text: "From"))
+        XCTAssertNotNil(try sut.inspect().find(text: "1:38\u{202F}PM – 3:38\u{202F}PM"))
+    }
+
     func testRecurringSomeDays() throws {
         let objects = ObjectCollectionBuilder()
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -471,6 +471,17 @@ internal constructor(
                     .map { it.dayOfWeek }
                     .toSet() && days.count() > 1
 
+        public val isWeekdays: Boolean =
+            days ==
+                setOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                )
+        public val isWeekends: Boolean = days == setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+
         public val fromStartOfService: Boolean = start.local.time == LocalTime(3, 0)
         public val toEndOfService: Boolean =
             end.local.time == LocalTime(2, 59) || end.local.time == LocalTime(3, 0)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -13,6 +13,7 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
 import kotlinx.datetime.plus
 
 class AlertTest {
@@ -231,6 +232,8 @@ class AlertTest {
             )
         assertEquals(recurrence, alert.recurrenceRange())
         assertFalse(recurrence.daily)
+        assertFalse(recurrence.isWeekdays)
+        assertFalse(recurrence.isWeekends)
     }
 
     @Test
@@ -263,6 +266,33 @@ class AlertTest {
             )
         assertEquals(expectedInfo, alert.recurrenceRange())
         assertFalse(expectedInfo.daily)
+        assertTrue(expectedInfo.isWeekdays)
+    }
+
+    @Test
+    fun `recurrenceRange identifies weekends`() {
+        val selectedDays = setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY)
+        val alert =
+            ObjectCollectionBuilder.Single.alert {
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, Month.MAY, 2), LocalTime(3, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, Month.MAY, 4), LocalTime(3, 0, 0)),
+                )
+                activePeriod(
+                    EasternTimeInstant(LocalDate(2026, Month.MAY, 9), LocalTime(3, 0, 0)),
+                    EasternTimeInstant(LocalDate(2026, Month.MAY, 11), LocalTime(3, 0, 0)),
+                )
+            }
+        val expectedInfo =
+            Alert.RecurrenceInfo(
+                alert.activePeriod.first().start,
+                alert.activePeriod.last().end!!,
+                selectedDays,
+                endDayKnown = true,
+            )
+        assertEquals(expectedInfo, alert.recurrenceRange())
+        assertFalse(expectedInfo.daily)
+        assertTrue(expectedInfo.isWeekends)
     }
 
     @Test


### PR DESCRIPTION
### Summary

_Ticket:_ [For recurring alerts in alert details, use concise weekdays for common scenarios](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214187151402023)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added unit tests for logic and UI.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
