### PR TITLE
feat: Add channel debug last update times

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
@@ -68,12 +68,14 @@ fun DebugView(
 
             debugState?.channelUpdates?.let {
                 Text("channel connections:")
-                it.forEach { (key, value) ->
-                    val trimmedKey = if (key.length > 25) "${key.substring(0, 25)}..." else key
-                    val duration =
-                        (now - value).absoluteValue.toString(DurationUnit.SECONDS, decimals = 0)
-                    Text("$trimmedKey last updated $duration ago")
-                }
+                it.entries
+                    .sortedBy { it.key }
+                    .forEach { (key, value) ->
+                        val trimmedKey = if (key.length > 25) "${key.substring(0, 25)}..." else key
+                        val duration =
+                            (now - value).absoluteValue.toString(DurationUnit.SECONDS, decimals = 0)
+                        Text("$trimmedKey last updated $duration ago")
+                    }
             }
         }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -15,18 +16,32 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.timer
+import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.Settings
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import org.koin.compose.koinInject
 
 @Composable
-fun DebugView(modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
+fun DebugView(
+    modifier: Modifier = Modifier,
+    debugRepository: IDebugRepository = koinInject(),
+    content: @Composable ColumnScope.() -> Unit,
+) {
     val debugMode = SettingsCache.get(Settings.DevDebugMode)
     if (!debugMode) return
     val textColor = colorResource(R.color.text)
     val color = colorResource(R.color.fill3)
     val density = LocalDensity.current
+
+    val debugState by debugRepository.state.collectAsStateWithLifecycle()
+    val now by timer(updateInterval = 1.seconds)
+
     Column(
         modifier
             .fillMaxWidth()
@@ -48,6 +63,18 @@ fun DebugView(modifier: Modifier = Modifier, content: @Composable ColumnScope.()
             }
             .padding(8.dp)
     ) {
-        ProvideTextStyle(Typography.footnote.copy(color = textColor)) { content() }
+        ProvideTextStyle(Typography.footnote.copy(color = textColor)) {
+            content()
+
+            debugState?.channelUpdates?.let {
+                Text("channel connections:")
+                it.forEach { (key, value) ->
+                    val trimmedKey = if (key.length > 25) "${key.substring(0, 25)}..." else key
+                    val duration =
+                        (now - value).absoluteValue.toString(DurationUnit.SECONDS, decimals = 0)
+                    Text("$trimmedKey last updated $duration ago")
+                }
+            }
+        }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.ActionButton
 import com.mbta.tid.mbta_app.android.component.ActionButtonKind
+import com.mbta.tid.mbta_app.android.component.DebugView
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.NavTextButton
 import com.mbta.tid.mbta_app.android.component.SheetHeader
@@ -152,6 +153,7 @@ fun FavoritesView(
         }
 
         ErrorBanner(errorBannerViewModel, modifier = Modifier.padding(top = 8.dp))
+        DebugView {}
         RouteCardList(
             routeCardData = routeCardData,
             emptyView = {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.DebugView
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
@@ -86,6 +87,7 @@ fun NearbyTransitView(
                 ),
         )
         ErrorBanner(errorBannerViewModel)
+        DebugView {}
         LaunchedEffect(
             stopIds,
             globalResponse,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
@@ -107,10 +107,7 @@ fun TripDetailsPage(
         }
         ErrorBanner(errorBannerViewModel, Modifier.padding(bottom = 8.dp))
         DebugView {
-            Column(
-                Modifier.align(Alignment.CenterHorizontally),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
+            Column(Modifier.align(Alignment.Start), horizontalAlignment = Alignment.Start) {
                 Text("trip id: ${filter.tripId}")
                 Text("vehicle id: ${filter.vehicleId ?: "null"}")
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -127,10 +127,7 @@ fun StopDetailsFilteredView(
 
             ErrorBanner(errorBannerViewModel, Modifier.padding(bottom = 16.dp))
             DebugView {
-                Column(
-                    Modifier.align(Alignment.CenterHorizontally),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
+                Column(Modifier.align(Alignment.Start), horizontalAlignment = Alignment.Start) {
                     Text("stop id: $stopId")
                     Text("trip id: ${tripFilter?.tripId ?: "null"}")
                     Text("vehicle id: ${tripFilter?.vehicleId ?: "null"}")

--- a/iosApp/iosApp/ComponentViews/DebugView.swift
+++ b/iosApp/iosApp/ComponentViews/DebugView.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Shared
 import SwiftUI
 
 struct DebugView<Content: View>: View {
@@ -15,6 +16,10 @@ struct DebugView<Content: View>: View {
     let content: () -> Content
 
     @EnvironmentObject var settingsCache: SettingsCache
+    @State var debugRepository = RepositoryDI().debug
+    @State private var debugState: DebugState? = nil
+    @State private var now = EasternTimeInstant.now()
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
         if settingsCache.get(.devDebugMode) {
@@ -23,9 +28,34 @@ struct DebugView<Content: View>: View {
                     .strokeBorder(Color(.text), style: .init(lineWidth: 2, dash: [10]))
                 VStack(alignment: .leading) {
                     content()
-                        .font(Typography.footnote)
-                }.padding(8)
+
+                    if let channelUpdates = debugState?.channelUpdates {
+                        Text(verbatim: "channel connections:")
+                        ForEach(channelUpdates.keys.sorted(), id: \.self) { key in
+                            let trimmedKey = if key.count > 25 { "\(key.prefix(25))..." } else { key }
+                            let updateDuration = if let updateTime = channelUpdates[key] {
+                                Duration(
+                                    secondsComponent: abs(now.minus(updateTime).inWholeSeconds),
+                                    attosecondsComponent: 0
+                                )
+                                .formatted(.units(allowed: [.seconds], width: .narrow))
+                            } else { "??" }
+
+                            Text(verbatim: "\(trimmedKey) last updated \(updateDuration) ago")
+                        }
+                    }
+                }
+                .multilineTextAlignment(.leading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .font(Typography.footnote)
+                .padding(8)
             }
+            .task {
+                for await state in debugRepository.state {
+                    debugState = state
+                }
+            }
+            .onReceive(timer) { input in now = input.toEasternInstant() }
             .frame(maxWidth: .infinity)
             .background(Color.fill3)
             .padding(4)

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -65,6 +65,7 @@ struct FavoritesView: View {
             }
 
             ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
+            DebugView { EmptyView() }
             RouteCardList(
                 routeCardData: favoritesVMState.routeCardData,
                 emptyView: {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitPage.swift
@@ -47,6 +47,7 @@ struct NearbyTransitPage: View {
                 )
                 .padding(.bottom, 16)
                 ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
+                DebugView { EmptyView() }
                 NearbyTransitView(
                     location: $location,
                     setIsReturningFromBackground: { errorBannerVM.setIsLoadingWhenPredictionsStale(isLoading: $0) },

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -311,7 +311,7 @@ struct StopDetailsFilteredView: View {
                 )
                 ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
                 DebugView {
-                    VStack {
+                    VStack(alignment: .leading) {
                         Text(verbatim: "stop id: \(stopId)")
                         Text(verbatim: "trip id: \(tripFilter?.tripId ?? "nil")")
                         Text(verbatim: "vehicle id: \(tripFilter?.vehicleId ?? "nil")")

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -59,7 +59,7 @@ struct TripDetailsPage: View {
                 TripDetailsHeader(route: route, direction: direction, navCallbacks: navCallbacks)
                 ErrorBanner(errorBannerVM, padding: [.init(.bottom, 8), .init(.horizontal, 14)])
                 DebugView {
-                    VStack {
+                    VStack(alignment: .leading) {
                         Text(verbatim: "trip id: \(filter.tripId)")
                         Text(verbatim: "vehicle id: \(filter.vehicleId ?? "nil")")
                     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/AppModule.kt
@@ -8,6 +8,7 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -65,6 +66,7 @@ public fun repositoriesModule(repositories: IRepositories): Module {
     return module {
         single<IConfigRepository> { repositories.config }
         single<ITabPreferencesRepository> { repositories.tabPreferences }
+        single<IDebugRepository> { repositories.debug }
         single<IErrorBannerStateRepository> { repositories.errorBanner }
         single<IGlobalRepository> { repositories.global }
         single<ILastLaunchedAppVersionRepository> { repositories.lastLaunchedAppVersion }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -17,6 +17,7 @@ import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.CachedSchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ConfigRepository
+import com.mbta.tid.mbta_app.repositories.DebugRepository
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.FavoritesRepository
 import com.mbta.tid.mbta_app.repositories.GlobalRepository
@@ -24,6 +25,7 @@ import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IConfigRepository
 import com.mbta.tid.mbta_app.repositories.ICurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -58,6 +60,7 @@ import com.mbta.tid.mbta_app.repositories.MockAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockConfigRepository
 import com.mbta.tid.mbta_app.repositories.MockCurrentAppVersionRepository
+import com.mbta.tid.mbta_app.repositories.MockDebugRepository
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -99,6 +102,7 @@ public interface IRepositories {
     public val alerts: IAlertsRepository?
     public val config: IConfigRepository
     public val currentAppVersion: ICurrentAppVersionRepository?
+    public val debug: IDebugRepository
     public val errorBanner: IErrorBannerStateRepository
     public val favorites: IFavoritesRepository
     public val global: IGlobalRepository
@@ -129,6 +133,7 @@ public class RepositoryDI : IRepositories, KoinComponent {
     override val alerts: IAlertsRepository by inject()
     override val config: IConfigRepository by inject()
     override val currentAppVersion: ICurrentAppVersionRepository by inject()
+    override val debug: IDebugRepository by inject()
     override val errorBanner: IErrorBannerStateRepository by inject()
     override val favorites: IFavoritesRepository by inject()
     override val global: IGlobalRepository by inject()
@@ -162,6 +167,7 @@ internal class RealRepositories : IRepositories {
     override val alerts = null
     override val config = ConfigRepository()
     override val currentAppVersion = null
+    override val debug = DebugRepository()
     override val errorBanner = ErrorBannerStateRepository()
     override val favorites = FavoritesRepository()
     override val global = GlobalRepository()
@@ -194,6 +200,7 @@ public class MockRepositories : IRepositories {
     override var config: IConfigRepository = MockConfigRepository()
     override var currentAppVersion: ICurrentAppVersionRepository =
         MockCurrentAppVersionRepository(AppVersion(0u, 0u, 0u))
+    override val debug: IDebugRepository = MockDebugRepository()
     override var errorBanner: IErrorBannerStateRepository = MockErrorBannerStateRepository()
     override var favorites: IFavoritesRepository = MockFavoritesRepository()
     override var global: IGlobalRepository = IdleGlobalRepository()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/makeNativeModule.kt
@@ -33,19 +33,19 @@ public fun makeNativeModule(
         single<INetworkConnectivityMonitor> { networkConnectivityMonitor }
         single<PhoenixSocket> { socket }
         factory<IAlertsRepository> {
-            AlertsRepository(get(), get(), get(named("coroutineDispatcherIO")))
+            AlertsRepository(get(), get(), get(), get(named("coroutineDispatcherIO")))
         }
         factory<IPredictionsRepository> {
-            PredictionsRepository(get(), get(), get(named("coroutineDispatcherIO")))
+            PredictionsRepository(get(), get(), get(), get(named("coroutineDispatcherIO")))
         }
         factory<ITripPredictionsRepository> {
-            TripPredictionsRepository(get(), get(), get(named("coroutineDispatcherIO")))
+            TripPredictionsRepository(get(), get(), get(), get(named("coroutineDispatcherIO")))
         }
         factory<IVehicleRepository> {
-            VehicleRepository(get(), get(), get(named("coroutineDispatcherIO")))
+            VehicleRepository(get(), get(), get(), get(named("coroutineDispatcherIO")))
         }
         factory<IVehiclesRepository> {
-            VehiclesRepository(get(), get(), get(named("coroutineDispatcherIO")))
+            VehiclesRepository(get(), get(), get(), get(named("coroutineDispatcherIO")))
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.network.receiveAll
+import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -16,12 +17,14 @@ import kotlinx.coroutines.sync.withLock
 internal class ChannelOwner<MessageData : Any>(
     socket: PhoenixSocket,
     dispatcher: CoroutineDispatcher,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
 ) {
     internal val owner =
         AsymmetricChannelOwner<MessageData, MessageData>(
             socket,
             dispatcher,
+            debugRepository,
             errorBannerStateRepository,
         )
     internal var channel: PhoenixChannel?
@@ -43,6 +46,7 @@ internal class ChannelOwner<MessageData : Any>(
 internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
     private val socket: PhoenixSocket,
     private val dispatcher: CoroutineDispatcher,
+    private val debugRepository: IDebugRepository,
     private val errorBannerStateRepository: IErrorBannerStateRepository,
 ) {
     internal var channel: PhoenixChannel? = null
@@ -66,6 +70,9 @@ internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
             val errorMessage =
                 if (rawPayload != null) {
                     try {
+                        CoroutineScope(dispatcher).launch {
+                            debugRepository.setChannelSuccess(spec.topic)
+                        }
                         return ApiResult.Ok(parse(rawPayload))
                     } catch (e: IllegalArgumentException) {
                         "Failed to parse ${message.subject} channel message: ${e.message}"
@@ -119,9 +126,17 @@ internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
                 }
                 channel.onFailure {
                     handleResult(ApiResult.Error(message = "${SocketError.FAILURE} - $it"))
+                    CoroutineScope(dispatcher).launch {
+                        debugRepository.clearChannelStatus(spec.topic)
+                    }
                 }
 
-                channel.onDetach { message -> println("leaving channel ${message.subject}") }
+                channel.onDetach { message ->
+                    println("leaving channel ${message.subject}")
+                    CoroutineScope(dispatcher).launch {
+                        debugRepository.clearChannelStatus(spec.topic)
+                    }
+                }
                 channel
                     .attach()
                     .receiveAll(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -18,11 +18,17 @@ public interface IAlertsRepository {
 
 internal class AlertsRepository(
     socket: PhoenixSocket,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
     ioDispatcher: CoroutineDispatcher,
 ) : IAlertsRepository, KoinComponent {
     private val channelOwner =
-        ChannelOwner<AlertsStreamDataResponse>(socket, ioDispatcher, errorBannerStateRepository)
+        ChannelOwner<AlertsStreamDataResponse>(
+            socket,
+            ioDispatcher,
+            debugRepository,
+            errorBannerStateRepository,
+        )
     internal var channel: PhoenixChannel? by channelOwner::channel
 
     override fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.repositories
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Clock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,7 +12,8 @@ import org.koin.core.component.KoinComponent
 
 public class DebugState(public val channelUpdates: Map<String, EasternTimeInstant> = emptyMap())
 
-public abstract class IDebugRepository internal constructor(initialState: DebugState? = null) :
+public abstract class IDebugRepository
+internal constructor(initialState: DebugState? = null, private val clock: Clock = Clock.System) :
     KoinComponent {
 
     protected val flow: MutableStateFlow<DebugState?> = MutableStateFlow(initialState)
@@ -22,7 +24,7 @@ public abstract class IDebugRepository internal constructor(initialState: DebugS
 
     public open suspend fun setChannelSuccess(topic: String) {
         mutex.withLock {
-            channelUpdates[topic] = EasternTimeInstant.now()
+            channelUpdates[topic] = EasternTimeInstant.now(clock)
             updateState()
         }
     }
@@ -40,7 +42,8 @@ public abstract class IDebugRepository internal constructor(initialState: DebugS
     }
 }
 
-public class DebugRepository : IDebugRepository(), KoinComponent
+public class DebugRepository(initialState: DebugState? = null, clock: Clock = Clock.System) :
+    IDebugRepository(initialState, clock), KoinComponent
 
 public class MockDebugRepository
 @DefaultArgumentInterop.Enabled

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
@@ -1,0 +1,63 @@
+package com.mbta.tid.mbta_app.repositories
+
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.koin.core.component.KoinComponent
+
+public class DebugState(public val channelUpdates: Map<String, EasternTimeInstant> = emptyMap())
+
+public abstract class IDebugRepository internal constructor(initialState: DebugState? = null) :
+    KoinComponent {
+
+    protected val flow: MutableStateFlow<DebugState?> = MutableStateFlow(initialState)
+    public val state: StateFlow<DebugState?> = flow.asStateFlow()
+
+    private val channelUpdates = mutableMapOf<String, EasternTimeInstant>()
+    private val mutex = Mutex()
+
+    public open suspend fun setChannelSuccess(topic: String) {
+        mutex.withLock {
+            channelUpdates[topic] = EasternTimeInstant.now()
+            updateState()
+        }
+    }
+
+    public open suspend fun clearChannelStatus(topic: String) {
+        mutex.withLock {
+            channelUpdates.remove(topic)
+            updateState()
+        }
+    }
+
+    private fun updateState() {
+        // Updates must be copied with .toMap to avoid concurrent modification exceptions in the UI
+        flow.value = DebugState(channelUpdates.toMap())
+    }
+}
+
+public class DebugRepository : IDebugRepository(), KoinComponent
+
+public class MockDebugRepository
+@DefaultArgumentInterop.Enabled
+constructor(
+    state: DebugState? = null,
+    private val onSetChannelSuccess: ((String) -> Unit)? = null,
+    private val onClearChannelStatus: ((String) -> Unit)? = null,
+) : IDebugRepository(state) {
+
+    override suspend fun setChannelSuccess(topic: String): Unit {
+        onSetChannelSuccess?.invoke(topic)
+    }
+
+    override suspend fun clearChannelStatus(topic: String) {
+        onClearChannelStatus?.invoke(topic)
+    }
+
+    public val mutableFlow: MutableStateFlow<DebugState?>
+        get() = flow
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -31,6 +31,7 @@ public interface IPredictionsRepository {
 
 internal class PredictionsRepository(
     socket: PhoenixSocket,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
     ioDispatcher: CoroutineDispatcher,
 ) : IPredictionsRepository, KoinComponent {
@@ -38,6 +39,7 @@ internal class PredictionsRepository(
         AsymmetricChannelOwner<PredictionsByStopJoinResponse, PredictionsByStopMessageResponse>(
             socket,
             ioDispatcher,
+            debugRepository,
             errorBannerStateRepository,
         )
     internal var channel: PhoenixChannel? by channelOwner::channel

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
@@ -29,6 +29,7 @@ public interface ITripPredictionsRepository {
 
 internal class TripPredictionsRepository(
     socket: PhoenixSocket,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
     ioDispatcher: CoroutineDispatcher,
 ) : ITripPredictionsRepository, KoinComponent {
@@ -36,6 +37,7 @@ internal class TripPredictionsRepository(
         ChannelOwner<PredictionsStreamDataResponse>(
             socket,
             ioDispatcher,
+            debugRepository,
             errorBannerStateRepository,
         )
     internal var channel: PhoenixChannel? by channelOwner::channel

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
@@ -22,11 +22,17 @@ public interface IVehicleRepository {
 
 internal class VehicleRepository(
     socket: PhoenixSocket,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
     ioDispatcher: CoroutineDispatcher,
 ) : IVehicleRepository, KoinComponent {
     private val channelOwner =
-        ChannelOwner<VehicleStreamDataResponse>(socket, ioDispatcher, errorBannerStateRepository)
+        ChannelOwner<VehicleStreamDataResponse>(
+            socket,
+            ioDispatcher,
+            debugRepository,
+            errorBannerStateRepository,
+        )
     internal var channel: PhoenixChannel? by channelOwner::channel
 
     override fun connect(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
@@ -29,11 +29,17 @@ public interface IVehiclesRepository {
 
 internal class VehiclesRepository(
     socket: PhoenixSocket,
+    debugRepository: IDebugRepository,
     errorBannerStateRepository: IErrorBannerStateRepository,
     ioDispatcher: CoroutineDispatcher,
 ) : IVehiclesRepository, KoinComponent {
     var channelOwner =
-        ChannelOwner<VehiclesStreamDataResponse>(socket, ioDispatcher, errorBannerStateRepository)
+        ChannelOwner<VehiclesStreamDataResponse>(
+            socket,
+            ioDispatcher,
+            debugRepository,
+            errorBannerStateRepository,
+        )
     internal var channel: PhoenixChannel? by channelOwner::channel
 
     override fun connect(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
@@ -35,9 +35,15 @@ class AlertsRepositoryTests {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val alertsRepo =
-            AlertsRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            AlertsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -52,9 +58,15 @@ class AlertsRepositoryTests {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val alertsRepo =
-            AlertsRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            AlertsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -67,8 +79,9 @@ class AlertsRepositoryTests {
     @Test
     fun testChannelClearedOnLeave() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val alertsRepo = AlertsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
         alertsRepo.channel = socket.getChannel(topic = AlertsChannel.topic, params = emptyMap())
         assertNotNull(alertsRepo.channel)
@@ -80,8 +93,9 @@ class AlertsRepositoryTests {
     @Test
     fun testSetsAlertsWhenMessageReceived() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val alertsRepo = AlertsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {
@@ -120,8 +134,9 @@ class AlertsRepositoryTests {
     @Test
     fun testSetsErrorWhenErrorReceived() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val alertsRepo = AlertsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val alertsRepo = AlertsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
@@ -1,0 +1,48 @@
+package com.mbta.tid.mbta_app.repositories
+
+import com.mbta.tid.mbta_app.mocks.MockClock
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.TestTimeSource
+import kotlinx.coroutines.runBlocking
+import org.koin.core.context.stopKoin
+
+class DebugRepositoryTests {
+    @AfterTest fun `stop koin`() = run { stopKoin() }
+
+    @Test
+    fun `initial state is null`() = runBlocking {
+        val repo = DebugRepository()
+        assertNull(repo.state.value)
+    }
+
+    @Test
+    fun `updates with topic success`() = runBlocking {
+        val now = EasternTimeInstant.now()
+        val clock = MockClock(now.instant, TestTimeSource())
+        val repo = DebugRepository(clock = clock)
+
+        repo.setChannelSuccess("topic")
+
+        assertEquals(mapOf("topic" to now), repo.state.value?.channelUpdates)
+    }
+
+    @Test
+    fun `clears topic`() = runBlocking {
+        val now = EasternTimeInstant.now()
+        val clock = MockClock(now.instant, TestTimeSource())
+        val repo = DebugRepository(clock = clock)
+
+        repo.setChannelSuccess("topic1")
+        repo.setChannelSuccess("topic2")
+
+        assertEquals(mapOf("topic1" to now, "topic2" to now), repo.state.value?.channelUpdates)
+
+        repo.clearChannelStatus("topic1")
+
+        assertEquals(mapOf("topic2" to now), repo.state.value?.channelUpdates)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -42,9 +42,15 @@ class PredictionsRepositoryTests : KoinTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            PredictionsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
 
         every { push.receive(any(), any()) } returns push
@@ -66,9 +72,15 @@ class PredictionsRepositoryTests : KoinTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            PredictionsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
 
         every { push.receive(any(), any()) } returns push
@@ -100,9 +112,15 @@ class PredictionsRepositoryTests : KoinTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            PredictionsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
 
         every { push.receive(any(), any()) } returns push
@@ -196,8 +214,10 @@ class PredictionsRepositoryTests : KoinTest {
         }
         val socket = mock<PhoenixSocket>(MockMode.autofill)
 
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val predictionsRepo = PredictionsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val predictionsRepo =
+            PredictionsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = MockPush()
         every { socket.getChannel(any(), any()) } returns channel
@@ -299,8 +319,10 @@ class PredictionsRepositoryTests : KoinTest {
     @Test
     fun testV2SetsErrorWhenReceivedOnJoin() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val predictionsRepo = PredictionsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val predictionsRepo =
+            PredictionsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {
@@ -345,8 +367,10 @@ class PredictionsRepositoryTests : KoinTest {
     @Test
     fun `v2 sets error when timeout on join`() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val predictionsRepo = PredictionsRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val predictionsRepo =
+            PredictionsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val push =
             object : PhoenixPush {
                 override fun receive(
@@ -375,9 +399,15 @@ class PredictionsRepositoryTests : KoinTest {
 
     @Test
     fun `shouldForgetPredictions false when never updated`() {
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(mock(MockMode.autofill), errorBannerRepo, Dispatchers.IO)
+            PredictionsRepository(
+                mock(MockMode.autofill),
+                debugRepo,
+                errorBannerRepo,
+                Dispatchers.IO,
+            )
         predictionsRepo.lastUpdated = null
         // there will not, in practice, be ten predictions and no last updated time
         assertFalse(predictionsRepo.shouldForgetPredictions(10))
@@ -385,27 +415,45 @@ class PredictionsRepositoryTests : KoinTest {
 
     @Test
     fun `shouldForgetPredictions false when no predictions`() {
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(mock(MockMode.autofill), errorBannerRepo, Dispatchers.IO)
+            PredictionsRepository(
+                mock(MockMode.autofill),
+                debugRepo,
+                errorBannerRepo,
+                Dispatchers.IO,
+            )
         predictionsRepo.lastUpdated = EasternTimeInstant(Instant.DISTANT_PAST)
         assertFalse(predictionsRepo.shouldForgetPredictions(0))
     }
 
     @Test
     fun `shouldForgetPredictions false when within ten minutes`() {
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(mock(MockMode.autofill), errorBannerRepo, Dispatchers.IO)
+            PredictionsRepository(
+                mock(MockMode.autofill),
+                debugRepo,
+                errorBannerRepo,
+                Dispatchers.IO,
+            )
         predictionsRepo.lastUpdated = EasternTimeInstant.now() - 9.9.minutes
         assertFalse(predictionsRepo.shouldForgetPredictions(10))
     }
 
     @Test
     fun `shouldForgetPredictions true when old and nonempty`() {
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val predictionsRepo =
-            PredictionsRepository(mock(MockMode.autofill), errorBannerRepo, Dispatchers.IO)
+            PredictionsRepository(
+                mock(MockMode.autofill),
+                debugRepo,
+                errorBannerRepo,
+                Dispatchers.IO,
+            )
         predictionsRepo.lastUpdated = EasternTimeInstant.now() - 10.1.minutes
         assertTrue(predictionsRepo.shouldForgetPredictions(10))
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
@@ -23,10 +23,12 @@ class TripPredictionsRepositoryTests {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val tripPredictionsRepo =
             TripPredictionsRepository(
                 socket,
+                debugRepo,
                 errorBannerRepo,
                 StandardTestDispatcher(testScheduler),
             )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
@@ -23,9 +23,15 @@ class VehicleRepositoryTests {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val vehicleRepo =
-            VehicleRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            VehicleRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
@@ -39,9 +39,15 @@ class VehiclesRepositoryTest : KoinTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val vehiclesRepo =
-            VehiclesRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            VehiclesRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -59,8 +65,9 @@ class VehiclesRepositoryTest : KoinTest {
     @Test
     fun testChannelClearedOnLeave() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val vehiclesRepo = VehiclesRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val vehiclesRepo = VehiclesRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
         vehiclesRepo.channel =
             socket.getChannel(
@@ -78,9 +85,15 @@ class VehiclesRepositoryTest : KoinTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = mock<PhoenixPush>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
         val vehiclesRepo =
-            VehiclesRepository(socket, errorBannerRepo, StandardTestDispatcher(testScheduler))
+            VehiclesRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
         every { channel.attach() } returns push
         every { push.receive(any(), any()) } returns push
         every { socket.getChannel(any(), any()) } returns channel
@@ -109,8 +122,9 @@ class VehiclesRepositoryTest : KoinTest {
             }
         }
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val vehiclesRepo = VehiclesRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val vehiclesRepo = VehiclesRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val channel = mock<PhoenixChannel>(MockMode.autofill)
         val push = MockPush()
         every { socket.getChannel(any(), any()) } returns channel
@@ -129,8 +143,9 @@ class VehiclesRepositoryTest : KoinTest {
     @Test
     fun testSetsErrorWhenErrorReceived() {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
+        val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val vehiclesRepo = VehiclesRepository(socket, errorBannerRepo, Dispatchers.IO)
+        val vehiclesRepo = VehiclesRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
         val push = mock<PhoenixPush>(MockMode.autofill)
         every { push.receive(any(), any()) } returns push
         class MockChannel : PhoenixChannel {


### PR DESCRIPTION
### Summary

_Ticket:_ [Display age of last update for predictions & alerts in debug mode](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215281963134654?focus=true)

Add to the debug view a list of connected topics, each with the last time that the channel received a successful event.

<img width="250" height="542" alt="Screenshot_20260610_143639" src="https://github.com/user-attachments/assets/bf178fca-9711-47eb-9138-729a3db145ad" />

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified the behavior on iOS and Android, added unit tests for the new DebugRepository