### PR TITLE
chore: bump bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,4 +359,4 @@ DEPENDENCIES
   xcodeproj
 
 BUNDLED WITH
-   2.5.3
+  4.0.11


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
I was having bundler issues. Part of it I think stemmed from something weird with my asdf setup, since the error suggested it was trying to use the system built-in version of ruby rather than the asdf installed one. I ended up entirely uninstalling & reinstalling asdf and all of the things it manages and am back to building successfully, but somewhere along the way I did this bump too which may have helped. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
