### PR TITLE
feat(iOS): page-specific error keys

### DIFF
--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -101,7 +101,10 @@ struct EditFavoritesPage: View {
                 toastVM.hideToast()
             }
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
-            .global($globalResponse, errorKey: ErrorKey(sheets: [], id: "AlertDetailsPage"))
+            .global(
+                $globalResponse,
+                errorKey: .companion.fromSheetTypes(sheetTypes: [.editFavorites], id: "AlertDetailsPage")
+            )
             .task {
                 for await model in viewModel.models {
                     favoritesVMState = model

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -83,7 +83,7 @@ struct FavoritesView: View {
                 showStopHeader: true
             )
         }
-        .global($globalData, errorKey: ErrorKey(sheets: [], id: "FavoritesView"))
+        .global($globalData, errorKey: ErrorKey.companion.fromSheetTypes(sheetTypes: [.favorites], id: "FavoritesView"))
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -83,7 +83,7 @@ struct FavoritesView: View {
                 showStopHeader: true
             )
         }
-        .global($globalData, errorKey: ErrorKey.companion.fromSheetTypes(sheetTypes: [.favorites], id: "FavoritesView"))
+        .global($globalData, errorKey: .companion.fromSheetTypes(sheetTypes: [.favorites], id: "FavoritesView"))
         .onAppear {
             favoritesVM.setActive(active: true, wasSentToBackground: false)
             favoritesVM.setAlerts(alerts: nearbyVM.alerts)

--- a/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
+++ b/iosApp/iosApp/Pages/Map/HomeMapViewHandlerExtension.swift
@@ -68,7 +68,10 @@ extension HomeMapView {
         vehiclesRepository.connect(
             routeId: routeId,
             directionId: directionId,
-            errorKey: ErrorKey(sheets: [], id: "HomeMapView.joinVehiclesChannel"),
+            errorKey: .companion.fromSheetTypes(
+                sheetTypes: [.stopDetails, .tripDetails],
+                id: "HomeMapView.joinVehiclesChannel"
+            ),
         ) { outcome in
             if case let .ok(result) = onEnum(of: outcome) {
                 if let routeCardData = routeCardDataState?.data {

--- a/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
+++ b/iosApp/iosApp/Pages/NearbyTransit/NearbyTransitView.swift
@@ -54,7 +54,7 @@ struct NearbyTransitView: View {
             }
         }
         .favorites($favorites)
-        .global($globalData, errorKey: ErrorKey(sheets: [], id: "NearbyTransitView"))
+        .global($globalData, errorKey: .companion.fromSheetTypes(sheetTypes: [.nearbyTransit], id: "NearbyTransitView"))
         .onAppear {
             loadEverything()
             didAppear?(self)
@@ -234,7 +234,7 @@ struct NearbyTransitView: View {
                 return
             }
             await fetchApi(
-                errorKey: ErrorKey(sheets: [], id: "NearbyTransitView.getSchedule"),
+                errorKey: .companion.fromSheetTypes(sheetTypes: [.nearbyTransit], id: "NearbyTransitView.getSchedule"),
                 getData: { try await schedulesRepository.getSchedule(stopIds: stopIds) },
                 onSuccess: { scheduleResponse = $0 },
                 onRefreshAfterError: loadEverything
@@ -246,7 +246,7 @@ struct NearbyTransitView: View {
         guard let stopIds else { return }
         predictionsRepository.connect(
             stopIds: stopIds,
-            errorKey: ErrorKey(sheets: [], id: "NearbyTransitView.joinPredictions"),
+            errorKey: .companion.fromSheetTypes(sheetTypes: [.nearbyTransit], id: "NearbyTransitView.joinPredictions"),
             onJoin: { outcome in
                 DispatchQueue.main.async {
                     switch onEnum(of: outcome) {

--- a/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteDetailsView.swift
@@ -51,7 +51,7 @@ struct RouteDetailsView: View {
                 loadingBody()
             }
         }
-        .global($globalData, errorKey: ErrorKey(sheets: [], id: "RouteDetailsView"))
+        .global($globalData, errorKey: .companion.fromSheetTypes(sheetTypes: [.editFavorites], id: "RouteDetailsView"))
         .onChange(of: globalData) { globalData in
             lineOrRoute = globalData?.getLineOrRoute(lineOrRouteId: selectionId)
         }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -193,7 +193,10 @@ struct StopDetailsFilteredDepartureDetails: View {
                 )
             }
         }
-        .global($global, errorKey: ErrorKey(sheets: [], id: "StopDetailsFilteredDepartureDetails"))
+        .global(
+            $global,
+            errorKey: .companion.fromSheetTypes(sheetTypes: [.stopDetails], id: "StopDetailsFilteredDepartureDetails")
+        )
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
             loadNextScheduleForStatus(noPredictionsStatus)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -91,7 +91,7 @@ struct StopDetailsPage: View {
             .favorites($favorites)
             .global(
                 $global,
-                errorKey: ErrorKey.companion.fromSheetTypes(sheetTypes: [.stopDetails], id: "StopDetailsPage")
+                errorKey: .companion.fromSheetTypes(sheetTypes: [.stopDetails], id: "StopDetailsPage")
             )
             .manageVM(stopDetailsVM, $vmState, alerts: nearbyVM.alerts, filters: filters, now: now.toEasternInstant())
             .manageVM(routeCardDataVM, $routeCardDataState)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsPage.swift
@@ -89,7 +89,10 @@ struct StopDetailsPage: View {
     var body: some View {
         stopDetails
             .favorites($favorites)
-            .global($global, errorKey: ErrorKey(sheets: [], id: "StopDetailsPage"))
+            .global(
+                $global,
+                errorKey: ErrorKey.companion.fromSheetTypes(sheetTypes: [.stopDetails], id: "StopDetailsPage")
+            )
             .manageVM(stopDetailsVM, $vmState, alerts: nearbyVM.alerts, filters: filters, now: now.toEasternInstant())
             .manageVM(routeCardDataVM, $routeCardDataState)
             .task {

--- a/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripDetailsView.swift
@@ -84,7 +84,7 @@ struct TripDetailsView: View {
     var body: some View {
         content
             .explainer($explainer)
-            .global($global, errorKey: ErrorKey(sheets: [], id: "TripDetailsView"))
+            .global($global, errorKey: .companion.fromSheetTypes(sheetTypes: [.tripDetails], id: "TripDetailsView"))
             .onAppear {
                 tripDetailsVMState = tripDetailsVM.models.value
             }

--- a/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
+++ b/iosApp/iosApp/Pages/TripDetails/TripDetailsPage.swift
@@ -99,7 +99,7 @@ struct TripDetailsPage: View {
                 global: global
             ))
         }
-        .global($global, errorKey: ErrorKey(sheets: [], id: "TripDetailsPage"))
+        .global($global, errorKey: .companion.fromSheetTypes(sheetTypes: [.tripDetails], id: "TripDetailsPage"))
         .task {
             while !Task.isCancelled {
                 now = Date.now.toEasternInstant()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/ErrorBannerStateRepository.kt
@@ -31,6 +31,38 @@ internal sealed class NetworkStatus {
  * retried across all pages.
  */
 public data class ErrorKey(public val sheets: Set<KClass<out SheetRoutes>>, public val id: String) {
+
+    // Convenience constructor and enum for working around swift sealed class and class
+    // reflection interop issues https://skie.touchlab.co/features/sealed#limitations
+
+    public companion object {
+        public fun fromSheetTypes(sheetTypes: Set<SheetType>, id: String): ErrorKey {
+            return ErrorKey(sheets = sheetTypes.map { it.toSheetRoutesClass() }.toSet(), id)
+        }
+    }
+
+    public enum class SheetType {
+        StopDetails,
+        TripDetails,
+        RouteDetails,
+        EditFavorites,
+        Favorites,
+        NearbyTransit,
+        RoutePicker;
+
+        internal fun toSheetRoutesClass(): KClass<out SheetRoutes> {
+            return when (this) {
+                StopDetails -> SheetRoutes.StopDetails::class
+                TripDetails -> SheetRoutes.TripDetails::class
+                RouteDetails -> SheetRoutes.RouteDetails::class
+                EditFavorites -> SheetRoutes.EditFavorites::class
+                Favorites -> SheetRoutes.Favorites::class
+                NearbyTransit -> SheetRoutes.NearbyTransit::class
+                RoutePicker -> SheetRoutes.RouteDetails::class
+            }
+        }
+    }
+
     public fun withSuffix(suffix: String): ErrorKey {
         return this.copy(id = "$id.$suffix")
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [ErrorBanner & VM Race Conditions](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215251110653563?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

iOS follow up to https://github.com/mbta/mobile_app/pull/1785 to specify the appropriate sheets in the ErrorKeys coming from iOS. This was tricker than I expected because there are kotlin->swift interop issues with sealed classes and class reflection. I opted for an easy but less-than-ideal workaround of a new `SheetType` enum, which is currently used only on the swift side. 

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in ~Localizable.xcstrings?
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Ran in simulator with simulated 3G, observed that errors for different pages cleared on page change

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
