### PR TITLE
fix: omit shuttles with no service

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Sentry (8.57.3):
-    - Sentry/Core (= 8.57.3)
-  - Sentry/Core (8.57.3)
+  - Sentry (8.58.2):
+    - Sentry/Core (= 8.58.2)
+  - Sentry/Core (8.58.2)
   - shared (1.0):
-    - Sentry (~> 8.57.3)
+    - Sentry (~> 8.58.2)
 
 DEPENDENCIES:
   - shared (from `../shared/`)
@@ -17,8 +17,8 @@ EXTERNAL SOURCES:
     :path: "../shared/"
 
 SPEC CHECKSUMS:
-  Sentry: c643eb180df401dd8c734c5036ddd9dd9218daa6
-  shared: da0a7839c39cb0a7fc06cf8e036d5237ea922fe2
+  Sentry: de29b881e83bd91cf99a927f82f1fd86bfb39db2
+  shared: 374a3d0ff522fb04ab76d7dade4150a4297d2656
 
 PODFILE CHECKSUM: 8b77545532cdf4b25adfa1dd92b4b893e9371c67
 

--- a/shared/shared.podspec
+++ b/shared/shared.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
     spec.vendored_frameworks      = 'build/cocoapods/framework/Shared.framework'
     spec.libraries                = 'c++'
     spec.ios.deployment_target    = '15.0'
-    spec.dependency 'Sentry', '~> 8.57.3'
+    spec.dependency 'Sentry', '~> 8.58.2'
     if !Dir.exist?('build/cocoapods/framework/Shared.framework') || Dir.empty?('build/cocoapods/framework/Shared.framework')
         raise "
         Kotlin framework 'Shared' doesn't exist yet, so a proper Xcode project can't be generated.

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1245,7 +1245,7 @@ public data class RouteCardData(
 
             // Typical shuttle with no service today
             val shuttleWithNoServiceToday =
-                upcomingTrips?.isEmpty() == true && lineOrRoute.isShuttle
+                upcomingTrips.orEmpty().isEmpty() && lineOrRoute.isShuttle
 
             return (hasUnseenTypicalPattern || hasUnseenUpcomingTrip) &&
                 !(shouldBeFilteredAsArrivalOnly) &&

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -6199,6 +6199,8 @@ class RouteCardDataTest {
 
         val stop = objects.stop { id = "test" }
 
+        val lastStop = objects.stop { id = "last-stop" }
+
         val serviceEndedRoute =
             objects.route {
                 id = "Shuttle-service-ended"
@@ -6210,7 +6212,7 @@ class RouteCardDataTest {
                 sortOrder = 1
                 representativeTrip {
                     headsign = "Test"
-                    stopIds = listOf(stop.id)
+                    stopIds = listOf(stop.id, lastStop.id)
                 }
                 typicality = RoutePattern.Typicality.Typical
             }


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Franklin Line shuttle appears at Canton Junction with no service today](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1214749868759676)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

apparently `upcomingTrips?.isEmpty() == true` when upcomingTrips is null is false... 🤦 

The pod file changes are the result of a[ recent dependabot upgrade](https://github.com/mbta/mobile_app/pull/1719).

### Testing

The test succeeded because it was also the last stop in the pattern so it "should be filtered as arrival only". Fixed that.