### PR TITLE
fix: wrong location case for all clear

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -192,7 +192,9 @@ public sealed class AlertSummary {
             return withContext(Dispatchers.Default) {
                 if (alert.significance(atTime) < AlertSignificance.Minor) return@withContext null
 
-                val location by lazy { alertLocation(alert, stopId, directionId, patterns, global) }
+                val location by lazy {
+                    alertLocation(alert, stopId, directionId, patterns, global, atTime)
+                }
 
                 if (alert.allClear(atTime)) {
                     return@withContext AllClear(location)
@@ -281,6 +283,7 @@ public sealed class AlertSummary {
             directionId: Int,
             patterns: List<RoutePattern>,
             global: GlobalResponse,
+            atTime: EasternTimeInstant,
         ): Location? {
             val routes = patterns.mapNotNull { global.routes[it.routeId] }.distinct()
 
@@ -314,7 +317,7 @@ public sealed class AlertSummary {
 
             val affectedStops = global.getAlertAffectedStops(alert, routes) ?: return null
 
-            if (alert.stopSkipped && affectedStops.isNotEmpty()) {
+            if (alert.stopSkipped && affectedStops.isNotEmpty() && alert.isActive(atTime)) {
                 return Location.AffectedStops(affectedStops.map { it.name })
             }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripShuttleAlertSummary.kt
@@ -43,6 +43,7 @@ constructor(
             informedTrips: List<UpcomingTrip>,
             global: GlobalResponse,
             recurrence: Recurrence?,
+            atTime: EasternTimeInstant,
         ): TripShuttleAlertSummary? {
             val tripIdentity = tripIdentity(patterns, informedTrips, global) ?: return null
             val currentStopName = global.getStop(stopId)?.name
@@ -55,6 +56,7 @@ constructor(
                         informedTrips.any { it.trip.routePatternId == pattern.id }
                     },
                     global,
+                    atTime,
                 )
             return if (currentStopName != null && location is Location.SuccessiveStops) {
                 TripShuttleAlertSummary(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripSpecificAlertSummary.kt
@@ -69,6 +69,7 @@ constructor(
                         informedTrips,
                         global,
                         recurrence,
+                        atTime,
                     )
                 }
                 Alert.Effect.StationClosure,
@@ -113,7 +114,7 @@ constructor(
                     val suspensionEffectStops =
                         if (alert.effect == Alert.Effect.Suspension) {
                             val location =
-                                alertLocation(alert, stopId, directionId, patterns, global)
+                                alertLocation(alert, stopId, directionId, patterns, global, atTime)
                             when (location) {
                                 is Location.SingleStop ->
                                     if (location.downstream == true) location.stopName else null

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -1931,7 +1931,7 @@ class AlertSummaryTest {
     }
 
     @Test
-    fun `summary with closure sets AffectedStops Location type`() = runBlocking {
+    fun `summary with closure sets AffectedStops Location type when active`() = runBlocking {
         val objects = ObjectCollectionBuilder()
 
         val now = EasternTimeInstant.now()
@@ -1998,6 +1998,46 @@ class AlertSummaryTest {
                 null,
             ),
             stationClosureSummary,
+        )
+    }
+
+    @Test
+    fun `summary with closure sets SingleStop Location type when all clear`() = runBlocking {
+        val objects = ObjectCollectionBuilder()
+
+        val now = EasternTimeInstant.now()
+
+        val stop =
+            objects.stop {
+                name = "Parent Name"
+                childStop {}
+            }
+        val childStop = objects.stops[stop.childStopIds.first()]
+
+        val route = objects.route {}
+        val pattern = objects.routePattern(route) { directionId = 0 }
+        val stopClosureAlert =
+            objects.alert {
+                effect = Alert.Effect.StopClosure
+                durationCertainty = Alert.DurationCertainty.Estimated
+                activePeriod(now.minus(1.hours), now.minus(5.minutes))
+                informedEntity(route = route.id.idText, stop = childStop?.id)
+            }
+
+        val stopClosureSummary =
+            AlertSummary.summarizing(
+                stopClosureAlert,
+                "",
+                0,
+                listOf(pattern),
+                now,
+                null,
+                GlobalResponse(objects),
+            )
+
+        assertEquals(
+            AlertSummary.AllClear(AlertSummary.Location.SingleStop(stop.name)),
+            stopClosureSummary,
         )
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | All clear for stop alerts](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214584716899330?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Whoops 😓 AffectedStops Location type should only be used for active closure alerts.

backend PR: https://github.com/mbta/mobile_app_backend/pull/495

### Testing

Added a test to make sure we only use AffectedStops for active alerts.
