### PR TITLE
fix(iOS): Don't set presentationBackground

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -557,11 +557,8 @@ struct ContentView: View {
                     VStack {
                         navSheetContents
                             .presentationDetents([.small, .medium, .almostFull], selection: $selectedDetent)
-                            // Setting background color helps preserve contrast with accessibility setting "Show
-                            // Borders" turned on
-                            .presentationBackground(Color(.sheetBackground))
+                            .presentationBackgroundInteraction(.enabled(upThrough: .medium))
                             .interactiveDismissDisabled()
-                            .modifier(AllowsBackgroundInteraction())
                     }
                     // within the sheet to prevent issues on iOS 16 with two modal views open at once
                     .fullScreenCover(
@@ -740,12 +737,5 @@ struct ContentView: View {
                 && !searchObserver.isSearching
 
         tabBarVisibility = shouldShowTabBar ? .visible : .hidden
-    }
-
-    struct AllowsBackgroundInteraction: ViewModifier {
-        func body(content: Content) -> some View {
-            content.presentationBackgroundInteraction(.enabled(upThrough: .medium))
-                .enableInjection()
-        }
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix iOS 17](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215928252721120?focus=true)
Introduced in #1715 

There seems to be a bug in iOS 17.4+ where this in combination with `presentationBackgroundInteraction` was causing the sheet to lock up entirely and prevent any interaction within the app. As far as I can tell, adding `presentationBackground` doesn't actually do anything when the accessibility toggle is turned on in iOS 17.4. ~WIP: Trying it out on iOS 26 to see if it makes a difference there.~ It doesn't seem to do anything in iOS 26 either.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

### Testing

Verified in the simulator that the app is now functional on iOS 17.4