### PR TITLE
Update README with libyaml installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project uses [Kotlin Multiplatform Mobile (KMM)](https://kotlinlang.org/doc
 
 ### Prerequisites
 
+Install libyaml, `brew install libyaml`. It is needed to install ruby
+
 Install the tools specified in `.tool-versions`. You can use [asdf](https://asdf-vm.com/) to help manage the required versions.
 
 Install [direnv](https://direnv.net/) if you don't already have it, copy `.envrc.example` to `.envrc`, populate any required values, then run `direnv allow`.


### PR DESCRIPTION
Added instructions to install libyaml as a prerequisite.

### Summary

_Ticket:_  None

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Update README with libyaml installation instructions because ruby was failing

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
- [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
N/A
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
