### PR TITLE
test: fix GlobalRepositoryTest on World Cup match days

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -70,7 +70,9 @@ internal constructor(
     )
 
     public fun withWorldCupService(today: LocalDate): GlobalResponse =
-        if (WorldCupService.isMatchDay(today)) this + WorldCupService.globalData else this
+        if (WorldCupService.isMatchDay(today) && !this.routes.containsKey(WorldCupService.route.id))
+            this + WorldCupService.globalData
+        else this
 
     private operator fun plus(other: GlobalResponse) =
         GlobalResponse(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/GlobalRepositoryTest.kt
@@ -13,6 +13,7 @@ import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.network.MobileBackendClient
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
@@ -212,14 +213,15 @@ class GlobalRepositoryTest : KoinTest {
                 )
             val expectedResponse =
                 GlobalResponse(
-                    facilities = mapOf("808" to facility),
-                    lines = mapOf(Line.Id("line-Green") to line),
-                    patternIdsByStop = mapOf("3992" to listOf("230-3-1", "230-5-1")),
-                    routes = mapOf(Route.Id("Shuttle-AirportGovernmentCenterLocal") to route),
-                    routePatterns = mapOf("39-3-0" to routePattern),
-                    stops = mapOf("3992" to stop),
-                    trips = mapOf("62145526_2" to trip),
-                )
+                        facilities = mapOf("808" to facility),
+                        lines = mapOf(Line.Id("line-Green") to line),
+                        patternIdsByStop = mapOf("3992" to listOf("230-3-1", "230-5-1")),
+                        routes = mapOf(Route.Id("Shuttle-AirportGovernmentCenterLocal") to route),
+                        routePatterns = mapOf("39-3-0" to routePattern),
+                        stops = mapOf("3992" to stop),
+                        trips = mapOf("62145526_2" to trip),
+                    )
+                    .withWorldCupService(EasternTimeInstant.now().serviceDate)
             assertEquals(ApiResult.Ok(expectedResponse), response)
             assertEquals(expectedResponse, repo.state.value)
         }


### PR DESCRIPTION
### Summary

_Ticket:_ none
[Slack thread](https://mbta.slack.com/archives/C062QNAJZ2M/p1781620390117269)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

I probably should have caught this in #1646, oops.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the test now passes instead of failing.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
