### PR TITLE
Show all downstream alerts up to the first suspension or shuttle

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -9,7 +9,6 @@ import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalTime
-import kotlinx.datetime.minus
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -610,9 +609,9 @@ internal constructor(
         }
 
         /**
-         * Gets the alerts of the first stop that is downstream of the target stop which has any
-         * alerts that are different from the alerts at the target stop. Considers only alerts that
-         * have specified stops.
+         * Gets the alerts of the stops that are downstream of the target stop which have alerts up
+         * to the first suspension or shuttle that are different from the alerts at the target stop.
+         * Considers only alerts that have specified stops.
          *
          * @param alerts: The full list of alerts
          * @param trip: The trip used to calculate downstream stops
@@ -625,14 +624,22 @@ internal constructor(
             targetStopWithChildren: Set<String>,
         ): List<Alert> {
             val stopIds = trip.stopIds ?: emptyList()
+            // find the index of the first stop id in target stop with children
+            val indexOfTargetStopInPattern =
+                stopIds.indexOfFirst { targetStopWithChildren.contains(it) }
+            // Return empty if target stop with children is not on stopIds
+            if (indexOfTargetStopInPattern < 0) return listOf()
+            // Return empty if target stop with children is the last stop id
+            if (indexOfTargetStopInPattern == stopIds.size - 1) return listOf()
 
+            // Filter out alerts without stop specified and lower than accessibility significance
             val alerts =
                 alerts.filter {
                     it.hasStopsSpecified &&
                         it.intrinsicSignificance >= AlertSignificance.Accessibility
                 }
 
-            val targetStopAlertIds =
+            val relevantAlerts =
                 alerts
                     .filter {
                         it.anyInformedEntitySatisfies {
@@ -642,36 +649,39 @@ internal constructor(
                             )
                             checkDirection(Matcher.Data(trip.directionId))
                             checkRoute(trip.routeId, routeType)
+                        }
+                    }
+                    .toList()
+
+            // obtaining the target stop alert ids
+            val targetStopAlertIds =
+                relevantAlerts
+                    .filter {
+                        it.anyInformedEntitySatisfies {
                             checkStopIn(Matcher.Data(targetStopWithChildren))
                         }
                     }
                     .map { it.id }
                     .toSet()
 
-            val indexOfTargetStopInPattern =
-                stopIds.indexOfFirst { targetStopWithChildren.contains(it) }
-            if (indexOfTargetStopInPattern != -1 && indexOfTargetStopInPattern < stopIds.size - 1) {
-                val downstreamStops = stopIds.subList(indexOfTargetStopInPattern + 1, stopIds.size)
-                val firstStopAlerts =
-                    downstreamStops
-                        .map { stop ->
-                            alerts.filter {
-                                it.anyInformedEntitySatisfies {
-                                    checkActivityIn(
-                                        InformedEntity.Activity.Exit,
-                                        InformedEntity.Activity.Ride,
-                                    )
-                                    checkDirection(Matcher.Data(trip.directionId))
-                                    checkRoute(trip.routeId, routeType)
-                                    checkStop(Matcher.Data(stop))
-                                } && !targetStopAlertIds.contains(it.id)
-                            }
-                        }
-                        .firstOrNull { it.isNotEmpty() } ?: listOf()
-                return firstStopAlerts
-            } else {
-                return listOf()
+            val downstreamStops = stopIds.subList(indexOfTargetStopInPattern + 1, stopIds.size)
+            val tripAlerts =
+                downstreamStops.flatMap { stop ->
+                    relevantAlerts.filter {
+                        it.anyInformedEntitySatisfies { checkStop(Matcher.Data(stop)) } &&
+                            !targetStopAlertIds.contains(it.id)
+                    }
+                }
+            if (tripAlerts.isEmpty()) return emptyList()
+            val lastIndex =
+                tripAlerts.indexOfFirst {
+                    setOf(Effect.Suspension, Effect.Shuttle).contains(it.effect)
+                }
+            // If there is an alert with suspension or shuttle, only return alerts up to that point
+            if (lastIndex >= 0) {
+                return tripAlerts.subList(0, lastIndex + 1)
             }
+            return tripAlerts
         }
 
         /**

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -598,7 +598,7 @@ class AlertTest {
     }
 
     @Test
-    fun `downstreamAlerts returns alerts for first downstream alerting stop`() {
+    fun `downstreamAlerts returns alerts for all downstream alerting stops`() {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()
         val targetStop = objects.stop()
@@ -670,7 +670,102 @@ class AlertTest {
                 setOf(targetStop.id),
             )
 
-        assertEquals(listOf(firstRideAlert), downstreamAlerts)
+        assertEquals(listOf(firstRideAlert, secondRideAlert), downstreamAlerts)
+    }
+
+    @Test
+    fun `downstreamAlerts returns alerts for all downstream alerting stops before suspension`() {
+        val objects = ObjectCollectionBuilder()
+        val route = objects.route()
+        val targetStop = objects.stop()
+        val stopWithBoardAlert = objects.stop()
+        val firstStopWithRideAlert = objects.stop()
+        val secondStopWithRideAlert = objects.stop()
+        val thirdStopWithRideAlert = objects.stop()
+
+        val alertRideTargetStop =
+            objects.alert {
+                effect = Alert.Effect.ServiceChange
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Ride),
+                    route = route.id.idText,
+                    stop = targetStop.id,
+                    directionId = 0,
+                )
+            }
+
+        val alertBoard =
+            objects.alert {
+                effect = Alert.Effect.ServiceChange
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Board),
+                    route = route.id.idText,
+                    stop = stopWithBoardAlert.id,
+                    directionId = 0,
+                )
+            }
+        val firstRideAlert =
+            objects.alert {
+                effect = Alert.Effect.ServiceChange
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Ride),
+                    route = route.id.idText,
+                    stop = firstStopWithRideAlert.id,
+                    directionId = null,
+                )
+            }
+
+        val secondRideAlert =
+            objects.alert {
+                effect = Alert.Effect.Suspension
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Ride),
+                    route = route.id.idText,
+                    stop = secondStopWithRideAlert.id,
+                    directionId = null,
+                )
+            }
+
+        val thirdRideAlert =
+            objects.alert {
+                effect = Alert.Effect.ServiceChange
+                informedEntity(
+                    listOf(Alert.InformedEntity.Activity.Ride),
+                    route = route.id.idText,
+                    stop = thirdStopWithRideAlert.id,
+                    directionId = null,
+                )
+            }
+
+        val trip =
+            objects.trip {
+                routeId = route.id.idText
+                directionId = 0
+                stopIds =
+                    listOf(
+                        targetStop.id,
+                        stopWithBoardAlert.id,
+                        firstStopWithRideAlert.id,
+                        secondStopWithRideAlert.id,
+                        thirdRideAlert.id,
+                    )
+            }
+
+        val downstreamAlerts =
+            Alert.downstreamAlerts(
+                listOf(
+                    alertRideTargetStop,
+                    alertBoard,
+                    firstRideAlert,
+                    secondRideAlert,
+                    thirdRideAlert,
+                ),
+                trip,
+                route.type,
+                setOf(targetStop.id),
+            )
+
+        assertEquals(listOf(firstRideAlert, secondRideAlert), downstreamAlerts)
     }
 
     @Test
@@ -892,9 +987,9 @@ class AlertTest {
             }
         val upcomingTripAlewife = objects.upcomingTrip(scheduleAlewife)
 
-        val shawmutShuttleAlert =
+        val shawmutClosureAlert =
             objects.alert {
-                effect = Alert.Effect.Shuttle
+                effect = Alert.Effect.StationClosure
                 activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
@@ -947,7 +1042,7 @@ class AlertTest {
                 alerts =
                     listOf(
                         ashmontShuttleAlert,
-                        shawmutShuttleAlert,
+                        shawmutClosureAlert,
                         parkShuttleAlert,
                         alewifeShuttleAlert,
                     ),
@@ -957,14 +1052,14 @@ class AlertTest {
                 tripsById = global.trips,
             )
         // ashmont alert not included b/c only first downstream alert on pattern returned
-        assertEquals(listOf(shawmutShuttleAlert), southboundDownstreamAlerts)
+        assertEquals(listOf(shawmutClosureAlert, ashmontShuttleAlert), southboundDownstreamAlerts)
 
         val northboundDownstreamAlerts =
             Alert.alertsDownstreamForPatterns(
                 alerts =
                     listOf(
                         ashmontShuttleAlert,
-                        shawmutShuttleAlert,
+                        shawmutClosureAlert,
                         parkShuttleAlert,
                         alewifeShuttleAlert,
                     ),


### PR DESCRIPTION
### Summary

_Ticket:_ ["First downstream alert" logic shouldn't include station closure/bypass alerts](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1214933929586667?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->
<img width="238" height="506" alt="Screenshot_20260624_134213" src="https://github.com/user-attachments/assets/88e216d2-abcf-4438-b8e8-f025f4d10449" />
<img width="238" height="506" alt="Screenshot_20260624_134317" src="https://github.com/user-attachments/assets/04db0527-2c08-4721-9e75-9d9e2f826477" />
<img width="238" height="506" alt="Screenshot_20260624_134457" src="https://github.com/user-attachments/assets/740f0d84-6d64-44db-a6a6-0fd50d72816c" />

What is this PR for?
Show all downstream alerts up to the first suspension or shuttle

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Tested that a suspension or a shuttle alert would be the last alert to show
- Updated unit tests
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
