### PR TITLE
fix?(TripDetailsViewModel): Remove tripPredictionsLoaded param, only generate stop list if predictions exist

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -73,7 +73,6 @@ class TripDetailsViewTest {
             trip,
             TripSchedulesResponse.Schedules(listOf(schedule)),
             PredictionsStreamDataResponse(objects),
-            true,
             vehicle,
         )
 
@@ -283,7 +282,7 @@ class TripDetailsViewTest {
                 onLogEvent = { event, properties -> loggedEvents.add(event to properties) }
             )
 
-        val unavailableTripData = TripData(tripFilter, null, null, null, true, vehicle)
+        val unavailableTripData = TripData(tripFilter, null, null, null, vehicle)
 
         val tripVMState = TripDetailsViewModel.State(unavailableTripData, null)
         val viewModel = MockTripDetailsViewModel(tripVMState)

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -116,7 +116,6 @@ struct TripDetailsView: View {
                let tripData = tripDetailsVMState?.tripData,
                let trip = tripData.trip,
                tripData.tripFilter == tripFilter,
-               tripData.tripPredictionsLoaded,
                let global,
                let route = global.getRoute(routeId: trip.routeId) {
                 let terminalStop = getParentFor(trip.stopIds?.first)

--- a/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripDetailsViewTests.swift
@@ -62,7 +62,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -148,7 +147,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: nil
             ),
             stopList: .init(trip: trip, stops: [
@@ -236,7 +234,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -319,7 +316,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -408,7 +404,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -495,7 +490,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -577,7 +571,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(
@@ -659,7 +652,6 @@ final class TripDetailsViewTests: XCTestCase {
                 trip: nil,
                 tripSchedules: nil,
                 tripPredictions: nil,
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(

--- a/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/TripDetails/TripDetailsPageTests.swift
@@ -59,7 +59,6 @@ final class TripDetailsPageTests: XCTestCase {
                 trip: trip,
                 tripSchedules: TripSchedulesResponse.Schedules(schedules: [schedule]),
                 tripPredictions: .init(objects: objects),
-                tripPredictionsLoaded: true,
                 vehicle: vehicle
             ),
             stopList: .init(trip: trip, stops: [.init(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/stopDetailsPage/TripData.kt
@@ -13,7 +13,6 @@ public data class TripData(
     val trip: Trip?,
     val tripSchedules: TripSchedulesResponse?,
     val tripPredictions: PredictionsStreamDataResponse?,
-    val tripPredictionsLoaded: Boolean = false,
     val vehicle: Vehicle?,
 ) {
     public val vehicleOnOtherTrip: Boolean =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -196,9 +196,9 @@ internal fun getTripData(
                     resolvedTrip.id == tripFilter.tripId &&
                     (tripFilter.vehicleId == null || tripFilter.vehicleId == vehicle?.id)
             ) {
-                TripData(tripFilter, resolvedTrip, tripSchedules, tripPredictions, true, vehicle)
+                TripData(tripFilter, resolvedTrip, tripSchedules, tripPredictions, vehicle)
             } else if (tripFilter != null && vehicle != null && !tripLoading) {
-                TripData(tripFilter, null, null, null, true, vehicle)
+                TripData(tripFilter, null, null, null, vehicle)
             } else {
                 null
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripDetailsStopList.kt
@@ -28,7 +28,7 @@ public fun getTripDetailsStopList(
                     tripData != null &&
                     tripData.trip != null &&
                     tripData.tripFilter == tripFilter &&
-                    tripData.tripPredictionsLoaded &&
+                    tripData.tripPredictions != null &&
                     globalResponse != null
             ) {
                 TripDetailsStopList.fromPieces(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
@@ -54,7 +54,9 @@ internal fun subscribeToTripPredictions(
     fun onReceive(message: ApiResult<PredictionsStreamDataResponse>) {
         onAnyMessageReceived()
         when (message) {
-            is ApiResult.Ok -> predictions = message.data
+            is ApiResult.Ok -> {
+                predictions = message.data
+            }
             is ApiResult.Error ->
                 println("Trip predictions stream failed to join: ${message.message}")
         }
@@ -75,8 +77,9 @@ internal fun subscribeToTripPredictions(
         }
     }
 
-    LaunchedEffect(tripId) { predictions = null }
     DisposableEffect(tripId, active) {
+        predictions = null
+
         connect(tripId, active, ::onReceive)
         onDispose { tripPredictionsRepository.disconnect() }
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
@@ -181,7 +181,7 @@ class TripDetailsViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             awaitItemSatisfying {
-                it.tripData?.tripFilter == filters && it.tripData.tripPredictionsLoaded
+                it.tripData?.tripFilter == filters && it.tripData.tripPredictions != null
             }
             assertTrue(predictionsLoaded)
             cancelAndIgnoreRemainingEvents()
@@ -345,7 +345,7 @@ class TripDetailsViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(
-                TripData(filters, null, null, null, true, vehicle),
+                TripData(filters, null, null, null, vehicle),
                 awaitItemSatisfying { it.tripData != null }.tripData,
             )
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [Hide trip details until predictions loaded](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215327861081436?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

This PR removes the `tripPredictionsLoaded` param, which I think is left over from an older implementation and is effectively always true here, even if `tripPredictions` is null. This instead checks if `tripPredictions` exists before generating the stop list. 

Note: If we want to show the stop list in the event that tripPredictions fail to load for some reason, then I think the clearest approach would be to change `tripPpredictions` to `ApiResult<PredictionStreamResponse>?` so that we can easily differentiate pre-load vs loaded vs error cases without relying on an additional param that we have to separately manage.


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally with Network Link Conditioner set to 3G. Confirmed that the trip details shimmer loads until predictions are available. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
