### PR TITLE
refactor(ErrorBannerStateRepository): errorKey String => ErrorKey

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
@@ -8,7 +8,6 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import kotlinx.coroutines.channels.Channel
@@ -45,7 +44,7 @@ class GetGlobalDataTest {
 
         var actualData: GlobalResponse? = null
         composeTestRule.setContent {
-            actualData = getGlobalData(ErrorKey(KeyType.Permanent, "errorKey"), globalRepo)
+            actualData = getGlobalData(ErrorKey(setOf(), "errorKey"), globalRepo)
         }
         // Data should be set immediately from the repo, even before getGlobalData has completed
         composeTestRule.waitUntilDefaultTimeout { globalData == actualData }
@@ -63,7 +62,7 @@ class GetGlobalDataTest {
         val errorRepo = MockErrorBannerStateRepository()
 
         composeTestRule.setContent {
-            getGlobalData(ErrorKey(KeyType.Permanent, "errorKey"), globalRepo, errorRepo)
+            getGlobalData(ErrorKey(setOf(), "errorKey"), globalRepo, errorRepo)
         }
 
         composeTestRule.waitUntilDefaultTimeout {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetGlobalDataTest.kt
@@ -6,7 +6,9 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import kotlinx.coroutines.channels.Channel
@@ -42,7 +44,9 @@ class GetGlobalDataTest {
             }
 
         var actualData: GlobalResponse? = null
-        composeTestRule.setContent { actualData = getGlobalData("errorKey", globalRepo) }
+        composeTestRule.setContent {
+            actualData = getGlobalData(ErrorKey(KeyType.Permanent, "errorKey"), globalRepo)
+        }
         // Data should be set immediately from the repo, even before getGlobalData has completed
         composeTestRule.waitUntilDefaultTimeout { globalData == actualData }
         assertEquals(globalData, actualData)
@@ -58,7 +62,9 @@ class GetGlobalDataTest {
 
         val errorRepo = MockErrorBannerStateRepository()
 
-        composeTestRule.setContent { getGlobalData("errorKey", globalRepo, errorRepo) }
+        composeTestRule.setContent {
+            getGlobalData(ErrorKey(KeyType.Permanent, "errorKey"), globalRepo, errorRepo)
+        }
 
         composeTestRule.waitUntilDefaultTimeout {
             when (val errorState = errorRepo.state.value) {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
@@ -12,7 +12,6 @@ import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.RouteStopsResult
@@ -56,12 +55,7 @@ class GetRouteStopsTest {
         var actualRouteStops: RouteStopsResult? = expectedRouteStops1
         composeTestRule.setContent {
             actualRouteStops =
-                getRouteStops(
-                    route.id,
-                    directionId,
-                    ErrorKey(KeyType.Permanent, "errorKey"),
-                    routeStopsRepo,
-                )
+                getRouteStops(route.id, directionId, ErrorKey(setOf(), "errorKey"), routeStopsRepo)
         }
 
         composeTestRule.waitUntilDefaultTimeout { actualRouteStops != null }
@@ -95,7 +89,7 @@ class GetRouteStopsTest {
                 getRouteStops(
                     Route.Id(""),
                     directionId,
-                    ErrorKey(KeyType.Permanent, "errorKey"),
+                    ErrorKey(setOf(), "errorKey"),
                     routeStopsRepo,
                 )
         }
@@ -120,13 +114,7 @@ class GetRouteStopsTest {
         val errorRepo = MockErrorBannerStateRepository()
 
         composeTestRule.setContent {
-            getRouteStops(
-                Route.Id(""),
-                0,
-                ErrorKey(KeyType.Permanent, "errorKey"),
-                schedulesRepo,
-                errorRepo,
-            )
+            getRouteStops(Route.Id(""), 0, ErrorKey(setOf(), "errorKey"), schedulesRepo, errorRepo)
         }
 
         composeTestRule.waitUntilDefaultTimeout {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/GetRouteStopsTest.kt
@@ -10,7 +10,9 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.RouteStopsResult
@@ -53,7 +55,13 @@ class GetRouteStopsTest {
         var directionId by mutableIntStateOf(0)
         var actualRouteStops: RouteStopsResult? = expectedRouteStops1
         composeTestRule.setContent {
-            actualRouteStops = getRouteStops(route.id, directionId, "errorKey", routeStopsRepo)
+            actualRouteStops =
+                getRouteStops(
+                    route.id,
+                    directionId,
+                    ErrorKey(KeyType.Permanent, "errorKey"),
+                    routeStopsRepo,
+                )
         }
 
         composeTestRule.waitUntilDefaultTimeout { actualRouteStops != null }
@@ -83,7 +91,13 @@ class GetRouteStopsTest {
 
         var directionId by mutableIntStateOf(0)
         composeTestRule.setContent {
-            actualRouteStops = getRouteStops(Route.Id(""), directionId, "errorKey", routeStopsRepo)
+            actualRouteStops =
+                getRouteStops(
+                    Route.Id(""),
+                    directionId,
+                    ErrorKey(KeyType.Permanent, "errorKey"),
+                    routeStopsRepo,
+                )
         }
 
         sync.send(Unit)
@@ -106,7 +120,13 @@ class GetRouteStopsTest {
         val errorRepo = MockErrorBannerStateRepository()
 
         composeTestRule.setContent {
-            getRouteStops(Route.Id(""), 0, "errorKey", schedulesRepo, errorRepo)
+            getRouteStops(
+                Route.Id(""),
+                0,
+                ErrorKey(KeyType.Permanent, "errorKey"),
+                schedulesRepo,
+                errorRepo,
+            )
         }
 
         composeTestRule.waitUntilDefaultTimeout {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -53,7 +53,6 @@ import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISubscriptionsRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.DeepLinkState
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -96,7 +95,7 @@ fun ContentView(
     }
 
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()
-    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "ContentView"))
+    val globalResponse = getGlobalData(ErrorKey(setOf(), "ContentView"))
     val hideMaps = SettingsCache.get(Settings.HideMaps)
     val includeAccessibility = SettingsCache.get(Settings.StationAccessibility)
     val notificationsEnabled = SettingsCache.get(Settings.Notifications)
@@ -143,7 +142,7 @@ fun ContentView(
     }
 
     LaunchedEffect(null) {
-        val errorKey = ErrorKey(KeyType.Permanent, "socket")
+        val errorKey = ErrorKey(setOf(), "socket")
         socket.onError { error, response ->
             scope.launch {
                 errorBannerRepository.setDataError(errorKey, "$error $response") { socket.attach() }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -49,9 +49,11 @@ import com.mbta.tid.mbta_app.model.SubscriptionRequest
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.repositories.DefaultTab
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISubscriptionsRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.DeepLinkState
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -94,7 +96,7 @@ fun ContentView(
     }
 
     val alertData: AlertsStreamDataResponse? = subscribeToAlerts()
-    val globalResponse = getGlobalData("ContentView")
+    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "ContentView"))
     val hideMaps = SettingsCache.get(Settings.HideMaps)
     val includeAccessibility = SettingsCache.get(Settings.StationAccessibility)
     val notificationsEnabled = SettingsCache.get(Settings.Notifications)
@@ -141,12 +143,13 @@ fun ContentView(
     }
 
     LaunchedEffect(null) {
+        val errorKey = ErrorKey(KeyType.Permanent, "socket")
         socket.onError { error, response ->
             scope.launch {
-                errorBannerRepository.setDataError("socket", "$error $response") { socket.attach() }
+                errorBannerRepository.setDataError(errorKey, "$error $response") { socket.attach() }
             }
         }
-        socket.onAttach { scope.launch { errorBannerRepository.clearDataError("socket") } }
+        socket.onAttach { scope.launch { errorBannerRepository.clearDataError(errorKey) } }
     }
 
     LifecycleResumeEffect(null) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
@@ -42,7 +42,6 @@ import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -55,7 +54,7 @@ fun AlertDetailsPage(
     goBack: () -> Unit,
 ) {
     val alert = getAlert(alerts, alertId, goBack)
-    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "AlertDetailsPage"))
+    val globalResponse = getGlobalData(ErrorKey(setOf(), "AlertDetailsPage"))
     val now by timer(5.seconds)
 
     val line = globalResponse?.getLine(lineId)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPage.kt
@@ -41,6 +41,8 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -53,7 +55,7 @@ fun AlertDetailsPage(
     goBack: () -> Unit,
 ) {
     val alert = getAlert(alerts, alertId, goBack)
-    val globalResponse = getGlobalData("AlertDetailsPage")
+    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "AlertDetailsPage"))
     val now by timer(5.seconds)
 
     val line = globalResponse?.getLine(lineId)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
@@ -49,7 +49,6 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
@@ -81,7 +80,7 @@ fun SaveFavoritesFlow(
         return
     }
 
-    val global = getGlobalData(ErrorKey(KeyType.Permanent, "SaveFavoritesFlow"))
+    val global = getGlobalData(ErrorKey(setOf(), "SaveFavoritesFlow"))
     val isUnFavoriting =
         directions.any { it.id == selectedDirection } &&
             isFavorite(RouteStopDirection(lineOrRoute.id, stop.id, selectedDirection))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlow.kt
@@ -48,6 +48,8 @@ import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.Stop
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
@@ -79,7 +81,7 @@ fun SaveFavoritesFlow(
         return
     }
 
-    val global = getGlobalData("SaveFavoritesFlow")
+    val global = getGlobalData(ErrorKey(KeyType.Permanent, "SaveFavoritesFlow"))
     val isUnFavoriting =
         directions.any { it.id == selectedDirection } &&
             isFavorite(RouteStopDirection(lineOrRoute.id, stop.id, selectedDirection))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -70,6 +70,8 @@ import com.mbta.tid.mbta_app.android.util.toPoint
 import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.map.StopLayerGenerator
 import com.mbta.tid.mbta_app.model.Vehicle
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
@@ -94,7 +96,7 @@ fun HomeMapView(
     mapboxConfigManager: IMapboxConfigManager = koinInject(),
     navCallbacks: NavigationCallbacks,
 ) {
-    val globalData = getGlobalData("HomeMapView")
+    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "HomeMapView"))
     val state by viewModel.models.collectAsStateWithLifecycle()
     var isTargeting by isTargetingState
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -71,7 +71,6 @@ import com.mbta.tid.mbta_app.android.util.typeText
 import com.mbta.tid.mbta_app.map.StopLayerGenerator
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
@@ -96,7 +95,7 @@ fun HomeMapView(
     mapboxConfigManager: IMapboxConfigManager = koinInject(),
     navCallbacks: NavigationCallbacks,
 ) {
-    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "HomeMapView"))
+    val globalData = getGlobalData(ErrorKey(setOf(), "HomeMapView"))
     val state by viewModel.models.collectAsStateWithLifecycle()
     var isTargeting by isTargetingState
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -97,7 +97,6 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.DeepLinkState
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -662,7 +661,7 @@ fun MapAndSheetPage(
             analytics.track(AnalyticsScreen.TripDetails)
         }
 
-        val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsSheetContents"))
+        val global = getGlobalData(ErrorKey(setOf(), "TripDetailsSheetContents"))
         val lineOrRoute = global?.getLineOrRoute(navRoute.filter.routeId)
         val routeColor = lineOrRoute?.backgroundColor?.let { Color.fromHex(it) }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -96,6 +96,8 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.DeepLinkState
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -660,7 +662,7 @@ fun MapAndSheetPage(
             analytics.track(AnalyticsScreen.TripDetails)
         }
 
-        val global = getGlobalData("TripDetailsSheetContents")
+        val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsSheetContents"))
         val lineOrRoute = global?.getLineOrRoute(navRoute.filter.routeId)
         val routeColor = lineOrRoute?.backgroundColor?.let { Color.fromHex(it) }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
@@ -63,7 +63,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -98,7 +97,7 @@ fun SaveFavoritePage(
 ) {
     val resources = LocalResources.current
 
-    val global = getGlobalData(ErrorKey(KeyType.Permanent, "SaveFavoritePage"))
+    val global = getGlobalData(ErrorKey(setOf(), "SaveFavoritePage"))
     val lineOrRoute = global?.getLineOrRoute(routeId)
     val stop = global?.getStop(stopId)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
@@ -60,8 +60,10 @@ import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -96,7 +98,7 @@ fun SaveFavoritePage(
 ) {
     val resources = LocalResources.current
 
-    val global = getGlobalData("SaveFavoritePage")
+    val global = getGlobalData(ErrorKey(KeyType.Permanent, "SaveFavoritePage"))
     val lineOrRoute = global?.getLineOrRoute(routeId)
     val stop = global?.getStop(stopId)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
@@ -33,7 +33,6 @@ import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
@@ -55,7 +54,7 @@ fun TripDetailsPage(
     tripDetailsVM: ITripDetailsViewModel = koinInject(),
 ) {
     val now by timer(updateInterval = 5.seconds)
-    val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsPage"))
+    val global = getGlobalData(ErrorKey(setOf(), "TripDetailsPage"))
 
     tripDetailsPageVM.koinScope = currentKoinScope()
     val tripDetailsPageState by tripDetailsPageVM.models.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPage.kt
@@ -32,6 +32,8 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
@@ -53,7 +55,7 @@ fun TripDetailsPage(
     tripDetailsVM: ITripDetailsViewModel = koinInject(),
 ) {
     val now by timer(updateInterval = 5.seconds)
-    val global = getGlobalData("TripDetailsPage")
+    val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsPage"))
 
     tripDetailsPageVM.koinScope = currentKoinScope()
     val tripDetailsPageState by tripDetailsPageVM.models.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
@@ -18,7 +18,6 @@ import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
 
@@ -31,7 +30,7 @@ fun RouteDetailsView(
     openModal: (ModalRoutes) -> Unit,
     errorBannerViewModel: IErrorBannerViewModel,
 ) {
-    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "RouteDetailsView"))
+    val globalData = getGlobalData(ErrorKey(setOf(), "RouteDetailsView"))
     val lineOrRoute = globalData?.getLineOrRoute(selectionId)
     if (lineOrRoute == null) {
         LoadingRouteStopListView(context, errorBannerViewModel)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteDetailsView.kt
@@ -17,6 +17,8 @@ import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
 
@@ -29,7 +31,7 @@ fun RouteDetailsView(
     openModal: (ModalRoutes) -> Unit,
     errorBannerViewModel: IErrorBannerViewModel,
 ) {
-    val globalData = getGlobalData("RouteDetailsView")
+    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "RouteDetailsView"))
     val lineOrRoute = globalData?.getLineOrRoute(selectionId)
     if (lineOrRoute == null) {
         LoadingRouteStopListView(context, errorBannerViewModel)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -77,6 +77,8 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.silverRoutes
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
@@ -126,7 +128,11 @@ fun RouteStopListView(
         }
 
     val routeStops =
-        getRouteStops(selectedRouteId, selectedDirection, "RouteDetailsView.routeStopIds")
+        getRouteStops(
+            selectedRouteId,
+            selectedDirection,
+            ErrorKey(KeyType.Permanent, "RouteDetailsView.routeStopIds"),
+        )
 
     val stopList =
         rememberSuspend(selectedRouteId, selectedDirection, routeStops, globalData) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -78,7 +78,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.silverRoutes
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
@@ -131,7 +130,7 @@ fun RouteStopListView(
         getRouteStops(
             selectedRouteId,
             selectedDirection,
-            ErrorKey(KeyType.Permanent, "RouteDetailsView.routeStopIds"),
+            ErrorKey(setOf(), "RouteDetailsView.routeStopIds"),
         )
 
     val stopList =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -45,6 +45,8 @@ import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath.Bus.routeType
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.ISearchRoutesViewModel
@@ -63,7 +65,7 @@ fun RoutePickerView(
     errorBannerViewModel: IErrorBannerViewModel,
     searchRoutesViewModel: ISearchRoutesViewModel = koinInject(),
 ) {
-    val globalData = getGlobalData("RoutePickerView")
+    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "RoutePickerView"))
     var searchInputState by rememberSaveable { mutableStateOf("") }
     var searchInputFocused by rememberSaveable { mutableStateOf(false) }
     val searchVMState by searchRoutesViewModel.models.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerView.kt
@@ -46,7 +46,6 @@ import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RoutePickerPath.Bus.routeType
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.ISearchRoutesViewModel
@@ -65,7 +64,7 @@ fun RoutePickerView(
     errorBannerViewModel: IErrorBannerViewModel,
     searchRoutesViewModel: ISearchRoutesViewModel = koinInject(),
 ) {
-    val globalData = getGlobalData(ErrorKey(KeyType.Permanent, "RoutePickerView"))
+    val globalData = getGlobalData(ErrorKey(setOf(), "RoutePickerView"))
     var searchInputState by rememberSaveable { mutableStateOf("") }
     var searchInputFocused by rememberSaveable { mutableStateOf(false) }
     val searchVMState by searchRoutesViewModel.models.collectAsState()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import kotlinx.coroutines.CoroutineScope
@@ -19,7 +20,7 @@ class GlobalDataViewModel(
     private val globalRepository: IGlobalRepository,
     private val errorBannerRepository: IErrorBannerStateRepository,
 ) : ViewModel() {
-    fun getGlobalData(errorKey: String) {
+    fun getGlobalData(errorKey: ErrorKey) {
         CoroutineScope(Dispatchers.IO).launch {
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
@@ -44,14 +45,14 @@ class GlobalDataViewModel(
 
 @Composable
 fun getGlobalData(
-    errorKey: String,
+    errorKey: ErrorKey,
     globalRepository: IGlobalRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
 ): GlobalResponse? {
     val viewModel: GlobalDataViewModel =
         viewModel(factory = GlobalDataViewModel.Factory(globalRepository, errorBannerRepository))
 
-    LaunchedEffect(Unit) { viewModel.getGlobalData("$errorKey.getGlobalData") }
+    LaunchedEffect(Unit) { viewModel.getGlobalData(errorKey.withSuffix("getGlobalData")) }
 
     return globalRepository.state.collectAsState().value
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
@@ -52,7 +52,7 @@ fun getGlobalData(
     val viewModel: GlobalDataViewModel =
         viewModel(factory = GlobalDataViewModel.Factory(globalRepository, errorBannerRepository))
 
-    LaunchedEffect(Unit) { viewModel.getGlobalData(errorKey.withSuffix("getGlobalData")) }
+    LaunchedEffect(Unit) { viewModel.getGlobalData(errorKey.withSuffix(".getGlobalData")) }
 
     return globalRepository.state.collectAsState().value
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getGlobalData.kt
@@ -52,7 +52,7 @@ fun getGlobalData(
     val viewModel: GlobalDataViewModel =
         viewModel(factory = GlobalDataViewModel.Factory(globalRepository, errorBannerRepository))
 
-    LaunchedEffect(Unit) { viewModel.getGlobalData(errorKey.withSuffix(".getGlobalData")) }
+    LaunchedEffect(Unit) { viewModel.getGlobalData(errorKey.withSuffix("getGlobalData")) }
 
     return globalRepository.state.collectAsState().value
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/getRouteStops.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.mbta.tid.mbta_app.android.util.fetchApi
 import com.mbta.tid.mbta_app.model.Route
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IRouteStopsRepository
 import com.mbta.tid.mbta_app.repositories.RouteStopsResult
@@ -26,7 +27,7 @@ class RouteStopsFetcher(
     fun getRouteStops(
         routeId: Route.Id,
         directionId: Int,
-        errorKey: String,
+        errorKey: ErrorKey,
         onSuccess: (RouteStopsResult) -> Unit,
     ) {
         CoroutineScope(Dispatchers.IO).launch {
@@ -50,7 +51,7 @@ class RouteStopsViewModel(
     private val _routeStops = MutableStateFlow<RouteStopsResult?>(null)
     val routeStops: StateFlow<RouteStopsResult?> = _routeStops
 
-    fun getRouteStops(routeId: Route.Id, directionId: Int, errorKey: String) {
+    fun getRouteStops(routeId: Route.Id, directionId: Int, errorKey: ErrorKey) {
         _routeStops.value = null
         routeStopsFetcher.getRouteStops(routeId, directionId, errorKey) { _routeStops.value = it }
     }
@@ -69,7 +70,7 @@ class RouteStopsViewModel(
 fun getRouteStops(
     routeId: Route.Id,
     directionId: Int,
-    errorKey: String,
+    errorKey: ErrorKey,
     routeStopsRepository: IRouteStopsRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
 ): RouteStopsResult? {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
@@ -13,7 +13,9 @@ import com.mbta.tid.mbta_app.model.StopDetailsUtils
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.viewModel.IRouteCardDataViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,7 +35,7 @@ class VehiclesViewModel(private val vehiclesRepository: IVehiclesRepository) : V
         vehiclesRepository.disconnect()
     }
 
-    fun connectToVehicles(routeDirection: RouteDirection?, errorKey: String) {
+    fun connectToVehicles(routeDirection: RouteDirection?, errorKey: ErrorKey) {
         disconnect()
 
         if (routeDirection != null) {
@@ -82,7 +84,10 @@ fun subscribeToVehicles(
 
     LifecycleResumeEffect(routeDirection) {
         CoroutineScope(Dispatchers.IO).launch {
-            viewModel.connectToVehicles(routeDirection, "VehiclesViewModel.subscribeToVehicles")
+            viewModel.connectToVehicles(
+                routeDirection,
+                ErrorKey(KeyType.Permanent, "VehiclesViewModel.subscribeToVehicles"),
+            )
         }
         onPauseOrDispose { viewModel.disconnect() }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
@@ -15,7 +15,6 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.VehiclesStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IVehiclesRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.viewModel.IRouteCardDataViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -86,7 +85,7 @@ fun subscribeToVehicles(
         CoroutineScope(Dispatchers.IO).launch {
             viewModel.connectToVehicles(
                 routeDirection,
-                ErrorKey(KeyType.Permanent, "VehiclesViewModel.subscribeToVehicles"),
+                ErrorKey(setOf(), "VehiclesViewModel.subscribeToVehicles"),
             )
         }
         onPauseOrDispose { viewModel.disconnect() }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -62,7 +62,6 @@ import com.mbta.tid.mbta_app.model.response.NextScheduleResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -87,7 +86,7 @@ fun StopDetailsFilteredDeparturesView(
     viewModel: IStopDetailsViewModel = koinInject(),
     analytics: Analytics = koinInject(),
 ) {
-    val global = getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsFilteredDeparturesView"))
+    val global = getGlobalData(ErrorKey(setOf(), "StopDetailsFilteredDeparturesView"))
     val leafFormat = remember(leaf, now, global) { leaf.format(now, global) }
     val tileData = leafFormat.tileData(selectedDirection.destination)
     val noPredictionsStatus = leafFormat.noPredictionsStatus()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -60,7 +60,9 @@ import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.NextScheduleResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TileData
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -85,7 +87,7 @@ fun StopDetailsFilteredDeparturesView(
     viewModel: IStopDetailsViewModel = koinInject(),
     analytics: Analytics = koinInject(),
 ) {
-    val global = getGlobalData("StopDetailsFilteredDeparturesView")
+    val global = getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsFilteredDeparturesView"))
     val leafFormat = remember(leaf, now, global) { leaf.format(now, global) }
     val tileData = leafFormat.tileData(selectedDirection.destination)
     val noPredictionsStatus = leafFormat.noPredictionsStatus()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -48,6 +48,8 @@ import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -76,7 +78,8 @@ fun StopDetailsFilteredView(
     stopDetailsViewModel: IStopDetailsViewModel = koinInject(),
 ) {
     val state by stopDetailsViewModel.models.collectAsState()
-    val global: GlobalResponse? = getGlobalData("StopDetailsFilteredView")
+    val global: GlobalResponse? =
+        getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsFilteredView"))
 
     val lineOrRoute: LineOrRoute? = global?.getLineOrRoute(stopFilter.routeId)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -49,7 +49,6 @@ import com.mbta.tid.mbta_app.model.TripDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -78,8 +77,7 @@ fun StopDetailsFilteredView(
     stopDetailsViewModel: IStopDetailsViewModel = koinInject(),
 ) {
     val state by stopDetailsViewModel.models.collectAsState()
-    val global: GlobalResponse? =
-        getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsFilteredView"))
+    val global: GlobalResponse? = getGlobalData(ErrorKey(setOf(), "StopDetailsFilteredView"))
 
     val lineOrRoute: LineOrRoute? = global?.getLineOrRoute(stopFilter.routeId)
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -19,6 +19,8 @@ import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
@@ -37,7 +39,7 @@ fun StopDetailsUnfilteredView(
     errorBannerViewModel: IErrorBannerViewModel,
     stopDetailsViewModel: IStopDetailsViewModel = koinInject(),
 ) {
-    val globalResponse = getGlobalData("StopDetailsUnfilteredView")
+    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsUnfilteredView"))
     val stop: Stop? = globalResponse?.getStop(stopId)
 
     val analytics: Analytics = koinInject()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredView.kt
@@ -20,7 +20,6 @@ import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
@@ -39,7 +38,7 @@ fun StopDetailsUnfilteredView(
     errorBannerViewModel: IErrorBannerViewModel,
     stopDetailsViewModel: IStopDetailsViewModel = koinInject(),
 ) {
-    val globalResponse = getGlobalData(ErrorKey(KeyType.Permanent, "StopDetailsUnfilteredView"))
+    val globalResponse = getGlobalData(ErrorKey(setOf(), "StopDetailsUnfilteredView"))
     val stop: Stop? = globalResponse?.getStop(stopId)
 
     val analytics: Analytics = koinInject()

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -35,7 +35,6 @@ import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ITripDetailsViewModel
@@ -59,7 +58,7 @@ fun TripDetailsView(
     analytics: Analytics = koinInject(),
 ) {
     val globalResponse: GlobalResponse? =
-        getGlobalData(errorKey = ErrorKey(KeyType.Permanent, "TripDetailsView"))
+        getGlobalData(errorKey = ErrorKey(setOf(), "TripDetailsView"))
     val state by tripDetailsVM.models.collectAsState()
     val tripData: TripData? = state.tripData
     val stopList = state.stopList

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsView.kt
@@ -34,6 +34,8 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripHeaderSpec
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ITripDetailsViewModel
@@ -56,7 +58,8 @@ fun TripDetailsView(
     tripDetailsVM: ITripDetailsViewModel = koinInject(),
     analytics: Analytics = koinInject(),
 ) {
-    val globalResponse: GlobalResponse? = getGlobalData(errorKey = "TripDetailsView")
+    val globalResponse: GlobalResponse? =
+        getGlobalData(errorKey = ErrorKey(KeyType.Permanent, "TripDetailsView"))
     val state by tripDetailsVM.models.collectAsState()
     val tripData: TripData? = state.tripData
     val stopList = state.stopList

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/fetchApi.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.util
 
 import android.util.Log
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 
 /**
@@ -11,7 +12,7 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
  */
 suspend fun <T : Any> fetchApi(
     errorBannerRepo: IErrorBannerStateRepository,
-    errorKey: String,
+    errorKey: ErrorKey,
     getData: suspend () -> ApiResult<T>,
     onSuccess: suspend (T) -> Unit = {},
     onRefreshAfterError: () -> Unit,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -102,7 +102,7 @@ struct ContentView: View {
                 notificationDeepLinkOwner.notificationDeepLink = nil
             }
         }
-        .global($globalData, errorKey: "ContentView")
+        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "ContentView"))
         .handleFcmTokenSubscriptions(
             fcmToken: fcmTokenContainer.token,
             includeAccessibility: includeAccessibility,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -102,7 +102,7 @@ struct ContentView: View {
                 notificationDeepLinkOwner.notificationDeepLink = nil
             }
         }
-        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "ContentView"))
+        .global($globalData, errorKey: ErrorKey(type: [], id: "ContentView"))
         .handleFcmTokenSubscriptions(
             fcmToken: fcmTokenContainer.token,
             includeAccessibility: includeAccessibility,

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -102,7 +102,7 @@ struct ContentView: View {
                 notificationDeepLinkOwner.notificationDeepLink = nil
             }
         }
-        .global($globalData, errorKey: ErrorKey(type: [], id: "ContentView"))
+        .global($globalData, errorKey: ErrorKey(sheets: [], id: "ContentView"))
         .handleFcmTokenSubscriptions(
             fcmToken: fcmTokenContainer.token,
             includeAccessibility: includeAccessibility,

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
@@ -94,7 +94,7 @@ struct AlertDetailsPage: View {
             }
         }
         .background(Color.fill2)
-        .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "AlertDetailsPage"))
+        .global($globalResponse, errorKey: ErrorKey(type: [], id: "AlertDetailsPage"))
         .onAppear { updateAlert() }
         .onChange(of: nearbyVM.alerts) { _ in updateAlert() }
         .onReceive(timer) { input in now = input }

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
@@ -94,7 +94,7 @@ struct AlertDetailsPage: View {
             }
         }
         .background(Color.fill2)
-        .global($globalResponse, errorKey: "AlertDetailsPage")
+        .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "AlertDetailsPage"))
         .onAppear { updateAlert() }
         .onChange(of: nearbyVM.alerts) { _ in updateAlert() }
         .onReceive(timer) { input in now = input }

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetailsPage.swift
@@ -94,7 +94,7 @@ struct AlertDetailsPage: View {
             }
         }
         .background(Color.fill2)
-        .global($globalResponse, errorKey: ErrorKey(type: [], id: "AlertDetailsPage"))
+        .global($globalResponse, errorKey: ErrorKey(sheets: [], id: "AlertDetailsPage"))
         .onAppear { updateAlert() }
         .onChange(of: nearbyVM.alerts) { _ in updateAlert() }
         .onReceive(timer) { input in now = input }

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -101,7 +101,7 @@ struct EditFavoritesPage: View {
                 toastVM.hideToast()
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
-            .global($globalResponse, errorKey: "AlertDetailsPage")
+            .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "AlertDetailsPage"))
             .task {
                 for await model in viewModel.models {
                     favoritesVMState = model

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -101,7 +101,7 @@ struct EditFavoritesPage: View {
                 toastVM.hideToast()
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
-            .global($globalResponse, errorKey: ErrorKey(type: [], id: "AlertDetailsPage"))
+            .global($globalResponse, errorKey: ErrorKey(sheets: [], id: "AlertDetailsPage"))
             .task {
                 for await model in viewModel.models {
                     favoritesVMState = model

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -101,7 +101,7 @@ struct EditFavoritesPage: View {
                 toastVM.hideToast()
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
-            .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "AlertDetailsPage"))
+            .global($globalResponse, errorKey: ErrorKey(type: [], id: "AlertDetailsPage"))
             .task {
                 for await model in viewModel.models {
                     favoritesVMState = model

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -83,7 +83,7 @@ struct FavoritesView: View {
                 showStopHeader: true
             )
         }
-        .global($globalData, errorKey: ErrorKey(type: [], id: "FavoritesView"))
+        .global($globalData, errorKey: ErrorKey(sheets: [], id: "FavoritesView"))
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -83,7 +83,7 @@ struct FavoritesView: View {
                 showStopHeader: true
             )
         }
-        .global($globalData, errorKey: "FavoritesView")
+        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "FavoritesView"))
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -83,7 +83,7 @@ struct FavoritesView: View {
                 showStopHeader: true
             )
         }
-        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "FavoritesView"))
+        .global($globalData, errorKey: ErrorKey(type: [], id: "FavoritesView"))
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -90,7 +90,7 @@ struct HomeMapView: View {
                     crosshairs
                 }
             }
-            .global($globalData, errorKey: ErrorKey(type: [], id: "HomeMapView"))
+            .global($globalData, errorKey: ErrorKey(sheets: [], id: "HomeMapView"))
             .task {
                 for await state in mapVM.models {
                     mapVMState = state

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -90,7 +90,7 @@ struct HomeMapView: View {
                     crosshairs
                 }
             }
-            .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "HomeMapView"))
+            .global($globalData, errorKey: ErrorKey(type: [], id: "HomeMapView"))
             .task {
                 for await state in mapVM.models {
                     mapVMState = state

--- a/iosApp/iosApp/Pages/Map/HomeMapView.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapView.swift
@@ -90,7 +90,7 @@ struct HomeMapView: View {
                     crosshairs
                 }
             }
-            .global($globalData, errorKey: "HomeMapView")
+            .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "HomeMapView"))
             .task {
                 for await state in mapVM.models {
                     mapVMState = state

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -68,7 +68,7 @@ extension HomeMapView {
         vehiclesRepository.connect(
             routeId: routeId,
             directionId: directionId,
-            errorKey: ErrorKey(type: [], id: "HomeMapView.joinVehiclesChannel"),
+            errorKey: ErrorKey(sheets: [], id: "HomeMapView.joinVehiclesChannel"),
         ) { outcome in
             if case let .ok(result) = onEnum(of: outcome) {
                 if let routeCardData = routeCardDataState?.data {

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -68,7 +68,7 @@ extension HomeMapView {
         vehiclesRepository.connect(
             routeId: routeId,
             directionId: directionId,
-            errorKey: ErrorKey(type: KeyType.Permanent(), id: "HomeMapView.joinVehiclesChannel"),
+            errorKey: ErrorKey(type: [], id: "HomeMapView.joinVehiclesChannel"),
         ) { outcome in
             if case let .ok(result) = onEnum(of: outcome) {
                 if let routeCardData = routeCardDataState?.data {

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -68,7 +68,7 @@ extension HomeMapView {
         vehiclesRepository.connect(
             routeId: routeId,
             directionId: directionId,
-            errorKey: "HomeMapView.joinVehiclesChannel",
+            errorKey: ErrorKey(type: KeyType.Permanent(), id: "HomeMapView.joinVehiclesChannel"),
         ) { outcome in
             if case let .ok(result) = onEnum(of: outcome) {
                 if let routeCardData = routeCardDataState?.data {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -54,7 +54,7 @@ struct NearbyTransitView: View {
             }
         }
         .favorites($favorites)
-        .global($globalData, errorKey: ErrorKey(type: [], id: "NearbyTransitView"))
+        .global($globalData, errorKey: ErrorKey(sheets: [], id: "NearbyTransitView"))
         .onAppear {
             loadEverything()
             didAppear?(self)
@@ -234,7 +234,7 @@ struct NearbyTransitView: View {
                 return
             }
             await fetchApi(
-                errorKey: ErrorKey(type: [], id: "NearbyTransitView.getSchedule"),
+                errorKey: ErrorKey(sheets: [], id: "NearbyTransitView.getSchedule"),
                 getData: { try await schedulesRepository.getSchedule(stopIds: stopIds) },
                 onSuccess: { scheduleResponse = $0 },
                 onRefreshAfterError: loadEverything
@@ -246,7 +246,7 @@ struct NearbyTransitView: View {
         guard let stopIds else { return }
         predictionsRepository.connect(
             stopIds: stopIds,
-            errorKey: ErrorKey(type: [], id: "NearbyTransitView.joinPredictions"),
+            errorKey: ErrorKey(sheets: [], id: "NearbyTransitView.joinPredictions"),
             onJoin: { outcome in
                 DispatchQueue.main.async {
                     switch onEnum(of: outcome) {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -54,7 +54,7 @@ struct NearbyTransitView: View {
             }
         }
         .favorites($favorites)
-        .global($globalData, errorKey: "NearbyTransitView")
+        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView"))
         .onAppear {
             loadEverything()
             didAppear?(self)
@@ -234,7 +234,7 @@ struct NearbyTransitView: View {
                 return
             }
             await fetchApi(
-                errorKey: "NearbyTransitView.getSchedule",
+                errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView.getSchedule"),
                 getData: { try await schedulesRepository.getSchedule(stopIds: stopIds) },
                 onSuccess: { scheduleResponse = $0 },
                 onRefreshAfterError: loadEverything
@@ -246,7 +246,7 @@ struct NearbyTransitView: View {
         guard let stopIds else { return }
         predictionsRepository.connect(
             stopIds: stopIds,
-            errorKey: "NearbyTransitView.joinPredictions",
+            errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView.joinPredictions"),
             onJoin: { outcome in
                 DispatchQueue.main.async {
                     switch onEnum(of: outcome) {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -54,7 +54,7 @@ struct NearbyTransitView: View {
             }
         }
         .favorites($favorites)
-        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView"))
+        .global($globalData, errorKey: ErrorKey(type: [], id: "NearbyTransitView"))
         .onAppear {
             loadEverything()
             didAppear?(self)
@@ -234,7 +234,7 @@ struct NearbyTransitView: View {
                 return
             }
             await fetchApi(
-                errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView.getSchedule"),
+                errorKey: ErrorKey(type: [], id: "NearbyTransitView.getSchedule"),
                 getData: { try await schedulesRepository.getSchedule(stopIds: stopIds) },
                 onSuccess: { scheduleResponse = $0 },
                 onRefreshAfterError: loadEverything
@@ -246,7 +246,7 @@ struct NearbyTransitView: View {
         guard let stopIds else { return }
         predictionsRepository.connect(
             stopIds: stopIds,
-            errorKey: ErrorKey(type: KeyType.Permanent(), id: "NearbyTransitView.joinPredictions"),
+            errorKey: ErrorKey(type: [], id: "NearbyTransitView.joinPredictions"),
             onJoin: { outcome in
                 DispatchQueue.main.async {
                     switch onEnum(of: outcome) {

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -51,7 +51,7 @@ struct RouteDetailsView: View {
                 loadingBody()
             }
         }
-        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "RouteDetailsView"))
+        .global($globalData, errorKey: ErrorKey(type: [], id: "RouteDetailsView"))
         .onChange(of: globalData) { globalData in
             lineOrRoute = globalData?.getLineOrRoute(lineOrRouteId: selectionId)
         }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -51,7 +51,7 @@ struct RouteDetailsView: View {
                 loadingBody()
             }
         }
-        .global($globalData, errorKey: ErrorKey(type: [], id: "RouteDetailsView"))
+        .global($globalData, errorKey: ErrorKey(sheets: [], id: "RouteDetailsView"))
         .onChange(of: globalData) { globalData in
             lineOrRoute = globalData?.getLineOrRoute(lineOrRouteId: selectionId)
         }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -51,7 +51,7 @@ struct RouteDetailsView: View {
                 loadingBody()
             }
         }
-        .global($globalData, errorKey: "RouteDetailsView")
+        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "RouteDetailsView"))
         .onChange(of: globalData) { globalData in
             lineOrRoute = globalData?.getLineOrRoute(lineOrRouteId: selectionId)
         }

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -155,7 +155,7 @@ struct RouteStopListView<RightSideContent: View>: View {
     private func loadRouteStops(routeId: Route.Id, directionId: Int32) {
         Task {
             await fetchApi(
-                errorKey: ErrorKey(type: [], id: "RouteStopListView.loadRouteStops"),
+                errorKey: ErrorKey(sheets: [], id: "RouteStopListView.loadRouteStops"),
                 getData: { try await routeStopsRepository.getRouteSegments(
                     routeId: routeId,
                     directionId: directionId

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -155,7 +155,7 @@ struct RouteStopListView<RightSideContent: View>: View {
     private func loadRouteStops(routeId: Route.Id, directionId: Int32) {
         Task {
             await fetchApi(
-                errorKey: "RouteStopListView.loadRouteStops",
+                errorKey: ErrorKey(type: KeyType.Permanent(), id: "RouteStopListView.loadRouteStops"),
                 getData: { try await routeStopsRepository.getRouteSegments(
                     routeId: routeId,
                     directionId: directionId

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -155,7 +155,7 @@ struct RouteStopListView<RightSideContent: View>: View {
     private func loadRouteStops(routeId: Route.Id, directionId: Int32) {
         Task {
             await fetchApi(
-                errorKey: ErrorKey(type: KeyType.Permanent(), id: "RouteStopListView.loadRouteStops"),
+                errorKey: ErrorKey(type: [], id: "RouteStopListView.loadRouteStops"),
                 getData: { try await routeStopsRepository.getRouteSegments(
                     routeId: routeId,
                     directionId: directionId

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -125,7 +125,7 @@ struct RoutePickerView: View {
                 }
             }.ignoresSafeArea(.keyboard, edges: .bottom)
         }
-        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "RoutePickerView"))
+        .global($globalData, errorKey: ErrorKey(type: [], id: "RoutePickerView"))
         .onAppear {
             searchRoutesViewModel.setPath(path: path)
         }

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -125,7 +125,7 @@ struct RoutePickerView: View {
                 }
             }.ignoresSafeArea(.keyboard, edges: .bottom)
         }
-        .global($globalData, errorKey: "RoutePickerView")
+        .global($globalData, errorKey: ErrorKey(type: KeyType.Permanent(), id: "RoutePickerView"))
         .onAppear {
             searchRoutesViewModel.setPath(path: path)
         }

--- a/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
+++ b/iosApp/iosApp/Pages/RoutePicker/RoutePickerView.swift
@@ -125,7 +125,7 @@ struct RoutePickerView: View {
                 }
             }.ignoresSafeArea(.keyboard, edges: .bottom)
         }
-        .global($globalData, errorKey: ErrorKey(type: [], id: "RoutePickerView"))
+        .global($globalData, errorKey: ErrorKey(sheets: [], id: "RoutePickerView"))
         .onAppear {
             searchRoutesViewModel.setPath(path: path)
         }

--- a/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
@@ -210,7 +210,7 @@ struct SaveFavoritePage: View {
         .frame(maxHeight: .infinity)
         .background(Color.fill2)
         .favorites($favorites)
-        .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "SaveFavoritePage"))
+        .global($globalResponse, errorKey: ErrorKey(type: [], id: "SaveFavoritePage"))
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .enableInjection()
     }

--- a/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
@@ -210,7 +210,7 @@ struct SaveFavoritePage: View {
         .frame(maxHeight: .infinity)
         .background(Color.fill2)
         .favorites($favorites)
-        .global($globalResponse, errorKey: ErrorKey(type: [], id: "SaveFavoritePage"))
+        .global($globalResponse, errorKey: ErrorKey(sheets: [], id: "SaveFavoritePage"))
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .enableInjection()
     }

--- a/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
@@ -210,7 +210,7 @@ struct SaveFavoritePage: View {
         .frame(maxHeight: .infinity)
         .background(Color.fill2)
         .favorites($favorites)
-        .global($globalResponse, errorKey: "SaveFavoritePage")
+        .global($globalResponse, errorKey: ErrorKey(type: KeyType.Permanent(), id: "SaveFavoritePage"))
         .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .enableInjection()
     }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -193,7 +193,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                 )
             }
         }
-        .global($global, errorKey: "StopDetailsFilteredDepartureDetails")
+        .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "StopDetailsFilteredDepartureDetails"))
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
             loadNextScheduleForStatus(noPredictionsStatus)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -193,7 +193,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                 )
             }
         }
-        .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "StopDetailsFilteredDepartureDetails"))
+        .global($global, errorKey: ErrorKey(type: [], id: "StopDetailsFilteredDepartureDetails"))
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
             loadNextScheduleForStatus(noPredictionsStatus)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -193,7 +193,7 @@ struct StopDetailsFilteredDepartureDetails: View {
                 )
             }
         }
-        .global($global, errorKey: ErrorKey(type: [], id: "StopDetailsFilteredDepartureDetails"))
+        .global($global, errorKey: ErrorKey(sheets: [], id: "StopDetailsFilteredDepartureDetails"))
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
             loadNextScheduleForStatus(noPredictionsStatus)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -89,7 +89,7 @@ struct StopDetailsPage: View {
     var body: some View {
         stopDetails
             .favorites($favorites)
-            .global($global, errorKey: ErrorKey(type: [], id: "StopDetailsPage"))
+            .global($global, errorKey: ErrorKey(sheets: [], id: "StopDetailsPage"))
             .manageVM(stopDetailsVM, $vmState, alerts: nearbyVM.alerts, filters: filters, now: now.toEasternInstant())
             .manageVM(routeCardDataVM, $routeCardDataState)
             .task {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -89,7 +89,7 @@ struct StopDetailsPage: View {
     var body: some View {
         stopDetails
             .favorites($favorites)
-            .global($global, errorKey: "StopDetailsPage")
+            .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "StopDetailsPage"))
             .manageVM(stopDetailsVM, $vmState, alerts: nearbyVM.alerts, filters: filters, now: now.toEasternInstant())
             .manageVM(routeCardDataVM, $routeCardDataState)
             .task {

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -89,7 +89,7 @@ struct StopDetailsPage: View {
     var body: some View {
         stopDetails
             .favorites($favorites)
-            .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "StopDetailsPage"))
+            .global($global, errorKey: ErrorKey(type: [], id: "StopDetailsPage"))
             .manageVM(stopDetailsVM, $vmState, alerts: nearbyVM.alerts, filters: filters, now: now.toEasternInstant())
             .manageVM(routeCardDataVM, $routeCardDataState)
             .task {

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -84,7 +84,7 @@ struct TripDetailsView: View {
     var body: some View {
         content
             .explainer($explainer)
-            .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "TripDetailsView"))
+            .global($global, errorKey: ErrorKey(type: [], id: "TripDetailsView"))
             .onAppear {
                 tripDetailsVMState = tripDetailsVM.models.value
             }

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -84,7 +84,7 @@ struct TripDetailsView: View {
     var body: some View {
         content
             .explainer($explainer)
-            .global($global, errorKey: "TripDetailsView")
+            .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "TripDetailsView"))
             .onAppear {
                 tripDetailsVMState = tripDetailsVM.models.value
             }

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -84,7 +84,7 @@ struct TripDetailsView: View {
     var body: some View {
         content
             .explainer($explainer)
-            .global($global, errorKey: ErrorKey(type: [], id: "TripDetailsView"))
+            .global($global, errorKey: ErrorKey(sheets: [], id: "TripDetailsView"))
             .onAppear {
                 tripDetailsVMState = tripDetailsVM.models.value
             }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -99,7 +99,7 @@ struct TripDetailsPage: View {
                 global: global
             ))
         }
-        .global($global, errorKey: ErrorKey(type: [], id: "TripDetailsPage"))
+        .global($global, errorKey: ErrorKey(sheets: [], id: "TripDetailsPage"))
         .task {
             while !Task.isCancelled {
                 now = Date.now.toEasternInstant()

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -99,7 +99,7 @@ struct TripDetailsPage: View {
                 global: global
             ))
         }
-        .global($global, errorKey: "TripDetailsPage")
+        .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "TripDetailsPage"))
         .task {
             while !Task.isCancelled {
                 now = Date.now.toEasternInstant()

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -99,7 +99,7 @@ struct TripDetailsPage: View {
                 global: global
             ))
         }
-        .global($global, errorKey: ErrorKey(type: KeyType.Permanent(), id: "TripDetailsPage"))
+        .global($global, errorKey: ErrorKey(type: [], id: "TripDetailsPage"))
         .task {
             while !Task.isCancelled {
                 now = Date.now.toEasternInstant()

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -25,7 +25,7 @@ struct ProductionAppView: View {
     @StateObject var contentVM: ContentViewModel = .init()
     @StateObject var socketProvider: SocketProvider
     @StateObject var viewportProvider: ViewportProvider
-    private static let errorDataKey = ErrorKey(type: [], id: "socket")
+    private static let errorDataKey = ErrorKey(sheets: [], id: "socket")
 
     init() {
         Self.initSentry()

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -25,7 +25,7 @@ struct ProductionAppView: View {
     @StateObject var contentVM: ContentViewModel = .init()
     @StateObject var socketProvider: SocketProvider
     @StateObject var viewportProvider: ViewportProvider
-    private static let errorDataKey = ErrorKey(type: KeyType.Permanent(), id: "socket")
+    private static let errorDataKey = ErrorKey(type: [], id: "socket")
 
     init() {
         Self.initSentry()

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -25,7 +25,7 @@ struct ProductionAppView: View {
     @StateObject var contentVM: ContentViewModel = .init()
     @StateObject var socketProvider: SocketProvider
     @StateObject var viewportProvider: ViewportProvider
-    private static let errorDataKey = "socket"
+    private static let errorDataKey = ErrorKey(type: KeyType.Permanent(), id: "socket")
 
     init() {
         Self.initSentry()

--- a/iosApp/iosApp/Utils/FetchApi.swift
+++ b/iosApp/iosApp/Utils/FetchApi.swift
@@ -15,7 +15,7 @@ import Shared
 /// If `getData` is interrupted by task cancellation, does nothing.
 func fetchApi<T>(
     _ errorBannerRepo: IErrorBannerStateRepository = RepositoryDI().errorBanner,
-    errorKey: String,
+    errorKey: ErrorKey,
     getData: () async throws -> ApiResult<T>,
     onSuccess: @MainActor (T) -> Void = { _ in },
     onRefreshAfterError: @escaping () -> Void

--- a/iosApp/iosApp/Utils/Modifiers/GlobalModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/GlobalModifier.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct GlobalModifier: ViewModifier {
     var globalRepository: IGlobalRepository = RepositoryDI().global
     @Binding var global: GlobalResponse?
-    let errorKey: String
+    let errorKey: ErrorKey
 
     @MainActor
     func activateGlobalListener() async {
@@ -27,7 +27,7 @@ struct GlobalModifier: ViewModifier {
         }
         Task {
             await fetchApi(
-                errorKey: "\(errorKey).loadGlobal",
+                errorKey: errorKey.withSuffix(suffix: "loadGlobal"),
                 getData: { try await globalRepository.getGlobalData() },
                 onRefreshAfterError: loadGlobal
             )
@@ -41,7 +41,7 @@ struct GlobalModifier: ViewModifier {
 }
 
 public extension View {
-    func global(_ global: Binding<GlobalResponse?>, errorKey: String) -> some View {
+    func global(_ global: Binding<GlobalResponse?>, errorKey: ErrorKey) -> some View {
         modifier(GlobalModifier(global: global, errorKey: errorKey))
     }
 }

--- a/iosApp/iosAppTests/Utils/FetchApiTests.swift
+++ b/iosApp/iosAppTests/Utils/FetchApiTests.swift
@@ -26,7 +26,7 @@ final class FetchApiTests: XCTestCase {
     func testCallsSuccessAndClearsError() async {
         let errorBannerRepo = ErrorBannerStateRepository()
         try? await errorBannerRepo.setDataError(
-            key: ErrorKey(type: KeyType.Permanent(), id: "a"),
+            key: ErrorKey(type: [], id: "a"),
             details: "",
             action: {}
         )
@@ -34,7 +34,7 @@ final class FetchApiTests: XCTestCase {
         let expSuccess = expectation(description: "calls onSuccess")
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
+            errorKey: ErrorKey(type: [], id: "a"),
             getData: { ApiResultOk(data: Data(4)) },
             onSuccess: {
                 XCTAssertEqual($0, Data(4))
@@ -52,7 +52,7 @@ final class FetchApiTests: XCTestCase {
         let expRefresh = expectation(description: "can refresh after error")
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
+            errorKey: ErrorKey(type: [], id: "a"),
             getData: { ApiResultError<Data>(code: 418, message: "I'm a teapot") },
             onSuccess: { _ in XCTFail("called onSuccess") },
             onRefreshAfterError: { expRefresh.fulfill() }
@@ -72,7 +72,7 @@ final class FetchApiTests: XCTestCase {
         let errorBannerRepo = ErrorBannerStateRepository()
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
+            errorKey: ErrorKey(type: [], id: "a"),
             getData: { throw AdHocError() },
             onSuccess: { (_: Data) in XCTFail("called onSuccess") },
             onRefreshAfterError: { XCTFail("called onRefresh") }
@@ -86,7 +86,7 @@ final class FetchApiTests: XCTestCase {
         let task = Task {
             await fetchApi(
                 errorBannerRepo,
-                errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
+                errorKey: ErrorKey(type: [], id: "a"),
                 getData: {
                     expFetchStarted.fulfill()
                     try await Task.sleep(for: .seconds(1))

--- a/iosApp/iosAppTests/Utils/FetchApiTests.swift
+++ b/iosApp/iosAppTests/Utils/FetchApiTests.swift
@@ -26,7 +26,7 @@ final class FetchApiTests: XCTestCase {
     func testCallsSuccessAndClearsError() async {
         let errorBannerRepo = ErrorBannerStateRepository()
         try? await errorBannerRepo.setDataError(
-            key: ErrorKey(type: [], id: "a"),
+            key: ErrorKey(sheets: [], id: "a"),
             details: "",
             action: {}
         )
@@ -34,7 +34,7 @@ final class FetchApiTests: XCTestCase {
         let expSuccess = expectation(description: "calls onSuccess")
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: [], id: "a"),
+            errorKey: ErrorKey(sheets: [], id: "a"),
             getData: { ApiResultOk(data: Data(4)) },
             onSuccess: {
                 XCTAssertEqual($0, Data(4))
@@ -52,7 +52,7 @@ final class FetchApiTests: XCTestCase {
         let expRefresh = expectation(description: "can refresh after error")
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: [], id: "a"),
+            errorKey: ErrorKey(sheets: [], id: "a"),
             getData: { ApiResultError<Data>(code: 418, message: "I'm a teapot") },
             onSuccess: { _ in XCTFail("called onSuccess") },
             onRefreshAfterError: { expRefresh.fulfill() }
@@ -72,7 +72,7 @@ final class FetchApiTests: XCTestCase {
         let errorBannerRepo = ErrorBannerStateRepository()
         await fetchApi(
             errorBannerRepo,
-            errorKey: ErrorKey(type: [], id: "a"),
+            errorKey: ErrorKey(sheets: [], id: "a"),
             getData: { throw AdHocError() },
             onSuccess: { (_: Data) in XCTFail("called onSuccess") },
             onRefreshAfterError: { XCTFail("called onRefresh") }
@@ -86,7 +86,7 @@ final class FetchApiTests: XCTestCase {
         let task = Task {
             await fetchApi(
                 errorBannerRepo,
-                errorKey: ErrorKey(type: [], id: "a"),
+                errorKey: ErrorKey(sheets: [], id: "a"),
                 getData: {
                     expFetchStarted.fulfill()
                     try await Task.sleep(for: .seconds(1))

--- a/iosApp/iosAppTests/Utils/FetchApiTests.swift
+++ b/iosApp/iosAppTests/Utils/FetchApiTests.swift
@@ -25,12 +25,16 @@ final class FetchApiTests: XCTestCase {
 
     func testCallsSuccessAndClearsError() async {
         let errorBannerRepo = ErrorBannerStateRepository()
-        try? await errorBannerRepo.setDataError(key: "a", details: "", action: {})
+        try? await errorBannerRepo.setDataError(
+            key: ErrorKey(type: KeyType.Permanent(), id: "a"),
+            details: "",
+            action: {}
+        )
         XCTAssertNotNil(errorBannerRepo.state.value)
         let expSuccess = expectation(description: "calls onSuccess")
         await fetchApi(
             errorBannerRepo,
-            errorKey: "a",
+            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
             getData: { ApiResultOk(data: Data(4)) },
             onSuccess: {
                 XCTAssertEqual($0, Data(4))
@@ -48,7 +52,7 @@ final class FetchApiTests: XCTestCase {
         let expRefresh = expectation(description: "can refresh after error")
         await fetchApi(
             errorBannerRepo,
-            errorKey: "a",
+            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
             getData: { ApiResultError<Data>(code: 418, message: "I'm a teapot") },
             onSuccess: { _ in XCTFail("called onSuccess") },
             onRefreshAfterError: { expRefresh.fulfill() }
@@ -68,7 +72,7 @@ final class FetchApiTests: XCTestCase {
         let errorBannerRepo = ErrorBannerStateRepository()
         await fetchApi(
             errorBannerRepo,
-            errorKey: "a",
+            errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
             getData: { throw AdHocError() },
             onSuccess: { (_: Data) in XCTFail("called onSuccess") },
             onRefreshAfterError: { XCTFail("called onRefresh") }
@@ -82,7 +86,7 @@ final class FetchApiTests: XCTestCase {
         let task = Task {
             await fetchApi(
                 errorBannerRepo,
-                errorKey: "a",
+                errorKey: ErrorKey(type: KeyType.Permanent(), id: "a"),
                 getData: {
                     expFetchStarted.fulfill()
                     try await Task.sleep(for: .seconds(1))

--- a/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
+++ b/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
@@ -41,7 +41,7 @@ final class GlobalModifierTests: XCTestCase {
         )
         loadKoinMocks(repositories: mockRepos)
 
-        let sut = Text("test").global(globalBinding, errorKey: "ErrorKey")
+        let sut = Text("test").global(globalBinding, errorKey: ErrorKey(type: KeyType.Permanent(), id: "ErrorKey"))
 
         ViewHosting.host(view: sut)
 

--- a/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
+++ b/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
@@ -41,7 +41,7 @@ final class GlobalModifierTests: XCTestCase {
         )
         loadKoinMocks(repositories: mockRepos)
 
-        let sut = Text("test").global(globalBinding, errorKey: ErrorKey(type: [], id: "ErrorKey"))
+        let sut = Text("test").global(globalBinding, errorKey: ErrorKey(sheets: [], id: "ErrorKey"))
 
         ViewHosting.host(view: sut)
 

--- a/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
+++ b/iosApp/iosAppTests/Utils/Modifiers/GlobalModifierTests.swift
@@ -41,7 +41,7 @@ final class GlobalModifierTests: XCTestCase {
         )
         loadKoinMocks(repositories: mockRepos)
 
-        let sut = Text("test").global(globalBinding, errorKey: ErrorKey(type: KeyType.Permanent(), id: "ErrorKey"))
+        let sut = Text("test").global(globalBinding, errorKey: ErrorKey(type: [], id: "ErrorKey"))
 
         ViewHosting.host(view: sut)
 

--- a/iosApp/iosAppTests/Views/HomeMapViewTests.swift
+++ b/iosApp/iosAppTests/Views/HomeMapViewTests.swift
@@ -471,7 +471,7 @@ final class HomeMapViewTests: XCTestCase {
 
         func connect(routeId _: LineOrRoute.Id,
                      directionId _: Int32,
-                     errorKey _: String,
+                     errorKey _: ErrorKey,
                      onReceive _: @escaping (ApiResult<VehiclesStreamDataResponse>) -> Void) {
             connectExp?.fulfill()
         }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
@@ -6,6 +6,7 @@ import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.network.receiveAll
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -37,7 +38,7 @@ internal class ChannelOwner<MessageData : Any>(
         spec: ChannelSpec,
         parseMessage: (String) -> MessageData,
         handleResult: (ApiResult<MessageData>) -> Unit,
-        errorKey: String,
+        errorKey: ErrorKey,
     ) = owner.connect(spec, parseMessage, parseMessage, handleResult, handleResult, errorKey)
 
     fun disconnect() = owner.disconnect()
@@ -59,7 +60,7 @@ internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
         parseMessage: (String) -> MessageData,
         handleJoinResult: (ApiResult<JoinData>) -> Unit,
         handleResult: (ApiResult<MessageData>) -> Unit,
-        errorKey: String,
+        errorKey: ErrorKey,
     ) {
         fun <Data : Any> parseResult(
             message: PhoenixMessage,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -42,7 +42,7 @@ internal class AlertsRepository(
                 }
                 onReceive(it)
             },
-            "AlertsRepository",
+            ErrorKey(KeyType.Permanent, "AlertsRepository"),
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -42,7 +42,7 @@ internal class AlertsRepository(
                 }
                 onReceive(it)
             },
-            ErrorKey(KeyType.Permanent, "AlertsRepository"),
+            ErrorKey(setOf(), "AlertsRepository"),
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -23,19 +23,14 @@ internal sealed class NetworkStatus {
 }
 
 /**
- * Represent the type of the error. [KeyType.Permanent] represents an error that should persist in
- * the banner and can be retried until it is successful. [KeyType.PageSpecific] represents an error
- * that should no longer be retried once the user has navigated to a [SheetRoutes] of a different
- * type.
+ * Represent an error, and the page(s) on which it occurred. If the current [SheetRoutes] matches
+ * the pages for the error, then it can be shown in the banner and retried. If the error for is a
+ * page that is not the current [SheetRoutes], then it should be discarded.
+ *
+ * An empty value for [ErrorKey.sheets] means that the error should be shown in the banner and
+ * retried across all pages.
  */
-public sealed class KeyType {
-
-    public data object Permanent : KeyType()
-
-    public data class PageSpecific(val sheet: KClass<out SheetRoutes>?) : KeyType()
-}
-
-public data class ErrorKey(public val type: KeyType, public val id: String) {
+public data class ErrorKey(public val sheets: Set<KClass<out SheetRoutes>>, public val id: String) {
     public fun withSuffix(suffix: String): ErrorKey {
         return this.copy(id = "$id$suffix")
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -5,6 +5,7 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,6 +20,25 @@ internal sealed class NetworkStatus {
     data object Connected : NetworkStatus()
 
     data object Disconnected : NetworkStatus()
+}
+
+/**
+ * Represent the type of the error. [KeyType.Permanent] represents an error that should persist in
+ * the banner and can be retried until it is successful. [KeyType.PageSpecific] represents an error
+ * that should no longer be retried once the user has navigated to a [SheetRoutes] of a different
+ * type.
+ */
+public sealed class KeyType {
+
+    public data object Permanent : KeyType()
+
+    public data class PageSpecific(val sheet: KClass<out SheetRoutes>?) : KeyType()
+}
+
+public data class ErrorKey(public val type: KeyType, public val id: String) {
+    public fun withSuffix(suffix: String): ErrorKey {
+        return this.copy(id = "$id$suffix")
+    }
 }
 
 public abstract class IErrorBannerStateRepository
@@ -43,7 +63,7 @@ internal constructor(initialState: ErrorBannerState? = null) : KoinComponent {
 
     private var sheetRoute: SheetRoutes? = null
     private var predictionsStale: ErrorBannerState.StalePredictions? = null
-    private val dataErrors = mutableMapOf<String, ErrorBannerState.DataError>()
+    private val dataErrors = mutableMapOf<ErrorKey, ErrorBannerState.DataError>()
     private val mutex = Mutex()
 
     protected open fun updateState() {
@@ -53,7 +73,7 @@ internal constructor(initialState: ErrorBannerState? = null) : KoinComponent {
                 dataErrors.isNotEmpty() ->
                     // encapsulate all the different error actions within one error
                     ErrorBannerState.DataError(
-                        messages = dataErrors.keys,
+                        messages = dataErrors.keys.map { it.id }.toSet(),
                         details = dataErrors.values.flatMap { it.details }.toSet(),
                         action = { dataErrors.values.forEach { it.action() } },
                     )
@@ -92,14 +112,14 @@ internal constructor(initialState: ErrorBannerState? = null) : KoinComponent {
         updateState()
     }
 
-    public suspend fun setDataError(key: String, details: String, action: () -> Unit) {
+    public suspend fun setDataError(key: ErrorKey, details: String, action: () -> Unit) {
         mutex.withLock {
-            dataErrors[key] = ErrorBannerState.DataError(setOf(key), setOf(details), action)
+            dataErrors[key] = ErrorBannerState.DataError(setOf(key.id), setOf(details), action)
         }
         updateState()
     }
 
-    public suspend fun clearDataError(key: String) {
+    public suspend fun clearDataError(key: ErrorKey) {
         mutex.withLock { dataErrors.remove(key) }
         updateState()
     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -32,7 +32,7 @@ internal sealed class NetworkStatus {
  */
 public data class ErrorKey(public val sheets: Set<KClass<out SheetRoutes>>, public val id: String) {
     public fun withSuffix(suffix: String): ErrorKey {
-        return this.copy(id = "$id$suffix")
+        return this.copy(id = "$id.$suffix")
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepository.kt
@@ -17,7 +17,7 @@ import org.koin.core.component.KoinComponent
 public interface IPredictionsRepository {
     public fun connect(
         stopIds: List<String>,
-        errorKey: String,
+        errorKey: ErrorKey,
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     )
@@ -52,7 +52,7 @@ internal class PredictionsRepository(
 
     override fun connect(
         stopIds: List<String>,
-        errorKey: String,
+        errorKey: ErrorKey,
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     ) {
@@ -107,7 +107,7 @@ constructor(
 
     override fun connect(
         stopIds: List<String>,
-        errorKey: String,
+        errorKey: ErrorKey,
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     ) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepository.kt
@@ -16,7 +16,7 @@ import org.koin.core.component.KoinComponent
 public interface ITripPredictionsRepository {
     public fun connect(
         tripId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
     )
 
@@ -50,7 +50,7 @@ internal class TripPredictionsRepository(
 
     override fun connect(
         tripId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
     ) {
         channelOwner.connect(
@@ -86,7 +86,7 @@ constructor(
 
     override fun connect(
         tripId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
     ) {
         onReceive(ApiResult.Ok(response))

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepository.kt
@@ -13,7 +13,7 @@ import org.koin.core.component.KoinComponent
 public interface IVehicleRepository {
     public fun connect(
         vehicleId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit,
     )
 
@@ -37,7 +37,7 @@ internal class VehicleRepository(
 
     override fun connect(
         vehicleId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit,
     ) {
         channelOwner.connect(
@@ -68,7 +68,7 @@ constructor(
 ) : IVehicleRepository {
     override fun connect(
         vehicleId: String,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit,
     ) {
         outcome?.let { onReceive(it) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepository.kt
@@ -20,7 +20,7 @@ public interface IVehiclesRepository {
     public fun connect(
         routeId: LineOrRoute.Id,
         directionId: Int,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehiclesStreamDataResponse>) -> Unit,
     )
 
@@ -45,7 +45,7 @@ internal class VehiclesRepository(
     override fun connect(
         routeId: LineOrRoute.Id,
         directionId: Int,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehiclesStreamDataResponse>) -> Unit,
     ) {
         channelOwner.connect(
@@ -94,7 +94,7 @@ constructor(
     override fun connect(
         routeId: LineOrRoute.Id,
         directionId: Int,
-        errorKey: String,
+        errorKey: ErrorKey,
         onReceive: (ApiResult<VehiclesStreamDataResponse>) -> Unit,
     ) {
         onConnect(routeId, directionId)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -17,7 +17,6 @@ import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
@@ -145,7 +144,7 @@ public class FavoritesViewModel(
 
         var active: Boolean by remember { mutableStateOf(false) }
 
-        val errorKey = ErrorKey(KeyType.Permanent, "FavoritesViewModel")
+        val errorKey = ErrorKey(setOf(), "FavoritesViewModel")
         val globalData = getGlobalData(errorKey)
         val stopIds =
             remember(favorites, globalData) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -13,9 +13,11 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.IPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.usecases.FavoritesUsecases
@@ -143,7 +145,7 @@ public class FavoritesViewModel(
 
         var active: Boolean by remember { mutableStateOf(false) }
 
-        val errorKey = "FavoritesViewModel"
+        val errorKey = ErrorKey(KeyType.Permanent, "FavoritesViewModel")
         val globalData = getGlobalData(errorKey)
         val stopIds =
             remember(favorites, globalData) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -32,7 +32,6 @@ import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.IMapLayerManager
@@ -740,7 +739,7 @@ public class MapViewModel(
 
     private fun fetchRailRouteShapes(onSuccess: (MapFriendlyRouteResponse) -> Unit) {
         CoroutineScope(iOCoroutineDispatcher).launch {
-            val errorKey = ErrorKey(KeyType.Permanent, "MapViewModel.fetchRailRouteShapes")
+            val errorKey = ErrorKey(setOf(), "MapViewModel.fetchRailRouteShapes")
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
                 errorKey = errorKey,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModel.kt
@@ -25,12 +25,14 @@ import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.MapFriendlyRouteResponse
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import com.mbta.tid.mbta_app.repositories.IRailRouteShapeRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.IStopRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.IMapLayerManager
@@ -738,7 +740,7 @@ public class MapViewModel(
 
     private fun fetchRailRouteShapes(onSuccess: (MapFriendlyRouteResponse) -> Unit) {
         CoroutineScope(iOCoroutineDispatcher).launch {
-            val errorKey = "MapViewModel.fetchRailRouteShapes"
+            val errorKey = ErrorKey(KeyType.Permanent, "MapViewModel.fetchRailRouteShapes")
             fetchApi(
                 errorBannerRepo = errorBannerRepository,
                 errorKey = errorKey,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModel.kt
@@ -12,6 +12,7 @@ import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.INearbyRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -80,7 +81,7 @@ public class NearbyViewModel(
 
         var active: Boolean by remember { mutableStateOf(false) }
 
-        val errorKey = "NearbyViewModel"
+        val errorKey = ErrorKey(setOf(SheetRoutes.NearbyTransit::class), "NearbyViewModel")
         val globalData = getGlobalData(errorKey)
         val schedules = getSchedules(stopIds, errorKey)
         val predictions =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
@@ -19,7 +19,6 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
@@ -104,7 +103,7 @@ public class StopDetailsViewModel(
 
         var active: Boolean by remember { mutableStateOf(true) }
 
-        val errorKey = ErrorKey(KeyType.Permanent, "StopDetailsViewModel")
+        val errorKey = ErrorKey(setOf(), "StopDetailsViewModel")
         val globalData = getGlobalData(errorKey, coroutineDispatcher = coroutineDispatcher)
 
         val stopIds =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
@@ -14,10 +14,12 @@ import com.mbta.tid.mbta_app.model.StopDetailsPageFilters
 import com.mbta.tid.mbta_app.model.StopDetailsUtils
 import com.mbta.tid.mbta_app.model.hasContext
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
@@ -102,7 +104,7 @@ public class StopDetailsViewModel(
 
         var active: Boolean by remember { mutableStateOf(true) }
 
-        val errorKey = "StopDetailsViewModel"
+        val errorKey = ErrorKey(KeyType.Permanent, "StopDetailsViewModel")
         val globalData = getGlobalData(errorKey, coroutineDispatcher = coroutineDispatcher)
 
         val stopIds =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -19,7 +19,6 @@ import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.discardTrackChangesAtCRCore
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import kotlin.jvm.JvmName
@@ -62,7 +61,7 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
 
     @Composable
     override fun runLogic(): State {
-        val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsPage"))
+        val global = getGlobalData(ErrorKey(setOf(), "TripDetailsPage"))
 
         val stop = global?.getStop(filter?.stopId)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModel.kt
@@ -18,6 +18,8 @@ import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.discardTrackChangesAtCRCore
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import kotlin.jvm.JvmName
@@ -60,7 +62,7 @@ public class TripDetailsPageViewModel(private val tripDetailsVM: ITripDetailsVie
 
     @Composable
     override fun runLogic(): State {
-        val global = getGlobalData("TripDetailsPage")
+        val global = getGlobalData(ErrorKey(KeyType.Permanent, "TripDetailsPage"))
 
         val stop = global?.getStop(filter?.stopId)
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModel.kt
@@ -12,11 +12,13 @@ import com.mbta.tid.mbta_app.model.TripDetailsStopList
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getTripData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getTripDetailsStopList
@@ -87,7 +89,7 @@ public class TripDetailsViewModel(
         var awaitingPredictionsAfterBackground: Boolean by remember { mutableStateOf(false) }
         var active: Boolean by remember { mutableStateOf(true) }
 
-        val errorKey = "TripDetailsViewModel"
+        val errorKey = ErrorKey(KeyType.Permanent, "TripDetailsViewModel")
         val globalData = getGlobalData(errorKey, coroutineDispatcher = coroutineDispatcher)
 
         val tripData =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModel.kt
@@ -18,7 +18,6 @@ import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getGlobalData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getTripData
 import com.mbta.tid.mbta_app.viewModel.composeStateHelpers.getTripDetailsStopList
@@ -89,7 +88,7 @@ public class TripDetailsViewModel(
         var awaitingPredictionsAfterBackground: Boolean by remember { mutableStateOf(false) }
         var active: Boolean by remember { mutableStateOf(true) }
 
-        val errorKey = ErrorKey(KeyType.Permanent, "TripDetailsViewModel")
+        val errorKey = ErrorKey(setOf(), "TripDetailsViewModel")
         val globalData = getGlobalData(errorKey, coroutineDispatcher = coroutineDispatcher)
 
         val tripData =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/fetchApi.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.viewModel.composeStateHelpers
 
 import com.mbta.tid.mbta_app.model.response.ApiResult
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 
 /**
@@ -10,7 +11,7 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
  */
 internal suspend fun <T : Any> fetchApi(
     errorBannerRepo: IErrorBannerStateRepository,
-    errorKey: String,
+    errorKey: ErrorKey,
     getData: suspend () -> ApiResult<T>,
     onSuccess: suspend (T) -> Unit = {},
     onRefreshAfterError: () -> Unit,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
@@ -50,7 +50,7 @@ internal fun getGlobalData(
     val globalResponse: GlobalResponse? by globalRepository.state.collectAsState()
     LaunchedEffect(Unit) {
         fetchGlobalData(
-            errorKey.withSuffix(".getGlobalData"),
+            errorKey.withSuffix("getGlobalData"),
             errorBannerRepository,
             globalRepository,
             coroutineDispatcher,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
 import kotlinx.coroutines.CoroutineDispatcher
@@ -15,7 +16,7 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 private fun fetchGlobalData(
-    errorKey: String,
+    errorKey: ErrorKey,
     errorBannerRepository: IErrorBannerStateRepository,
     globalRepository: IGlobalRepository,
     coroutineDispatcher: CoroutineDispatcher,
@@ -41,7 +42,7 @@ private fun fetchGlobalData(
 
 @Composable
 internal fun getGlobalData(
-    errorKey: String,
+    errorKey: ErrorKey,
     globalRepository: IGlobalRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -49,7 +50,7 @@ internal fun getGlobalData(
     val globalResponse: GlobalResponse? by globalRepository.state.collectAsState()
     LaunchedEffect(Unit) {
         fetchGlobalData(
-            "$errorKey.getGlobalData",
+            errorKey.withSuffix("getGlobalData"),
             errorBannerRepository,
             globalRepository,
             coroutineDispatcher,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getGlobalData.kt
@@ -50,7 +50,7 @@ internal fun getGlobalData(
     val globalResponse: GlobalResponse? by globalRepository.state.collectAsState()
     LaunchedEffect(Unit) {
         fetchGlobalData(
-            errorKey.withSuffix("getGlobalData"),
+            errorKey.withSuffix(".getGlobalData"),
             errorBannerRepository,
             globalRepository,
             coroutineDispatcher,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -54,7 +54,7 @@ internal fun getSchedules(
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): ScheduleResponse? {
-    val errorKey = errorKey.withSuffix(".getSchedules")
+    val errorKey = errorKey.withSuffix("getSchedules")
     var result: ScheduleResponse? by remember { mutableStateOf(null) }
 
     LaunchedEffect(stopIds) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISchedulesRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -19,7 +20,7 @@ import org.koin.compose.koinInject
 
 private fun fetchSchedules(
     stopIds: List<String>,
-    errorKey: String,
+    errorKey: ErrorKey,
     errorBannerRepository: IErrorBannerStateRepository,
     schedulesRepository: ISchedulesRepository,
     coroutineDispatcher: CoroutineDispatcher,
@@ -48,12 +49,12 @@ private fun fetchSchedules(
 @Composable
 internal fun getSchedules(
     stopIds: List<String>?,
-    errorKey: String,
+    errorKey: ErrorKey,
     schedulesRepository: ISchedulesRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): ScheduleResponse? {
-    val errorKey = "$errorKey.getSchedules"
+    val errorKey = errorKey.withSuffix("getSchedules")
     var result: ScheduleResponse? by remember { mutableStateOf(null) }
 
     LaunchedEffect(stopIds) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -54,7 +54,7 @@ internal fun getSchedules(
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): ScheduleResponse? {
-    val errorKey = errorKey.withSuffix("getSchedules")
+    val errorKey = errorKey.withSuffix(".getSchedules")
     var result: ScheduleResponse? by remember { mutableStateOf(null) }
 
     LaunchedEffect(stopIds) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
-private fun fetchTripErrorKey(errorKey: ErrorKey) = errorKey.withSuffix(".fetchTrip")
+private fun fetchTripErrorKey(errorKey: ErrorKey) = errorKey.withSuffix("fetchTrip")
 
 private fun fetchTrip(
     tripId: String,
@@ -44,7 +44,7 @@ private fun fetchTrip(
 }
 
 private fun fetchTripSchedulesErrorKey(errorKey: ErrorKey) =
-    errorKey.withSuffix(".fetchTripSchedules")
+    errorKey.withSuffix("fetchTripSchedules")
 
 private fun fetchTripSchedules(
     tripId: String,
@@ -86,7 +86,7 @@ internal fun getTripData(
     tripRepository: ITripRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
 ): TripData? {
-    val errorKey = errorKey.withSuffix(".getTripData")
+    val errorKey = errorKey.withSuffix("getTripData")
 
     var trip: Trip? by remember { mutableStateOf(null) }
     var tripSchedules: TripSchedulesResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -12,6 +12,7 @@ import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.ITripRepository
@@ -22,7 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
-private fun fetchTripErrorKey(prefix: String) = "${prefix}.fetchTrip"
+private fun fetchTripErrorKey(errorKey: ErrorKey) = errorKey.withSuffix("fetchTrip")
 
 private fun fetchTrip(
     tripId: String,
@@ -42,7 +43,8 @@ private fun fetchTrip(
     }
 }
 
-private fun fetchTripSchedulesErrorKey(prefix: String) = "${prefix}.fetchTripSchedules"
+private fun fetchTripSchedulesErrorKey(errorKey: ErrorKey) =
+    errorKey.withSuffix("fetchTripSchedules")
 
 private fun fetchTripSchedules(
     tripId: String,
@@ -65,7 +67,7 @@ private fun fetchTripSchedules(
 }
 
 private data class FetchParams(
-    val errorKey: String,
+    val errorKey: ErrorKey,
     val coroutineDispatcher: CoroutineDispatcher,
     val errorBannerRepository: IErrorBannerStateRepository,
     val tripRepository: ITripRepository,
@@ -77,14 +79,14 @@ internal fun getTripData(
     active: Boolean,
     context: TripDetailsViewModel.Context?,
     onPredictionMessageReceived: () -> Unit,
-    errorKey: String,
+    errorKey: ErrorKey,
     coroutineDispatcher: CoroutineDispatcher,
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     tripPredictionsRepository: ITripPredictionsRepository = koinInject(),
     tripRepository: ITripRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
 ): TripData? {
-    val errorKey = "$errorKey.getTripData"
+    val errorKey = errorKey.withSuffix("getTripData")
 
     var trip: Trip? by remember { mutableStateOf(null) }
     var tripSchedules: TripSchedulesResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
-private fun fetchTripErrorKey(errorKey: ErrorKey) = errorKey.withSuffix("fetchTrip")
+private fun fetchTripErrorKey(errorKey: ErrorKey) = errorKey.withSuffix(".fetchTrip")
 
 private fun fetchTrip(
     tripId: String,
@@ -44,7 +44,7 @@ private fun fetchTrip(
 }
 
 private fun fetchTripSchedulesErrorKey(errorKey: ErrorKey) =
-    errorKey.withSuffix("fetchTripSchedules")
+    errorKey.withSuffix(".fetchTripSchedules")
 
 private fun fetchTripSchedules(
     tripId: String,
@@ -86,7 +86,7 @@ internal fun getTripData(
     tripRepository: ITripRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
 ): TripData? {
-    val errorKey = errorKey.withSuffix("getTripData")
+    val errorKey = errorKey.withSuffix(".getTripData")
 
     var trip: Trip? by remember { mutableStateOf(null) }
     var tripSchedules: TripSchedulesResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -32,7 +32,7 @@ internal fun subscribeToPredictions(
     predictionsRepository: IPredictionsRepository = koinInject(),
     checkPredictionsStaleInterval: Duration = 5.seconds,
 ): PredictionsStreamDataResponse? {
-    val errorKey = errorKey.withSuffix(".subscribeToPredictions")
+    val errorKey = errorKey.withSuffix("subscribeToPredictions")
     val staleTimer by timer(checkPredictionsStaleInterval)
 
     var predictions: PredictionsByStopJoinResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -32,7 +32,7 @@ internal fun subscribeToPredictions(
     predictionsRepository: IPredictionsRepository = koinInject(),
     checkPredictionsStaleInterval: Duration = 5.seconds,
 ): PredictionsStreamDataResponse? {
-    val errorKey = errorKey.withSuffix("subscribeToPredictions")
+    val errorKey = errorKey.withSuffix(".subscribeToPredictions")
     val staleTimer by timer(checkPredictionsStaleInterval)
 
     var predictions: PredictionsByStopJoinResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -12,6 +12,7 @@ import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopMessageResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.orEmpty
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IPredictionsRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -25,13 +26,13 @@ internal fun subscribeToPredictions(
     stopIds: List<String>?,
     sheetRoute: SheetRoutes?,
     active: Boolean,
-    errorKey: String,
+    errorKey: ErrorKey,
     onAnyMessageReceived: () -> Unit = {},
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     predictionsRepository: IPredictionsRepository = koinInject(),
     checkPredictionsStaleInterval: Duration = 5.seconds,
 ): PredictionsStreamDataResponse? {
-    val errorKey = "$errorKey.subscribeToPredictions"
+    val errorKey = errorKey.withSuffix("subscribeToPredictions")
     val staleTimer by timer(checkPredictionsStaleInterval)
 
     var predictions: PredictionsByStopJoinResponse? by remember { mutableStateOf(null) }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ITripPredictionsRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
@@ -20,13 +21,14 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import org.koin.compose.koinInject
 
-internal fun tripPredictionsErrorKey(prefix: String) = "$prefix.subscribeToTripPredictions"
+internal fun tripPredictionsErrorKey(errorKey: ErrorKey) =
+    errorKey.withSuffix("subscribeToTripPredictions")
 
 @OptIn(ExperimentalTime::class)
 @Composable
 internal fun subscribeToTripPredictions(
     tripFilter: TripDetailsPageFilter?,
-    errorKey: String,
+    errorKey: ErrorKey,
     active: Boolean,
     context: TripDetailsViewModel.Context?,
     onAnyMessageReceived: () -> Unit = {},

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
@@ -22,7 +22,7 @@ import kotlin.time.ExperimentalTime
 import org.koin.compose.koinInject
 
 internal fun tripPredictionsErrorKey(errorKey: ErrorKey) =
-    errorKey.withSuffix("subscribeToTripPredictions")
+    errorKey.withSuffix(".subscribeToTripPredictions")
 
 @OptIn(ExperimentalTime::class)
 @Composable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
@@ -22,7 +22,7 @@ import kotlin.time.ExperimentalTime
 import org.koin.compose.koinInject
 
 internal fun tripPredictionsErrorKey(errorKey: ErrorKey) =
-    errorKey.withSuffix(".subscribeToTripPredictions")
+    errorKey.withSuffix("subscribeToTripPredictions")
 
 @OptIn(ExperimentalTime::class)
 @Composable

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -23,7 +23,7 @@ internal fun subscribeToVehicle(
     vehicleRepository: IVehicleRepository = koinInject(),
 ): Vehicle? {
     var vehicle: Vehicle? by remember { mutableStateOf(null) }
-    val errorKey = errorKey.withSuffix("subscribeToVehicle")
+    val errorKey = errorKey.withSuffix("w+")
 
     fun connect(vehicleId: String?, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit) {
         vehicleRepository.disconnect()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -23,7 +23,7 @@ internal fun subscribeToVehicle(
     vehicleRepository: IVehicleRepository = koinInject(),
 ): Vehicle? {
     var vehicle: Vehicle? by remember { mutableStateOf(null) }
-    val errorKey = errorKey.withSuffix("w+")
+    val errorKey = errorKey.withSuffix("subscribeToVehicle")
 
     fun connect(vehicleId: String?, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit) {
         vehicleRepository.disconnect()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
 import org.koin.compose.koinInject
@@ -16,13 +17,13 @@ import org.koin.compose.koinInject
 @Composable
 internal fun subscribeToVehicle(
     vehicleId: String?,
-    errorKey: String,
+    errorKey: ErrorKey,
     active: Boolean,
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
 ): Vehicle? {
     var vehicle: Vehicle? by remember { mutableStateOf(null) }
-    val errorKey = "$errorKey.subscribeToVehicle"
+    val errorKey = errorKey.withSuffix("subscribeToVehicle")
 
     fun connect(vehicleId: String?, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit) {
         vehicleRepository.disconnect()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
@@ -76,11 +76,11 @@ class ErrorBannerStateRepositoryTest {
             SheetRoutes.NearbyTransit,
         ) {}
 
-        repo.setDataError("global", "") {}
+        repo.setDataError(ErrorKey(KeyType.Permanent, "global"), "") {}
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
 
-        repo.clearDataError("global")
+        repo.clearDataError(ErrorKey(KeyType.Permanent, "global"))
 
         assertIs<ErrorBannerState.StalePredictions>(repo.state.value)
     }
@@ -90,9 +90,9 @@ class ErrorBannerStateRepositoryTest {
         val repo = ErrorBannerStateRepository()
         val actionsCalled = mutableSetOf<String>()
 
-        repo.setDataError("a", "") { actionsCalled.add("a") }
-        repo.setDataError("b", "") { actionsCalled.add("b") }
-        repo.setDataError("c", "") { actionsCalled.add("c") }
+        repo.setDataError(ErrorKey(KeyType.Permanent, "a"), "") { actionsCalled.add("a") }
+        repo.setDataError(ErrorKey(KeyType.Permanent, "b"), "") { actionsCalled.add("b") }
+        repo.setDataError(ErrorKey(KeyType.Permanent, "c"), "") { actionsCalled.add("c") }
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
         repo.state.value?.action?.invoke()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepositoryTest.kt
@@ -76,11 +76,11 @@ class ErrorBannerStateRepositoryTest {
             SheetRoutes.NearbyTransit,
         ) {}
 
-        repo.setDataError(ErrorKey(KeyType.Permanent, "global"), "") {}
+        repo.setDataError(ErrorKey(setOf(), "global"), "") {}
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
 
-        repo.clearDataError(ErrorKey(KeyType.Permanent, "global"))
+        repo.clearDataError(ErrorKey(setOf(), "global"))
 
         assertIs<ErrorBannerState.StalePredictions>(repo.state.value)
     }
@@ -90,9 +90,9 @@ class ErrorBannerStateRepositoryTest {
         val repo = ErrorBannerStateRepository()
         val actionsCalled = mutableSetOf<String>()
 
-        repo.setDataError(ErrorKey(KeyType.Permanent, "a"), "") { actionsCalled.add("a") }
-        repo.setDataError(ErrorKey(KeyType.Permanent, "b"), "") { actionsCalled.add("b") }
-        repo.setDataError(ErrorKey(KeyType.Permanent, "c"), "") { actionsCalled.add("c") }
+        repo.setDataError(ErrorKey(setOf(), "a"), "") { actionsCalled.add("a") }
+        repo.setDataError(ErrorKey(setOf(), "b"), "") { actionsCalled.add("b") }
+        repo.setDataError(ErrorKey(setOf(), "c"), "") { actionsCalled.add("c") }
 
         assertIs<ErrorBannerState.DataError>(repo.state.value)
         repo.state.value?.action?.invoke()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -60,7 +60,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = "testV2ChannelSetOnRun",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelSetOnRun"),
         )
         advanceUntilIdle()
 
@@ -90,7 +90,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = "testV2ChannelJoinTwiceLeavesOldChannel",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelJoinTwiceLeavesOldChannel"),
         )
         advanceUntilIdle()
 
@@ -100,7 +100,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("3", "4"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = "testV2ChannelJoinTwiceLeavesOldChannel",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelJoinTwiceLeavesOldChannel"),
         )
         advanceUntilIdle()
 
@@ -130,7 +130,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = "testV2ChannelClearedOnLeave",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelClearedOnLeave"),
         )
         advanceUntilIdle()
 
@@ -238,7 +238,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertEquals("v_1", data.vehicles["v_1"]?.id)
             },
             onMessage = { /* no-op */ },
-            errorKey = "testV2SetsPredictionsOnJoinResponse",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2SetsPredictionsOnJoinResponse"),
         )
     }
 
@@ -354,7 +354,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertEquals(SocketError.RECEIVED_ERROR, outcome.message)
             },
             onMessage = { /* no-op */ },
-            errorKey = "testV2SetsErrorWhenReceivedOnJoin",
+            errorKey = ErrorKey(KeyType.Permanent, "testV2SetsErrorWhenReceivedOnJoin"),
         )
     }
 
@@ -393,7 +393,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertContains(outcome.message, SocketError.TIMEOUT)
             },
             onMessage = { /* no-op */ },
-            errorKey = "v2 sets error when timeout on join",
+            errorKey = ErrorKey(KeyType.Permanent, "v2 sets error when timeout on join"),
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -60,7 +60,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelSetOnRun"),
+            errorKey = ErrorKey(setOf(), "testV2ChannelSetOnRun"),
         )
         advanceUntilIdle()
 
@@ -90,7 +90,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelJoinTwiceLeavesOldChannel"),
+            errorKey = ErrorKey(setOf(), "testV2ChannelJoinTwiceLeavesOldChannel"),
         )
         advanceUntilIdle()
 
@@ -100,7 +100,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("3", "4"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelJoinTwiceLeavesOldChannel"),
+            errorKey = ErrorKey(setOf(), "testV2ChannelJoinTwiceLeavesOldChannel"),
         )
         advanceUntilIdle()
 
@@ -130,7 +130,7 @@ class PredictionsRepositoryTests : KoinTest {
             stopIds = listOf("1", "2"),
             onJoin = { /* no-op */ },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2ChannelClearedOnLeave"),
+            errorKey = ErrorKey(setOf(), "testV2ChannelClearedOnLeave"),
         )
         advanceUntilIdle()
 
@@ -238,7 +238,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertEquals("v_1", data.vehicles["v_1"]?.id)
             },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2SetsPredictionsOnJoinResponse"),
+            errorKey = ErrorKey(setOf(), "testV2SetsPredictionsOnJoinResponse"),
         )
     }
 
@@ -354,7 +354,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertEquals(SocketError.RECEIVED_ERROR, outcome.message)
             },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testV2SetsErrorWhenReceivedOnJoin"),
+            errorKey = ErrorKey(setOf(), "testV2SetsErrorWhenReceivedOnJoin"),
         )
     }
 
@@ -393,7 +393,7 @@ class PredictionsRepositoryTests : KoinTest {
                 assertContains(outcome.message, SocketError.TIMEOUT)
             },
             onMessage = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "v2 sets error when timeout on join"),
+            errorKey = ErrorKey(setOf(), "v2 sets error when timeout on join"),
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
@@ -39,7 +39,7 @@ class TripPredictionsRepositoryTests {
         tripPredictionsRepo.connect(
             tripId = "Test",
             onReceive = {},
-            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
+            errorKey = ErrorKey(setOf(), "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/TripPredictionsRepositoryTests.kt
@@ -39,7 +39,7 @@ class TripPredictionsRepositoryTests {
         tripPredictionsRepo.connect(
             tripId = "Test",
             onReceive = {},
-            errorKey = "testChannelClearedBeforeJoin",
+            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
@@ -39,7 +39,7 @@ class VehicleRepositoryTests {
         vehicleRepo.connect(
             vehicleId = "Test",
             onReceive = {},
-            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
+            errorKey = ErrorKey(setOf(), "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehicleRepositoryTests.kt
@@ -39,7 +39,7 @@ class VehicleRepositoryTests {
         vehicleRepo.connect(
             vehicleId = "Test",
             onReceive = {},
-            errorKey = "testChannelClearedBeforeJoin",
+            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
@@ -56,7 +56,7 @@ class VehiclesRepositoryTest : KoinTest {
             routeId = Route.Id("Red"),
             directionId = 0,
             onReceive = { /* no-op */ },
-            errorKey = ErrorKey(KeyType.Permanent, "testChannelSetOnRun"),
+            errorKey = ErrorKey(setOf(), "testChannelSetOnRun"),
         )
         advanceUntilIdle()
         assertNotNull(vehiclesRepo.channel)
@@ -102,7 +102,7 @@ class VehiclesRepositoryTest : KoinTest {
             routeId = Route.Id("Test"),
             directionId = 0,
             onReceive = {},
-            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
+            errorKey = ErrorKey(setOf(), "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }
@@ -136,7 +136,7 @@ class VehiclesRepositoryTest : KoinTest {
             onReceive = { outcome ->
                 assertEquals(VehiclesStreamDataResponse(emptyMap()), outcome.dataOrThrow())
             },
-            errorKey = ErrorKey(KeyType.Permanent, "testSetsVehiclesOnJoinResponse"),
+            errorKey = ErrorKey(setOf(), "testSetsVehiclesOnJoinResponse"),
         )
     }
 
@@ -177,7 +177,7 @@ class VehiclesRepositoryTest : KoinTest {
                 assertIs<ApiResult.Error<*>>(outcome)
                 assertContains(outcome.message, SocketError.FAILURE)
             },
-            errorKey = ErrorKey(KeyType.Permanent, "testSetsErrorWhenErrorReceived"),
+            errorKey = ErrorKey(setOf(), "testSetsErrorWhenErrorReceived"),
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
@@ -56,7 +56,7 @@ class VehiclesRepositoryTest : KoinTest {
             routeId = Route.Id("Red"),
             directionId = 0,
             onReceive = { /* no-op */ },
-            errorKey = "testChannelSetOnRun",
+            errorKey = ErrorKey(KeyType.Permanent, "testChannelSetOnRun"),
         )
         advanceUntilIdle()
         assertNotNull(vehiclesRepo.channel)
@@ -102,7 +102,7 @@ class VehiclesRepositoryTest : KoinTest {
             routeId = Route.Id("Test"),
             directionId = 0,
             onReceive = {},
-            errorKey = "testChannelClearedBeforeJoin",
+            errorKey = ErrorKey(KeyType.Permanent, "testChannelClearedBeforeJoin"),
         )
         advanceUntilIdle()
         verify { channel.detach() }
@@ -136,7 +136,7 @@ class VehiclesRepositoryTest : KoinTest {
             onReceive = { outcome ->
                 assertEquals(VehiclesStreamDataResponse(emptyMap()), outcome.dataOrThrow())
             },
-            errorKey = "testSetsVehiclesOnJoinResponse",
+            errorKey = ErrorKey(KeyType.Permanent, "testSetsVehiclesOnJoinResponse"),
         )
     }
 
@@ -177,7 +177,7 @@ class VehiclesRepositoryTest : KoinTest {
                 assertIs<ApiResult.Error<*>>(outcome)
                 assertContains(outcome.message, SocketError.FAILURE)
             },
-            errorKey = "testSetsErrorWhenErrorReceived",
+            errorKey = ErrorKey(KeyType.Permanent, "testSetsErrorWhenErrorReceived"),
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
@@ -7,7 +7,9 @@ import com.mbta.tid.mbta_app.model.ErrorBannerState
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
+import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
+import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import dev.mokkery.MockMode
@@ -89,7 +91,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
 
-            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
             val state = awaitItem().errorState
             assertEquals(setOf("FakeError"), (state as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), state.details)
@@ -109,7 +111,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             viewModel.clearState()
@@ -147,7 +149,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), nextState.details)
@@ -171,7 +173,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             viewModel.setSheetRoute(SheetRoutes.Favorites)
             advanceUntilIdle()
-            errorRepo.setDataError("FakeError", "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), nextState.details)
@@ -265,7 +267,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             var nextState = awaitItem().errorState
             assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("error details"), nextState.details)
@@ -274,7 +276,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 1.seconds
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             nextState = awaitItem().errorState
             assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("error details"), nextState.details)
@@ -327,12 +329,12 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 2.minutes
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
             verifyNoMoreCalls(sentryRepo)
         }
@@ -375,12 +377,12 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 1.seconds
-            errorRepo.setDataError("ErrorKey", "error details") {}
+            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
             verifyNoMoreCalls(sentryRepo)
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
@@ -9,7 +9,6 @@ import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
-import com.mbta.tid.mbta_app.repositories.KeyType
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import dev.mokkery.MockMode
@@ -91,7 +90,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
 
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(setOf(), "FakeError"), "FakeDetails", action)
             val state = awaitItem().errorState
             assertEquals(setOf("FakeError"), (state as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), state.details)
@@ -111,7 +110,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(setOf(), "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             viewModel.clearState()
@@ -149,7 +148,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(setOf(), "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), nextState.details)
@@ -173,7 +172,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             viewModel.setSheetRoute(SheetRoutes.Favorites)
             advanceUntilIdle()
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "FakeError"), "FakeDetails", action)
+            errorRepo.setDataError(ErrorKey(setOf(), "FakeError"), "FakeDetails", action)
             val nextState = awaitItem().errorState
             assertEquals(setOf("FakeError"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("FakeDetails"), nextState.details)
@@ -267,7 +266,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             var nextState = awaitItem().errorState
             assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("error details"), nextState.details)
@@ -276,7 +275,7 @@ internal class ErrorBannerViewModelTest : KoinTest {
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 1.seconds
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             nextState = awaitItem().errorState
             assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
             assertEquals(setOf("error details"), nextState.details)
@@ -329,12 +328,12 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 2.minutes
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
             verifyNoMoreCalls(sentryRepo)
         }
@@ -377,12 +376,12 @@ internal class ErrorBannerViewModelTest : KoinTest {
 
         testViewModelFlow(viewModel).test {
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
             viewModel.clearState()
             assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
             clock.now += 1.seconds
-            errorRepo.setDataError(ErrorKey(KeyType.Permanent, "ErrorKey"), "error details") {}
+            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
             assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
             verifyNoMoreCalls(sentryRepo)
         }


### PR DESCRIPTION
### Summary

Ticket: [ErrorBanner & VM Race Conditions](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215251110653563?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Pure refactor in support of https://github.com/mbta/mobile_app/pull/1785. 

This changes every string `errorKey` to a new `ErrorKey` with a set of `SheetRoutes` that it applies too (set as suggested by @EmmaSimon  [in the follow up PR ](https://github.com/mbta/mobile_app/pull/1785#discussion_r3421473425)- thank you!). In the follow-up PR, I will convert most of these empty set keys to `PageSpecific` and add logic to ignore or clear errors that aren't for the current page.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Updated tests & confirmed existing tests pass - this is a pure refactor
* Confirmed app still runs as expected 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
