### PR TITLE
fix: clear stale favorites

### DIFF
--- a/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
@@ -20,7 +20,7 @@ extension FavoritesUsecases {
         try await __updateRouteStopDirections(
             newValues: newValues as [RouteStopDirection: Any],
             context: context,
-            defaultDirection: defaultDirection,
+            defaultDirection: .init(int: defaultDirection),
             fcmToken: fcmToken,
             includeAccessibility: includeAccessibility,
             locale: NSLocalizedString("key/current_locale", comment: "")

--- a/iosApp/iosApp/ViewModels/IFavoritesViewModelExtension.swift
+++ b/iosApp/iosApp/ViewModels/IFavoritesViewModelExtension.swift
@@ -20,7 +20,7 @@ extension IFavoritesViewModel {
         __updateFavorites(
             updatedFavorites: updatedFavorites,
             context: context,
-            defaultDirection: defaultDirection,
+            defaultDirection: .init(int: defaultDirection),
             fcmToken: fcmToken,
             includeAccessibility: includeAccessibility,
             locale: NSLocalizedString("key/current_locale", comment: ""),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
@@ -27,20 +27,22 @@ public abstract class Analytics {
     public fun favoritesUpdated(
         updatedFavorites: Map<RouteStopDirection, Boolean>,
         context: EditFavoritesContext,
-        defaultDirection: Int,
+        defaultDirection: Int?,
     ) {
 
         updatedFavorites.entries
             .groupBy { Pair(it.key.route, it.key.stop) }
             .forEach { (_routeStop, routeStopFavorites) ->
                 routeStopFavorites.forEach { (rsd, isFavorited) ->
+                    val isDefaultDirection =
+                        if (defaultDirection != null) rsd.direction == defaultDirection else "N/A"
                     logEvent(
                         "updated_favorites",
                         "action" to if (isFavorited) "add" else "remove",
                         "route_id" to rsd.route.idText,
                         "stop_id" to rsd.stop,
                         "direction_id" to "${rsd.direction}",
-                        "is_default_direction" to "${rsd.direction == defaultDirection}",
+                        "is_default_direction" to "$isDefaultDirection",
                         "context" to context.name,
                         "updated_both_directions_at_once" to "${routeStopFavorites.size == 2}",
                     )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpdateSubscriptionsRequests.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpdateSubscriptionsRequests.kt
@@ -10,7 +10,7 @@ public data class WriteSubscriptionsRequest
 internal constructor(
     @SerialName("fcm_token") val fcmToken: String,
     val subscriptions: List<SubscriptionRequest>,
-    val locale: String,
+    val locale: String?,
 )
 
 @Serializable
@@ -18,7 +18,7 @@ public data class UpdateAccessibilityRequest
 internal constructor(
     @SerialName("fcm_token") val fcmToken: String,
     @SerialName("include_accessibility") val includeAccessibility: Boolean,
-    val locale: String,
+    val locale: String?,
 )
 
 @Serializable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SubscriptionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SubscriptionsRepository.kt
@@ -18,13 +18,13 @@ public interface ISubscriptionsRepository {
     public suspend fun updateSubscriptions(
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
-        locale: String,
+        locale: String?,
     )
 
     public suspend fun updateAccessibility(
         fcmToken: String,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     )
 }
 
@@ -35,7 +35,7 @@ internal class SubscriptionsRepository : ISubscriptionsRepository, KoinComponent
     override suspend fun updateSubscriptions(
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
-        locale: String,
+        locale: String?,
     ) {
         val requestBody = WriteSubscriptionsRequest(fcmToken, subscriptions, locale)
         ApiResult.runCatching {
@@ -52,7 +52,7 @@ internal class SubscriptionsRepository : ISubscriptionsRepository, KoinComponent
     override suspend fun updateAccessibility(
         fcmToken: String,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     ) {
         val requestBody = UpdateAccessibilityRequest(fcmToken, includeAccessibility, locale)
         ApiResult.runCatching {
@@ -68,15 +68,15 @@ internal class SubscriptionsRepository : ISubscriptionsRepository, KoinComponent
 }
 
 public class MockSubscriptionsRepository(
-    public val onUpdateSubscriptions: (String, List<SubscriptionRequest>, String) -> Unit =
+    public val onUpdateSubscriptions: (String, List<SubscriptionRequest>, String?) -> Unit =
         { _, _, _ ->
         },
-    public val onUpdateAccessibility: (String, Boolean, String) -> Unit = { _, _, _ -> },
+    public val onUpdateAccessibility: (String, Boolean, String?) -> Unit = { _, _, _ -> },
 ) : ISubscriptionsRepository {
     override suspend fun updateSubscriptions(
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
-        locale: String,
+        locale: String?,
     ) {
         onUpdateSubscriptions(fcmToken, subscriptions, locale)
     }
@@ -84,7 +84,7 @@ public class MockSubscriptionsRepository(
     override suspend fun updateAccessibility(
         fcmToken: String,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     ) {
         onUpdateAccessibility(fcmToken, includeAccessibility, locale)
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
@@ -40,7 +40,7 @@ public class FavoritesUsecases(
         defaultDirection: Int,
         fcmToken: String?,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     ) {
         val storedFavorites = repository.getFavorites()
         val currentFavorites = storedFavorites.routeStopDirection.toMutableMap()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
@@ -37,7 +37,7 @@ public class FavoritesUsecases(
     public suspend fun updateRouteStopDirections(
         newValues: Map<RouteStopDirection, FavoriteSettings?>,
         context: EditFavoritesContext,
-        defaultDirection: Int,
+        defaultDirection: Int?,
         fcmToken: String?,
         includeAccessibility: Boolean,
         locale: String?,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -69,7 +69,7 @@ public interface IFavoritesViewModel {
         defaultDirection: Int,
         fcmToken: String?,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     )
 }
 
@@ -103,7 +103,7 @@ public class FavoritesViewModel(
             val defaultDirection: Int,
             val fcmToken: String?,
             val includeAccessibility: Boolean,
-            val locale: String,
+            val locale: String?,
         ) : Event
     }
 
@@ -134,6 +134,7 @@ public class FavoritesViewModel(
             mutableStateOf(null)
         }
 
+        var fcmTokenForClearingStaleFavorites: String? by remember { mutableStateOf(null) }
         var hadOldPinnedRoutes: Boolean by remember { mutableStateOf(false) }
         var shouldShowFirstTimeToast: Boolean by remember { mutableStateOf(false) }
         var shouldShowNotificationsHint: Boolean by remember { mutableStateOf(false) }
@@ -171,9 +172,9 @@ public class FavoritesViewModel(
             favorites
                 .mapNotNull { rsd ->
                     val lineOrRoute = global.getLineOrRoute(rsd.route)
-                    val missingRoute = lineOrRoute == null
-                    val missingStop = global.getStop(rsd.stop) == null
-                    val missingDirection =
+                    val routeExists = lineOrRoute != null
+                    val stopExists = global.getStop(rsd.stop) != null
+                    val directionExists =
                         lineOrRoute?.let {
                             global.getPatternsFor(rsd.stop, it).any { pattern ->
                                 pattern.directionId == rsd.direction
@@ -181,9 +182,9 @@ public class FavoritesViewModel(
                         } ?: false
                     val removalReason =
                         when {
-                            missingRoute -> RemovalReason.MissingRoute
-                            missingStop -> RemovalReason.MissingStop
-                            missingDirection -> RemovalReason.MissingDirection
+                            !routeExists -> RemovalReason.MissingRoute
+                            !stopExists -> RemovalReason.MissingStop
+                            !directionExists -> RemovalReason.MissingDirection
                             else -> null
                         }
                     return@mapNotNull removalReason?.let { rsd to removalReason }
@@ -203,48 +204,7 @@ public class FavoritesViewModel(
         EventSink(eventHandlingTimeout = 2.seconds, sentryRepository = sentryRepository) { event ->
             when (event) {
                 is Event.ClearStaleFavorites -> {
-                    val fcmToken = event.fcmToken
-                    val resolvedFavorites = favorites
-                    if (globalData == null || resolvedFavorites == null || fcmToken == null)
-                        return@EventSink
-
-                    val staleFavorites = getStaleFavorites(resolvedFavorites.keys, globalData)
-                    if (staleFavorites.isNotEmpty()) {
-
-                        /**
-                         * This was erroneously clearing favorites and the reason for that isn't
-                         * clear. For now, we've added more logging to try and determine why this is
-                         * happening.
-                         */
-                        //                        updateFavorites(
-                        //                            staleFavorites.associateWith { null },
-                        //                            EditFavoritesContext.StaleCheck,
-                        //                            // There's no real default direction, but it's
-                        // only used for analytics
-                        //                            0,
-                        //                            fcmToken,
-                        //                            false,
-                        //                        )
-                        sentryRepository.captureMessage("Clearing stale favorites") {
-                            addBreadcrumb(
-                                Breadcrumb(
-                                    message = "Removing ${staleFavorites.size} stale favorite(s)",
-                                    data =
-                                        mutableMapOf(
-                                            "staleFavorites" to
-                                                staleFavorites.map { (rsd, removalReason) ->
-                                                    mapOf(
-                                                        "route" to rsd.route.idText,
-                                                        "stop" to rsd.stop,
-                                                        "direction" to rsd.direction,
-                                                        "removalReason" to removalReason,
-                                                    )
-                                                }
-                                        ),
-                                )
-                            )
-                        }
-                    }
+                    fcmTokenForClearingStaleFavorites = event.fcmToken
                 }
                 Event.DismissNotificationsHint -> {
                     shouldShowNotificationsHint = false
@@ -276,6 +236,48 @@ public class FavoritesViewModel(
                         event.locale,
                     )
                     reloadFavorites()
+                }
+            }
+        }
+
+        LaunchedEffect(globalData, favorites, fcmTokenForClearingStaleFavorites) {
+            val fcmToken = fcmTokenForClearingStaleFavorites
+            val resolvedFavorites = favorites
+            if (globalData == null || resolvedFavorites == null || fcmToken == null) {
+                return@LaunchedEffect
+            }
+
+            fcmTokenForClearingStaleFavorites = null
+
+            val staleFavorites = getStaleFavorites(resolvedFavorites.keys, globalData)
+            if (staleFavorites.isNotEmpty()) {
+                updateFavorites(
+                    staleFavorites.mapValues { null },
+                    EditFavoritesContext.StaleCheck,
+                    // There's no real default direction, but it's only used for analytics
+                    0,
+                    fcmToken,
+                    false,
+                    locale = null,
+                )
+                sentryRepository.captureMessage("Clearing stale favorites") {
+                    addBreadcrumb(
+                        Breadcrumb(
+                            message = "Removing ${staleFavorites.size} stale favorite(s)",
+                            data =
+                                mutableMapOf(
+                                    "staleFavorites" to
+                                        staleFavorites.map { (rsd, removalReason) ->
+                                            mapOf(
+                                                "route" to rsd.route.idText,
+                                                "stop" to rsd.stop,
+                                                "direction" to rsd.direction,
+                                                "removalReason" to removalReason,
+                                            )
+                                        }
+                                ),
+                        )
+                    )
                 }
             }
         }
@@ -387,7 +389,7 @@ public class FavoritesViewModel(
         defaultDirection: Int,
         fcmToken: String?,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     ) {
         fireEvent(
             Event.UpdateFavorites(
@@ -463,7 +465,7 @@ constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State())
         defaultDirection: Int,
         fcmToken: String?,
         includeAccessibility: Boolean,
-        locale: String,
+        locale: String?,
     ) {
         onUpdateFavorites(updatedFavorites)
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -66,7 +66,7 @@ public interface IFavoritesViewModel {
     public fun updateFavorites(
         updatedFavorites: Map<RouteStopDirection, FavoriteSettings?>,
         context: EditFavoritesContext,
-        defaultDirection: Int,
+        defaultDirection: Int?,
         fcmToken: String?,
         includeAccessibility: Boolean,
         locale: String?,
@@ -100,7 +100,7 @@ public class FavoritesViewModel(
         public data class UpdateFavorites(
             val updatedFavorites: Map<RouteStopDirection, FavoriteSettings?>,
             val context: EditFavoritesContext,
-            val defaultDirection: Int,
+            val defaultDirection: Int?,
             val fcmToken: String?,
             val includeAccessibility: Boolean,
             val locale: String?,
@@ -254,8 +254,7 @@ public class FavoritesViewModel(
                 updateFavorites(
                     staleFavorites.mapValues { null },
                     EditFavoritesContext.StaleCheck,
-                    // There's no real default direction, but it's only used for analytics
-                    0,
+                    defaultDirection = null,
                     fcmToken,
                     false,
                     locale = null,
@@ -386,7 +385,7 @@ public class FavoritesViewModel(
     override fun updateFavorites(
         updatedFavorites: Map<RouteStopDirection, FavoriteSettings?>,
         context: EditFavoritesContext,
-        defaultDirection: Int,
+        defaultDirection: Int?,
         fcmToken: String?,
         includeAccessibility: Boolean,
         locale: String?,
@@ -462,7 +461,7 @@ constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State())
     override fun updateFavorites(
         updatedFavorites: Map<RouteStopDirection, FavoriteSettings?>,
         context: EditFavoritesContext,
-        defaultDirection: Int,
+        defaultDirection: Int?,
         fcmToken: String?,
         includeAccessibility: Boolean,
         locale: String?,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -35,7 +35,6 @@ import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import kotlin.test.AfterTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -920,7 +919,6 @@ internal class FavoritesViewModelTest : KoinTest {
     }
 
     @Test
-    @Ignore
     fun `clears stale favorites when stop is missing`() = runTest {
         val now = EasternTimeInstant.now()
 
@@ -930,13 +928,7 @@ internal class FavoritesViewModelTest : KoinTest {
         }
         val favoritesAfter = buildFavorites { routeStopDirection(route1.id, stop1.id, 0) }
 
-        val favoritesRepo = mock<IFavoritesRepository>(MockMode.autofill)
-
-        everySuspend { favoritesRepo.getFavorites() } sequentially
-            {
-                returns(favoritesBefore)
-                repeat { returns(favoritesAfter) }
-            }
+        val favoritesRepo = MockFavoritesRepository(favorites = favoritesBefore)
 
         val dispatcher = StandardTestDispatcher(testScheduler)
 
@@ -962,7 +954,6 @@ internal class FavoritesViewModelTest : KoinTest {
     }
 
     @Test
-    @Ignore
     fun `clears stale favorites when route is missing`() = runTest {
         val now = EasternTimeInstant.now()
 
@@ -972,13 +963,7 @@ internal class FavoritesViewModelTest : KoinTest {
         }
         val favoritesAfter = buildFavorites { routeStopDirection(route1.id, stop1.id, 0) }
 
-        val favoritesRepo = mock<IFavoritesRepository>(MockMode.autofill)
-
-        everySuspend { favoritesRepo.getFavorites() } sequentially
-            {
-                returns(favoritesBefore)
-                repeat { returns(favoritesAfter) }
-            }
+        val favoritesRepo = MockFavoritesRepository(favorites = favoritesBefore)
 
         val dispatcher = StandardTestDispatcher(testScheduler)
 
@@ -1004,7 +989,6 @@ internal class FavoritesViewModelTest : KoinTest {
     }
 
     @Test
-    @Ignore
     fun `clears stale favorites when direction is missing`() = runTest {
         val now = EasternTimeInstant.now()
 
@@ -1022,13 +1006,7 @@ internal class FavoritesViewModelTest : KoinTest {
         }
         val favoritesAfter = buildFavorites { routeStopDirection(route.id, stop.id, 0) }
 
-        val favoritesRepo = mock<IFavoritesRepository>(MockMode.autofill)
-
-        everySuspend { favoritesRepo.getFavorites() } sequentially
-            {
-                returns(favoritesBefore)
-                repeat { returns(favoritesAfter) }
-            }
+        val favoritesRepo = MockFavoritesRepository(favorites = favoritesBefore)
 
         val dispatcher = StandardTestDispatcher(testScheduler)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Sentry Bug | Empty static RouteCardData](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213986119380531)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This Sentry message was never a bug; it was added to indicate favorites that are stale and will probably be cleared, but that doesn’t even happen very often, and the corresponding Sentry message to indicate that favorites were actually cleared fell through the cracks of our triage process (and also appears to have never fired at all on iOS).

The mystery of the disappearing favorites turns out to have been a bug hiding behind a bug, dodging tests with a third bug. Fundamentally, the logic for checking if the favorited direction was missing was backwards, so directions that did exist were the ones selected for deletion. If this happened every time, I think we would have caught it fairly quickly, but we also weren’t correctly waiting for the favorites to load before trying to clear favorites, so it was rare on Android and impossible on iOS for anything to actually happen at all. We should have caught this in tests, but our tests were only looking for a change that was created explicitly in the mock, so the actual functionality wasn’t being tested at all. All three of those are fixed.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked with some temporary logging that if I create a stale favorite, it gets cleared, on both Android and iOS. Updated unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
