### PR TITLE
refactor: Explicit wildcard type for alert informed entity matching

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
@@ -89,7 +89,11 @@ class StopSubheaderTest {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()
         val stop = objects.stop { wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE }
-        val alert = objects.alert { effect = Alert.Effect.ElevatorClosure }
+        val alert =
+            objects.alert {
+                effect = Alert.Effect.ElevatorClosure
+                informedEntity()
+            }
 
         val lineOrRoute = LineOrRoute.Route(route)
         loadKoinMocks {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -270,6 +270,7 @@ class StopDetailsViewTest {
             builder.alert {
                 effect = Alert.Effect.ElevatorClosure
                 header = "Elevator alert header"
+                informedEntity()
             }
 
         val global = GlobalResponse(builder)
@@ -357,6 +358,7 @@ class StopDetailsViewTest {
             builder.alert {
                 effect = Alert.Effect.ElevatorClosure
                 header = "Elevator alert header"
+                informedEntity()
             }
 
         val global = GlobalResponse(builder)

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -450,6 +450,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 start: now.minus(hours: 3 * 24),
                 end: now.plus(hours: 3 * 24)
             )
+            alert.informedEntity(stop: stop.id)
         }
 
         // in practice any trips should be skipped but for major alerts we want to hide trips if they somehow aren't
@@ -510,6 +511,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 start: now.minus(hours: 3 * 24),
                 end: now.plus(hours: 3 * 24)
             )
+            alert.informedEntity(stop: stop.id)
         }
 
         // in practice any trips should be skipped but for major alerts we want to hide trips if they somehow aren't
@@ -569,6 +571,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .suspension
             alert.header = "Fuchsia Line suspended from Here to There"
+            alert.informedEntity(stop: stop.id)
         }
         let trip = objects.upcomingTrip(prediction: objects.prediction { prediction in
             prediction.trip = objects.trip { _ in }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.model.Alert.InformedEntity.Matcher
 import com.mbta.tid.mbta_app.model.RoutePattern.Typicality
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -348,23 +349,26 @@ internal constructor(
                 }
             }
 
-            fun checkDirection(directionId: Int?) {
+            fun checkDirection(directionId: Matcher<Int>) {
                 if (!isSatisfied) return
-                if (directionId == null) return
                 if (this@InformedEntity.directionId == null) return
-                if (this@InformedEntity.directionId != directionId) {
-                    isSatisfied = false
+                when (directionId) {
+                    Matcher.Wildcard -> return
+                    is Matcher.Data<Int> -> {
+                        if (this@InformedEntity.directionId != directionId.value) {
+                            isSatisfied = false
+                        }
+                    }
                 }
             }
 
-            fun checkRoute(route: Route?) {
-                checkRoute(route?.id, route?.type)
+            fun checkRoute(route: Route) {
+                checkRoute(route.id, route.type)
             }
 
-            fun checkRoute(routeId: Route.Id?, routeType: RouteType?) {
+            fun checkRoute(routeId: Route.Id, routeType: RouteType) {
                 if (!isSatisfied) return
-                checkRouteType(routeType)
-                if (routeId == null) return
+                checkRouteType(Matcher.Data(routeType))
                 checkRouteIdIn(listOf(routeId))
             }
 
@@ -376,38 +380,57 @@ internal constructor(
                 }
             }
 
-            fun checkRouteType(routeType: RouteType?) {
+            fun checkRouteType(routeType: Matcher<RouteType>) {
                 if (!isSatisfied) return
-                if (routeType == null) return
-                if (this@InformedEntity.routeType == null) return
-                if (this@InformedEntity.routeType != routeType) {
-                    isSatisfied = false
+                when (routeType) {
+                    Matcher.Wildcard -> return
+
+                    is Matcher.Data -> {
+                        if (this@InformedEntity.routeType == null) return
+                        if (this@InformedEntity.routeType != routeType.value) {
+                            isSatisfied = false
+                        }
+                    }
                 }
             }
 
-            fun checkStop(stopId: String?) {
+            fun checkStop(stopId: Matcher<String>) {
                 if (!isSatisfied) return
-                if (stopId == null) return
+                when (stopId) {
+                    Matcher.Wildcard -> return
+
+                    is Matcher.Data -> {
+                        if (this@InformedEntity.stop == null) return
+                        if (this@InformedEntity.stop != stopId.value) {
+                            isSatisfied = false
+                        }
+                    }
+                }
+            }
+
+            fun checkStopIn(stopIds: Matcher<Collection<String>>) {
+                if (!isSatisfied) return
                 if (this@InformedEntity.stop == null) return
-                if (this@InformedEntity.stop != stopId) {
-                    isSatisfied = false
+                when (stopIds) {
+                    Matcher.Wildcard -> return
+                    is Matcher.Data -> {
+                        if (this@InformedEntity.stop !in stopIds.value) {
+                            isSatisfied = false
+                        }
+                    }
                 }
             }
 
-            fun checkStopIn(stopIds: Collection<String>) {
+            fun checkTrip(tripId: Matcher<String>) {
                 if (!isSatisfied) return
-                if (this@InformedEntity.stop == null) return
-                if (this@InformedEntity.stop !in stopIds) {
-                    isSatisfied = false
-                }
-            }
-
-            fun checkTrip(tripId: String?) {
-                if (!isSatisfied) return
-                if (tripId == null) return
-                if (this@InformedEntity.trip == null) return
-                if (this@InformedEntity.trip != tripId) {
-                    isSatisfied = false
+                when (tripId) {
+                    Matcher.Wildcard -> return
+                    is Matcher.Data<*> -> {
+                        if (this@InformedEntity.trip == null) return
+                        if (this@InformedEntity.trip != tripId.value) {
+                            isSatisfied = false
+                        }
+                    }
                 }
             }
 
@@ -543,9 +566,9 @@ internal constructor(
          */
         fun applicableAlerts(
             alerts: Collection<Alert>,
-            directionId: Int?,
+            directionId: Int,
             routeIds: List<Route.Id>,
-            routeType: RouteType?,
+            routeType: RouteType,
             stopIds: Set<String>?,
             tripId: String?,
         ): List<Alert> {
@@ -553,13 +576,11 @@ internal constructor(
                 .filter { alert ->
                     alert.anyInformedEntitySatisfies {
                         checkActivity(InformedEntity.Activity.Board)
-                        checkDirection(directionId)
+                        checkDirection(Matcher.Data(directionId))
                         checkRouteIdIn(routeIds)
-                        checkRouteType(routeType)
-                        if (stopIds != null) {
-                            checkStopIn(stopIds)
-                        }
-                        checkTrip(tripId)
+                        checkRouteType(Matcher.Data(routeType))
+                        checkStopIn(stopIds?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
+                        checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
                     }
                 }
                 .distinct()
@@ -600,7 +621,7 @@ internal constructor(
         fun downstreamAlerts(
             alerts: Collection<Alert>,
             trip: Trip,
-            routeType: RouteType?,
+            routeType: RouteType,
             targetStopWithChildren: Set<String>,
         ): List<Alert> {
             val stopIds = trip.stopIds ?: emptyList()
@@ -619,9 +640,9 @@ internal constructor(
                                 InformedEntity.Activity.Exit,
                                 InformedEntity.Activity.Ride,
                             )
-                            checkDirection(trip.directionId)
+                            checkDirection(Matcher.Data(trip.directionId))
                             checkRoute(trip.routeId, routeType)
-                            checkStopIn(targetStopWithChildren)
+                            checkStopIn(Matcher.Data(targetStopWithChildren))
                         }
                     }
                     .map { it.id }
@@ -640,9 +661,9 @@ internal constructor(
                                         InformedEntity.Activity.Exit,
                                         InformedEntity.Activity.Ride,
                                     )
-                                    checkDirection(trip.directionId)
+                                    checkDirection(Matcher.Data(trip.directionId))
                                     checkRoute(trip.routeId, routeType)
-                                    checkStop(stop)
+                                    checkStop(Matcher.Data(stop))
                                 } && !targetStopAlertIds.contains(it.id)
                             }
                         }
@@ -660,7 +681,7 @@ internal constructor(
         fun alertsDownstreamForPatterns(
             alerts: Collection<Alert>,
             patterns: List<RoutePattern>,
-            routeType: RouteType?,
+            routeType: RouteType,
             targetStopWithChildren: Set<String>,
             tripsById: Map<String, Trip>,
         ): List<Alert> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -300,16 +300,25 @@ internal constructor(
             @SerialName("using_wheelchair") UsingWheelchair,
         }
 
+        internal sealed class Matcher<out T> {
+            data class Data<T>(val value: T) : Matcher<T>()
+
+            data object Wildcard : Matcher<Nothing>()
+        }
+
         internal fun appliesTo(
-            directionId: Int? = null,
-            facilityId: String? = null,
-            routeId: Route.Id? = null,
-            routeType: RouteType? = null,
-            stopId: String? = null,
-            tripId: String? = null,
+            directionId: Matcher<Int> = Matcher.Wildcard,
+            facilityId: Matcher<String> = Matcher.Wildcard,
+            routeId: Matcher<Route.Id> = Matcher.Wildcard,
+            routeType: Matcher<RouteType> = Matcher.Wildcard,
+            stopId: Matcher<String> = Matcher.Wildcard,
+            tripId: Matcher<String> = Matcher.Wildcard,
         ): Boolean {
-            fun <T> matches(expected: T?, actual: T?) =
-                expected == null || actual == null || expected == actual
+            fun <T> matches(expected: Matcher<T>, actual: T?): Boolean =
+                when (expected) {
+                    is Matcher.Data -> actual == null || expected.value == actual
+                    Matcher.Wildcard -> true
+                }
 
             return matches(directionId, this.directionId) &&
                 matches(facilityId, this.facility) &&
@@ -571,7 +580,9 @@ internal constructor(
                     it.effect == Effect.ElevatorClosure &&
                         it.anyInformedEntity { entity ->
                             entity.activities.contains(InformedEntity.Activity.UsingWheelchair) &&
-                                stopIds.any { stopId -> entity.appliesTo(stopId = stopId) }
+                                stopIds.any { stopId ->
+                                    entity.appliesTo(stopId = InformedEntity.Matcher.Data(stopId))
+                                }
                         }
                 }
                 .distinct()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
@@ -42,7 +42,14 @@ public class AlertAssociatedStop internal constructor(internal val stop: Stop) {
                 if (greenRoutes.contains(pattern.routeId) && !pattern.isTypical()) continue
                 relevantAlerts =
                     nullStopAlerts.filter { alert ->
-                        alert.anyInformedEntity { entityMatcher(it, null, pattern, route) }
+                        alert.anyInformedEntity {
+                            it.appliesTo(
+                                stopId = Alert.InformedEntity.Matcher.Data(stop.id),
+                                routeId = Alert.InformedEntity.Matcher.Data(pattern.routeId),
+                                routeType = Alert.InformedEntity.Matcher.Data(route.type),
+                                directionId = Alert.InformedEntity.Matcher.Data(pattern.directionId),
+                            )
+                        }
                     } + relevantAlerts
             }
 
@@ -88,20 +95,6 @@ public enum class StopAlertState {
     AllClear,
 }
 
-private fun entityMatcher(
-    entity: Alert.InformedEntity,
-    stop: Stop?,
-    pattern: RoutePattern,
-    route: Route?,
-): Boolean {
-    return entity.appliesTo(
-        stopId = stop?.id,
-        routeId = pattern.routeId,
-        routeType = route?.type,
-        directionId = pattern.directionId,
-    )
-}
-
 private fun getServiceAlerts(alerts: List<Alert>, atTime: EasternTimeInstant): List<Alert> {
     // In practice, AlertAssociatedStop is only used for the map, where only Major alerts are shown.
     return alerts.filter { alert ->
@@ -143,7 +136,8 @@ private fun getAlertStateByRoute(
 
             val patternStates =
                 (patterns ?: emptyList()).map {
-                    val route = global.routes[it.routeId]
+                    val route = global.routes[it.routeId] ?: return@mapNotNull null
+
                     statesForPattern(it, stop, route, serviceAlerts)
                 }
 
@@ -185,13 +179,20 @@ private fun stopState(
 private fun statesForPattern(
     pattern: RoutePattern,
     stop: Stop,
-    route: Route?,
+    route: Route,
     serviceAlerts: List<Alert>,
 ): StopAlertState {
 
     val matchingAlert =
         serviceAlerts.find { alert ->
-            alert.anyInformedEntity { entityMatcher(it, stop, pattern, route) }
+            alert.anyInformedEntity {
+                it.appliesTo(
+                    stopId = Alert.InformedEntity.Matcher.Data(stop.id),
+                    routeId = Alert.InformedEntity.Matcher.Data(pattern.routeId),
+                    routeType = Alert.InformedEntity.Matcher.Data(route.type),
+                    directionId = Alert.InformedEntity.Matcher.Data(pattern.directionId),
+                )
+            }
         } ?: return StopAlertState.Normal
     if (matchingAlert.effect == Alert.Effect.Shuttle) {
         return StopAlertState.Shuttle

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -461,10 +461,10 @@ public sealed class AlertSummary {
 
         private fun matchesWholeRoute(alert: Alert, routeId: Route.Id, directionId: Int): Boolean =
             alert.anyInformedEntity {
-                it.appliesTo(directionId = directionId, routeId = routeId) &&
-                    it.trip == null &&
-                    it.stop == null &&
-                    it.facility == null
+                it.appliesTo(
+                    directionId = Alert.InformedEntity.Matcher.Data(directionId),
+                    routeId = Alert.InformedEntity.Matcher.Data(routeId),
+                ) && it.trip == null && it.stop == null && it.facility == null
             }
 
         private fun matchesAllStopsOnPatterns(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -429,14 +429,15 @@ public sealed class AlertSummary {
                         } else emptyList()
                     )
                     .mapNotNull { (pattern, stopIds) ->
+                        val routeType = routes.firstOrNull()?.type ?: return@mapNotNull null
                         val stopIdsOnPattern =
                             stopIds
                                 ?.filter { stopOnTrip ->
                                     alert.anyInformedEntitySatisfies {
                                         // `affectedStops` only includes parent stops, here we check
                                         // if the child stops on each pattern are affected
-                                        checkStop(stopOnTrip)
-                                        checkRoute(pattern.routeId, routes.firstOrNull()?.type)
+                                        checkStop(Alert.InformedEntity.Matcher.Data(stopOnTrip))
+                                        checkRoute(pattern.routeId, routeType)
                                     }
                                 }
                                 ?.mapNotNull { global.stops[it]?.resolveParent(global)?.id }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.model.Alert.InformedEntity.Matcher
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -197,12 +198,16 @@ public data class RouteCardData(
 
         public fun alertsHere(tripId: String? = null): List<Alert> =
             alertsHere.filter { alert ->
-                (tripId == null || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+                alert.anyInformedEntitySatisfies {
+                    checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
+                }
             }
 
         public fun alertsDownstream(tripId: String? = null): List<Alert> =
             alertsDownstream.filter { alert ->
-                (tripId == null || alert.anyInformedEntitySatisfies { checkTrip(tripId) })
+                alert.anyInformedEntitySatisfies {
+                    checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
+                }
             }
 
         private data class PotentialService(
@@ -967,8 +972,9 @@ public data class RouteCardData(
                                     }
                             is Route.Id -> listOf(path.routeOrLineId)
                         }
-                    val routeType: RouteType? =
+                    val routeType: RouteType =
                         routes.firstOrNull()?.let { globalData.getRoute(it)?.type }
+                            ?: return@forEachLeaf
                     val isCRCore = globalData.getStop(path.stopId)?.isCRCore ?: false
                     val applicableAlerts =
                         Alert.applicableAlerts(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -207,7 +207,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                     tripPredictions?.trips?.values?.singleOrNull()?.routeId
                         ?: tripSchedules?.routeId()
                         ?: trip.routeId
-                val route = globalData.routes[routeId]
+                val route = globalData.routes[routeId] ?: return@withContext null
 
                 var predictions = emptyList<Prediction>()
                 if (tripPredictions != null) {
@@ -476,23 +476,23 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             entry: WorkingEntry,
             fallbackTime: EasternTimeInstant?,
             alertsData: AlertsStreamDataResponse?,
-            route: Route?,
+            route: Route,
             tripId: String,
             directionId: Int,
         ): UpcomingFormat.Disruption? {
             val entryTime = (entry.prediction ?: entry.schedule)?.stopTime ?: fallbackTime
-            val entryRouteType = route?.type
+            val entryRouteType = route.type
 
             val alert =
                 alertsData?.alerts?.values?.find { alert ->
                     (entryTime?.let { alert.isActive(it) } ?: true) &&
                         alert.anyInformedEntity {
                             it.appliesTo(
-                                directionId = directionId,
-                                routeId = route?.id,
-                                routeType = entryRouteType,
-                                stopId = entry.stopId,
-                                tripId = tripId,
+                                directionId = Alert.InformedEntity.Matcher.Data(directionId),
+                                routeId = Alert.InformedEntity.Matcher.Data(route.id),
+                                routeType = Alert.InformedEntity.Matcher.Data(entryRouteType),
+                                stopId = Alert.InformedEntity.Matcher.Data(entry.stopId),
+                                tripId = Alert.InformedEntity.Matcher.Data(tripId),
                             )
                         } &&
                         // there's no UI yet for secondary alerts in trip details
@@ -500,7 +500,7 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
                             ?: alert.intrinsicSignificance) >= AlertSignificance.Major
                 }
             if (alert == null) return null
-            return UpcomingFormat.Disruption(alert, route?.let { MapStopRoute.matching(it) })
+            return UpcomingFormat.Disruption(alert, MapStopRoute.matching(route))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -202,8 +202,8 @@ internal constructor(
             .distinct()
     }
 
-    public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
-        if (alert == null || routes == null) return null
+    public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>): List<Stop>? {
+        if (alert == null) return null
         val routeEntities =
             routes.flatMap { route ->
                 alert.matchingEntities { entity -> entity.satisfies { checkRoute(route) } }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -202,8 +202,8 @@ internal constructor(
             .distinct()
     }
 
-    public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>): List<Stop>? {
-        if (alert == null) return null
+    public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
+        if (alert == null || routes == null) return null
         val routeEntities =
             routes.flatMap { route ->
                 alert.matchingEntities { entity -> entity.satisfies { checkRoute(route) } }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -101,7 +101,7 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
             remember(alerts, filter, patterns, now, global, route) {
                 val alerts = alerts
                 val filter = filter
-                if (alerts != null && filter != null) {
+                if (alerts != null && filter != null && route != null) {
                     val activeRelevantAlerts =
                         alerts.alerts.values.filter {
                             (it.isActive(time = now) || it.willBeActiveSoon(time = now)) &&
@@ -111,8 +111,8 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
                     Alert.applicableAlerts(
                             activeRelevantAlerts,
                             filter.directionId,
-                            listOfNotNull(route?.id),
-                            route?.type,
+                            listOf(route.id),
+                            route.type,
                             null,
                             filter.tripId,
                         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -401,7 +401,7 @@ class AlertTest {
                 ),
                 0,
                 listOf(route.id),
-                null,
+                route.type,
                 setOf(stop.id),
                 tripId = null,
             )
@@ -433,9 +433,9 @@ class AlertTest {
         assertEquals(
             Alert.applicableAlerts(
                 listOf(validAlert, invalidAlert),
-                null,
+                0,
                 listOf(route.id),
-                null,
+                route.type,
                 setOf(stop.id),
                 tripId = null,
             ),
@@ -462,9 +462,9 @@ class AlertTest {
         assertEquals(
             Alert.applicableAlerts(
                 listOf(alert),
-                null,
+                0,
                 listOf(route.id),
-                null,
+                route.type,
                 setOf(stop.id),
                 tripId = null,
             ),
@@ -486,9 +486,9 @@ class AlertTest {
         assertEquals(
             Alert.applicableAlerts(
                 listOf(alert),
-                null,
+                0,
                 listOf(route.id),
-                null,
+                route.type,
                 setOf(stop.id),
                 tripId = null,
             ),
@@ -514,9 +514,9 @@ class AlertTest {
         assertEquals(
             Alert.applicableAlerts(
                 listOf(alert),
-                null,
+                0,
                 listOf(route.id),
-                null,
+                route.type,
                 setOf(stop.id),
                 tripId = null,
             ),
@@ -547,7 +547,7 @@ class AlertTest {
         assertEquals(
             Alert.applicableAlerts(
                 listOf(alert, otherModeAlert),
-                null,
+                0,
                 listOf(route.id),
                 route.type,
                 setOf(stop.id),
@@ -588,9 +588,9 @@ class AlertTest {
             listOf(alert),
             Alert.applicableAlerts(
                 listOf(alert, otherAlert),
-                directionId = null,
+                directionId = 0,
                 listOf(route.id),
-                routeType = null,
+                routeType = route.type,
                 stopIds = null,
                 tripId = null,
             ),
@@ -666,7 +666,7 @@ class AlertTest {
             Alert.downstreamAlerts(
                 listOf(alertRideTargetStop, alertBoard, firstRideAlert, secondRideAlert),
                 trip,
-                null,
+                route.type,
                 setOf(targetStop.id),
             )
 
@@ -765,7 +765,7 @@ class AlertTest {
             Alert.downstreamAlerts(
                 listOf(alertAllStops, alertDownstream2Only),
                 trip,
-                null,
+                route.type,
                 setOf(targetStop.id),
             )
 
@@ -797,7 +797,7 @@ class AlertTest {
             }
 
         val downstreamAlerts =
-            Alert.downstreamAlerts(listOf(alert), trip, null, setOf(targetStop.id))
+            Alert.downstreamAlerts(listOf(alert), trip, route.type, setOf(targetStop.id))
 
         assertEquals(listOf(), downstreamAlerts)
     }
@@ -952,7 +952,7 @@ class AlertTest {
                         alewifeShuttleAlert,
                     ),
                 patterns = listOf(routePatternAshmont, routePatternBraintree),
-                null,
+                route.type,
                 targetStopWithChildren = setOf(park.id),
                 tripsById = global.trips,
             )
@@ -969,7 +969,7 @@ class AlertTest {
                         alewifeShuttleAlert,
                     ),
                 patterns = listOf(routePatternAlewife),
-                null,
+                route.type,
                 targetStopWithChildren = setOf(park.id),
                 tripsById = global.trips,
             )
@@ -1072,9 +1072,8 @@ class AlertTest {
             }
 
         assertTrue(alert.anyInformedEntitySatisfies { checkRoute(Route.Id("1"), RouteType.BUS) })
-        assertTrue(alert.anyInformedEntitySatisfies { checkRoute(null, RouteType.BUS) })
-        assertFalse(alert.anyInformedEntitySatisfies { checkRoute(null, RouteType.COMMUTER_RAIL) })
-        assertTrue(alert.anyInformedEntitySatisfies { checkRoute(Route.Id("1"), null) })
-        assertTrue(alert.anyInformedEntitySatisfies { checkRoute(null, null) })
+        assertFalse(
+            alert.anyInformedEntitySatisfies { checkRoute(Route.Id("CR"), RouteType.COMMUTER_RAIL) }
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -5736,7 +5736,7 @@ class RouteCardDataTest {
                             parkElevatorAlert,
                         ),
                     patterns = listOf(routePatternAshmont, routePatternBraintree),
-                    null,
+                    route.type,
                     targetStopWithChildren = setOf(park.id),
                     tripsById = global.trips,
                 )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -167,16 +167,18 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns empty list with no data`() = test {
-        val trip = trip {}
+        val route = objects.route {}
+        val trip = trip { routeId = route.id.idText }
         assertEquals(TripDetailsStopList(trip, stops = emptyList()), fromPieces(null, null))
     }
 
     @Test
     fun `fromPieces returns schedules when there are no predictions`() = test {
-        trip {}
-        val sched1 = schedule("A", 10)
-        val sched2 = schedule("B", 20)
-        val sched3 = schedule("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val sched1 = schedule("A", 10, routeId = route.id)
+        val sched2 = schedule("B", 20, routeId = route.id)
+        val sched3 = schedule("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, schedule = sched1),
@@ -189,10 +191,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns null with scheduled IDs and no predictions`() = test {
-        trip {}
-        val sched1 = schedule("A", 10)
-        val sched2 = schedule("B", 20)
-        val sched3 = schedule("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val sched1 = schedule("A", 10, routeId = route.id)
+        val sched2 = schedule("B", 20, routeId = route.id)
+        val sched3 = schedule("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(entry("A", 997), entry("B", 998), entry("C", 999)),
             fromPieces(schedulesResponseOf(sched1.stopId, sched2.stopId, sched3.stopId), null),
@@ -228,7 +231,8 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces returns null with unavailable schedules and no predictions`() = test {
-        val trip = trip {}
+        val route = objects.route {}
+        val trip = trip { routeId = route.id.idText }
         assertEquals(
             TripDetailsStopList(trip, stops = emptyList()),
             fromPieces(TripSchedulesResponse.Unknown, null),
@@ -237,10 +241,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces preserves predictions with no schedules`() = test {
-        trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
@@ -253,13 +258,14 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces matches full set of predictions to full set of schedules`() = test {
-        trip {}
-        val sched1 = schedule("A", 10)
-        val sched2 = schedule("B", 20)
-        val sched3 = schedule("C", 30)
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val sched1 = schedule("A", 10, routeId = route.id)
+        val sched2 = schedule("B", 20, routeId = route.id)
+        val sched3 = schedule("C", 30, routeId = route.id)
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, schedule = sched1, prediction = pred1),
@@ -272,10 +278,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces aligns scheduled stop IDs with existing predictions`() = test {
-        trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
@@ -288,9 +295,10 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces extrapolates stop sequences before current predictions`() = test {
-        trip {}
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10),
@@ -304,9 +312,10 @@ class TripDetailsStopListTest {
     @Test
     fun `fromPieces extrapolates stop sequences after current predictions`() = test {
         // this case is rare
-        trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
@@ -319,13 +328,14 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces accepts sibling stops with full schedules`() = test {
-        trip {}
-        val sched1 = schedule("A1", 10)
-        val sched2 = schedule("B1", 20)
-        val sched3 = schedule("C1", 30)
-        val pred1 = prediction("A2", 10)
-        val pred2 = prediction("B2", 20)
-        val pred3 = prediction("C2", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val sched1 = schedule("A1", 10, routeId = route.id)
+        val sched2 = schedule("B1", 20, routeId = route.id)
+        val sched3 = schedule("C1", 30, routeId = route.id)
+        val pred1 = prediction("A2", 10, routeId = route.id)
+        val pred2 = prediction("B2", 20, routeId = route.id)
+        val pred3 = prediction("C2", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A2", 10, schedule = sched1, prediction = pred1),
@@ -338,13 +348,14 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces accepts sibling stops with stop IDs`() = test {
-        trip {}
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
         stop("A1")
         stop("B1")
         stop("C1")
-        val pred1 = prediction("A2", 10)
-        val pred2 = prediction("B2", 20)
-        val pred3 = prediction("C2", 30)
+        val pred1 = prediction("A2", 10, routeId = route.id)
+        val pred2 = prediction("B2", 20, routeId = route.id)
+        val pred3 = prediction("C2", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A2", 10, prediction = pred1),
@@ -358,11 +369,12 @@ class TripDetailsStopListTest {
     @Test
     fun `fromPieces resolves duplicate predictions towards schedule`() = test {
         // this case is rare
-        trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3a = prediction("C1", 30)
-        val pred3b = prediction("C2", 30)
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3a = prediction("C1", 30, routeId = route.id)
+        val pred3b = prediction("C2", 30, routeId = route.id)
         assertEquals(
             stopListOf(
                 entry("A", 10, prediction = pred1),
@@ -384,6 +396,7 @@ class TripDetailsStopListTest {
     @Test
     fun `fromPieces can deduplicate predictions by stop sequence from real data`() = runBlocking {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route {}
 
         val p1 =
             objects.prediction {
@@ -391,6 +404,7 @@ class TripDetailsStopListTest {
                 departureTime = EasternTimeInstant(2024, Month.MAY, 10, 15, 32, 12)
                 stopSequence = 600
                 stopId = "70200"
+                routeId = route.id.idText
             }
         val p2 =
             objects.prediction {
@@ -398,6 +412,7 @@ class TripDetailsStopListTest {
                 departureTime = null
                 stopSequence = 600
                 stopId = "71199"
+                routeId = route.id.idText
             }
         val p3 =
             objects.prediction {
@@ -405,6 +420,7 @@ class TripDetailsStopListTest {
                 departureTime = null
                 stopSequence = 610
                 stopId = "70201"
+                routeId = route.id.idText
             }
 
         val predictions = PredictionsStreamDataResponse(objects)
@@ -435,7 +451,7 @@ class TripDetailsStopListTest {
                 parentStationId = "place-pktrm"
             }
 
-        val trip = objects.trip {}
+        val trip = objects.trip { routeId = route.id.idText }
 
         val alertsData = AlertsStreamDataResponse(objects)
         val globalData = GlobalResponse(objects, emptyMap())
@@ -499,6 +515,7 @@ class TripDetailsStopListTest {
     @Test
     fun `fromPieces handles happy path with schedules and vehicles`() = runBlocking {
         val objects = ObjectCollectionBuilder()
+        val route = objects.route {}
 
         val vehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.InTransitTo }
         val outOfDateVehicle = objects.vehicle { currentStatus = Vehicle.CurrentStatus.StoppedAt }
@@ -508,6 +525,7 @@ class TripDetailsStopListTest {
             objects.schedule {
                 stopId = stop1.id
                 stopSequence = 1
+                routeId = route.id.idText
             }
         val prediction1 = objects.prediction(schedule1) { vehicleId = outOfDateVehicle.id }
 
@@ -516,6 +534,7 @@ class TripDetailsStopListTest {
             objects.schedule {
                 stopId = stop2.id
                 stopSequence = 2
+                routeId = route.id.idText
             }
         val prediction2 = objects.prediction(schedule2) { vehicleId = outOfDateVehicle.id }
 
@@ -524,10 +543,11 @@ class TripDetailsStopListTest {
             objects.schedule {
                 stopId = stop3.id
                 stopSequence = 3
+                routeId = route.id.idText
             }
         val prediction3 = objects.prediction(schedule3) { vehicleId = outOfDateVehicle.id }
 
-        val trip = objects.trip {}
+        val trip = objects.trip { routeId = route.id.idText }
         val schedules = TripSchedulesResponse.Schedules(listOf(schedule1, schedule2, schedule3))
         val predictions = PredictionsStreamDataResponse(objects)
         val alertsData = AlertsStreamDataResponse(objects)
@@ -737,11 +757,12 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces discards stops vehicle has passed`() = test {
-        trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
-        val trip = objects.trip {}
+        val route = objects.route {}
+        trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
+        val trip = objects.trip { routeId = route.id.idText }
         val vehicle =
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.InTransitTo
@@ -761,10 +782,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces discards stops vehicle is currently at`() = test {
-        val trip = trip {}
-        val pred1 = prediction("A", 10)
-        prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        val trip = trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
 
         val vehicle =
             objects.vehicle {
@@ -783,10 +805,11 @@ class TripDetailsStopListTest {
 
     @Test
     fun `fromPieces checks trip before discarding past stops`() = test {
-        val trip = trip {}
-        val pred1 = prediction("A", 10)
-        val pred2 = prediction("B", 20)
-        val pred3 = prediction("C", 30)
+        val route = objects.route {}
+        val trip = trip { routeId = route.id.idText }
+        val pred1 = prediction("A", 10, routeId = route.id)
+        val pred2 = prediction("B", 20, routeId = route.id)
+        val pred3 = prediction("C", 30, routeId = route.id)
 
         val vehicle =
             objects.vehicle {
@@ -835,6 +858,9 @@ class TripDetailsStopListTest {
     @Test
     fun `fromPieces does not crash on multi-route trips`() = test {
         val now = EasternTimeInstant.now()
+        val route1 = objects.route { id = "1" }
+        val route2 = objects.route { id = "2" }
+
         trip { routeId = "1" }
         val pred1 = prediction("A", 10, routeId = Route.Id("1"), time = now + 1.minutes)
         val pred2 = prediction("A", 10, routeId = Route.Id("2"), time = now + 1.minutes)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
@@ -236,7 +236,8 @@ class TripDetailsViewModelTest : KoinTest {
     fun testEmitsSelectedVehicleAndTripStops() = runTest {
         val objects = TestData.clone()
         val stopIds = (1..5).map { objects.stop().id }
-        val trip = objects.trip {}
+        val route = objects.route {}
+        val trip = objects.trip { routeId = route.id.idText }
         val vehicle =
             objects.vehicle {
                 this.tripId = trip.id
@@ -252,6 +253,7 @@ class TripDetailsViewModelTest : KoinTest {
                                 this.trip = trip
                                 this.stopId = stopId
                                 this.stopSequence = index
+                                this.routeId = route.id.idText
                             }
                         }
                     ),


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, follow up to https://github.com/mbta/mobile_app/pull/1766

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

The linked PR was a fix for a sneaky bug; when we are matching alert informed entities, null is effectively a wildcard. Sometimes, we'd have a null data field (route id for example) because of an invalid data scenario, not because we'd intentionally want to wildcard match on that data field

This PR makes the typing more strict to hopefully prevent situations where null data fields are unknowingly passed to alert matching as a wildcard; if we actually want a wildcard match when we have null data, we have to explicitly transform it into the new Wildcard type.

This change is the clunkiest on the `checkRoute(routeId, routeType)` predicate, where previously both values were nullable. I opted to make both required, which results in some early returns in places where we don't have both route id & type. As long as global data is up to date we should always have both pieces of data, so I feel good about doing this, but please let me know if there is an edge case I am missing that would warrant keeping them nullable! I did toy around with making routeId required and routeType nullable, which I think is doable but awkward.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~ - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Updated typing of unit tests & confirmed otherwise that they all pass as expected.
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
