### PR TITLE
chore: ignore recurring DataErrors

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ErrorBannerTests.kt
@@ -10,7 +10,6 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
-import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Rule
 import org.junit.Test
@@ -23,7 +22,7 @@ class ErrorBannerTests {
     @Test
     fun testRespondsToState() {
         val errorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-        val viewModel = ErrorBannerViewModel(errorRepo, MockSentryRepository(), Clock.System)
+        val viewModel = ErrorBannerViewModel(errorRepo, MockSentryRepository())
 
         composeTestRule.setContent { ErrorBanner(viewModel) }
 
@@ -47,8 +46,7 @@ class ErrorBannerTests {
     fun testNetworkError() {
         val networkErrorRepo =
             MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-        val networkErrorVM =
-            ErrorBannerViewModel(networkErrorRepo, MockSentryRepository(), Clock.System)
+        val networkErrorVM = ErrorBannerViewModel(networkErrorRepo, MockSentryRepository())
 
         composeTestRule.setContent { ErrorBanner(networkErrorVM) }
 
@@ -66,7 +64,7 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository(), Clock.System)
+        val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository())
         composeTestRule.setContent { ErrorBanner(dataErrorVM) }
 
         composeTestRule.onNodeWithText("Error loading data").assertExists()
@@ -82,7 +80,7 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository())
         composeTestRule.setContent { ErrorBanner(staleVM) }
 
         composeTestRule.onNodeWithText("Updated 2 minutes ago").assertExists()
@@ -98,7 +96,7 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository())
         composeTestRule.setContent { ErrorBanner(staleVM) }
 
         composeTestRule.onNodeWithText("Updated 1 minute ago").assertExists()
@@ -114,7 +112,7 @@ class ErrorBannerTests {
                         action = {},
                     )
             )
-        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+        val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository())
         staleVM.setIsLoadingWhenPredictionsStale(true)
         composeTestRule.setContent { ErrorBanner(staleVM) }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
@@ -29,7 +29,6 @@ import dev.mokkery.resetCalls
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import kotlin.collections.emptyList
-import kotlin.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -65,7 +64,6 @@ class FavoritesViewTest {
                     ErrorBannerViewModel(
                         errorRepository = MockErrorBannerStateRepository(),
                         MockSentryRepository(),
-                        Clock.System,
                     ),
                 toastViewModel = toastVM,
                 alertData = AlertsStreamDataResponse(objects),
@@ -119,7 +117,6 @@ class FavoritesViewTest {
                     ErrorBannerViewModel(
                         errorRepository = MockErrorBannerStateRepository(),
                         MockSentryRepository(),
-                        Clock.System,
                     ),
                 toastViewModel = MockToastViewModel(),
                 alertData = AlertsStreamDataResponse(objects),
@@ -169,7 +166,6 @@ class FavoritesViewTest {
                     ErrorBannerViewModel(
                         errorRepository = MockErrorBannerStateRepository(),
                         MockSentryRepository(),
-                        Clock.System,
                     ),
                 toastViewModel = MockToastViewModel(),
                 alertData = AlertsStreamDataResponse(objects),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/ErrorBanner.kt
@@ -42,7 +42,6 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.ErrorBannerViewModel
 import com.mbta.tid.mbta_app.viewModel.IErrorBannerViewModel
-import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import org.koin.compose.KoinContext
 import org.koin.dsl.koinApplication
@@ -171,11 +170,10 @@ class ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository(), Clock.System)
+    val dataErrorVM = ErrorBannerViewModel(dataErrorRepo, MockSentryRepository())
 
     val networkErrorRepo = MockErrorBannerStateRepository(state = ErrorBannerState.NetworkError {})
-    val networkErrorVM =
-        ErrorBannerViewModel(networkErrorRepo, MockSentryRepository(), Clock.System)
+    val networkErrorVM = ErrorBannerViewModel(networkErrorRepo, MockSentryRepository())
 
     val staleRepo =
         MockErrorBannerStateRepository(
@@ -185,8 +183,8 @@ class ErrorBannerPreviews() {
                     action = {},
                 )
         )
-    val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
-    val staleLoadingVM = ErrorBannerViewModel(staleRepo, MockSentryRepository(), Clock.System)
+    val staleVM = ErrorBannerViewModel(staleRepo, MockSentryRepository())
+    val staleLoadingVM = ErrorBannerViewModel(staleRepo, MockSentryRepository())
 
     // The preview requires Koin to contain the cache in order to render,
     // but it won't actually use the debug value set here when displayed

--- a/iosApp/iosAppTests/Views/ErrorBannerTests.swift
+++ b/iosApp/iosAppTests/Views/ErrorBannerTests.swift
@@ -19,8 +19,7 @@ final class ErrorBannerTests: XCTestCase {
         let repo = MockErrorBannerStateRepository(state: nil)
         let errorBannerVM = ErrorBannerViewModel(
             errorRepository: repo,
-            sentryRepository: MockSentryRepository(),
-            clock: SystemClock
+            sentryRepository: MockSentryRepository()
         )
 
         let sut = ErrorBanner(errorBannerVM)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModel.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.ErrorBannerState
@@ -13,11 +12,7 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import io.sentry.kotlin.multiplatform.SentryLevel
-import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import kotlin.jvm.JvmName
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -42,7 +37,6 @@ public interface IErrorBannerViewModel {
 public class ErrorBannerViewModel(
     private val errorRepository: IErrorBannerStateRepository,
     private val sentryRepository: ISentryRepository,
-    private val clock: Clock,
 ) :
     MoleculeViewModel<ErrorBannerViewModel.Event, ErrorBannerViewModel.State>(),
     IErrorBannerViewModel {
@@ -60,72 +54,15 @@ public class ErrorBannerViewModel(
         public data object ClearState : Event
     }
 
-    private data class ClearedDataError(
-        val keys: Set<String>,
-        val details: Set<String>,
-        val clearedAt: EasternTimeInstant,
-    )
-
     private var awaitingPredictionsAfterBackground: Boolean by mutableStateOf(false)
 
     @set:JvmName("setSheetRouteState") private var sheetRoute: SheetRoutes? by mutableStateOf(null)
 
     @Composable
     override fun runLogic(): State {
-        var errorState: ErrorBannerState? by remember { mutableStateOf(null) }
-
-        var clearedError: ClearedDataError? by remember { mutableStateOf(null) }
-
         LaunchedEffect(Unit) { errorRepository.subscribeToNetworkStatusChanges() }
 
-        val errorRepoState by errorRepository.state.collectAsState()
-        LaunchedEffect(errorRepoState) {
-            val newErrorState = errorRepoState
-            val previousErrorState = errorState
-            val previousClearedError = clearedError
-            if (previousErrorState is ErrorBannerState.DataError && newErrorState == null) {
-                clearedError =
-                    ClearedDataError(
-                        previousErrorState.messages,
-                        previousErrorState.details,
-                        EasternTimeInstant.now(clock),
-                    )
-            } else if (
-                previousErrorState == null &&
-                    newErrorState is ErrorBannerState.DataError &&
-                    previousClearedError != null
-            ) {
-                // data error was cleared and then came back instantly, that’s not good
-                val oldKeys = previousClearedError.keys
-                val newKeys = newErrorState.messages
-                val commonKeys = oldKeys intersect newKeys
-                if (
-                    EasternTimeInstant.now(clock) - previousClearedError.clearedAt < 1.minutes &&
-                        commonKeys.isNotEmpty()
-                ) {
-                    sentryRepository.captureMessage("Recurring DataError ${commonKeys.sorted()}") {
-                        addBreadcrumb(
-                            Breadcrumb(
-                                SentryLevel.ERROR,
-                                type = "error",
-                                message = "Recurring DataError",
-                                category = null,
-                                mutableMapOf(
-                                    "previousClearedError.keys" to previousClearedError.keys,
-                                    "previousClearedError.details" to previousClearedError.details,
-                                    "previousClearedError.clearedAt" to
-                                        previousClearedError.clearedAt,
-                                    "newErrorState.messages" to newErrorState.messages,
-                                    "newErrorState.details" to newErrorState.details,
-                                ),
-                            )
-                        )
-                    }
-                }
-                clearedError = null
-            }
-            errorState = newErrorState
-        }
+        val errorState by errorRepository.state.collectAsState()
 
         EventSink(eventHandlingTimeout = 1.seconds, sentryRepository = sentryRepository) { event ->
             when (event) {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/ErrorBannerViewModelTest.kt
@@ -8,28 +8,15 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.network.INetworkConnectivityMonitor
 import com.mbta.tid.mbta_app.repositories.ErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ErrorKey
-import com.mbta.tid.mbta_app.repositories.ISentryRepository
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import dev.mokkery.MockMode
-import dev.mokkery.answering.calls
-import dev.mokkery.answering.throwsErrorWith
-import dev.mokkery.every
-import dev.mokkery.matcher.any
 import dev.mokkery.mock
-import dev.mokkery.verify
-import dev.mokkery.verifyNoMoreCalls
-import io.sentry.kotlin.multiplatform.Scope
-import io.sentry.kotlin.multiplatform.SentryLevel
-import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -233,157 +220,6 @@ internal class ErrorBannerViewModelTest : KoinTest {
             )
             advanceUntilIdle()
             expectNoEvents()
-        }
-    }
-
-    @Test
-    fun `records recurring DataErrors in Sentry`() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
-
-        val errorRepo = ErrorBannerStateRepository()
-        val sentryScope = mock<Scope>(MockMode.autofill)
-        val sentryRepo =
-            mock<ISentryRepository>(MockMode.autofill) {
-                every { captureMessage(any(), any()) } calls
-                    { (_: String, additionalDetails: Scope.() -> Unit) ->
-                        sentryScope.additionalDetails()
-                    }
-            }
-
-        val clock =
-            object : Clock {
-                var now = Clock.System.now()
-
-                override fun now() = now
-            }
-
-        setUpKoin(dispatcher, clock) {
-            errorBanner = errorRepo
-            sentry = sentryRepo
-        }
-
-        val viewModel: ErrorBannerViewModel = get()
-
-        testViewModelFlow(viewModel).test {
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            var nextState = awaitItem().errorState
-            assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
-            assertEquals(setOf("error details"), nextState.details)
-            clock.now += 1.seconds
-            val clearedAt = clock.now
-            viewModel.clearState()
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            clock.now += 1.seconds
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            nextState = awaitItem().errorState
-            assertEquals(setOf("ErrorKey"), (nextState as ErrorBannerState.DataError).messages)
-            assertEquals(setOf("error details"), nextState.details)
-            verify { sentryRepo.captureMessage("Recurring DataError [ErrorKey]", any()) }
-            verify {
-                sentryScope.addBreadcrumb(
-                    Breadcrumb(
-                        level = SentryLevel.ERROR,
-                        type = "error",
-                        message = "Recurring DataError",
-                        category = null,
-                        data =
-                            mutableMapOf(
-                                "previousClearedError.keys" to setOf("ErrorKey"),
-                                "previousClearedError.details" to setOf("error details"),
-                                "previousClearedError.clearedAt" to EasternTimeInstant(clearedAt),
-                                "newErrorState.messages" to setOf("ErrorKey"),
-                                "newErrorState.details" to setOf("error details"),
-                            ),
-                    )
-                )
-            }
-        }
-    }
-
-    @Test
-    fun `does not record DataErrors if over a minute since cleared`() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
-
-        val errorRepo = ErrorBannerStateRepository()
-        val sentryRepo =
-            mock<ISentryRepository>(MockMode.autofill) {
-                every { captureMessage(any(), any()) } throwsErrorWith
-                    "should not have captured Sentry message"
-            }
-
-        val clock =
-            object : Clock {
-                var now = Clock.System.now()
-
-                override fun now() = now
-            }
-
-        setUpKoin(dispatcher, clock) {
-            errorBanner = errorRepo
-            sentry = sentryRepo
-        }
-
-        val viewModel: ErrorBannerViewModel = get()
-
-        testViewModelFlow(viewModel).test {
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
-            viewModel.clearState()
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            clock.now += 2.minutes
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            assertIs<ErrorBannerState.DataError>(awaitItem().errorState)
-            verifyNoMoreCalls(sentryRepo)
-        }
-    }
-
-    @Test
-    fun `does not record DataErrors if offline`() = runTest {
-        val dispatcher = StandardTestDispatcher(testScheduler)
-
-        val errorRepo = ErrorBannerStateRepository()
-        val sentryRepo =
-            mock<ISentryRepository>(MockMode.autofill) {
-                every { captureMessage(any(), any()) } throwsErrorWith
-                    "should not have captured Sentry message"
-            }
-
-        val clock =
-            object : Clock {
-                var now = Clock.System.now()
-
-                override fun now() = now
-            }
-
-        val mockNetworkMonitor =
-            object : INetworkConnectivityMonitor {
-                override fun registerListener(
-                    onNetworkAvailable: () -> Unit,
-                    onNetworkLost: () -> Unit,
-                ) {
-                    onNetworkLost()
-                }
-            }
-
-        setUpKoin(dispatcher, clock, mockNetworkMonitor) {
-            errorBanner = errorRepo
-            sentry = sentryRepo
-        }
-
-        val viewModel: ErrorBannerViewModel = get()
-
-        testViewModelFlow(viewModel).test {
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
-            viewModel.clearState()
-            assertEquals(ErrorBannerViewModel.State(false, null), awaitItem())
-            clock.now += 1.seconds
-            errorRepo.setDataError(ErrorKey(setOf(), "ErrorKey"), "error details") {}
-            assertIs<ErrorBannerState.NetworkError>(awaitItem().errorState)
-            verifyNoMoreCalls(sentryRepo)
         }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Sentry - Manage Recurring DataErrors Alerting](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1213627359415084)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Removing this completely lets us clean up a lot of code.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that the tests all still build.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
