### PR TITLE
fix(Android): Collect map updates as state

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -267,21 +267,20 @@ fun MapAndSheetPage(
             else -> null
         })
 
-    val mapUpdates = tripDetailsViewModel.mapUpdates
-    LaunchedEffect(mapUpdates) {
-        mapUpdates.collect { mapUpdate ->
-            when (mapUpdate) {
-                is TripDetailsViewModel.MapUpdate.SelectedVehicle -> {
-                    val follow =
-                        currentNavEntry is SheetRoutes.TripDetails &&
-                            nearbyTransit.viewportProvider.isVehicleOverview
-                    filters?.tripFilter?.let {
-                        mapViewModel.selectedVehicleUpdated(mapUpdate.vehicle, follow)
-                    }
+    val mapUpdate by tripDetailsViewModel.mapUpdates.collectAsStateWithLifecycle(null)
+    LaunchedEffect(mapUpdate) {
+        when (val update = mapUpdate) {
+            is TripDetailsViewModel.MapUpdate.SelectedVehicle -> {
+                val follow =
+                    currentNavEntry is SheetRoutes.TripDetails &&
+                        nearbyTransit.viewportProvider.isVehicleOverview
+                filters?.tripFilter?.let {
+                    mapViewModel.selectedVehicleUpdated(update.vehicle, follow)
                 }
-                is TripDetailsViewModel.MapUpdate.TripStops ->
-                    mapViewModel.tripStopsUpdated(mapUpdate.tripStops)
             }
+            is TripDetailsViewModel.MapUpdate.TripStops ->
+                mapViewModel.tripStopsUpdated(update.tripStops)
+            else -> {}
         }
     }
 


### PR DESCRIPTION


### Summary

_Ticket:_ [🤖 | Vehicles are no longer followed on the map on trip details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214619549806667?focus=true)

The issue here was that since we were using `.collect` instead of collecting the updates as state, and since we're setting `currentNavEntry` directly rather than delegating it, the current nav entry was always locked into null, the value it was set to during the initial `.collect`, so `follow` would always be false. 

I checked our other usages of `.collect` and they all seem to be only using values from the collect itself, or delegated properties, but I'm going to make a follow up PR to convert all or most of them to use state.


### Testing

Verified that the vehicles are followed and map behaves as expected