### PR TITLE
feat: add script to count words with needs-review translations

### DIFF
--- a/bin/needs-review-word-count.py
+++ b/bin/needs-review-word-count.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import json
+
+with open('iosApp/iosApp/Localizable.xcstrings', 'rt') as f:
+    xcstrings_data: dict[str, dict] = json.load(f)
+
+en_strings_needs_review: list[str] = []
+for key, string_data in xcstrings_data['strings'].items():
+    localizations = string_data['localizations']
+    if 'stringUnit' in localizations['es']:
+        if any(x['stringUnit']['state'] == 'needs_review' for x in localizations.values()):
+            if 'en' in localizations:
+                en_string = localizations['en']['stringUnit']['value']
+            else:
+                en_string = key
+            en_strings_needs_review.append(en_string)
+    elif 'variations' in localizations['es']:
+        en_variations_plural: dict = localizations['en']['variations']['plural']
+        en_strings = [x['stringUnit']['value'] for x in en_variations_plural.values()]
+        en_strings_needs_review.extend(en_strings)
+    else:
+        raise ValueError(f"neither stringUnit nor variations found at key {key} in {localizations}")
+
+en_words_needs_review = sum(len(x.split()) for x in en_strings_needs_review)
+print(f"Translations that need review:")
+print(f"{len(en_strings_needs_review)} strings, {en_words_needs_review} English words")


### PR DESCRIPTION
### Summary

_Ticket:_ [Export another batch of translations](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215390462678709)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

A script like this was mentioned in a previous translation export task as probably worth writing.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the script returns a plausible-looking quantity right now:
```
Translations that need review:
117 strings, 425 English words
```

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
