### PR TITLE
Set notification visibility to public to show content when Android ph…

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
@@ -59,6 +59,7 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
                 .setAutoCancel(true)
                 .setSound(defaultSoundUri)
                 .setContentIntent(pendingIntent)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
         val notificationManager = NotificationManagerCompat.from(applicationContext)
 


### PR DESCRIPTION
…ones hide sensitive content notifications

### Summary

_Ticket:_ [Show notifications on android lock screen w/ privacy setting](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1215199524799205?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Show notification content when Android device is set to hide sensitive content on notifications

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
- [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Tested with the emulator, changing the notification settings to hide sensitive content from notifications, tested that it failed with no changes => implemented changes and tested that it show the content, and it did

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->


[Back end change for notifications when app is running on the background](https://github.com/mbta/mobile_app_backend/pull/551)
