### PR TITLE
fix(RouteCardData.format): Don't limit # of predictions in stop details when branched

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -6,7 +6,7 @@ public enum class AppVariant(
     public val darkMapStyle: String,
 ) {
     DevOrange(
-        "mobile-app-backend.mbtace.com",
+        "mobile-app-backend-dev-orange.mbtace.com",
         "mapbox://styles/mbtamobileapp/cm02vf0cf00cu01pnfgnu5onh",
         "mapbox://styles/mbtamobileapp/cm02vgvsp003c01ombyewgu70",
     ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppVariant.kt
@@ -6,7 +6,7 @@ public enum class AppVariant(
     public val darkMapStyle: String,
 ) {
     DevOrange(
-        "mobile-app-backend-dev-orange.mbtace.com",
+        "mobile-app-backend.mbtace.com",
         "mapbox://styles/mbtamobileapp/cm02vf0cf00cu01pnfgnu5onh",
         "mapbox://styles/mbtamobileapp/cm02vgvsp003c01ombyewgu70",
     ),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -450,7 +450,7 @@ public data class RouteCardData(
             val predictionsUnavailableBranches =
                 if (remainingRowsToShow > 0) {
                     nonDisruptedHeadsigns
-                        // count as predictions unavailable only if there are no predictionsß
+                        // count as predictions unavailable only if there are no predictions
                         .filter { upcomingTripBranches.none { row -> row.headsign == it.key } }
                         .sortedBy {
                             it.value.routePatterns.minOfOrNull { pattern -> pattern.sortOrder }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -402,12 +402,22 @@ public data class RouteCardData(
                 )
             }
 
+            val maxRowsToShow =
+                if (context == Context.StopDetailsFiltered) {
+                    // We want to show every upcoming trip, plus a row for any headsign with a
+                    // disruption or unavailable predictions. This comfortably overestimates the #
+                    // of
+                    // rows to show.
+                    upcomingTrips.size + dataByHeadsign.size
+                } else {
+                    BRANCHING_LEAF_ROWS
+                }
             val disruptedHeadsignBranches =
                 disruptedHeadsigns
                     .sortedBy {
                         it.value.routePatterns.minOfOrNull { pattern -> pattern.sortOrder }
                     }
-                    .take(BRANCHING_LEAF_ROWS)
+                    .take(maxRowsToShow)
                     .map { (headsign, groupedData) ->
                         val route =
                             if (shouldIncludeRoute)
@@ -421,11 +431,10 @@ public data class RouteCardData(
                             UpcomingFormat.Disruption(groupedData.majorAlert!!, mapStopRoute),
                         )
                     }
-
-            var remainingRowsToShow = max(1, BRANCHING_LEAF_ROWS - disruptedHeadsignBranches.size)
+            var remainingBranchesToShow = max(1, maxRowsToShow - disruptedHeadsignBranches.size)
 
             val upcomingTripBranches =
-                formattedTrips.take(remainingRowsToShow).map { formatted ->
+                formattedTrips.take(remainingBranchesToShow).map { formatted ->
                     val upcomingTrip = formatted.trip
                     val route =
                         if (shouldIncludeRoute) globalData?.getRoute(upcomingTrip.routeId) else null
@@ -436,11 +445,13 @@ public data class RouteCardData(
                     )
                 }
 
-            remainingRowsToShow = max(0, remainingRowsToShow - upcomingTripBranches.size)
+            remainingBranchesToShow = max(0, remainingBranchesToShow - upcomingTripBranches.size)
 
             val predictionsUnavailableBranches =
-                if (remainingRowsToShow > 0) {
+                if (remainingBranchesToShow > 0) {
                     nonDisruptedHeadsigns
+                        // count as predictions unavailable only if there are no predictionsß
+                        .filter { upcomingTripBranches.none { row -> row.headsign == it.key } }
                         .sortedBy {
                             it.value.routePatterns.minOfOrNull { pattern -> pattern.sortOrder }
                         }
@@ -469,7 +480,7 @@ public data class RouteCardData(
                                 null
                             }
                         }
-                        .take(remainingRowsToShow)
+                        .take(remainingBranchesToShow)
                 } else {
                     emptyList()
                 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -431,10 +431,10 @@ public data class RouteCardData(
                             UpcomingFormat.Disruption(groupedData.majorAlert!!, mapStopRoute),
                         )
                     }
-            var remainingBranchesToShow = max(1, maxRowsToShow - disruptedHeadsignBranches.size)
+            var remainingRowsToShow = max(1, maxRowsToShow - disruptedHeadsignBranches.size)
 
             val upcomingTripBranches =
-                formattedTrips.take(remainingBranchesToShow).map { formatted ->
+                formattedTrips.take(remainingRowsToShow).map { formatted ->
                     val upcomingTrip = formatted.trip
                     val route =
                         if (shouldIncludeRoute) globalData?.getRoute(upcomingTrip.routeId) else null
@@ -445,10 +445,10 @@ public data class RouteCardData(
                     )
                 }
 
-            remainingBranchesToShow = max(0, remainingBranchesToShow - upcomingTripBranches.size)
+            remainingRowsToShow = max(0, remainingRowsToShow - upcomingTripBranches.size)
 
             val predictionsUnavailableBranches =
-                if (remainingBranchesToShow > 0) {
+                if (remainingRowsToShow > 0) {
                     nonDisruptedHeadsigns
                         // count as predictions unavailable only if there are no predictionsß
                         .filter { upcomingTripBranches.none { row -> row.headsign == it.key } }
@@ -480,7 +480,7 @@ public data class RouteCardData(
                                 null
                             }
                         }
-                        .take(remainingBranchesToShow)
+                        .take(remainingRowsToShow)
                 } else {
                     emptyList()
                 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
+import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.atTime
 
@@ -1384,6 +1385,130 @@ class RouteCardDataLeafTest {
                         subwayServiceStartTime = null,
                         emptyList(),
                         anyEnumValueExcept(RouteCardData.Context.StopDetailsFiltered),
+                    )
+                    .format(now, RedLine.global),
+            )
+        }
+
+    @Test
+    fun `formats Red Line southbound as branching all upcoming trips with Braintree suspension stop details`() =
+        runBlocking {
+
+            // ⚠ Southbound to Ashmont 3 min, 12 min, 15 min
+            val objects = RedLine.objects()
+            val now = EasternTimeInstant.now()
+
+            val prediction1 =
+                objects.prediction {
+                    arrivalTime = now + 3.minutes
+                    departureTime = arrivalTime
+                    trip = objects.trip(RedLine.ashmontSouth)
+                    stopId = RedLine.jfkUmass.south1.id
+                }
+
+            val prediction2 =
+                objects.prediction {
+                    arrivalTime = now + 12.minutes
+                    departureTime = arrivalTime
+                    trip = objects.trip(RedLine.ashmontSouth)
+                    stopId = RedLine.jfkUmass.south1.id
+                }
+
+            val prediction3 =
+                objects.prediction {
+                    arrivalTime = now + 15.minutes
+                    departureTime = arrivalTime
+                    trip = objects.trip(RedLine.ashmontSouth)
+                    stopId = RedLine.jfkUmass.south1.id
+                }
+
+            val alert =
+                objects.alert {
+                    effect = Alert.Effect.Suspension
+                    activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
+                    informedEntity =
+                        RedLine.stopsBraintreeBranchSouth
+                            .map {
+                                Alert.InformedEntity(
+                                    activities = listOf(Alert.InformedEntity.Activity.Board),
+                                    directionId = 0,
+                                    route = RedLine.route.id,
+                                    routeType = RouteType.HEAVY_RAIL,
+                                    stop = it,
+                                    trip = null,
+                                )
+                            }
+                            .toMutableList()
+                }
+
+            val mapStopRoute = MapStopRoute.matching(RedLine.route)
+
+            assertEquals(
+                LeafFormat.Branched(
+                    listOf(
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Ashmont",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction1),
+                                    RouteType.HEAVY_RAIL,
+                                    TripInstantDisplay.Minutes(3, false),
+                                    lastTrip = false,
+                                ),
+                                null,
+                            ),
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Ashmont",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction2),
+                                    RouteType.HEAVY_RAIL,
+                                    TripInstantDisplay.Minutes(12, false),
+                                    lastTrip = false,
+                                ),
+                                null,
+                            ),
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Ashmont",
+                            UpcomingFormat.Some(
+                                UpcomingFormat.Some.FormattedTrip(
+                                    objects.upcomingTrip(prediction3),
+                                    RouteType.HEAVY_RAIL,
+                                    TripInstantDisplay.Minutes(15, false),
+                                    lastTrip = false,
+                                ),
+                                null,
+                            ),
+                        ),
+                        LeafFormat.Branched.BranchRow(
+                            null,
+                            "Braintree",
+                            UpcomingFormat.Disruption(alert, mapStopRoute),
+                        ),
+                    )
+                ),
+                RouteCardData.Leaf(
+                        RedLine.lineOrRoute,
+                        RedLine.jfkUmass.itself,
+                        0,
+                        listOf(RedLine.ashmontSouth, RedLine.braintreeSouth),
+                        setOf(RedLine.jfkUmass.south1.id, RedLine.jfkUmass.south2.id),
+                        listOf(
+                            objects.upcomingTrip(prediction1),
+                            objects.upcomingTrip(prediction2),
+                            objects.upcomingTrip(prediction3),
+                        ),
+                        listOf(alert),
+                        allDataLoaded = true,
+                        hasSchedulesToday = true,
+                        subwayServiceStartTime = null,
+                        emptyList(),
+                        RouteCardData.Context.StopDetailsFiltered,
                     )
                     .format(now, RedLine.global),
             )


### PR DESCRIPTION
### Summary

_Ticket:_ [Looking at GL truncated prediction list](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215285475661021?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->


iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit test
* Ran locally & confirmed at Boylston I now see all predictions
<img width="45%" alt="image" src="https://github.com/user-attachments/assets/6e585cb9-ca55-4a42-8858-8510915debf3" />

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
