### PR TITLE
perf(Socket): Retry connecting more quickly

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/phoenix/PhoenixSocketWrapper.kt
@@ -7,6 +7,18 @@ import org.phoenixframework.Socket
 
 @JvmInline
 value class PhoenixSocketWrapper(private val socket: Socket) : PhoenixSocket {
+
+    init {
+        socket.reconnectAfterMs = { tries ->
+            if (tries > 9) 2_000
+            else listOf(10L, 50L, 100L, 150L, 200L, 250L, 500L, 1_000L, 2_000L)[tries - 1]
+        }
+
+        socket.rejoinAfterMs = { tries ->
+            if (tries > 2) 2_000 else listOf(1_000L, 2_000L)[tries - 1]
+        }
+    }
+
     override fun onAttach(callback: () -> Unit): String = socket.onOpen(callback)
 
     override fun onDetach(callback: () -> Unit): String = socket.onClose(callback)

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -60,6 +60,17 @@ struct ProductionAppView: View {
 
     private static func initSocket() -> PhoenixSocket {
         let socket = Socket(appVariant.socketUrl)
+
+        // decreasing default from 5s
+        socket.reconnectAfter = { tries in
+            tries > 9 ? 2.0 : [0.01, 0.05, 0.1, 0.15, 0.2, 0.25, 0.5, 1.0, 2.0][tries - 1]
+        }
+
+        // decreasing default from 10s
+        socket.rejoinAfter = { tries in
+            tries > 2 ? 2 : [1, 2][tries - 1]
+        }
+
         socket.withRawMessages()
         socket.onOpen {
             Logger().debug("Socket opened")


### PR DESCRIPTION
### Summary

_Ticket:_ [Investigate: Stuck on shimmer load sometimes on startup](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214148953775143?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
I haven't been able to reproduce getting stuck on shimmer loading, but this seems like a reasonable thing to try. Waiting 5 or 10 seconds does feel like a really long time, and maybe that gets hit when switching between networks. Seems like there is at least a chance this helps!

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Ran locally on iOS & android with a broken predictions channel name and logging on retry, confirmed the retry interval looked right
* To test sockets, turned off wifi & confirmed logs appear on interval. On both iOS & android the retries stopped after a point with no wifi, but they did restart when wifi was turned back on, so maybe there is something going on at a lower-level there. I don't think that really matters though, since retries did reliably start back up.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
