### PR TITLE
fix: Upcoming alert timeframes

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetails.kt
@@ -66,6 +66,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.viewModel.ToastViewModel.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.DatePeriod
@@ -87,8 +88,7 @@ fun AlertDetails(
     val routeLabel = line?.longName ?: routes?.firstOrNull()?.label
     val stopLabel = stop?.name
     val formattedAlert = FormattedAlert(alert)
-    val currentPeriod = alert.currentPeriod(now)
-    val nextPeriod = if (currentPeriod == null) alert.nextPeriod(now) else null
+
     val isElevatorAlert = alert.effect == Alert.Effect.ElevatorClosure
     val elevatorSubtitle = if (isElevatorAlert) alert.header else null
 
@@ -103,7 +103,7 @@ fun AlertDetails(
     ) {
         AlertTitle(routeLabel, stopLabel, formattedAlert, elevatorSubtitle, isElevatorAlert)
         if (!isElevatorAlert) {
-            AlertPeriod(alert, currentPeriod, nextPeriod, now)
+            AlertPeriod(alert, now)
 
             Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 AffectedStopCollapsible(
@@ -121,7 +121,7 @@ fun AlertDetails(
         }
         AlertDescription(alert, affectedStopsKnown = affectedStops.isNotEmpty())
         if (isElevatorAlert) {
-            AlertPeriod(alert, currentPeriod, nextPeriod, now)
+            AlertPeriod(alert, now)
         }
         AlertFooter(alert.updatedAt)
     }
@@ -167,12 +167,7 @@ private fun AlertTitle(
 }
 
 @Composable
-private fun AlertPeriod(
-    alert: Alert,
-    currentPeriod: Alert.ActivePeriod?,
-    nextPeriod: Alert.ActivePeriod?,
-    now: EasternTimeInstant,
-) {
+private fun AlertPeriod(alert: Alert, now: EasternTimeInstant) {
     // This is all because Jetpack Compose has no built in table layout, we need the "Start" and
     // "End" label texts to take up the same column width, but they can be variable widths in
     // different languages, so we can't use a fixed size, but we also need the label and formatted
@@ -196,6 +191,9 @@ private fun AlertPeriod(
         }
     }
 
+    val currentPeriod = alert.currentPeriod(now)
+    val nextPeriod =
+        if (currentPeriod == null) alert.nextPeriod(now, kotlin.time.Duration.INFINITE) else null
     val relevantPeriod = currentPeriod ?: nextPeriod
     val recurrence = alert.recurrenceRange()
 

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -73,7 +73,7 @@ struct AlertDetails: View {
     }
 
     private var currentPeriod: Shared.Alert.ActivePeriod? { alert.currentPeriod(time: now) }
-    private var nextPeriod: Shared.Alert.ActivePeriod? { alert.nextPeriod(time: now) }
+    private var nextPeriod: Shared.Alert.ActivePeriod? { alert.nextPeriod(time: now, within: .max) }
     private var relevantPeriod: Shared.Alert.ActivePeriod? { currentPeriod ?? nextPeriod }
 
     static var calendar: Calendar {
@@ -150,16 +150,16 @@ struct AlertDetails: View {
                     }
                 }
             }
-        } else if let currentPeriod {
+        } else if let relevantPeriod {
             Grid(alignment: .leading, horizontalSpacing: 8, verticalSpacing: 14) {
                 GridRow {
                     Text("Start", comment: "Label for the start date of a disruption")
                         .frame(minWidth: 48, alignment: .leading)
-                    Text(currentPeriod.formatStart())
+                    Text(relevantPeriod.formatStart())
                 }
                 GridRow {
                     Text("End", comment: "Label for the end date of a disruption")
-                    Text(currentPeriod.formatEnd())
+                    Text(relevantPeriod.formatEnd())
                 }
             }
         } else {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
@@ -440,8 +441,10 @@ internal constructor(
      * Gets an active period which is not currently active but which will start in the next 24
      * hours.
      */
-    public fun nextPeriod(time: EasternTimeInstant): ActivePeriod? =
-        activePeriod.firstOrNull { it.start > time && it.start <= time + 24.hours }
+    public fun nextPeriod(time: EasternTimeInstant, within: Duration = 24.hours): ActivePeriod? =
+        activePeriod.firstOrNull {
+            it.start > time && (within == Duration.INFINITE || it.start <= time + within)
+        }
 
     internal fun isActive(time: EasternTimeInstant) = currentPeriod(time) != null
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert details | future alerts show no longer in effect](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214223715905141?focus=true)

This was only happening on iOS, but I also added a parameter for the next period check duration so that we won't have this problem in the future if/when we start showing alerts more than 24 hours in the future.

### Testing

Verified that future alerts don't show as no longer in effect on iOS and Android