### PR TITLE
feat: send analytics event when opening notification

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainActivity.kt
@@ -10,7 +10,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import com.google.firebase.Firebase
+import com.google.firebase.analytics.analytics
 import com.google.firebase.messaging.FirebaseMessaging
+import com.mbta.tid.mbta_app.android.analytics.AnalyticsProvider
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
 import com.mbta.tid.mbta_app.android.util.fcmToken
 import com.mbta.tid.mbta_app.initializeSentry
@@ -24,6 +27,10 @@ class MainActivity : ComponentActivity() {
     val deepLinkPathKey = "deep_link_path"
 
     fun handleIntent(intent: Intent?) {
+        val notificationAnalyticsLabel = intent?.getStringExtra("analytics_label")
+        if (notificationAnalyticsLabel != null) {
+            AnalyticsProvider(Firebase.analytics).notificationClicked(notificationAnalyticsLabel)
+        }
         val deepLinkPath =
             if (intent?.hasExtra(deepLinkPathKey) == true) {
                 intent.getStringExtra(deepLinkPathKey)

--- a/iosApp/iosApp/IOSApp.swift
+++ b/iosApp/iosApp/IOSApp.swift
@@ -82,6 +82,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let userInfo = response.notification.request.content.userInfo
         Messaging.messaging().appDidReceiveMessage(userInfo)
 
+        if let analyticsLabel = userInfo["analytics_label"] as? String {
+            AnalyticsProvider.shared.notificationClicked(analyticsLabel: analyticsLabel)
+        }
+
         if let deepLinkPath = userInfo["deep_link_path"] as? String {
             Self.notificationDeepLinkOwner.notificationDeepLink = .companion.from(url: deepLinkPath)
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
@@ -72,6 +72,15 @@ public abstract class Analytics {
         )
     }
 
+    public fun notificationClicked(analyticsLabel: String) {
+        val pieces = analyticsLabel.split(';')
+        val parameters = pieces.map { piece ->
+            val (name, value) = piece.split('=', limit = 2)
+            name to value
+        }.toTypedArray()
+        logEvent("notification_clicked", *parameters)
+    }
+
     public fun performedSearch(query: String) {
         logEvent("search", "query" to query)
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/analytics/Analytics.kt
@@ -74,10 +74,13 @@ public abstract class Analytics {
 
     public fun notificationClicked(analyticsLabel: String) {
         val pieces = analyticsLabel.split(';')
-        val parameters = pieces.map { piece ->
-            val (name, value) = piece.split('=', limit = 2)
-            name to value
-        }.toTypedArray()
+        val parameters =
+            pieces
+                .map { piece ->
+                    val (name, value) = piece.split('=', limit = 2)
+                    name to value
+                }
+                .toTypedArray()
         logEvent("notification_clicked", *parameters)
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/analytics/AnalyticsTest.kt
@@ -121,4 +121,18 @@ class AnalyticsTest {
             ),
         )
     }
+
+    @Test
+    fun testNotificationClicked() {
+        var loggedEvent: Pair<String, Map<String, String>>? = null
+        val analytics = MockAnalytics({ event, params -> loggedEvent = Pair(event, params) })
+        analytics.notificationClicked("route=66,68;effect=suspension;type=update")
+        assertEquals(
+            loggedEvent,
+            Pair(
+                "notification_clicked",
+                mapOf("route" to "66,68", "effect" to "suspension", "type" to "update"),
+            ),
+        )
+    }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Notifications | Click analytics](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214587659492421)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Manually sends an event to Google Analytics when a notification is clicked, based on the metadata added in https://github.com/mbta/mobile_app_backend/pull/515.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked in Firebase debug view that this works on both platforms.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
