### PR TITLE
fix(iOS): Trip stops border radius

### DIFF
--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -112,9 +112,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                         internalPadding: .init(top: 0, leading: 5, bottom: 0, trailing: 0)
                     )
                     .background(Color.fill3)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                    .padding(1)
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
+                    .withRoundedBorder(width: 2)
                     .padding(.top, 1)
                     .padding(.horizontal, -4)
                 }

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -91,7 +91,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
     var body: some View {
         VStack(spacing: 0) {
             stopRow
-                .background(background)
+                .background(background?.padding(1).clipShape(RoundedRectangle(cornerRadius: 12)))
                 .overlay {
                     if targeted {
                         VStack {
@@ -110,12 +110,13 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                         routeAccents: routeAccents,
                         onViewDetails: { onOpenAlertDetails(disruption.alert) },
                         internalPadding: .init(top: 0, leading: 5, bottom: 0, trailing: 0)
-                    ).background(Color.fill3)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                        .padding(1)
-                        .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
-                        .padding(.top, 1)
-                        .padding(.horizontal, -4)
+                    )
+                    .background(Color.fill3)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .padding(1)
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.halo, lineWidth: 2))
+                    .padding(.top, 1)
+                    .padding(.horizontal, -4)
                 }
             }
         }

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -93,7 +93,6 @@ struct TripStops: View {
     var body: some View {
         ZStack {
             Color.fill2
-                .padding(1)
                 .withRoundedBorder(color: Color.halo, width: 2)
                 .padding(.horizontal, 6)
                 .padding(


### PR DESCRIPTION
### Summary

_Ticket:_ [ | Stop list border radius](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214753534941129?focus=true)

While obsessively zooming in to check the borders, I also noticed that there was a 1pt padding on the TripStops background color that was also slightly messing up the radius.

### Testing

Verified that the border radius on trip stops and route details is correct, and verified that things still look okay with the show borders accessibility setting turned on