### PR TITLE
fix(ios.Deeplinks) Address race condition when opening a notification when app isn't opened

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -39,6 +39,7 @@ import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -170,7 +171,8 @@ fun StopDetailsFilteredView(
         }
     }
 
-    return if (global != null && lineOrRoute != null && stop != null) {
+    @Composable
+    fun Loaded(lineOrRoute: LineOrRoute, stop: Stop, global: GlobalResponse) {
         val routeHex: String = lineOrRoute.backgroundColor
 
         val routeColor: Color = Color.fromHex(routeHex)
@@ -226,7 +228,27 @@ fun StopDetailsFilteredView(
                 }
             }
         }
+    }
+
+    return if (global != null && lineOrRoute != null && stop != null) {
+        Loaded(lineOrRoute, stop, global)
     } else {
-        Column() { LoadingDepartures() }
+        val routeData =
+            LoadingPlaceholders.routeCardData(
+                stopFilter.routeId,
+                10,
+                RouteCardData.Context.StopDetailsFiltered,
+                now,
+            )
+
+        CompositionLocalProvider(IsLoadingSheetContents provides true) {
+            Column(modifier = Modifier.loading()) {
+                Loaded(
+                    routeData.lineOrRoute,
+                    routeData.stopData.first().stop,
+                    GlobalResponse(ObjectCollectionBuilder("StopDetailFilteredViewLoading")),
+                )
+            }
+        }
     }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -80,7 +80,6 @@ struct ContentView: View {
             Task { await contentVM.loadPendingFeaturePromosAndTabPreferences() }
             Task { await contentVM.loadOnboardingScreens() }
             Task {
-                try? await Task.sleep(for: .milliseconds(100))
                 if let notificationDeepLink = notificationDeepLinkOwner.notificationDeepLink {
                     handleDeepLink(deepLinkState: notificationDeepLink)
                     notificationDeepLinkOwner.notificationDeepLink = nil
@@ -116,10 +115,14 @@ struct ContentView: View {
             favoritesVM.clearStaleFavorites(fcmToken: fcmTokenContainer.token)
         }
         .onChange(of: contentVM.defaultTab) { newTab in
-            selectedTab = switch newTab {
-            case .favorites: .favorites
-            case .nearby: .nearby
-            case nil: nil
+            // if we aren't on an entrypoint, then the default tab may have loaded after
+            // we navigated via deeplink. Don't navigate away from the deeplinked location
+            if nearbyVM.navigationStack.lastSafe().isEntrypoint {
+                selectedTab = switch newTab {
+                case .favorites: .favorites
+                case .nearby: .nearby
+                case nil: nil
+                }
             }
         }
         .onChange(of: selectedTab) { nextTab in

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -120,59 +120,10 @@ struct StopDetailsFilteredView: View {
     var body: some View {
         VStack(spacing: 0) {
             if let lineOrRoute, let global, let stop {
-                let allPatternsForStop: [RoutePattern] = global.getPatternsFor(stopId: stopId, lineOrRoute: lineOrRoute)
+                loaded(lineOrRoute: lineOrRoute, stop: stop, global: global)
 
-                let directions: [Direction] = lineOrRoute.directions(
-                    globalData: global,
-                    stop: stop,
-                    patterns: allPatternsForStop.filter { pattern in
-                        pattern.isTypical()
-                    }
-                )
-
-                let availableDirections = directions.filter {
-                    !stop.isLastStopForAllPatterns(directionId: $0.id, patterns: allPatternsForStop, global: global)
-                }
-
-                VStack(spacing: 0) {
-                    ZStack {
-                        Color.fill2.ignoresSafeArea(.all)
-                        header(
-                            lineOrRoute: lineOrRoute,
-                            directions: directions,
-                            availableDirections: availableDirections
-                        )
-                    }
-                    .fixedSize(horizontal: false, vertical: true)
-
-                    ZStack(alignment: .top) {
-                        Color(hex: lineOrRoute.backgroundColor).ignoresSafeArea(.all)
-                        Rectangle()
-                            .fill(Color.halo)
-                            .frame(height: 2)
-                            .frame(maxWidth: .infinity)
-
-                        ScrollView(.vertical, showsIndicators: false) {
-                            VStack(spacing: 16) {
-                                DirectionPicker(
-                                    availableDirections: availableDirections.map(\.id),
-                                    directions: directions,
-                                    route: lineOrRoute.sortRoute,
-                                    filter: stopFilter,
-                                    setFilter: { setStopFilter($0) }
-                                )
-                                .fixedSize(horizontal: false, vertical: true)
-                                .padding([.horizontal, .top], 16)
-                                .padding(.bottom, 6)
-                                .dynamicTypeSize(...DynamicTypeSize.accessibility1)
-
-                                departures(directions: directions)
-                            }
-                        }
-                    }
-                }
             } else {
-                loadingDepartures()
+                loading()
             }
         }
         .task {
@@ -192,6 +143,61 @@ struct StopDetailsFilteredView: View {
         .accessibilityHidden(inSaveFavoritesFlow)
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .enableInjection()
+    }
+
+    @ViewBuilder
+    func loaded(lineOrRoute: LineOrRoute, stop: Stop, global: GlobalResponse) -> some View {
+        let allPatternsForStop: [RoutePattern] = global.getPatternsFor(stopId: stopId, lineOrRoute: lineOrRoute)
+
+        let directions: [Direction] = lineOrRoute.directions(
+            globalData: global,
+            stop: stop,
+            patterns: allPatternsForStop.filter { pattern in
+                pattern.isTypical()
+            }
+        )
+
+        let availableDirections = directions.filter {
+            !stop.isLastStopForAllPatterns(directionId: $0.id, patterns: allPatternsForStop, global: global)
+        }
+
+        VStack(spacing: 0) {
+            ZStack {
+                Color.fill2.ignoresSafeArea(.all)
+                header(
+                    lineOrRoute: lineOrRoute,
+                    directions: directions,
+                    availableDirections: availableDirections
+                )
+            }
+            .fixedSize(horizontal: false, vertical: true)
+
+            ZStack(alignment: .top) {
+                Color(hex: lineOrRoute.backgroundColor).ignoresSafeArea(.all)
+                Rectangle()
+                    .fill(Color.halo)
+                    .frame(height: 2)
+                    .frame(maxWidth: .infinity)
+
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: 16) {
+                        DirectionPicker(
+                            availableDirections: availableDirections.map(\.id),
+                            directions: directions,
+                            route: lineOrRoute.sortRoute,
+                            filter: stopFilter,
+                            setFilter: { setStopFilter($0) }
+                        )
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding([.horizontal, .top], 16)
+                        .padding(.bottom, 6)
+                        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+
+                        departures(directions: directions)
+                    }
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -217,6 +223,22 @@ struct StopDetailsFilteredView: View {
         } else {
             loadingDepartures()
         }
+    }
+
+    @ViewBuilder
+    func loading() -> some View {
+        let routeData = LoadingPlaceholders.shared.routeCardData(
+            routeId: stopFilter.routeId,
+            trips: 10,
+            context: .stopDetailsFiltered,
+            now: nowInstant
+        )
+
+        return loaded(
+            lineOrRoute: routeData.lineOrRoute,
+            stop: routeData.stopData.first!.stop,
+            global: GlobalResponse(objects: ObjectCollectionBuilder())
+        ).loadingPlaceholder()
     }
 
     func loadingDepartures() -> some View {


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: tapping on a notification doesn't bring you to the expected place](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1214846099965965?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
* Fixes the immediate iOS deep linking issue - a race condition between setting the selected tab to the default tab & navigating to the deeplink. Now, we ignore the default tab if we have already navigated to the deeplinked page.

* Fixes shimmer loading state when deeplinked into the app. In https://github.com/mbta/mobile_app/pull/1741, I had mistakenly made it so that if route+stop+global data hadn't loaded, then we show the shimmer treatment for just the departure list w/out header or direction placeholders. Now, we show a shimmery loading version of the full page if we don't have that key data, such as when coming from a deep link haven't loaded it yet.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~ - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Tested that deeplink to a stop on iOS when the app has been force killed works
* Tested that the shimmer loading looks as expected on iOS & android

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
