### PR TITLE
feat: introduce StopCardData for grouping favorites by stop

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -22,6 +22,7 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
 import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.StopCardData
 import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
@@ -251,8 +252,13 @@ class EditFavoritesPageTest : KoinTest {
         )
 
     val routeCardData = listOf(routeCard)
+    val stopCardData = StopCardData.fromRouteCardData(routeCardData, sortByDistanceFrom = null)
     val greenLineRouteCardData = listOf(greenLineRouteCard)
+    val greenLineStopCardData =
+        StopCardData.fromRouteCardData(greenLineRouteCardData, sortByDistanceFrom = null)
     val combinedRouteCardData = listOf(routeCard, greenLineRouteCard)
+    val combinedStopCardData =
+        StopCardData.fromRouteCardData(combinedRouteCardData, sortByDistanceFrom = null)
 
     val globalResponse = GlobalResponse(builder)
 
@@ -275,7 +281,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     routeCardData,
+                    stopCardData,
                     routeCardData,
+                    stopCardData,
                     null,
                 )
             )
@@ -308,6 +316,8 @@ class EditFavoritesPageTest : KoinTest {
                     emptyMap(),
                     false,
                     false,
+                    emptyList(),
+                    emptyList(),
                     emptyList(),
                     emptyList(),
                     null,
@@ -346,7 +356,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     null,
                 )
             )
@@ -361,7 +373,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     greenLineRouteCardData,
+                    greenLineStopCardData,
                     greenLineRouteCardData,
+                    greenLineStopCardData,
                     null,
                 )
             }
@@ -421,7 +435,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     null,
                 )
             )
@@ -437,8 +453,10 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     if (updatedFavorites.size == 1) greenLineRouteCardData
                     else combinedRouteCardData,
+                    if (updatedFavorites.size == 1) greenLineStopCardData else combinedStopCardData,
                     if (updatedFavorites.size == 1) greenLineRouteCardData
                     else combinedRouteCardData,
+                    if (updatedFavorites.size == 1) greenLineStopCardData else combinedStopCardData,
                     null,
                 )
             }
@@ -513,7 +531,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     null,
                 )
             )
@@ -578,7 +598,9 @@ class EditFavoritesPageTest : KoinTest {
                     false,
                     false,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     combinedRouteCardData,
+                    combinedStopCardData,
                     null,
                 )
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
@@ -49,6 +49,8 @@ class FavoritesViewTest {
                         false,
                         emptyList(),
                         emptyList(),
+                        emptyList(),
+                        emptyList(),
                         null,
                     )
             )
@@ -100,6 +102,8 @@ class FavoritesViewTest {
                         true,
                         emptyList(),
                         emptyList(),
+                        emptyList(),
+                        emptyList(),
                         null,
                     )
             )
@@ -147,6 +151,8 @@ class FavoritesViewTest {
                         emptyMap(),
                         false,
                         true,
+                        emptyList(),
+                        emptyList(),
                         emptyList(),
                         emptyList(),
                         null,

--- a/iosApp/iosAppTests/Pages/Favorites/EditFavoritesPageTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/EditFavoritesPageTests.swift
@@ -21,7 +21,9 @@ final class EditFavoritesPageTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
+            stopCardData: [],
             staticRouteCardData: [],
+            staticStopCardData: [],
             loadedLocation: nil,
         ))
 
@@ -54,7 +56,9 @@ final class EditFavoritesPageTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
+            stopCardData: [],
             staticRouteCardData: [],
+            staticStopCardData: [],
             loadedLocation: nil,
         ))
 
@@ -108,7 +112,9 @@ final class EditFavoritesPageTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
+            stopCardData: [],
             staticRouteCardData: [],
+            staticStopCardData: [],
             loadedLocation: nil,
         ))
 
@@ -156,6 +162,42 @@ final class EditFavoritesPageTests: XCTestCase {
 
         let updateFavoritesExp = XCTestExpectation(description: "Update favorites called for route 15 only")
 
+        let staticRouteCardData: [RouteCardData] = [
+            .init(lineOrRoute: .route(route15),
+                  stopData: [.init(route: route15,
+                                   stop: stop15,
+                                   data: [.init(lineOrRoute: .route(route15),
+                                                stop: stop15,
+                                                directionId: 0,
+                                                routePatterns: [],
+                                                stopIds: [],
+                                                upcomingTrips: [],
+                                                alertsHere: [],
+                                                allDataLoaded: true,
+                                                hasSchedulesToday: true,
+                                                subwayServiceStartTime: nil,
+                                                alertsDownstream: [],
+                                                context: .favorites)],
+                                   globalData: globalData)],
+                  at: EasternTimeInstant.now()),
+            .init(lineOrRoute: .route(route67),
+                  stopData: [.init(route: route67,
+                                   stop: stop67,
+                                   data: [.init(lineOrRoute: .route(route67),
+                                                stop: stop67,
+                                                directionId: 0,
+                                                routePatterns: [],
+                                                stopIds: [],
+                                                upcomingTrips: [],
+                                                alertsHere: [],
+                                                allDataLoaded: true,
+                                                hasSchedulesToday: true,
+                                                subwayServiceStartTime: nil,
+                                                alertsDownstream: [],
+                                                context: .favorites)],
+                                   globalData: globalData)],
+                  at: EasternTimeInstant.now()),
+        ]
         let favoritesVM = MockFavoritesViewModel(initialState: .init(
             awaitingPredictionsAfterBackground: false,
             favorites: [
@@ -165,42 +207,12 @@ final class EditFavoritesPageTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
-            staticRouteCardData: [
-                .init(lineOrRoute: .route(route15),
-                      stopData: [.init(route: route15,
-                                       stop: stop15,
-                                       data: [.init(lineOrRoute: .route(route15),
-                                                    stop: stop15,
-                                                    directionId: 0,
-                                                    routePatterns: [],
-                                                    stopIds: [],
-                                                    upcomingTrips: [],
-                                                    alertsHere: [],
-                                                    allDataLoaded: true,
-                                                    hasSchedulesToday: true,
-                                                    subwayServiceStartTime: nil,
-                                                    alertsDownstream: [],
-                                                    context: .favorites)],
-                                       globalData: globalData)],
-                      at: EasternTimeInstant.now()),
-                .init(lineOrRoute: .route(route67),
-                      stopData: [.init(route: route67,
-                                       stop: stop67,
-                                       data: [.init(lineOrRoute: .route(route67),
-                                                    stop: stop67,
-                                                    directionId: 0,
-                                                    routePatterns: [],
-                                                    stopIds: [],
-                                                    upcomingTrips: [],
-                                                    alertsHere: [],
-                                                    allDataLoaded: true,
-                                                    hasSchedulesToday: true,
-                                                    subwayServiceStartTime: nil,
-                                                    alertsDownstream: [],
-                                                    context: .favorites)],
-                                       globalData: globalData)],
-                      at: EasternTimeInstant.now()),
-            ],
+            stopCardData: [],
+            staticRouteCardData: staticRouteCardData,
+            staticStopCardData: StopCardData.companion.fromRouteCardData(
+                routeCardData: staticRouteCardData,
+                sortByDistanceFrom: nil
+            ),
             loadedLocation: nil,
         ))
 
@@ -238,6 +250,25 @@ final class EditFavoritesPageTests: XCTestCase {
         let updateFavoritesExp = XCTestExpectation(description: "Update favorites called for route 15 only")
         let undoFavoritesExp = XCTestExpectation(description: "Favorite update undone")
 
+        let staticRouteCardData: [RouteCardData] = [
+            .init(lineOrRoute: .route(route15),
+                  stopData: [.init(route: route15,
+                                   stop: stop15,
+                                   data: [.init(lineOrRoute: .route(route15),
+                                                stop: stop15,
+                                                directionId: 0,
+                                                routePatterns: [],
+                                                stopIds: [],
+                                                upcomingTrips: [],
+                                                alertsHere: [],
+                                                allDataLoaded: true,
+                                                hasSchedulesToday: true,
+                                                subwayServiceStartTime: nil,
+                                                alertsDownstream: [],
+                                                context: .favorites)],
+                                   globalData: globalData)],
+                  at: EasternTimeInstant.now()),
+        ]
         let favoritesVM = MockFavoritesViewModel(initialState: .init(
             awaitingPredictionsAfterBackground: false,
             favorites: [
@@ -246,25 +277,12 @@ final class EditFavoritesPageTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
-            staticRouteCardData: [
-                .init(lineOrRoute: .route(route15),
-                      stopData: [.init(route: route15,
-                                       stop: stop15,
-                                       data: [.init(lineOrRoute: .route(route15),
-                                                    stop: stop15,
-                                                    directionId: 0,
-                                                    routePatterns: [],
-                                                    stopIds: [],
-                                                    upcomingTrips: [],
-                                                    alertsHere: [],
-                                                    allDataLoaded: true,
-                                                    hasSchedulesToday: true,
-                                                    subwayServiceStartTime: nil,
-                                                    alertsDownstream: [],
-                                                    context: .favorites)],
-                                       globalData: globalData)],
-                      at: EasternTimeInstant.now()),
-            ],
+            stopCardData: [],
+            staticRouteCardData: staticRouteCardData,
+            staticStopCardData: StopCardData.companion.fromRouteCardData(
+                routeCardData: staticRouteCardData,
+                sortByDistanceFrom: nil
+            ),
             loadedLocation: nil,
         ))
 

--- a/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
@@ -30,6 +30,34 @@ final class FavoritesViewTests: XCTestCase {
             prediction.departureTime = now.plus(minutes: 5)
         })
         let globalData = GlobalResponse(objects: objects)
+        let realtimeLeaf = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
+            directionId: 0,
+            routePatterns: [routePattern],
+            stopIds: [stop.id],
+            upcomingTrips: [trip],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: true,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .favorites
+        )
+        let staticLeaf = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
+            directionId: 0,
+            routePatterns: [routePattern],
+            stopIds: [stop.id],
+            upcomingTrips: [],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: false,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .favorites
+        )
         let favoritesVM = MockFavoritesViewModel(initialState: .init(
             awaitingPredictionsAfterBackground: false,
             favorites: [.init(route: route.id, stop: stop.id, direction: 0): .init()],
@@ -40,47 +68,23 @@ final class FavoritesViewTests: XCTestCase {
                 stopData: [.init(
                     route: route,
                     stop: stop,
-                    data: [.init(
-                        lineOrRoute: .route(route),
-                        stop: stop,
-                        directionId: 0,
-                        routePatterns: [routePattern],
-                        stopIds: [stop.id],
-                        upcomingTrips: [trip],
-                        alertsHere: [],
-                        allDataLoaded: true,
-                        hasSchedulesToday: true,
-                        subwayServiceStartTime: nil,
-                        alertsDownstream: [],
-                        context: .favorites
-                    )],
+                    data: [realtimeLeaf],
                     globalData: globalData
                 )],
                 at: now
             )],
+            stopCardData: [.init(stop: stop, data: [realtimeLeaf])],
             staticRouteCardData: [.init(
                 lineOrRoute: .route(route),
                 stopData: [.init(
                     route: route,
                     stop: stop,
-                    data: [.init(
-                        lineOrRoute: .route(route),
-                        stop: stop,
-                        directionId: 0,
-                        routePatterns: [routePattern],
-                        stopIds: [stop.id],
-                        upcomingTrips: [],
-                        alertsHere: [],
-                        allDataLoaded: true,
-                        hasSchedulesToday: false,
-                        subwayServiceStartTime: nil,
-                        alertsDownstream: [],
-                        context: .favorites
-                    )],
+                    data: [staticLeaf],
                     globalData: globalData
                 )],
                 at: now
             )],
+            staticStopCardData: [.init(stop: stop, data: [staticLeaf])],
             loadedLocation: nil,
         ))
 
@@ -119,6 +123,34 @@ final class FavoritesViewTests: XCTestCase {
 
         loadKoinMocks(objects: objects)
 
+        let realtimeLeaf = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
+            directionId: 0,
+            routePatterns: [routePattern],
+            stopIds: [stop.id],
+            upcomingTrips: [trip],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: true,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .favorites
+        )
+        let staticLeaf = RouteCardData.Leaf(
+            lineOrRoute: .route(route),
+            stop: stop,
+            directionId: 0,
+            routePatterns: [routePattern],
+            stopIds: [stop.id],
+            upcomingTrips: [],
+            alertsHere: [],
+            allDataLoaded: true,
+            hasSchedulesToday: false,
+            subwayServiceStartTime: nil,
+            alertsDownstream: [],
+            context: .favorites
+        )
         let favoritesVM = MockFavoritesViewModel(initialState: .init(
             awaitingPredictionsAfterBackground: false,
             favorites: [.init(route: route.id, stop: stop.id, direction: 0): .init()],
@@ -129,47 +161,23 @@ final class FavoritesViewTests: XCTestCase {
                 stopData: [.init(
                     route: route,
                     stop: stop,
-                    data: [.init(
-                        lineOrRoute: .route(route),
-                        stop: stop,
-                        directionId: 0,
-                        routePatterns: [routePattern],
-                        stopIds: [stop.id],
-                        upcomingTrips: [trip],
-                        alertsHere: [],
-                        allDataLoaded: true,
-                        hasSchedulesToday: true,
-                        subwayServiceStartTime: nil,
-                        alertsDownstream: [],
-                        context: .favorites
-                    )],
+                    data: [realtimeLeaf],
                     globalData: globalData
                 )],
                 at: now
             )],
+            stopCardData: [.init(stop: stop, data: [realtimeLeaf])],
             staticRouteCardData: [.init(
                 lineOrRoute: .route(route),
                 stopData: [.init(
                     route: route,
                     stop: stop,
-                    data: [.init(
-                        lineOrRoute: .route(route),
-                        stop: stop,
-                        directionId: 0,
-                        routePatterns: [routePattern],
-                        stopIds: [stop.id],
-                        upcomingTrips: [],
-                        alertsHere: [],
-                        allDataLoaded: true,
-                        hasSchedulesToday: false,
-                        subwayServiceStartTime: nil,
-                        alertsDownstream: [],
-                        context: .favorites
-                    )],
+                    data: [staticLeaf],
                     globalData: globalData
                 )],
                 at: now
             )],
+            staticStopCardData: [.init(stop: stop, data: [staticLeaf])],
             loadedLocation: nil
         ))
 
@@ -197,7 +205,9 @@ final class FavoritesViewTests: XCTestCase {
             shouldShowFirstTimeToast: false,
             shouldShowNotificationsHint: false,
             routeCardData: [],
+            stopCardData: [],
             staticRouteCardData: [],
+            staticStopCardData: [],
             loadedLocation: nil,
         ))
         let sut = FavoritesView(
@@ -374,7 +384,9 @@ final class FavoritesViewTests: XCTestCase {
                 shouldShowFirstTimeToast: true,
                 shouldShowNotificationsHint: false,
                 routeCardData: [],
+                stopCardData: [],
                 staticRouteCardData: [],
+                staticStopCardData: [],
                 loadedLocation: nil
             )
         )
@@ -411,7 +423,9 @@ final class FavoritesViewTests: XCTestCase {
                 shouldShowFirstTimeToast: false,
                 shouldShowNotificationsHint: true,
                 routeCardData: [],
+                stopCardData: [],
                 staticRouteCardData: [],
+                staticStopCardData: [],
                 loadedLocation: nil
             )
         )
@@ -446,7 +460,9 @@ final class FavoritesViewTests: XCTestCase {
                 shouldShowFirstTimeToast: false,
                 shouldShowNotificationsHint: true,
                 routeCardData: [],
+                stopCardData: [],
                 staticRouteCardData: [],
+                staticStopCardData: [],
                 loadedLocation: nil
             )
         )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -130,7 +130,7 @@ public data class RouteCardData(
         private val subwayServiceStartTime: EasternTimeInstant?,
         private val alertsDownstream: List<Alert>,
         internal val context: Context,
-    ) {
+    ) : Comparable<Leaf> {
 
         /** Convenience constructor for testing to avoid having to set hasSchedulesTodayByPattern */
         public constructor(
@@ -164,7 +164,11 @@ public data class RouteCardData(
             context,
         )
 
-        internal val id: Int = directionId
+        override fun compareTo(other: Leaf): Int {
+            val thisPattern = this.routePatterns.firstOrNull()
+            val otherPattern = other.routePatterns.firstOrNull()
+            return nullsLast<RoutePattern>().compare(thisPattern, otherPattern)
+        }
 
         public val routeStopDirection: RouteStopDirection =
             RouteStopDirection(lineOrRoute.id, stop.id, directionId)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/StopCardData.kt
@@ -1,0 +1,29 @@
+package com.mbta.tid.mbta_app.model
+
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.units.Length
+
+public data class StopCardData(val stop: Stop, val data: List<RouteCardData.Leaf>) {
+    internal fun distanceFrom(position: Position): Length = this.stop.distanceFrom(position)
+
+    public companion object {
+        public fun fromRouteCardData(
+            routeCardData: List<RouteCardData>,
+            sortByDistanceFrom: Position?,
+        ): List<StopCardData> {
+            val stopCardData =
+                routeCardData
+                    .flatMap { it.stopData }
+                    .groupBy { it.stop.id }
+                    .values
+                    .map { routeStops ->
+                        val stop = routeStops.first().stop
+                        val data = routeStops.flatMap { it.data }
+                        StopCardData(stop, data.sort())
+                    }
+            return if (sortByDistanceFrom != null)
+                stopCardData.sortedBy { it.distanceFrom(sortByDistanceFrom) }
+            else stopCardData
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.StopCardData
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
@@ -112,10 +113,12 @@ public class FavoritesViewModel(
         val shouldShowFirstTimeToast: Boolean = false,
         val shouldShowNotificationsHint: Boolean = false,
         val routeCardData: List<RouteCardData>?,
+        val stopCardData: List<StopCardData>?,
         val staticRouteCardData: List<RouteCardData>?,
+        val staticStopCardData: List<StopCardData>?,
         val loadedLocation: Position?,
     ) {
-        public constructor() : this(false, null, false, false, null, null, null)
+        public constructor() : this(false, null, false, false, null, null, null, null, null)
     }
 
     @set:JvmName("setAlertsState")
@@ -139,7 +142,9 @@ public class FavoritesViewModel(
         var shouldShowNotificationsHint: Boolean by remember { mutableStateOf(false) }
 
         var routeCardData: List<RouteCardData>? by remember { mutableStateOf(null) }
+        var stopCardData: List<StopCardData>? by remember { mutableStateOf(null) }
         var staticRouteCardData: List<RouteCardData>? by remember { mutableStateOf(null) }
+        var staticStopCardData: List<StopCardData>? by remember { mutableStateOf(null) }
         var loadedLocation: Position? by remember { mutableStateOf(null) }
 
         var active: Boolean by remember { mutableStateOf(false) }
@@ -307,6 +312,10 @@ public class FavoritesViewModel(
                     )
                 loadedLocation = location
             }
+            stopCardData =
+                routeCardData?.let {
+                    StopCardData.fromRouteCardData(it, sortByDistanceFrom = location)
+                }
         }
 
         LaunchedEffect(stopIds, globalData, favorites, location) {
@@ -328,6 +337,10 @@ public class FavoritesViewModel(
                         sentryRepository,
                     )
             }
+            staticStopCardData =
+                staticRouteCardData?.let {
+                    StopCardData.fromRouteCardData(it, sortByDistanceFrom = location)
+                }
         }
 
         LaunchedEffect(hadOldPinnedRoutes, isFirstExposureToNewFavorites) {
@@ -340,7 +353,9 @@ public class FavoritesViewModel(
             shouldShowFirstTimeToast,
             shouldShowNotificationsHint && favorites?.isNotEmpty() == true,
             routeCardData,
+            stopCardData,
             staticRouteCardData,
+            staticStopCardData,
             loadedLocation,
         )
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/StopCardDataTest.kt
@@ -1,0 +1,188 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.utils.TestData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StopCardDataTest {
+    @Test
+    fun `fromRouteCardData groups by stop`() {
+        val now = EasternTimeInstant.now()
+        val objects = TestData.clone()
+        val ruggles = objects.getStop("place-rugg")
+        val tremontAtMelneaCass =
+            objects.stop {
+                id = "1227"
+                name = "Tremont St @ Melnea Cass Blvd"
+            }
+        val boylston = objects.getStop("place-boyls")
+        val ol = LineOrRoute.Route(objects.getRoute("Orange"))
+        val gl =
+            LineOrRoute.Line(
+                objects.getLine("line-Green"),
+                setOf(
+                    objects.getRoute("Green-B"),
+                    objects.getRoute("Green-C"),
+                    objects.getRoute("Green-D"),
+                    objects.getRoute("Green-E"),
+                ),
+            )
+        val bus43 =
+            LineOrRoute.Route(
+                objects.route {
+                    id = "43"
+                    directionNames = listOf("Outbound", "Inbound")
+                    directionDestinations = listOf("Ruggles Station", "Park Street Station")
+                }
+            )
+        val bus43Inbound =
+            objects.routePattern(bus43.route) {
+                directionId = 1
+                sortOrder = 504301000
+                typicality = RoutePattern.Typicality.Typical
+                representativeTrip {
+                    headsign = "Park St & Tremont St"
+                    stopIds = listOf("17869", "1227", "10000")
+                }
+            }
+
+        val global = GlobalResponse(objects)
+
+        val olSouthboundLeaf =
+            RouteCardData.Leaf(
+                ol,
+                ruggles,
+                0,
+                listOf(objects.getRoutePattern("Orange-3-0")),
+                ruggles.childStopIds.toSet(),
+                upcomingTrips = emptyList(),
+                alertsHere = emptyList(),
+                allDataLoaded = true,
+                hasSchedulesToday = true,
+                subwayServiceStartTime = null,
+                alertsDownstream = emptyList(),
+                RouteCardData.Context.Favorites,
+            )
+
+        val olNorthboundLeaf =
+            RouteCardData.Leaf(
+                ol,
+                ruggles,
+                1,
+                listOf(objects.getRoutePattern("Orange-3-1")),
+                ruggles.childStopIds.toSet(),
+                upcomingTrips = emptyList(),
+                alertsHere = emptyList(),
+                allDataLoaded = true,
+                hasSchedulesToday = true,
+                subwayServiceStartTime = null,
+                alertsDownstream = emptyList(),
+                RouteCardData.Context.Favorites,
+            )
+
+        val bus43RugglesLeaf =
+            RouteCardData.Leaf(
+                bus43,
+                ruggles,
+                1,
+                listOf(bus43Inbound),
+                ruggles.childStopIds.toSet(),
+                upcomingTrips = emptyList(),
+                alertsHere = emptyList(),
+                allDataLoaded = true,
+                hasSchedulesToday = true,
+                subwayServiceStartTime = null,
+                alertsDownstream = emptyList(),
+                RouteCardData.Context.Favorites,
+            )
+
+        val bus43TremontAtMelneaCassLeaf =
+            RouteCardData.Leaf(
+                bus43,
+                tremontAtMelneaCass,
+                1,
+                listOf(bus43Inbound),
+                setOf(tremontAtMelneaCass.id),
+                upcomingTrips = emptyList(),
+                alertsHere = emptyList(),
+                allDataLoaded = true,
+                hasSchedulesToday = true,
+                subwayServiceStartTime = null,
+                alertsDownstream = emptyList(),
+                RouteCardData.Context.Favorites,
+            )
+
+        val glWestboundLeaf =
+            RouteCardData.Leaf(
+                gl,
+                boylston,
+                0,
+                listOf(
+                    objects.getRoutePattern("Green-B-812-0"),
+                    objects.getRoutePattern("Green-C-832-0"),
+                    objects.getRoutePattern("Green-D-855-0"),
+                    objects.getRoutePattern("Green-E-886-0"),
+                ),
+                boylston.childStopIds.toSet(),
+                upcomingTrips = emptyList(),
+                alertsHere = emptyList(),
+                allDataLoaded = true,
+                hasSchedulesToday = true,
+                subwayServiceStartTime = null,
+                alertsDownstream = emptyList(),
+                RouteCardData.Context.Favorites,
+            )
+
+        val routeCardData =
+            listOf(
+                RouteCardData(
+                    ol,
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            ol,
+                            ruggles,
+                            listOf(olSouthboundLeaf, olNorthboundLeaf),
+                            global,
+                        )
+                    ),
+                    now,
+                ),
+                RouteCardData(
+                    bus43,
+                    listOf(
+                        RouteCardData.RouteStopData(
+                            bus43,
+                            ruggles,
+                            listOf(bus43RugglesLeaf),
+                            global,
+                        ),
+                        RouteCardData.RouteStopData(
+                            bus43,
+                            tremontAtMelneaCass,
+                            listOf(bus43TremontAtMelneaCassLeaf),
+                            global,
+                        ),
+                    ),
+                    now,
+                ),
+                RouteCardData(
+                    gl,
+                    listOf(
+                        RouteCardData.RouteStopData(gl, boylston, listOf(glWestboundLeaf), global)
+                    ),
+                    now,
+                ),
+            )
+
+        assertEquals(
+            listOf(
+                StopCardData(ruggles, listOf(olSouthboundLeaf, olNorthboundLeaf, bus43RugglesLeaf)),
+                StopCardData(tremontAtMelneaCass, listOf(bus43TremontAtMelneaCassLeaf)),
+                StopCardData(boylston, listOf(glWestboundLeaf)),
+            ),
+            StopCardData.fromRouteCardData(routeCardData, sortByDistanceFrom = null),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.StopCardData
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
@@ -63,18 +64,19 @@ internal class FavoritesViewModelTest : KoinTest {
     val objects = ObjectCollectionBuilder()
     val stop1 =
         objects.stop {
+            id = "stop1"
             latitude = 0.0
             longitude = 0.0
         }
     val stop2 =
         objects.stop {
-            id = "stop1"
+            id = "stop2"
             latitude = 1.0
             longitude = 1.0
         }
     val stop3 =
         objects.stop {
-            id = "stop2"
+            id = "stop3"
             latitude = -0.5
             longitude = -0.5
         }
@@ -173,7 +175,9 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = null,
                     routeCardData = null,
+                    stopCardData = null,
                     staticRouteCardData = null,
+                    staticStopCardData = null,
                     loadedLocation = null,
                 ),
                 awaitItem(),
@@ -183,7 +187,9 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = emptyMap(),
                     routeCardData = null,
+                    stopCardData = null,
                     staticRouteCardData = null,
+                    staticStopCardData = null,
                     loadedLocation = null,
                 ),
                 awaitItem(),
@@ -193,7 +199,9 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = emptyMap(),
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = emptyList(),
+                    staticStopCardData = emptyList(),
                     loadedLocation = null,
                 ),
                 awaitItem(),
@@ -354,7 +362,9 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = null,
                     routeCardData = null,
+                    stopCardData = null,
                     staticRouteCardData = null,
+                    staticStopCardData = null,
                     loadedLocation = null,
                 ),
                 awaitItem(),
@@ -364,7 +374,9 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favorites.routeStopDirection,
                     routeCardData = null,
+                    stopCardData = null,
                     staticRouteCardData = null,
+                    staticStopCardData = null,
                     loadedLocation = null,
                 ),
                 awaitItem(),
@@ -378,7 +390,15 @@ internal class FavoritesViewModelTest : KoinTest {
                         false,
                         false,
                         expectedRealtimeData,
+                        StopCardData.fromRouteCardData(
+                            expectedRealtimeData,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                         expectedStaticData,
+                        StopCardData.fromRouteCardData(
+                            expectedStaticData,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                         stop1.position,
                     )
             }
@@ -472,7 +492,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesBefore.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataBefore,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataBefore,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     loadedLocation = stop1.position,
                 ),
                 awaitItemSatisfying {
@@ -486,7 +512,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesAfter.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataBefore,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataBefore,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     loadedLocation = stop1.position,
                 ),
                 awaitItem(),
@@ -496,7 +528,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesAfter.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataAfter,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataAfter,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     loadedLocation = stop1.position,
                 ),
                 awaitItem(),
@@ -568,7 +606,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesBefore.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataBefore,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataBefore,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     loadedLocation = stop1.position,
                 ),
                 awaitItemSatisfying {
@@ -882,7 +926,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesBefore.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataBefore,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataBefore,
+                            sortByDistanceFrom = stop3.position,
+                        ),
                     loadedLocation = stop3.position,
                 ),
                 awaitItemSatisfying {
@@ -1109,7 +1159,13 @@ internal class FavoritesViewModelTest : KoinTest {
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesBefore.routeStopDirection,
                     routeCardData = emptyList(),
+                    stopCardData = emptyList(),
                     staticRouteCardData = expectedStaticDataBefore,
+                    staticStopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataBefore,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     loadedLocation = stop1.position,
                 ),
                 awaitItemSatisfying {


### PR DESCRIPTION
### Summary

_Ticket:_ [Group favorites by stop | new data structure](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215721826698287)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

It’s conceivable that at some point we will realize we can’t actually just reuse the `RouteCardData.Leaf` fully as-is, but I can’t think of a reason why.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added new shared test and updated existing tests. Most existing tests were just updated to calculate the new `StopCardData` from the old `RouteCardData`, which will stop making as much sense as we move favorites to grouped by stop, but some existing tests were updated to define a `Leaf` that both data structures are explicitly set to use, which will still be defensible after we’ve moved (although it’ll probably be more succinct to define the `Leaf` inline in the `StopCardData` the same way they were previously defined inline in the `RouteCardData`, which is why I didn’t use this strategy everywhere).

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
