### PR TITLE
feat: show extra stop if nearest stop on pattern has a major alert

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -211,8 +211,7 @@ class MapAndSheetPageTest : KoinTest {
             repositoryOverrides = {
                 nearby =
                     MockNearbyRepository(
-                        stopIds = listOf(sampleStop.id, greenLineStop.id),
-                        response = NearbyResponse(builder),
+                        response = NearbyResponse(listOf(sampleStop.id, greenLineStop.id))
                     )
                 settings = MockSettingsRepository(mapOf(Settings.HideMaps to hideMaps))
             },

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewModelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetViewModelTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -19,7 +20,7 @@ class MapAndSheetViewModelTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     @Test
-    fun testNearbyStopIds() {
+    fun testNearbyResponse() {
         val objects = ObjectCollectionBuilder()
 
         val route = objects.route()
@@ -33,8 +34,8 @@ class MapAndSheetViewModelTest {
         val position1 = Position(0.0, 0.0)
         val position2 = Position(1.0, 1.0)
 
-        val response1 = listOf(stop1.id)
-        val response2 = listOf(stop2.id)
+        val response1 = NearbyResponse(listOf(stop1.id))
+        val response2 = NearbyResponse(listOf(stop2.id))
         assertNotEquals(response1, response2, "not actually testing anything")
 
         val nearbyRepository =
@@ -42,7 +43,7 @@ class MapAndSheetViewModelTest {
                 override fun getStopIdsNearby(
                     global: GlobalResponse,
                     location: Position,
-                ): List<String> {
+                ): NearbyResponse {
                     return if (location === position1) {
                         response1
                     } else {
@@ -65,11 +66,11 @@ class MapAndSheetViewModelTest {
             }
         }
 
-        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyStopIds != null }
-        assertEquals(response1, nearbyVM.nearbyStopIds)
+        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyResponse != null }
+        assertEquals(response1, nearbyVM.nearbyResponse)
 
         position = position2
-        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyStopIds != response1 }
-        assertEquals(response2, nearbyVM.nearbyStopIds)
+        composeTestRule.waitUntilDefaultTimeout { nearbyVM.nearbyResponse != response1 }
+        assertEquals(response2, nearbyVM.nearbyResponse)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -1,6 +1,9 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
@@ -10,19 +13,23 @@ import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
+import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.utils.TestData
 import com.mbta.tid.mbta_app.utils.buildFavorites
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.koinInject
@@ -170,8 +177,7 @@ class NearbyTransitViewTest : KoinTest {
             repositoryOverrides = {
                 nearby =
                     MockNearbyRepository(
-                        stopIds = listOf(sampleStop.id, greenLineStop.id),
-                        response = NearbyResponse(builder),
+                        response = NearbyResponse(listOf(sampleStop.id, greenLineStop.id))
                     )
             },
         )
@@ -212,8 +218,7 @@ class NearbyTransitViewTest : KoinTest {
             repositoryOverrides = {
                 nearby =
                     MockNearbyRepository(
-                        stopIds = listOf(sampleStop.id, greenLineStop.id),
-                        response = NearbyResponse(builder),
+                        response = NearbyResponse(listOf(sampleStop.id, greenLineStop.id))
                     )
                 settings = MockSettingsRepository(settings = mapOf())
                 favorites =
@@ -267,5 +272,61 @@ class NearbyTransitViewTest : KoinTest {
             hasText("This would be the no nearby stops view")
         )
         composeTestRule.onNodeWithText("This would be the no nearby stops view").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testFilterChangesWithAlerts() {
+        val objects = TestData.clone()
+        val harvardNorthbound = objects.getStop("70068")
+        val centralNorthbound = objects.getStop("70070")
+        val alert =
+            objects.alert {
+                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
+                effect = Alert.Effect.Suspension
+                informedEntity(
+                    activities =
+                        listOf(
+                            Alert.InformedEntity.Activity.Board,
+                            Alert.InformedEntity.Activity.Exit,
+                            Alert.InformedEntity.Activity.Ride,
+                        ),
+                    stop = harvardNorthbound.id,
+                )
+            }
+        loadKoinMocks(
+            objects,
+            repositoryOverrides = {
+                alerts = MockAlertsRepository()
+                nearby =
+                    MockNearbyRepository(
+                        response =
+                            NearbyResponse(listOf(harvardNorthbound.id, centralNorthbound.id))
+                    )
+            },
+        )
+
+        var alerts by mutableStateOf(AlertsStreamDataResponse(emptyMap()))
+
+        composeTestRule.setContent {
+            NearbyTransitView(
+                alertData = alerts,
+                globalResponse = GlobalResponse(objects),
+                targetLocation = harvardNorthbound.position,
+                setLastLocation = {},
+                setIsTargeting = {},
+                onOpenStopDetails = { _, _ -> },
+                noNearbyStopsView = {},
+                errorBannerViewModel = koinInject(),
+            )
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Harvard"))
+        composeTestRule.onNodeWithText("Harvard").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Central").assertDoesNotExist()
+
+        alerts = AlertsStreamDataResponse(mapOf(alert.id to alert))
+
+        composeTestRule.onNodeWithText("Central").assertIsDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -43,13 +44,18 @@ fun NearbyTransitView(
     nearbyVM: NearbyTransitViewModel = koinViewModel(),
     errorBannerViewModel: IErrorBannerViewModel,
 ) {
+    val now by timer(updateInterval = 5.seconds)
     LaunchedEffect(targetLocation, globalResponse) {
         if (globalResponse != null && targetLocation != null) {
             nearbyVM.getNearby(globalResponse, targetLocation, setLastLocation, setIsTargeting)
         }
     }
-    val now by timer(updateInterval = 5.seconds)
-    val stopIds = nearbyVM.nearbyStopIds
+    val stopIds =
+        remember(nearbyVM.nearbyResponse, globalResponse, alertData, now) {
+            if (globalResponse != null)
+                nearbyVM.nearbyResponse?.filter(globalResponse, alertData, now)
+            else null
+        }
     val schedules = getSchedule(stopIds, "NearbyTransitView.getSchedule")
     val predictionsVM =
         subscribeToPredictions(
@@ -90,6 +96,7 @@ fun NearbyTransitView(
             now,
         ) {
             nearbyVM.loadRouteCardData(
+                stopIds,
                 globalResponse,
                 targetLocation,
                 schedules,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewModel.kt
@@ -7,13 +7,13 @@ import androidx.lifecycle.ViewModel
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
 import org.maplibre.spatialk.geojson.Position
@@ -21,10 +21,8 @@ import org.maplibre.spatialk.geojson.Position
 class NearbyTransitViewModel(private val nearbyRepository: INearbyRepository) :
     KoinComponent, ViewModel() {
     var loading by mutableStateOf(false)
-    var nearbyStopIds by mutableStateOf<List<String>?>(null)
+    var nearbyResponse by mutableStateOf<NearbyResponse?>(null)
     var routeCardData by mutableStateOf<List<RouteCardData>?>(null)
-
-    private var fetchNearbyTask: Job? = null
 
     fun getNearby(
         globalResponse: GlobalResponse,
@@ -32,18 +30,15 @@ class NearbyTransitViewModel(private val nearbyRepository: INearbyRepository) :
         setLastLocation: (Position) -> Unit,
         setIsTargeting: (Boolean) -> Unit,
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
-            if (loading) {
-                fetchNearbyTask?.cancel()
-            }
-            val stopIds = nearbyRepository.getStopIdsNearby(globalResponse, location)
-            nearbyStopIds = stopIds
+        CoroutineScope(Dispatchers.Default).launch {
+            nearbyResponse = nearbyRepository.getStopIdsNearby(globalResponse, location)
             setLastLocation(location)
             setIsTargeting(false)
         }
     }
 
     fun loadRouteCardData(
+        stopIds: List<String>?,
         global: GlobalResponse?,
         location: Position?,
         schedules: ScheduleResponse?,
@@ -51,7 +46,6 @@ class NearbyTransitViewModel(private val nearbyRepository: INearbyRepository) :
         alerts: AlertsStreamDataResponse?,
         now: EasternTimeInstant,
     ) {
-        val stopIds = nearbyStopIds
         if (global == null || location == null || stopIds == null) {
             return
         }
@@ -72,11 +66,6 @@ class NearbyTransitViewModel(private val nearbyRepository: INearbyRepository) :
 
     fun reset() {
         loading = false
-        nearbyStopIds = null
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        fetchNearbyTask?.cancel()
+        nearbyResponse = null
     }
 }

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -60,10 +60,16 @@ struct NearbyTransitView: View {
             didAppear?(self)
         }
         .onChange(of: globalData) { globalData in
-            getNearby(location: location, globalData: globalData)
+            getNearby(location: location, globalData: globalData, alerts: nearbyVM.alerts, atTime: now)
         }
         .onChange(of: location) { newLocation in
-            getNearby(location: newLocation, globalData: globalData)
+            getNearby(location: newLocation, globalData: globalData, alerts: nearbyVM.alerts, atTime: now)
+        }
+        .onChange(of: nearbyVM.alerts) { alerts in
+            filterNearby(globalData: globalData, alerts: alerts, atTime: now)
+        }
+        .onChange(of: now) { now in
+            filterNearby(globalData: globalData, alerts: nearbyVM.alerts, atTime: now)
         }
         .onChange(of: nearbyVM.nearbyState.stopIds) { [oldValue = nearbyVM.nearbyState.stopIds] newNearbyStops in
             let oldSet = oldValue != nil ? Set(oldValue ?? []) : nil
@@ -179,12 +185,17 @@ struct NearbyTransitView: View {
     var didLoadData: ((Self) -> Void)?
 
     private func loadEverything() {
-        getNearby(location: location, globalData: globalData)
+        getNearby(location: location, globalData: globalData, alerts: nearbyVM.alerts, atTime: now)
         joinPredictions(nearbyVM.nearbyState.stopIds)
         getSchedule()
     }
 
-    func getNearby(location: CLLocationCoordinate2D?, globalData: GlobalResponse?) {
+    func getNearby(
+        location: CLLocationCoordinate2D?,
+        globalData: GlobalResponse?,
+        alerts: AlertsStreamDataResponse?,
+        atTime: Date
+    ) {
         self.location = location
         self.globalData = globalData
         guard let globalData else { return }
@@ -194,7 +205,25 @@ struct NearbyTransitView: View {
             scheduleResponse = nil
             return
         }
-        nearbyVM.getNearbyStops(global: globalData, location: location)
+        nearbyVM.getNearbyStops(
+            global: globalData,
+            location: location,
+            alerts: alerts,
+            atTime: atTime.toEasternInstant()
+        )
+    }
+
+    func filterNearby(
+        globalData: GlobalResponse?,
+        alerts: AlertsStreamDataResponse?,
+        atTime: Date
+    ) {
+        guard let globalData else { return }
+        nearbyVM.filterNearbyStops(
+            global: globalData,
+            alerts: alerts,
+            atTime: atTime.toEasternInstant()
+        )
     }
 
     func getSchedule() {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -75,7 +75,7 @@ struct NearbyTransitView: View {
             let oldSet = oldValue != nil ? Set(oldValue ?? []) : nil
             let newSet = newNearbyStops != nil ? Set(newNearbyStops ?? []) : nil
             if oldSet != newSet {
-                getSchedule()
+                getSchedule(newNearbyStops)
                 joinPredictions(newNearbyStops)
                 scrollToTop()
             }
@@ -89,6 +89,7 @@ struct NearbyTransitView: View {
             now: now,
         )) { newParams in
             DispatchQueue.main.async {
+                // KB: Potential problem? - state.stopIds might not match the loaded schedules & predictions
                 nearbyVM.loadRouteCardData(
                     state: newParams.state,
                     global: newParams.global,
@@ -187,7 +188,7 @@ struct NearbyTransitView: View {
     private func loadEverything() {
         getNearby(location: location, globalData: globalData, alerts: nearbyVM.alerts, atTime: now)
         joinPredictions(nearbyVM.nearbyState.stopIds)
-        getSchedule()
+        getSchedule(nearbyVM.nearbyState.stopIds)
     }
 
     func getNearby(
@@ -226,9 +227,9 @@ struct NearbyTransitView: View {
         )
     }
 
-    func getSchedule() {
+    func getSchedule(_ stopIds: [String]?) {
         Task {
-            guard let stopIds = nearbyVM.nearbyState.stopIds else {
+            guard let stopIds = stopIds ?? nearbyVM.nearbyState.stopIds else {
                 scheduleResponse = nil
                 return
             }

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -16,6 +16,7 @@ class NearbyViewModel: ObservableObject {
     struct NearbyTransitState: Equatable {
         var loadedLocation: CLLocationCoordinate2D?
         var loading: Bool = false
+        var nearbyResponse: NearbyResponse?
         var stopIds: [String]?
     }
 
@@ -192,7 +193,12 @@ class NearbyViewModel: ObservableObject {
         _ = navigationStack.popLast()
     }
 
-    func getNearbyStops(global: GlobalResponse, location: CLLocationCoordinate2D) {
+    func getNearbyStops(
+        global: GlobalResponse,
+        location: CLLocationCoordinate2D,
+        alerts: AlertsStreamDataResponse?,
+        atTime: EasternTimeInstant
+    ) {
         guard !location.isRoughlyEqualTo(nearbyState.loadedLocation) else {
             return
         }
@@ -206,15 +212,25 @@ class NearbyViewModel: ObservableObject {
             }
             nearbyState.loading = true
 
-            let stopIds = nearbyRepository.getStopIdsNearby(
+            nearbyState.stopIds = nil
+            let nearbyResponse = nearbyRepository.getStopIdsNearby(
                 global: global,
                 location: location.positionKt
             )
+            nearbyState.nearbyResponse = nearbyResponse
             lastLoadedLocation = location
-            nearbyState.stopIds = stopIds
+            nearbyState.stopIds = nearbyResponse.filter(globalData: global, alerts: alerts, atTime: atTime)
             nearbyState.loadedLocation = location
             nearbyState.loading = false
             isTargeting = false
+        }
+    }
+
+    func filterNearbyStops(global: GlobalResponse, alerts: AlertsStreamDataResponse?, atTime: EasternTimeInstant) {
+        Task { @MainActor [weak self] in
+            // wait for any getNearbyStops calls to have finished
+            let _ = await fetchNearbyTask?.result
+            nearbyState.stopIds = nearbyState.nearbyResponse?.filter(globalData: global, alerts: alerts, atTime: atTime)
         }
     }
 

--- a/iosApp/iosApp/ViewModels/NearbyViewModel.swift
+++ b/iosApp/iosApp/ViewModels/NearbyViewModel.swift
@@ -49,6 +49,7 @@ class NearbyViewModel: ObservableObject {
     private let nearbyRepository: INearbyRepository
     private let visitHistoryUsecase: VisitHistoryUsecase
     private var fetchNearbyTask: Task<Void, Never>?
+    private var loadRouteCardDataTask: Task<Void, Error>?
     private var analytics: Analytics
 
     init(
@@ -229,8 +230,12 @@ class NearbyViewModel: ObservableObject {
     func filterNearbyStops(global: GlobalResponse, alerts: AlertsStreamDataResponse?, atTime: EasternTimeInstant) {
         Task { @MainActor [weak self] in
             // wait for any getNearbyStops calls to have finished
-            let _ = await fetchNearbyTask?.result
-            nearbyState.stopIds = nearbyState.nearbyResponse?.filter(globalData: global, alerts: alerts, atTime: atTime)
+            let _ = await self?.fetchNearbyTask?.result
+            self?.nearbyState.stopIds = self?.nearbyState.nearbyResponse?.filter(
+                globalData: global,
+                alerts: alerts,
+                atTime: atTime
+            )
         }
     }
 
@@ -242,9 +247,13 @@ class NearbyViewModel: ObservableObject {
         alerts: AlertsStreamDataResponse?,
         now: Date,
     ) {
-        Task {
+        if let loadRouteCardDataTask, !loadRouteCardDataTask.isCancelled {
+            loadRouteCardDataTask.cancel()
+        }
+
+        loadRouteCardDataTask = Task { [weak self] in
             guard let global, let stopIds = state.stopIds, let location = state.loadedLocation else {
-                Task { @MainActor in routeCardData = nil }
+                Task { @MainActor in self?.routeCardData = nil }
                 return
             }
             let cardData = try await RouteCardData.companion.routeCardsForStopList(
@@ -257,7 +266,9 @@ class NearbyViewModel: ObservableObject {
                 now: now.toEasternInstant(),
                 context: .nearbyTransit
             )
-            Task { @MainActor in routeCardData = cardData }
+            Task { @MainActor in
+                self?.routeCardData = cardData
+            }
         }
     }
 

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitPageTests.swift
@@ -56,7 +56,12 @@ final class NearbyTransitPageTests: XCTestCase {
                 super.init()
             }
 
-            override func getNearbyStops(global _: GlobalResponse, location: CLLocationCoordinate2D) {
+            override func getNearbyStops(
+                global _: GlobalResponse,
+                location: CLLocationCoordinate2D,
+                alerts _: AlertsStreamDataResponse?,
+                atTime _: EasternTimeInstant
+            ) {
                 debugPrint("ViewModel getting nearby")
                 closure(location)
                 expectation.fulfill()
@@ -111,7 +116,12 @@ final class NearbyTransitPageTests: XCTestCase {
                 super.init(navigationStack: navigationStack)
             }
 
-            override func getNearbyStops(global _: GlobalResponse, location _: CLLocationCoordinate2D) {
+            override func getNearbyStops(
+                global _: GlobalResponse,
+                location _: CLLocationCoordinate2D,
+                alerts _: AlertsStreamDataResponse?,
+                atTime _: EasternTimeInstant
+            ) {
                 expectation.fulfill()
             }
         }

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -27,11 +27,17 @@ final class NearbyTransitViewTests: XCTestCase {
 
         init(_ expectation: XCTestExpectation, _ closure: @escaping (CLLocationCoordinate2D) -> Void = { _ in }) {
             self.expectation = expectation
+            expectation.assertForOverFulfill = false
             self.closure = closure
             super.init()
         }
 
-        override func getNearbyStops(global _: GlobalResponse, location: CLLocationCoordinate2D) {
+        override func getNearbyStops(
+            global _: GlobalResponse,
+            location: CLLocationCoordinate2D,
+            alerts _: AlertsStreamDataResponse?,
+            atTime _: EasternTimeInstant
+        ) {
             debugPrint("ViewModel getting nearby")
             closure(location)
             expectation.fulfill()
@@ -517,5 +523,51 @@ final class NearbyTransitViewTests: XCTestCase {
         XCTAssertNil(try? sut.inspect().find(LoadingCard<Text>.self))
         XCTAssertNotNil(try sut.inspect().find(text: "No nearby stops"))
         XCTAssertNotNil(try sut.inspect().find(text: "You’re outside the MBTA service area."))
+    }
+
+    @MainActor func testFilterChangesWithAlerts() throws {
+        let objects = TestData.clone()
+
+        let harvardNorthbound = objects.getStop(id: "70068")
+        let centralNorthbound = objects.getStop(id: "70070")
+        let alert = objects.alert { alert in
+            alert.activePeriod(start: .init(instant: .companion.DISTANT_PAST), end: nil)
+            alert.effect = .suspension
+            alert.informedEntity(activities: [.board, .exit, .ride], stop: harvardNorthbound.id)
+        }
+
+        let repositories = MockRepositories()
+        repositories.useObjects(objects: objects)
+        repositories.alerts = MockAlertsRepository()
+        repositories.nearby = MockNearbyRepository(response: .init(stopIds: [
+            harvardNorthbound.id,
+            centralNorthbound.id,
+        ]))
+        loadKoinMocks(repositories: repositories)
+
+        let nearbyVM = NearbyViewModel()
+        nearbyVM.alerts = .init(alerts: [:])
+
+        let sut = NearbyTransitView(
+            location: .constant(mockLocation),
+            setIsReturningFromBackground: { _ in },
+            nearbyVM: nearbyVM,
+            noNearbyStops: noNearbyStops
+        )
+
+        let expBefore = sut.inspection.inspect(after: 1) { view in
+            XCTAssertNotNil(try view.find(text: "Harvard"))
+            XCTAssertThrowsError(try view.find(text: "Central"))
+
+            nearbyVM.alerts = .init(alerts: [alert.id: alert])
+        }
+
+        let expAfter = sut.inspection.inspect(after: 2) { view in
+            XCTAssertNotNil(try view.find(text: "Central"))
+        }
+
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+
+        wait(for: [expBefore, expAfter], timeout: 3)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/endToEnd/EndToEndRepositories.kt
@@ -115,10 +115,7 @@ internal fun endToEndModule(): Module {
         single<IGlobalRepository> { MockGlobalRepository(globalData) }
         single<ILastLaunchedAppVersionRepository> { MockLastLaunchedAppVersionRepository(null) }
         single<INearbyRepository> {
-            MockNearbyRepository(
-                NearbyResponse(listOf(stopParkStreet.id)),
-                listOf(stopParkStreet.id),
-            )
+            MockNearbyRepository(NearbyResponse(listOf(stopParkStreet.id)))
         }
         single<IOnboardingRepository> { MockOnboardingRepository() }
         single<IPinnedRoutesRepository> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -647,7 +647,7 @@ public data class RouteCardData(
                 val allDataLoaded = schedules != null
 
                 ListBuilder(allDataLoaded, context, now)
-                    .addStaticStopsData(stopIds, globalData, context, favorites)
+                    .addStaticStopsData(stopIds, globalData, context, alerts, favorites)
                     .addUpcomingTrips(schedules, predictions, now, globalData, alerts)
                     .filterIrrelevantData(now, cutoffTime, context, globalData)
                     .addAlerts(
@@ -685,7 +685,7 @@ public data class RouteCardData(
                 if (globalData == null) return@withContext null
 
                 ListBuilder(true, context, now)
-                    .addStaticStopsData(stopIds, globalData, context, favorites)
+                    .addStaticStopsData(stopIds, globalData, context, alerts = null, favorites)
                     // We don't need alerts here, this is just to satisfy the null check
                     .addAlerts(
                         alerts = AlertsStreamDataResponse(emptyMap()),
@@ -766,6 +766,7 @@ public data class RouteCardData(
             stopIds: List<String>,
             globalData: GlobalResponse,
             context: Context,
+            alerts: AlertsStreamDataResponse?,
             favorites: Set<RouteStopDirection>?,
         ): ListBuilder {
 
@@ -776,6 +777,8 @@ public data class RouteCardData(
                     parentToAllStops,
                     globalData,
                     context,
+                    alerts,
+                    atTime = now,
                     favorites,
                 )
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -49,9 +51,12 @@ internal constructor(
             parentToAllStops: Map<Stop, Set<String>>,
             globalData: GlobalResponse,
             context: RouteCardData.Context,
+            alerts: AlertsStreamDataResponse?,
+            atTime: EasternTimeInstant,
             favorites: Set<RouteStopDirection>? = null,
         ): Map<LineOrRoute, Map<Stop, PatternsForStop>> {
             val usedPatternIds = mutableSetOf<String>()
+            val majorAlertUsedPatternIds = mutableSetOf<String>()
             val patternsGrouped = mutableMapOf<LineOrRoute, MutableMap<Stop, PatternsForStop>>()
 
             val inFavorites = context == RouteCardData.Context.Favorites
@@ -63,18 +68,38 @@ internal constructor(
 
             globalData.run {
                 parentToAllStops.forEach { (parentStop, allStopsForParent) ->
-                    val patternsByRouteOrLine =
-                        patternsByRouteOrLine(allStopsForParent, globalData)
-                            // filter out a route if we've already seen all of its patterns
-                            .filterNot { (_key, routePatterns) ->
-                                usedPatternIds.containsAll(routePatterns.map { it.id }.toSet())
-                            }
+                    val patternsByRouteOrLine = patternsByRouteOrLine(allStopsForParent, globalData)
                     for ((lineOrRoute, routePatterns) in patternsByRouteOrLine) {
                         if (skipNonFavorite(lineOrRoute, parentStop)) continue
 
+                        val directions = routePatterns.map { it.directionId }.distinct()
+                        val hasMajorAlert =
+                            directions.associateWith { directionId ->
+                                if (alerts != null)
+                                    Alert.applicableAlerts(
+                                            alerts.alerts.values,
+                                            directionId,
+                                            lineOrRoute.allRoutes.map { it.id },
+                                            routeType = lineOrRoute.type,
+                                            stopIds = allStopsForParent,
+                                            tripId = null,
+                                        )
+                                        .any { it.significance(atTime) == AlertSignificance.Major }
+                                else false
+                            }
+
                         val routeStops = patternsGrouped.getOrPut(lineOrRoute) { mutableMapOf() }
                         val patternsNotSeenAtEarlierStops =
-                            routePatterns.map { it.id }.toSet().minus(usedPatternIds)
+                            routePatterns
+                                .filterNot {
+                                    it.id in usedPatternIds ||
+                                        (hasMajorAlert[it.directionId] == true &&
+                                            it.id in majorAlertUsedPatternIds)
+                                }
+                                .map { it.id }
+                                .toSet()
+
+                        if (patternsNotSeenAtEarlierStops.isEmpty()) continue
 
                         fun skipNonFavorite(pattern: RoutePattern): Boolean =
                             inFavorites &&
@@ -91,7 +116,13 @@ internal constructor(
                         }
                         // We need stops from the same route pattern to show up for favorites
                         if (!inFavorites) {
-                            usedPatternIds.addAll(routePatterns.map { it.id })
+                            for (routePattern in routePatterns) {
+                                val patternIdCollection =
+                                    if (hasMajorAlert[routePattern.directionId] == true)
+                                        majorAlertUsedPatternIds
+                                    else usedPatternIds
+                                patternIdCollection.add(routePattern.id)
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponse.kt
@@ -1,10 +1,40 @@
 package com.mbta.tid.mbta_app.model.response
 
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
-@Serializable
-public data class NearbyResponse(@SerialName("stop_ids") val stopIds: List<String>) {
+public data class NearbyResponse(val stopIds: List<String>) {
     public constructor(objects: ObjectCollectionBuilder) : this(objects.stops.keys.toList())
+
+    public fun filter(
+        globalData: GlobalResponse,
+        alerts: AlertsStreamDataResponse?,
+        atTime: EasternTimeInstant,
+    ): List<String> {
+        val originalStopIdSet = stopIds.toSet()
+        val originalStopOrder = stopIds.mapIndexed { index, id -> Pair(id, index) }.toMap()
+
+        val parentToAllStops = Stop.resolvedParentToAllStops(stopIds, globalData)
+
+        val filteredStopIds =
+            RoutePattern.patternsGroupedByLineOrRouteAndStop(
+                    parentToAllStops,
+                    globalData,
+                    context = RouteCardData.Context.NearbyTransit,
+                    alerts,
+                    atTime,
+                )
+                .flatMap {
+                    it.value.keys.flatMap { stop ->
+                        stop.childStopIds.toSet().plus(stop.id).intersect(originalStopIdSet)
+                    }
+                }
+                .distinct()
+                .sortedBy { originalStopOrder[it] }
+
+        return filteredStopIds
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepository.kt
@@ -1,9 +1,6 @@
 package com.mbta.tid.mbta_app.repositories
 
-import com.mbta.tid.mbta_app.model.RouteCardData
-import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import org.koin.core.component.KoinComponent
@@ -17,11 +14,11 @@ public interface INearbyRepository {
      * [LocationType.STOP]. Omits stops that serves route pattern that are all served by closer
      * stops.
      */
-    public fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String>
+    public fun getStopIdsNearby(global: GlobalResponse, location: Position): NearbyResponse
 }
 
 public class NearbyRepository : KoinComponent, INearbyRepository {
-    override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> {
+    override fun getStopIdsNearby(global: GlobalResponse, location: Position): NearbyResponse {
         val searchPosition = Position(latitude = location.latitude, longitude = location.longitude)
 
         var radius = 0.5.miles
@@ -58,47 +55,16 @@ public class NearbyRepository : KoinComponent, INearbyRepository {
                 }
                 .toList()
 
-        return filterStopsWithRedundantPatterns(allNearbyStops, global)
-    }
-
-    /**
-     * Filter the given list of stopIds to the stops that don't have service redundant to earlier
-     * stops in the list; each stop must serve at least one route pattern that is not seen by any
-     * earlier stop.
-     */
-    private fun filterStopsWithRedundantPatterns(
-        stopIds: List<String>,
-        globalData: GlobalResponse,
-    ): List<String> {
-        val originalStopIdSet = stopIds.toSet()
-        val originalStopOrder = stopIds.mapIndexed { index, id -> Pair(id, index) }.toMap()
-
-        val parentToAllStops = Stop.resolvedParentToAllStops(stopIds, globalData)
-
-        return RoutePattern.patternsGroupedByLineOrRouteAndStop(
-                parentToAllStops,
-                globalData,
-                context = RouteCardData.Context.NearbyTransit,
-            )
-            .flatMap {
-                it.value.keys.flatMap { stop ->
-                    stop.childStopIds.toSet().plus(stop.id).intersect(originalStopIdSet)
-                }
-            }
-            .distinct()
-            .sortedBy { originalStopOrder[it] }
+        return NearbyResponse(allNearbyStops)
     }
 }
 
-public class MockNearbyRepository(
-    private val response: NearbyResponse,
-    private val stopIds: List<String> = response.stopIds,
-) : INearbyRepository {
-    override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> =
-        stopIds
+public class MockNearbyRepository(private val response: NearbyResponse) : INearbyRepository {
+    override fun getStopIdsNearby(global: GlobalResponse, location: Position): NearbyResponse =
+        response
 }
 
 internal class IdleNearbyRepository : INearbyRepository {
-    override fun getStopIdsNearby(global: GlobalResponse, location: Position): List<String> =
-        emptyList()
+    override fun getStopIdsNearby(global: GlobalResponse, location: Position): NearbyResponse =
+        NearbyResponse(emptyList())
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -80,7 +80,13 @@ class RouteCardDataTest {
                         )
                 ),
                 RouteCardData.ListBuilder(false, context, now)
-                    .addStaticStopsData(nearby.stopIds, global, context, null)
+                    .addStaticStopsData(
+                        nearby.stopIds,
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .data,
             )
         }
@@ -173,7 +179,13 @@ class RouteCardDataTest {
                         )
                 ),
                 RouteCardData.ListBuilder(true, context, now)
-                    .addStaticStopsData(nearby.stopIds, global, context, null)
+                    .addStaticStopsData(
+                        nearby.stopIds,
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .data,
             )
         }
@@ -252,7 +264,13 @@ class RouteCardDataTest {
                     )
             ),
             RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global, context, null)
+                .addStaticStopsData(
+                    nearby.stopIds,
+                    global,
+                    context,
+                    alerts = null,
+                    favorites = null,
+                )
                 .data,
         )
     }
@@ -387,6 +405,7 @@ class RouteCardDataTest {
                         listOf(stop1.id, stop2.id, stop3.id),
                         global,
                         context,
+                        alerts = null,
                         favorites,
                     )
                     .data,
@@ -543,6 +562,7 @@ class RouteCardDataTest {
                         listOf(stop1.id, stop2.id, stop3.id),
                         global,
                         context,
+                        alerts = null,
                         favorites,
                     )
                     .data,
@@ -635,7 +655,13 @@ class RouteCardDataTest {
                         ),
                 ),
                 RouteCardData.ListBuilder(false, context, now)
-                    .addStaticStopsData(nearby.stopIds, global, context, null)
+                    .addStaticStopsData(
+                        nearby.stopIds,
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .data,
             )
         }
@@ -744,7 +770,13 @@ class RouteCardDataTest {
                     )
             ),
             RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global, context, null)
+                .addStaticStopsData(
+                    nearby.stopIds,
+                    global,
+                    context,
+                    alerts = null,
+                    favorites = null,
+                )
                 .data,
         )
     }
@@ -815,7 +847,13 @@ class RouteCardDataTest {
                     )
             ),
             RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global, context, null)
+                .addStaticStopsData(
+                    nearby.stopIds,
+                    global,
+                    context,
+                    alerts = null,
+                    favorites = null,
+                )
                 .data,
         )
     }
@@ -925,7 +963,13 @@ class RouteCardDataTest {
                         ),
                 ),
                 RouteCardData.ListBuilder(false, context, now)
-                    .addStaticStopsData(nearby.stopIds, global, context, null)
+                    .addStaticStopsData(
+                        nearby.stopIds,
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .data,
             )
         }
@@ -1060,7 +1104,13 @@ class RouteCardDataTest {
                     )
             ),
             RouteCardData.ListBuilder(false, context, now)
-                .addStaticStopsData(nearby.stopIds, global, context, null)
+                .addStaticStopsData(
+                    nearby.stopIds,
+                    global,
+                    context,
+                    alerts = null,
+                    favorites = null,
+                )
                 .data,
         )
     }
@@ -1264,7 +1314,13 @@ class RouteCardDataTest {
                         )
                 ),
                 RouteCardData.ListBuilder(false, context, now)
-                    .addStaticStopsData(nearby.stopIds, global, context, null)
+                    .addStaticStopsData(
+                        nearby.stopIds,
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .data,
             )
         }
@@ -1412,7 +1468,13 @@ class RouteCardDataTest {
                         )
                 ),
                 RouteCardData.ListBuilder(true, context, time)
-                    .addStaticStopsData(listOf(stop1.id, stop2.id), global, context, null)
+                    .addStaticStopsData(
+                        listOf(stop1.id, stop2.id),
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .addUpcomingTrips(
                         null,
                         PredictionsStreamDataResponse(objects),
@@ -1558,7 +1620,13 @@ class RouteCardDataTest {
                         )
                 ),
                 RouteCardData.ListBuilder(true, context, now)
-                    .addStaticStopsData(listOf(stop1.id, stop2.id, stop3.id), global, context, null)
+                    .addStaticStopsData(
+                        listOf(stop1.id, stop2.id, stop3.id),
+                        global,
+                        context,
+                        alerts = null,
+                        favorites = null,
+                    )
                     .addUpcomingTrips(
                         ScheduleResponse(objects),
                         PredictionsStreamDataResponse(objects),
@@ -1671,6 +1739,7 @@ class RouteCardDataTest {
                     listOf(platform.id),
                     globalData,
                     context,
+                    alerts = null,
                     favorites = emptySet(),
                 )
                 .addUpcomingTrips(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RoutePatternTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.RoutePattern.PatternsForStop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -52,6 +53,8 @@ internal class RoutePatternTest {
                 Stop.resolvedParentToAllStops(listOf(stop1.id, stop2.id, stop3.id), global),
                 global,
                 RouteCardData.Context.NearbyTransit,
+                alerts = null,
+                atTime = EasternTimeInstant.now(),
             ),
         )
     }
@@ -85,6 +88,8 @@ internal class RoutePatternTest {
                 Stop.resolvedParentToAllStops(listOf(stop1.id, stop2.id, stop3.id), global),
                 global,
                 RouteCardData.Context.Favorites,
+                alerts = null,
+                atTime = EasternTimeInstant.now(),
             ),
         )
     }
@@ -113,6 +118,8 @@ internal class RoutePatternTest {
                 Stop.resolvedParentToAllStops(listOf(stop1.id, stop2.id, stop3.id), global),
                 global,
                 RouteCardData.Context.Favorites,
+                alerts = null,
+                atTime = EasternTimeInstant.now(),
                 setOf(
                     RouteStopDirection(route.id, stop1.id, rp1.directionId),
                     RouteStopDirection(route.id, stop3.id, rp2.directionId),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponseTest.kt
@@ -1,0 +1,172 @@
+package com.mbta.tid.mbta_app.model.response
+
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Instant
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.turf.measurement.offset
+import org.maplibre.spatialk.units.Bearing
+import org.maplibre.spatialk.units.extensions.degrees
+import org.maplibre.spatialk.units.extensions.miles
+import org.maplibre.spatialk.units.extensions.times
+
+class NearbyResponseTest {
+    val searchPoint = Position(latitude = 42.3513706803105, longitude = -71.06649626809957)
+
+    fun pointAtDistance(distanceMiles: Double): Position =
+        searchPoint.offset(distanceMiles.miles, Bearing.North + Random.nextDouble() * 360.degrees)
+
+    @Test
+    fun `filters stops that are redundant to closer ones based on route patterns served`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route { type = RouteType.HEAVY_RAIL }
+        val patternAllStops = objects.routePattern(route)
+        val patternStop3 = objects.routePattern(route) {}
+
+        val station =
+            objects.stop {
+                position = pointAtDistance(0.01)
+                childStopIds = listOf("stop1", "stop1Node")
+            }
+
+        val stop1 =
+            objects.stop {
+                id = "stop1"
+                position = pointAtDistance(0.01)
+                vehicleType = RouteType.HEAVY_RAIL
+                parentStationId = station.id
+            }
+
+        val stop2 =
+            objects.stop {
+                position = pointAtDistance(0.02)
+                vehicleType = RouteType.HEAVY_RAIL
+            }
+
+        val stop3 =
+            objects.stop {
+                position = pointAtDistance(0.03)
+                vehicleType = RouteType.HEAVY_RAIL
+            }
+
+        val patternIdsByStop: Map<String, List<String>> =
+            mapOf(
+                stop1.id to listOf(patternAllStops.id),
+                stop2.id to listOf(patternAllStops.id),
+                stop3.id to listOf(patternAllStops.id, patternStop3.id),
+            )
+
+        val globalData = GlobalResponse(objects, patternIdsByStop)
+
+        val response = NearbyResponse(listOf(stop1.id, stop2.id, stop3.id))
+
+        assertEquals(
+            listOf(stop1.id, stop3.id),
+            response.filter(
+                globalData,
+                AlertsStreamDataResponse(objects),
+                atTime = EasternTimeInstant.now(),
+            ),
+        )
+    }
+
+    @Test
+    fun `includes two stops if nearer has a major alert`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop { position = pointAtDistance(0.1) }
+        val stop2 = objects.stop { position = pointAtDistance(0.2) }
+
+        objects.routePattern(objects.route()) {
+            representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
+        }
+
+        objects.alert {
+            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
+                stop = stop1.id,
+            )
+            effect = Alert.Effect.StopClosure
+        }
+
+        val globalData = GlobalResponse(objects)
+        val alerts = AlertsStreamDataResponse(objects)
+        val response = NearbyResponse(listOf(stop1.id, stop2.id))
+
+        assertEquals(
+            listOf(stop1.id, stop2.id),
+            response.filter(globalData, alerts, atTime = EasternTimeInstant.now()),
+        )
+    }
+
+    @Test
+    fun `does not include a second stop if nearer has a secondary alert`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop { position = pointAtDistance(0.1) }
+        val stop2 = objects.stop { position = pointAtDistance(0.2) }
+
+        objects.routePattern(objects.route()) {
+            representativeTrip { stopIds = listOf(stop1.id, stop2.id) }
+        }
+
+        objects.alert {
+            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
+                stop = stop1.id,
+            )
+            effect = Alert.Effect.ServiceChange
+        }
+
+        val globalData = GlobalResponse(objects)
+        val alerts = AlertsStreamDataResponse(objects)
+        val response = NearbyResponse(listOf(stop1.id, stop2.id))
+
+        assertEquals(
+            listOf(stop1.id),
+            response.filter(globalData, alerts, atTime = EasternTimeInstant.now()),
+        )
+    }
+
+    @Test
+    fun `skips second to include third if nearest two have a major alert`() {
+        val objects = ObjectCollectionBuilder()
+
+        val stop1 = objects.stop { position = pointAtDistance(0.1) }
+        val stop2 = objects.stop { position = pointAtDistance(0.2) }
+        val stop3 = objects.stop { position = pointAtDistance(0.3) }
+
+        objects.routePattern(objects.route()) {
+            representativeTrip { stopIds = listOf(stop1.id, stop2.id, stop3.id) }
+        }
+
+        objects.alert {
+            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
+                stop = stop1.id,
+            )
+            informedEntity(
+                listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
+                stop = stop2.id,
+            )
+            effect = Alert.Effect.StopClosure
+        }
+
+        val globalData = GlobalResponse(objects)
+        val alerts = AlertsStreamDataResponse(objects)
+        val response = NearbyResponse(listOf(stop1.id, stop2.id, stop3.id))
+
+        assertEquals(
+            listOf(stop1.id, stop3.id),
+            response.filter(globalData, alerts, atTime = EasternTimeInstant.now()),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
@@ -214,14 +214,14 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop, listOf(blockedStation.id))
 
         val repo = NearbyRepository()
-        val stopIdsExcludingRedundant = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(listOf(goodStop.id), stopIdsExcludingRedundant)
+        assertEquals(NearbyResponse(listOf(goodStop.id)), response)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/NearbyRepositoryTest.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.RoutePattern
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -72,14 +73,14 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop)
 
         val repo = NearbyRepository()
-        val stopIds = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(listOf(nearbySubwayStop.id, nearbyCRStop.id), stopIds)
+        assertEquals(NearbyResponse(listOf(nearbySubwayStop.id, nearbyCRStop.id)), response)
     }
 
     @Test
@@ -111,18 +112,18 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop)
 
         val repo = NearbyRepository()
-        val stopIdsIncludingRedundant = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(listOf(stop1.id), stopIdsIncludingRedundant)
+        assertEquals(NearbyResponse(listOf(stop1.id)), response)
     }
 
     @Test
-    fun `filters stops that are redundant to closer ones based on route patterns served`() {
+    fun `does not filter stops that are redundant to closer ones based on route patterns served`() {
         val objects = ObjectCollectionBuilder()
         val route = objects.route { type = RouteType.HEAVY_RAIL }
         val patternAllStops = objects.routePattern(route)
@@ -167,14 +168,14 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop)
 
         val repo = NearbyRepository()
-        val stopIdsExcludingRedundant = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(listOf(stop1.id, stop3.id), stopIdsExcludingRedundant)
+        assertEquals(NearbyResponse(listOf(stop1.id, stop2.id, stop3.id)), response)
     }
 
     @Test
@@ -201,14 +202,14 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop)
 
         val repo = NearbyRepository()
-        val stopIds = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(listOf(nearbySubwayStop.id, nearbyCRStop.id), stopIds)
+        assertEquals(NearbyResponse(listOf(nearbySubwayStop.id, nearbyCRStop.id)), response)
     }
 
     @Test
@@ -226,13 +227,13 @@ internal class NearbyRepositoryTest {
         val globalData = GlobalResponse(objects, patternIdsByStop)
 
         val repo = NearbyRepository()
-        val stopIds = runBlocking {
+        val response = runBlocking {
             repo.getStopIdsNearby(
                 globalData,
                 Position(latitude = searchPoint.latitude, longitude = searchPoint.longitude),
             )
         }
 
-        assertEquals(emptyList(), stopIds)
+        assertEquals(NearbyResponse(emptyList()), response)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Show an additional nearby stop if the nearest one is closed](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210112078012935)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This isn’t particularly complicated, although SwiftUI’s lack of Compose’s `remember` makes it tricky on iOS.

|iOS|Android|
|---|-------|
|<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-05-21 at 15 10 50" src="https://github.com/user-attachments/assets/3dc2d5af-8b41-4faf-90b3-f742fd380688" />|<img width="1080" height="2400" alt="Screenshot_20260521_152036" src="https://github.com/user-attachments/assets/765da7e4-d1cc-49b4-9e69-681177debc71" />|

On iOS, there’s a weird issue where, when panning the map, the old set of loaded stops flashes in for a bit before the sheet goes back to loading and then to the new stops. This is new on this PR, and I’m not really sure how to fix it. I plan to take a closer look in the morning, but if you can catch it before I get to it, thanks a bunch.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Manually checked on both Android and iOS that the new behavior works. Added tests for the logic and at the UI level to test the state management.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
