### PR TITLE
fix(TripDetailsStopList): Don't match alerts on other routes

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -481,7 +481,6 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             directionId: Int,
         ): UpcomingFormat.Disruption? {
             val entryTime = (entry.prediction ?: entry.schedule)?.stopTime ?: fallbackTime
-            // route ID & entryRouteType are nil, which is messing with alert matching I think
             val entryRouteType = route?.type
 
             val alert =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -206,14 +206,13 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                 val routeId =
                     tripPredictions?.trips?.values?.singleOrNull()?.routeId
                         ?: tripSchedules?.routeId()
+                        ?: trip.routeId
                 val route = globalData.routes[routeId]
 
                 var predictions = emptyList<Prediction>()
                 if (tripPredictions != null) {
                     val tripPredictionsWithCorrectRoute =
-                        tripPredictions.predictions.values.filter {
-                            routeId == null || it.routeId == routeId
-                        }
+                        tripPredictions.predictions.values.filter { it.routeId == routeId }
                     predictions =
                         deduplicatePredictionsByStopSequence(
                             tripPredictionsWithCorrectRoute,
@@ -482,6 +481,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             directionId: Int,
         ): UpcomingFormat.Disruption? {
             val entryTime = (entry.prediction ?: entry.schedule)?.stopTime ?: fallbackTime
+            // route ID & entryRouteType are nil, which is messing with alert matching I think
             val entryRouteType = route?.type
 
             val alert =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -200,6 +200,33 @@ class TripDetailsStopListTest {
     }
 
     @Test
+    fun `fromPieces doesn't include disruption on different route when no schedules or predictions`() =
+        test {
+            objects.route { id = "Red" }
+            val trip = trip {
+                routeId = "Red"
+                directionId = 1
+                stopIds = listOf("A", "B", "C")
+            }
+            val sched1 = schedule("A", 10)
+            val sched2 = schedule("B", 20)
+            val sched3 = schedule("C", 30)
+
+            val alertOtherRoute =
+                alert(Alert.Effect.Suspension) {
+                    informedEntity(directionId = 1, route = "Silver", stop = "A")
+                }
+            assertEquals(
+                stopListOf(entry("A", 997, disruption = null), entry("B", 998), entry("C", 999)),
+                fromPieces(
+                    schedulesResponseOf(sched1.stopId, sched2.stopId, sched3.stopId),
+                    null,
+                    trip = trip,
+                ),
+            )
+        }
+
+    @Test
     fun `fromPieces returns null with unavailable schedules and no predictions`() = test {
         val trip = trip {}
         assertEquals(


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: Seemingly unrelated alert appears in Trip Details](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215327861081439?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Resolve issue where we display an unrelated alert in trip details for added trips. 
The cause is that we are resolving route id from the schedules, and since added trips don't have schedules, the route id is resolving to nil, which for the purposes of entity matching is effectively a wildcard. 

As [discussed in slack 
](https://mbta.slack.com/archives/C062QNAJZ2M/p1780598166770059) I do want to make the typing for wildcard more explicit to help prevent this kind of bug going forward, but that is getting pretty gnarly so I'm going to do that separately.
iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added a unit test. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
