### PR TITLE
fix(Android): Remove instances of .collect

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/location/ViewportProvider.kt
@@ -32,11 +32,14 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.utils.ViewportManager
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -51,6 +54,8 @@ interface IViewportProvider {
     var isAnimating: Boolean
 
     var cameraStateFlow: Flow<CameraState>
+
+    var cameraStateFlowDebounced: Flow<CameraState>
 
     fun getViewportImmediate(): MapViewportState
 
@@ -111,6 +116,8 @@ class ViewportProvider(
         _cameraState.asStateFlow().distinctUntilChanged { old, new ->
             old.center.isRoughlyEqualTo(new.center)
         }
+    @OptIn(FlowPreview::class)
+    override var cameraStateFlowDebounced = cameraStateFlow.debounce(0.5.seconds)
 
     private var lastEdgeInsets: EdgeInsets = EdgeInsets(0.0, 0.0, 0.0, 0.0)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -35,6 +34,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.ViewAnnotationAnchor
@@ -95,13 +95,13 @@ fun HomeMapView(
     navCallbacks: NavigationCallbacks,
 ) {
     val globalData = getGlobalData("HomeMapView")
-    val state by viewModel.models.collectAsState()
+    val state by viewModel.models.collectAsStateWithLifecycle()
     var isTargeting by isTargetingState
 
     val configLoadAttempted by
-        mapboxConfigManager.configLoadAttempted.collectAsState(initial = false)
+        mapboxConfigManager.configLoadAttempted.collectAsStateWithLifecycle(false)
 
-    val currentLocation by locationDataManager.currentLocation.collectAsState(initial = null)
+    val currentLocation by locationDataManager.currentLocation.collectAsStateWithLifecycle(null)
     val isDarkMode = isSystemInDarkTheme()
 
     val allowTargeting = currentNavEntry?.allowTargeting ?: true
@@ -127,7 +127,7 @@ fun HomeMapView(
             viewportProvider.cameraStateFlow.map { it.zoom }
         }
     val zoomLevel by
-        cameraZoomFlow.collectAsState(initial = ViewportProvider.Companion.Defaults.zoom)
+        cameraZoomFlow.collectAsStateWithLifecycle(ViewportProvider.Companion.Defaults.zoom)
 
     val showCurrentLocation = currentNavEntry?.showCurrentLocation ?: true
     val pulsingRingColor: Int = colorResource(R.color.key_inverse).toArgb()
@@ -138,8 +138,10 @@ fun HomeMapView(
         rotateEnabled = false
         pitchEnabled = false
     }
-    LaunchedEffect(Unit) {
-        mapState.cameraChangedEvents.collect { viewportProvider.updateCameraState(it.cameraState) }
+
+    val cameraChange by mapState.cameraChangedEvents.collectAsStateWithLifecycle(null)
+    LaunchedEffect(cameraChange) {
+        cameraChange?.let { viewportProvider.updateCameraState(it.cameraState) }
     }
     LaunchedEffect(viewportProvider, sheetPadding) {
         viewportProvider.setSheetPadding(sheetPadding, density, layoutDirection)
@@ -214,17 +216,14 @@ fun HomeMapView(
                     }
                 }
 
-                MapEffect(null) { map ->
-                    mapState.styleLoadedEvents.collect {
-                        val layerManager = MapLayerManager(map.mapboxMap, context)
-                        layerManager.loadImages()
-                        layerManager.setUpAnchorLayers()
-                        map.location.updateSettings {
-                            layerBelow = MapLayerManager.puckAnchorLayerId
-                        }
-                        viewModel.layerManagerInitialized(layerManager)
-                        viewModel.mapStyleLoaded()
-                    }
+                val styleLoad by mapState.styleLoadedEvents.collectAsStateWithLifecycle(null)
+                MapEffect(styleLoad) { map ->
+                    val layerManager = MapLayerManager(map.mapboxMap, context)
+                    layerManager.loadImages()
+                    layerManager.setUpAnchorLayers()
+                    map.location.updateSettings { layerBelow = MapLayerManager.puckAnchorLayerId }
+                    viewModel.layerManagerInitialized(layerManager)
+                    viewModel.mapStyleLoaded()
                 }
 
                 MapEffect(state.layersInitialized, showCurrentLocation) { map ->
@@ -240,15 +239,12 @@ fun HomeMapView(
                     }
                 }
 
-                LaunchedEffect(locationDataManager) {
-                    locationDataManager.currentLocation.collect { location ->
-                        if (location != null) {
-                            locationProvider.sendLocation(
-                                Point.fromLngLat(location.longitude, location.latitude)
-                            )
-                            if (viewportProvider.isFollowingPuck) {
-                                viewModel.recenter(MapViewModel.Event.RecenterType.CurrentLocation)
-                            }
+                val location by locationDataManager.currentLocation.collectAsStateWithLifecycle()
+                LaunchedEffect(location) {
+                    location?.let {
+                        locationProvider.sendLocation(Point.fromLngLat(it.longitude, it.latitude))
+                        if (viewportProvider.isFollowingPuck) {
+                            viewModel.recenter(MapViewModel.Event.RecenterType.CurrentLocation)
                         }
                     }
                 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -186,7 +185,7 @@ fun MapAndSheetPage(
 
     val now by timer(updateInterval = 5.seconds)
 
-    val routeCardDataState by routeCardDataViewModel.models.collectAsState()
+    val routeCardDataState by routeCardDataViewModel.models.collectAsStateWithLifecycle()
     val tileScrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
 
@@ -288,7 +287,7 @@ fun MapAndSheetPage(
         navControllerInitialized = navControllerInitialized || currentNavBackStackEntry != null
     }
 
-    val deepLinkState by deepLinkStateFlow.collectAsState()
+    val deepLinkState by deepLinkStateFlow.collectAsStateWithLifecycle()
     LaunchedEffect(deepLinkState, navControllerInitialized) {
         val state = deepLinkState
         if (!navControllerInitialized || state == null || state == DeepLinkState.None)
@@ -329,7 +328,7 @@ fun MapAndSheetPage(
         notificationsBetaViewModel.setSheetRoute(currentNavEntry)
     }
 
-    val filterUpdates by stopDetailsViewModel.filterUpdates.collectAsState()
+    val filterUpdates by stopDetailsViewModel.filterUpdates.collectAsStateWithLifecycle()
     LaunchedEffect(filterUpdates) { filterUpdates?.let { updateStopDetailsFilters(it) } }
 
     val vehiclesData: List<Vehicle> =
@@ -506,7 +505,7 @@ fun MapAndSheetPage(
     }
 
     LaunchedEffect(
-        mapboxConfigManager.lastMapboxErrorTimestamp.collectAsState(initial = null).value
+        mapboxConfigManager.lastMapboxErrorTimestamp.collectAsStateWithLifecycle(null).value
     ) {
         mapboxConfigManager.loadConfig()
     }
@@ -839,11 +838,9 @@ fun MapAndSheetPage(
         outerSheetPadding ->
         val showSearchBar = remember(currentNavEntry) { currentNavEntry?.showSearchBar ?: true }
         if (hideMaps) {
-            LaunchedEffect(null) {
-                nearbyTransit.locationDataManager.currentLocation.collect { location ->
-                    nearbyTransit.viewportProvider.updateCameraState(location)
-                }
-            }
+            val location by
+                nearbyTransit.locationDataManager.currentLocation.collectAsStateWithLifecycle()
+            LaunchedEffect(location) { nearbyTransit.viewportProvider.updateCameraState(location) }
 
             Box(Modifier.fillMaxSize().background(colorResource(R.color.sheet_background))) {
                 SearchBarOverlay(
@@ -905,7 +902,8 @@ fun MapAndSheetPage(
                         }
                     },
                 ) {
-                    val searchBarHeight by nearbyTabViewModel.searchBarHeight.collectAsState()
+                    val searchBarHeight by
+                        nearbyTabViewModel.searchBarHeight.collectAsStateWithLifecycle()
                     val mapPadding =
                         remember(sheetPadding, searchBarHeight) {
                             sheetPadding.plus(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/managedTargetLocation.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/managedTargetLocation.kt
@@ -7,33 +7,34 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
-import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.flow.debounce
 import org.maplibre.spatialk.geojson.Position
 
 @Composable
 fun managedTargetLocation(nearbyTransit: NearbyTransit, reset: () -> Unit = {}): State<Position?> {
-    var position = remember { mutableStateOf<Position?>(null) }
-    LaunchedEffect(nearbyTransit.locationDataManager) {
-        nearbyTransit.locationDataManager.currentLocation.collect { location ->
-            if (
-                nearbyTransit.viewportProvider.isFollowingPuck &&
-                    !nearbyTransit.viewportProvider.isManuallyCentering
-            ) {
-                position.value = location?.let { Position(it.longitude, it.latitude) }
-            }
+    val position = remember { mutableStateOf<Position?>(null) }
+
+    val location by nearbyTransit.locationDataManager.currentLocation.collectAsStateWithLifecycle()
+    LaunchedEffect(location) {
+        if (
+            nearbyTransit.viewportProvider.isFollowingPuck &&
+                !nearbyTransit.viewportProvider.isManuallyCentering
+        ) {
+            position.value = location?.let { Position(it.longitude, it.latitude) }
         }
     }
-    LaunchedEffect(nearbyTransit.viewportProvider) {
-        nearbyTransit.viewportProvider.cameraStateFlow.debounce(0.5.seconds).collect {
-            // since this LaunchedEffect is cancelled when not on the page
-            // we don't need to check
+
+    val cameraState by
+        nearbyTransit.viewportProvider.cameraStateFlowDebounced.collectAsStateWithLifecycle(null)
+    LaunchedEffect(cameraState) {
+        cameraState?.let {
             if (!nearbyTransit.viewportProvider.isFollowingPuck) {
                 position.value = it.center.toPosition()
             }
         }
     }
+
     LaunchedEffect(nearbyTransit.viewportProvider.isManuallyCentering) {
         if (nearbyTransit.viewportProvider.isManuallyCentering) {
             reset()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.viewModel
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -75,57 +76,55 @@ public class ErrorBannerViewModel(
 
         var clearedError: ClearedDataError? by remember { mutableStateOf(null) }
 
-        LaunchedEffect(Unit) {
-            errorRepository.subscribeToNetworkStatusChanges()
-            errorRepository.state.collect { newErrorState ->
-                val previousErrorState = errorState
-                val previousClearedError = clearedError
-                if (previousErrorState is ErrorBannerState.DataError && newErrorState == null) {
-                    clearedError =
-                        ClearedDataError(
-                            previousErrorState.messages,
-                            previousErrorState.details,
-                            EasternTimeInstant.now(clock),
-                        )
-                } else if (
-                    previousErrorState == null &&
-                        newErrorState is ErrorBannerState.DataError &&
-                        previousClearedError != null
+        LaunchedEffect(Unit) { errorRepository.subscribeToNetworkStatusChanges() }
+
+        val errorRepoState by errorRepository.state.collectAsState()
+        LaunchedEffect(errorRepoState) {
+            val newErrorState = errorRepoState
+            val previousErrorState = errorState
+            val previousClearedError = clearedError
+            if (previousErrorState is ErrorBannerState.DataError && newErrorState == null) {
+                clearedError =
+                    ClearedDataError(
+                        previousErrorState.messages,
+                        previousErrorState.details,
+                        EasternTimeInstant.now(clock),
+                    )
+            } else if (
+                previousErrorState == null &&
+                    newErrorState is ErrorBannerState.DataError &&
+                    previousClearedError != null
+            ) {
+                // data error was cleared and then came back instantly, that’s not good
+                val oldKeys = previousClearedError.keys
+                val newKeys = newErrorState.messages
+                val commonKeys = oldKeys intersect newKeys
+                if (
+                    EasternTimeInstant.now(clock) - previousClearedError.clearedAt < 1.minutes &&
+                        commonKeys.isNotEmpty()
                 ) {
-                    // data error was cleared and then came back instantly, that’s not good
-                    val oldKeys = previousClearedError.keys
-                    val newKeys = newErrorState.messages
-                    val commonKeys = oldKeys intersect newKeys
-                    if (
-                        EasternTimeInstant.now(clock) - previousClearedError.clearedAt <
-                            1.minutes && commonKeys.isNotEmpty()
-                    ) {
-                        sentryRepository.captureMessage(
-                            "Recurring DataError ${commonKeys.sorted()}"
-                        ) {
-                            addBreadcrumb(
-                                Breadcrumb(
-                                    SentryLevel.ERROR,
-                                    type = "error",
-                                    message = "Recurring DataError",
-                                    category = null,
-                                    mutableMapOf(
-                                        "previousClearedError.keys" to previousClearedError.keys,
-                                        "previousClearedError.details" to
-                                            previousClearedError.details,
-                                        "previousClearedError.clearedAt" to
-                                            previousClearedError.clearedAt,
-                                        "newErrorState.messages" to newErrorState.messages,
-                                        "newErrorState.details" to newErrorState.details,
-                                    ),
-                                )
+                    sentryRepository.captureMessage("Recurring DataError ${commonKeys.sorted()}") {
+                        addBreadcrumb(
+                            Breadcrumb(
+                                SentryLevel.ERROR,
+                                type = "error",
+                                message = "Recurring DataError",
+                                category = null,
+                                mutableMapOf(
+                                    "previousClearedError.keys" to previousClearedError.keys,
+                                    "previousClearedError.details" to previousClearedError.details,
+                                    "previousClearedError.clearedAt" to
+                                        previousClearedError.clearedAt,
+                                    "newErrorState.messages" to newErrorState.messages,
+                                    "newErrorState.details" to newErrorState.details,
+                                ),
                             )
-                        }
+                        )
                     }
-                    clearedError = null
                 }
-                errorState = newErrorState
+                clearedError = null
             }
+            errorState = newErrorState
         }
 
         EventSink(eventHandlingTimeout = 1.seconds, sentryRepository = sentryRepository) { event ->


### PR DESCRIPTION
### Summary

_Ticket:_ Follow up to #1742, [🤖 | Vehicles are no longer followed on the map on trip details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214619549806667?focus=true)

This refactors most usages of flow `.collect` calls, and replaces them with `.collectAsStateWithLifecycle` and `LauchedEffect`. It also replaces any instances that I ran into of `.collectAsState` with `.collectAsStateWithLifecycle`. There are some cases where we can't use the lifecycle, like molecule VMs. This comes out of a bug where a closure variable used in a `.collect` callback was getting stuck with the initial null value it was set to. I'm changing these to avoid issues in the future if we decide to start using variables from a closure anywhere, and to discourage the pattern being mimicked in new code.

### Testing

Verified that each piece of refactored logic was still functional