### PR TITLE
fix: unsubscribe from notifications if flag is disabled

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -389,7 +389,7 @@ class EditFavoritesPageTest : KoinTest {
 
         val update = mapOf(RouteStopDirection(route.id, sampleStop.id, 0) to null)
         verifySuspend(VerifyMode.exactly(1)) {
-            viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0, null, false, "en")
+            viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0, null, "en")
         }
 
         composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
@@ -468,7 +468,7 @@ class EditFavoritesPageTest : KoinTest {
 
         val update = mapOf(RouteStopDirection(route.id, sampleStop.id, 0) to null)
         verifySuspend(VerifyMode.exactly(1)) {
-            viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0, null, false, "en")
+            viewModel.updateFavorites(update, EditFavoritesContext.Favorites, 0, null, "en")
         }
 
         composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
@@ -486,7 +486,7 @@ class EditFavoritesPageTest : KoinTest {
 
         val undo = mapOf(RouteStopDirection(route.id, sampleStop.id, 0) to FavoriteSettings())
         verifySuspend(VerifyMode.exactly(1)) {
-            viewModel.updateFavorites(undo, EditFavoritesContext.Favorites, 0, null, false, "en")
+            viewModel.updateFavorites(undo, EditFavoritesContext.Favorites, 0, null, "en")
         }
         composeTestRule.waitUntilDefaultTimeout { undo == updatedWith }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManageFavoritesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/ManageFavoritesTest.kt
@@ -12,6 +12,7 @@ import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockSubscriptionsRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
@@ -34,7 +35,12 @@ class ManageFavoritesTest {
         val rsd1 = RouteStopDirection(Route.Id("route1"), "stop1", 1)
         val favoritesRepo = MockFavoritesRepository(buildFavorites { routeStopDirection(rsd0) })
         val favoritesUseCases =
-            FavoritesUsecases(favoritesRepo, MockSubscriptionsRepository(), MockAnalytics())
+            FavoritesUsecases(
+                favoritesRepo,
+                MockSettingsRepository(),
+                MockSubscriptionsRepository(),
+                MockAnalytics(),
+            )
 
         var managedFavorites: ManagedFavorites? = null
         composeTestRule.setContent {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -100,14 +100,16 @@ fun ContentView(
     val pendingFeaturePromos = viewModel.pendingFeaturePromos.collectAsState().value
     val currentLocale = stringResource(R.string.current_locale)
 
-    if (notificationsEnabled) {
-        LaunchedEffect(fcmToken) {
-            fcmToken?.let {
-                val favorites = favoritesUsecases.getRouteStopDirectionFavorites()
-                val subscriptions =
-                    SubscriptionRequest.fromFavorites(favorites, includeAccessibility)
-                subscriptionsRepository.updateSubscriptions(it, subscriptions, currentLocale)
-            }
+    LaunchedEffect(fcmToken, notificationsEnabled) {
+        fcmToken?.let {
+            val favorites = favoritesUsecases.getRouteStopDirectionFavorites()
+            val subscriptions = SubscriptionRequest.fromFavorites(favorites, includeAccessibility)
+            subscriptionsRepository.updateSubscriptions(
+                it,
+                subscriptions,
+                currentLocale,
+                notificationsEnabled,
+            )
         }
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -108,7 +108,6 @@ fun EditFavoritesPage(
             ?: removeToastFallbackText
     }
 
-    val includeAccessibility = SettingsCache.get(Settings.StationAccessibility)
     // to make deletion animations work nicely, we persist the first staticRouteCardData we saw, and
     // then we visually hide things that are no longer in the favorites
     var firstStaticRouteCardData by remember { mutableStateOf<List<RouteCardData>?>(null) }
@@ -149,7 +148,6 @@ fun EditFavoritesPage(
                     EditFavoritesContext.Favorites,
                     deletedFavorite.direction,
                     fcmToken,
-                    includeAccessibility,
                     currentLocale,
                 )
 
@@ -166,7 +164,6 @@ fun EditFavoritesPage(
                                         EditFavoritesContext.Favorites,
                                         deletedFavorite.direction,
                                         fcmToken,
-                                        includeAccessibility,
                                         currentLocale,
                                     )
                                     toastViewModel.hideToast()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
@@ -65,6 +65,7 @@ import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockSubscriptionsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
@@ -143,6 +144,7 @@ fun SaveFavoritePage(
     }
 
     val includeAccessibility = SettingsCache.get(Settings.StationAccessibility)
+    val notificationsEnabled = SettingsCache.get(Settings.Notifications)
     val currentLocale = stringResource(R.string.current_locale)
 
     fun updateFavorites(update: Map<RouteStopDirection, FavoriteSettings?>) {
@@ -151,7 +153,6 @@ fun SaveFavoritePage(
             context,
             selectedDirection,
             fcmToken,
-            includeAccessibility,
             currentLocale,
         )
     }
@@ -315,6 +316,7 @@ private fun SaveFavoritePagePreviewAdd() {
                 single {
                     FavoritesUsecases(
                         MockFavoritesRepository(),
+                        MockSettingsRepository(),
                         MockSubscriptionsRepository(),
                         MockAnalytics(),
                     )
@@ -369,6 +371,7 @@ private fun SaveFavoritePagePreviewEdit() {
                                 )
                             )
                         ),
+                        MockSettingsRepository(),
                         MockSubscriptionsRepository(),
                         MockAnalytics(),
                     )

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/manageFavorites.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/manageFavorites.kt
@@ -36,7 +36,6 @@ fun manageFavorites(favoritesUseCases: FavoritesUsecases = koinInject()): Manage
                 context,
                 defaultDirection,
                 if (notificationsEnabled) fcmToken else null,
-                includeAccessibility,
                 currentLocale,
             )
         }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -633,7 +633,6 @@ struct ContentView: View {
                             context: context,
                             defaultDirection: selectedDirection,
                             fcmToken: fcmTokenContainer.token,
-                            includeAccessibility: includeAccessibility,
                         )
                     },
                     navCallbacks: navCallbacks,

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -35,7 +35,6 @@ struct EditFavoritesPage: View {
             context: .favorites,
             defaultDirection: rsd.direction,
             fcmToken: fcmTokenContainer.token,
-            includeAccessibility: settingsCache.get(.stationAccessibility),
         )
 
         let labels = rsd.getLabels(globalResponse)
@@ -70,7 +69,6 @@ struct EditFavoritesPage: View {
                         context: .favorites,
                         defaultDirection: rsd.direction,
                         fcmToken: fcmTokenContainer.token,
-                        includeAccessibility: settingsCache.get(.stationAccessibility),
                     )
                 }
             ),

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -485,7 +485,6 @@ struct RouteStopListContentView<RightSideContent: View>: View {
                 context: editContext,
                 defaultDirection: selectedDirection,
                 fcmToken: fcmTokenContainer.token,
-                includeAccessibility: settingsCache.get(.stationAccessibility),
             )
         }
     }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -175,7 +175,6 @@ struct StopDetailsFilteredView: View {
                             context: .stopDetails,
                             defaultDirection: routeStopDirection.direction,
                             fcmToken: fcmTokenContainer.token,
-                            includeAccessibility: settingsCache.get(.stationAccessibility),
                         )
                     },
                     onClose: { inSaveFavoritesFlow = false },

--- a/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/FavoritesUsecasesExtension.swift
@@ -15,15 +15,13 @@ extension FavoritesUsecases {
         context: EditFavoritesContext,
         defaultDirection: Int32,
         fcmToken: String?,
-        includeAccessibility: Bool,
     ) async throws {
         try await __updateRouteStopDirections(
             newValues: newValues as [RouteStopDirection: Any],
             context: context,
             defaultDirection: .init(int: defaultDirection),
             fcmToken: fcmToken,
-            includeAccessibility: includeAccessibility,
-            locale: NSLocalizedString("key/current_locale", comment: "")
+            locale: NSLocalizedString("key/current_locale", comment: ""),
         )
     }
 }

--- a/iosApp/iosApp/Utils/Modifiers/FcmSubscriptionModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/FcmSubscriptionModifier.swift
@@ -20,7 +20,7 @@ struct FcmSubscriptionModifier: ViewModifier {
     @State var favorites: Favorites = LoadedFavorites.last
 
     func updateSubscriptions(_ fcmToken: String?, _ notificationsEnabled: Bool) {
-        if notificationsEnabled, let fcmToken {
+        if let fcmToken {
             Task {
                 let subscriptions = SubscriptionRequest.companion.fromFavorites(
                     favorites: favorites.routeStopDirection,
@@ -29,7 +29,8 @@ struct FcmSubscriptionModifier: ViewModifier {
                 try await subscriptionsRepository.updateSubscriptions(
                     fcmToken: fcmToken,
                     subscriptions: subscriptions,
-                    locale: NSLocalizedString("key/current_locale", comment: "")
+                    locale: NSLocalizedString("key/current_locale", comment: ""),
+                    notificationsEnabled: notificationsEnabled,
                 )
             }
         }

--- a/iosApp/iosApp/ViewModels/IFavoritesViewModelExtension.swift
+++ b/iosApp/iosApp/ViewModels/IFavoritesViewModelExtension.swift
@@ -15,14 +15,12 @@ extension IFavoritesViewModel {
         context: EditFavoritesContext,
         defaultDirection: Int32,
         fcmToken: String?,
-        includeAccessibility: Bool,
     ) {
         __updateFavorites(
             updatedFavorites: updatedFavorites,
             context: context,
             defaultDirection: .init(int: defaultDirection),
             fcmToken: fcmToken,
-            includeAccessibility: includeAccessibility,
             locale: NSLocalizedString("key/current_locale", comment: ""),
         )
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -102,6 +102,6 @@ public fun repositoriesModule(repositories: IRepositories): Module {
         single { ConfigUseCase(get(), get()) }
         single<IFeaturePromoUseCase> { FeaturePromoUseCase(get(), get()) }
         single { VisitHistoryUsecase(get()) }
-        single { FavoritesUsecases(get(), get(), get()) }
+        single { FavoritesUsecases(get(), get(), get(), get()) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SubscriptionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SubscriptionsRepository.kt
@@ -19,6 +19,7 @@ public interface ISubscriptionsRepository {
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
         locale: String?,
+        notificationsEnabled: Boolean,
     )
 
     public suspend fun updateAccessibility(
@@ -36,7 +37,9 @@ internal class SubscriptionsRepository : ISubscriptionsRepository, KoinComponent
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
         locale: String?,
+        notificationsEnabled: Boolean,
     ) {
+        val subscriptions = if (notificationsEnabled) subscriptions else emptyList()
         val requestBody = WriteSubscriptionsRequest(fcmToken, subscriptions, locale)
         ApiResult.runCatching {
             mobileBackendClient
@@ -77,6 +80,7 @@ public class MockSubscriptionsRepository(
         fcmToken: String,
         subscriptions: List<SubscriptionRequest>,
         locale: String?,
+        notificationsEnabled: Boolean,
     ) {
         onUpdateSubscriptions(fcmToken, subscriptions, locale)
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecases.kt
@@ -5,7 +5,9 @@ import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.SubscriptionRequest
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
+import com.mbta.tid.mbta_app.repositories.ISettingsRepository
 import com.mbta.tid.mbta_app.repositories.ISubscriptionsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
 import kotlin.experimental.ExperimentalObjCRefinement
 import kotlin.native.ShouldRefineInSwift
 import kotlinx.coroutines.CoroutineScope
@@ -20,6 +22,7 @@ import org.koin.core.component.KoinComponent
 
 public class FavoritesUsecases(
     private val repository: IFavoritesRepository,
+    private val settingsRepository: ISettingsRepository,
     private val subscriptionsRepository: ISubscriptionsRepository,
     private val analytics: Analytics,
 ) : KoinComponent {
@@ -39,7 +42,6 @@ public class FavoritesUsecases(
         context: EditFavoritesContext,
         defaultDirection: Int?,
         fcmToken: String?,
-        includeAccessibility: Boolean,
         locale: String?,
     ) {
         val storedFavorites = repository.getFavorites()
@@ -64,9 +66,19 @@ public class FavoritesUsecases(
         }
         repository.setFavorites(storedFavorites.copy(routeStopDirection = currentFavorites))
         fcmToken?.let {
-            val subs = SubscriptionRequest.fromFavorites(currentFavorites, includeAccessibility)
+            val settings = settingsRepository.getSettings()
+            val subs =
+                SubscriptionRequest.fromFavorites(
+                    currentFavorites,
+                    includeAccessibility = settings[Settings.StationAccessibility] ?: false,
+                )
             CoroutineScope(Dispatchers.IO).launch {
-                subscriptionsRepository.updateSubscriptions(it, subs, locale)
+                subscriptionsRepository.updateSubscriptions(
+                    fcmToken,
+                    subs,
+                    locale,
+                    notificationsEnabled = settings[Settings.Notifications] ?: false,
+                )
             }
         }
         getRouteStopDirectionFavorites()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -68,7 +68,6 @@ public interface IFavoritesViewModel {
         context: EditFavoritesContext,
         defaultDirection: Int?,
         fcmToken: String?,
-        includeAccessibility: Boolean,
         locale: String?,
     )
 }
@@ -102,7 +101,6 @@ public class FavoritesViewModel(
             val context: EditFavoritesContext,
             val defaultDirection: Int?,
             val fcmToken: String?,
-            val includeAccessibility: Boolean,
             val locale: String?,
         ) : Event
     }
@@ -232,7 +230,6 @@ public class FavoritesViewModel(
                         event.context,
                         event.defaultDirection,
                         event.fcmToken,
-                        event.includeAccessibility,
                         event.locale,
                     )
                     reloadFavorites()
@@ -256,7 +253,6 @@ public class FavoritesViewModel(
                     EditFavoritesContext.StaleCheck,
                     defaultDirection = null,
                     fcmToken,
-                    false,
                     locale = null,
                 )
                 sentryRepository.captureMessage("Clearing stale favorites") {
@@ -387,18 +383,10 @@ public class FavoritesViewModel(
         context: EditFavoritesContext,
         defaultDirection: Int?,
         fcmToken: String?,
-        includeAccessibility: Boolean,
         locale: String?,
     ) {
         fireEvent(
-            Event.UpdateFavorites(
-                updatedFavorites,
-                context,
-                defaultDirection,
-                fcmToken,
-                includeAccessibility,
-                locale,
-            )
+            Event.UpdateFavorites(updatedFavorites, context, defaultDirection, fcmToken, locale)
         )
     }
 }
@@ -463,7 +451,6 @@ constructor(initialState: FavoritesViewModel.State = FavoritesViewModel.State())
         context: EditFavoritesContext,
         defaultDirection: Int?,
         fcmToken: String?,
-        includeAccessibility: Boolean,
         locale: String?,
     ) {
         onUpdateFavorites(updatedFavorites)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecasesTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/FavoritesUsecasesTests.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.SubscriptionRequest
 import com.mbta.tid.mbta_app.model.WindowRequest
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.MockSubscriptionsRepository
 import com.mbta.tid.mbta_app.utils.buildFavorites
 import kotlin.test.Test
@@ -25,7 +26,13 @@ class FavoritesUsecasesTests : KoinTest {
         val routeStopDirection = RouteStopDirection(Route.Id("Red"), "place-alfcl", 0)
         val savedFavorites = buildFavorites { routeStopDirection(routeStopDirection) }
         val repository = MockFavoritesRepository(savedFavorites)
-        val usecase = FavoritesUsecases(repository, MockSubscriptionsRepository(), MockAnalytics())
+        val usecase =
+            FavoritesUsecases(
+                repository,
+                MockSettingsRepository(),
+                MockSubscriptionsRepository(),
+                MockAnalytics(),
+            )
         assertEquals(
             usecase.getRouteStopDirectionFavorites(),
             mapOf(routeStopDirection to FavoriteSettings()),
@@ -35,7 +42,13 @@ class FavoritesUsecasesTests : KoinTest {
     @Test
     fun testGetEmptyRouteStopDirectionFavorites() = runBlocking {
         val repository = MockFavoritesRepository()
-        val usecase = FavoritesUsecases(repository, MockSubscriptionsRepository(), MockAnalytics())
+        val usecase =
+            FavoritesUsecases(
+                repository,
+                MockSettingsRepository(),
+                MockSubscriptionsRepository(),
+                MockAnalytics(),
+            )
         assertEquals(usecase.getRouteStopDirectionFavorites(), emptyMap())
     }
 
@@ -50,6 +63,7 @@ class FavoritesUsecasesTests : KoinTest {
         val useCase =
             FavoritesUsecases(
                 repository,
+                MockSettingsRepository(),
                 MockSubscriptionsRepository(),
                 MockAnalytics(onLogEvent = { event, attrs -> eventLogged = event }),
             )
@@ -62,7 +76,6 @@ class FavoritesUsecasesTests : KoinTest {
             EditFavoritesContext.Favorites,
             0,
             null,
-            false,
             "en",
         )
 
@@ -87,7 +100,13 @@ class FavoritesUsecasesTests : KoinTest {
                 }
             )
 
-        val useCase = FavoritesUsecases(repository, subscriptionsRepository, MockAnalytics())
+        val useCase =
+            FavoritesUsecases(
+                repository,
+                MockSettingsRepository(),
+                subscriptionsRepository,
+                MockAnalytics(),
+            )
 
         val expectedSubs =
             listOf(
@@ -155,7 +174,6 @@ class FavoritesUsecasesTests : KoinTest {
             EditFavoritesContext.Favorites,
             0,
             "fake_token",
-            false,
             "en",
         )
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -580,7 +580,6 @@ internal class FavoritesViewModelTest : KoinTest {
                 EditFavoritesContext.Favorites,
                 0,
                 null,
-                false,
                 "en",
             )
             awaitItemSatisfying {
@@ -1047,10 +1046,9 @@ internal class FavoritesViewModelTest : KoinTest {
             }
 
         val subscriptionsRepository = mock<ISubscriptionsRepository>(MockMode.autofill)
-        everySuspend { subscriptionsRepository.updateSubscriptions(any(), any(), any()) } calls
-            {
-                delay(20.days)
-            }
+        everySuspend {
+            subscriptionsRepository.updateSubscriptions(any(), any(), any(), any())
+        } calls { delay(20.days) }
 
         val sentryRepository = mock<ISentryRepository>(MockMode.autofill)
         every { sentryRepository.captureException(any()) } calls
@@ -1123,7 +1121,6 @@ internal class FavoritesViewModelTest : KoinTest {
                 EditFavoritesContext.Favorites,
                 0,
                 "fcmToken",
-                false,
                 "en",
             )
             awaitItemSatisfying {


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: notifications still sent after disabling notifications in settings](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214637408025102)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This feels like a nice holistic approach to me.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that on both Android and iOS the subscriptions are removed if the flag is off.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
