### PR TITLE
fix(ios.StopDetailsFilteredView): Fix broken direction picker toggle on GL

### DIFF
--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -167,7 +167,7 @@ struct NearbyTransitView: View {
                         pushNavEntry: { _ in },
                         showStopHeader: true
                     )
-                    .loadingPlaceholder()
+                    .loadingPlaceholder(withShimmer: false)
                 }
             }
             .padding(.vertical, 4)

--- a/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
+++ b/iosApp/iosApp/Pages/StopDetails/DirectionPicker.swift
@@ -21,20 +21,6 @@ struct DirectionPicker: View {
         availableDirections: [Int32],
         directions: [Direction],
         route: Route,
-        filter: StopDetailsFilter?,
-        setFilter: @escaping (StopDetailsFilter?) -> Void
-    ) {
-        self.availableDirections = availableDirections
-        self.directions = directions
-        self.route = route
-        selectedDirectionId = filter?.directionId
-        updateDirectionId = { setFilter(.init(routeId: route.id, directionId: $0)) }
-    }
-
-    init(
-        availableDirections: [Int32],
-        directions: [Direction],
-        route: Route,
         selectedDirectionId: Int32?,
         updateDirectionId: @escaping (Int32) -> Void
     ) {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -158,8 +158,11 @@ struct StopDetailsFilteredView: View {
                                     availableDirections: availableDirections.map(\.id),
                                     directions: directions,
                                     route: lineOrRoute.sortRoute,
-                                    filter: stopFilter,
-                                    setFilter: { setStopFilter($0) }
+                                    selectedDirectionId: stopFilter.directionId,
+                                    updateDirectionId: { setStopFilter(StopDetailsFilter(
+                                        routeId: stopFilter.routeId,
+                                        directionId: $0
+                                    )) }
                                 )
                                 .fixedSize(horizontal: false, vertical: true)
                                 .padding([.horizontal, .top], 16)

--- a/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/DirectionPickerTests.swift
@@ -22,8 +22,8 @@ final class DirectionPickerTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let route = objects.route { _ in }
 
-        let setFilter1Exp: XCTestExpectation = .init(description: "set filter called with direction 1")
-        let setFilter0Exp: XCTestExpectation = .init(description: "set filter called with direction 0")
+        let setDirection0Exp: XCTestExpectation = .init(description: "updateDirectionId called with 1")
+        let setDirection1Exp: XCTestExpectation = .init(description: "updateDirectionId called with 0")
 
         let filter: StopDetailsFilter? = .init(
             routeId: route.id,
@@ -33,20 +33,21 @@ final class DirectionPickerTests: XCTestCase {
         let sut = DirectionPicker(availableDirections: [0, 1],
                                   directions: directions,
                                   route: route,
-                                  filter: filter, setFilter: { filter in
-                                      if filter?.directionId == 1 {
-                                          setFilter1Exp.fulfill()
+                                  selectedDirectionId: 0,
+                                  updateDirectionId: { newDirectionId in
+                                      if newDirectionId == 1 {
+                                          setDirection1Exp.fulfill()
                                       }
-                                      if filter?.directionId == 0 {
-                                          setFilter0Exp.fulfill()
+                                      if newDirectionId == 0 {
+                                          setDirection0Exp.fulfill()
                                       }
                                   })
         XCTAssertNotNil(try sut.inspect().find(text: "Selected Destination"))
         XCTAssertNotNil(try? sut.inspect().find(text: "Other Destination"))
         try sut.inspect().find(button: "Other Destination").tap()
-        wait(for: [setFilter1Exp], timeout: 1)
+        wait(for: [setDirection1Exp], timeout: 1)
         try sut.inspect().find(button: "Selected Destination").tap()
-        wait(for: [setFilter0Exp], timeout: 1)
+        wait(for: [setDirection0Exp], timeout: 1)
     }
 
     func testFormatsNorthSouth() throws {
@@ -61,7 +62,8 @@ final class DirectionPickerTests: XCTestCase {
         let sut = DirectionPicker(availableDirections: [0, 1],
                                   directions: directions,
                                   route: route,
-                                  filter: filter, setFilter: { _ in })
+                                  selectedDirectionId: 0,
+                                  updateDirectionId: { _ in })
         XCTAssertNotNil(try sut.inspect().find(text: "Northbound to"))
         XCTAssertNotNil(try? sut.inspect().find(text: "Southbound to"))
     }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredViewTests.swift
@@ -253,11 +253,111 @@ final class StopDetailsFilteredViewTests: XCTestCase {
         )
 
         let exp = sut.inspection.inspect(after: 2) { view in
-            try view.find(text: "Outbound to")
+            XCTAssertNotNil(try view.find(text: "Outbound to"))
         }
         ViewHosting.host(view: sut.environmentObject(ViewportProvider()).withFixedSettings([
             .devDebugMode: false,
         ]))
         wait(for: [exp], timeout: 4)
+    }
+
+    @MainActor func testCorrectlySetsStopFilterWhenChangingDirectionAtGLStop() throws {
+        let objects = TestData.clone()
+
+        let route: Route = objects.getRoute(id: "Green-B")
+        let stop = objects.getStop(id: "place-boyls")
+
+        let directionId: Int32 = 0
+        let now = EasternTimeInstant.now()
+
+        let pattern0 = objects.getRoutePattern(id: "Green-B-812-0")
+        let pattern1 = objects.getRoutePattern(id: "Green-B-812-1")
+
+        let trip0 = objects.getTrip(id: "canonical-Green-B-C1-0")
+        let trip1 = objects.getTrip(id: "canonical-Green-B-C1-0")
+
+        let upcomingTrip0 = objects.upcomingTrip(prediction: objects.prediction { prediction in
+            prediction.trip = trip0
+            prediction.departureTime = now.plus(minutes: 2)
+        })
+
+        let upcomingTrip1 = objects.upcomingTrip(prediction: objects.prediction { prediction in
+            prediction.trip = trip1
+            prediction.departureTime = now.plus(minutes: 4)
+        })
+
+        let favoritesRepository = MockFavoritesRepository()
+
+        let stopData: RouteCardData.RouteStopData = .init(route: route, stop: stop, data: [RouteCardData.Leaf(
+            lineOrRoute: LineOrRoute.Route(route: route),
+            stop: stop,
+            directionId: 0,
+            routePatterns: [],
+            stopIds: Set([stop.id]),
+            upcomingTrips: [upcomingTrip0],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: true,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .stopDetailsFiltered
+        ), RouteCardData.Leaf(
+            lineOrRoute: LineOrRoute.Route(route: route),
+            stop: stop,
+            directionId: 1,
+            routePatterns: [],
+            stopIds: Set([stop.id]),
+            upcomingTrips: [upcomingTrip1],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: true,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .stopDetailsFiltered
+        )],
+        globalData: GlobalResponse(objects: objects))
+
+        let routeData = StopDetailsViewModel.RouteDataFiltered(
+            filteredWith: .init(stopId: stop.id, stopFilter: .init(routeId: route.lineId!, directionId: 0),
+                                tripFilter: nil),
+            stopData: stopData
+        )
+
+        let stopDetailsVM = MockStopDetailsViewModel(initialState: .init(routeData: routeData,
+                                                                         alertSummaries: [:],
+                                                                         awaitingPredictionsAfterBackground: false))
+
+        let setStopFilterExp = XCTestExpectation(description: "setStopFilter called for GL direction 1")
+
+        let sut = StopDetailsFilteredView(
+            stopId: stop.id,
+            stopFilter: .init(routeId: route.lineId!, directionId: directionId),
+            tripFilter: nil,
+            routeData: nil,
+            favorites: .init(routeStopDirection: [:]),
+            global: .init(objects: objects),
+            now: Date.now,
+            onUpdateFavorites: {},
+            setStopFilter: { filter in if filter?.directionId == 1, filter?.routeId.idText == "line-Green" {
+                setStopFilterExp.fulfill()
+            } else {
+                XCTFail("setStopFilter called with wrong params \(filter?.directionId) \(filter?.routeId)")
+            }
+            },
+            setTripFilter: { _ in },
+            navCallbacks: .companion.empty,
+            errorBannerVM: MockErrorBannerViewModel(),
+            nearbyVM: .init(),
+            mapVM: MockMapViewModel(),
+            stopDetailsVM: stopDetailsVM,
+        )
+
+        let exp = sut.inspection.inspect(after: 2) { view in
+            try view.find(button: "Eastbound to").tap()
+        }
+        ViewHosting.host(view: sut.environmentObject(ViewportProvider()).withFixedSettings([
+            .devDebugMode: false,
+        ]))
+        wait(for: [exp, setStopFilterExp], timeout: 4)
     }
 }


### PR DESCRIPTION
### Summary

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Follow up to https://github.com/mbta/mobile_app/pull/1741. In changing the DirectionPicker constructor while moving where the DirectionPicker was called, I had mistakenly always set the stopFilter `routeId` field to the `routeId`.  Really it is `routeOrLineId` (as indicated by the type, not the name). This removes the special DirectionPicker constructor that was being used in the StopDetailsFilterView for consistency with the android implementation, and similarly just copies the old filter & changes directionId rather than building one from scratch.


iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added a unit test
* Ran locally, confirmed I can now toggle GL directions

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
