### PR TITLE
chore(iOS): 2.1.2 version bump

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.1.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>ITSAppUsesNonExemptEncryption</key>


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

Bump only the iOS version, because we're only doing an iOS release to get #1804 out.

### Testing

N/A