### PR TITLE
feat: group favorites by stop, not route

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
@@ -26,7 +26,10 @@ class StopSubheaderTest {
         val stop = objects.stop {}
 
         composeTestRule.setContent {
-            StopSubheader(RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()))
+            StopSubheader(
+                RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()),
+                includeIcon = false,
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
     }
@@ -41,7 +44,10 @@ class StopSubheaderTest {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
-            StopSubheader(RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()))
+            StopSubheader(
+                RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()),
+                includeIcon = false,
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertDoesNotExist()
@@ -57,7 +63,10 @@ class StopSubheaderTest {
             settings = MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
         }
         composeTestRule.setContent {
-            StopSubheader(RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()))
+            StopSubheader(
+                RouteCardData.RouteStopData(LineOrRoute.Route(route), stop, emptyList()),
+                includeIcon = false,
+            )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
         composeTestRule.onNodeWithText("Not accessible").assertIsDisplayed()
@@ -100,7 +109,8 @@ class StopSubheaderTest {
                             RouteCardData.Context.StopDetailsUnfiltered,
                         )
                     ),
-                )
+                ),
+                includeIcon = false,
             )
         }
         composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardListTest.kt
@@ -1,0 +1,269 @@
+package com.mbta.tid.mbta_app.android.component.stopCard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
+import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.StopCardData
+import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.ScheduleResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.maplibre.spatialk.geojson.Position
+
+class StopCardListTest {
+    val builder = ObjectCollectionBuilder()
+    val now = EasternTimeInstant.now()
+    val route =
+        builder.route {
+            id = "route_1"
+            type = RouteType.BUS
+            color = "FF0000"
+            directionNames = listOf("North", "South")
+            directionDestinations = listOf("Downtown", "Uptown")
+            longName = "Sample Route Long Name"
+            shortName = "SR"
+            textColor = "000000"
+            lineId = "line_1"
+            routePatternIds = mutableListOf("pattern_1", "pattern_2")
+        }
+    val routePatternOne =
+        builder.routePattern(route) {
+            id = "pattern_1"
+            directionId = 0
+            name = "Sample Route Pattern"
+            routeId = "route_1"
+            representativeTripId = "trip_1"
+        }
+    val routePatternTwo =
+        builder.routePattern(route) {
+            id = "pattern_2"
+            directionId = 1
+            name = "Sample Route Pattern Two"
+            routeId = "route_1"
+            representativeTripId = "trip_1"
+        }
+    val sampleStop =
+        builder.stop {
+            id = "stop_1"
+            name = "Sample Stop"
+            locationType = LocationType.STOP
+            latitude = 0.0
+            longitude = 0.0
+        }
+    val line =
+        builder.line {
+            id = "line_1"
+            color = "FF0000"
+            textColor = "FFFFFF"
+        }
+    val trip =
+        builder.trip {
+            id = "trip_1"
+            routeId = "route_1"
+            directionId = 0
+            headsign = "Sample Headsign"
+            routePatternId = "pattern_1"
+            stopIds = listOf(sampleStop.id)
+        }
+    val prediction =
+        builder.prediction {
+            id = "prediction_1"
+            revenue = true
+            stopId = "stop_1"
+            tripId = "trip_1"
+            routeId = "route_1"
+            stopSequence = 1
+            directionId = 0
+            arrivalTime = now.plus(1.minutes)
+            departureTime = now.plus(1.5.minutes)
+        }
+
+    val greenLineRoute =
+        builder.route {
+            id = "route_2"
+            type = RouteType.LIGHT_RAIL
+            color = "008000"
+            directionNames = listOf("Inbound", "Outbound")
+            directionDestinations = listOf("Park Street", "Lechmere")
+            longName = "Green Line D"
+            shortName = "D"
+            textColor = "FFFFFF"
+            lineId = "line-Green"
+            routePatternIds = mutableListOf("pattern_3", "pattern_4")
+        }
+    val greenLineRoutePatternOne =
+        builder.routePattern(greenLineRoute) {
+            id = "pattern_3"
+            directionId = 0
+            name = "Green Line Pattern"
+            routeId = "route_2"
+            representativeTripId = "trip_2"
+        }
+    val greenLine =
+        builder.line {
+            id = "line-Green"
+            shortName = "Green Line"
+            longName = "Green Line Long Name"
+            color = "008000"
+            textColor = "FFFFFF"
+        }
+    val greenLineStop =
+        builder.stop {
+            id = "stop_2"
+            name = "Green Line Stop"
+            locationType = LocationType.STOP
+            latitude = 0.0
+            longitude = 0.0
+        }
+    val greenLineTrip =
+        builder.trip {
+            id = "trip_2"
+            routeId = "route_2"
+            directionId = 0
+            headsign = "Green Line Head Sign"
+            routePatternId = "pattern_3"
+            stopIds = listOf(greenLineStop.id)
+        }
+    val greenLinePrediction =
+        builder.prediction {
+            id = "prediction_2"
+            revenue = true
+            stopId = "stop_2"
+            tripId = "trip_2"
+            routeId = "route_2"
+            stopSequence = 1
+            directionId = 0
+            arrivalTime = now.plus(5.minutes)
+            departureTime = now.plus(5.5.minutes)
+        }
+
+    val globalResponse = GlobalResponse(builder)
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        loadKoinMocks(builder)
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testStopCardListDisplaysCorrectly(): Unit = runBlocking {
+        val routeCardData =
+            RouteCardData.routeCardsForStopList(
+                listOf(sampleStop.id, greenLineStop.id),
+                globalResponse,
+                Position(0.0, 0.0),
+                ScheduleResponse(builder),
+                predictions = PredictionsStreamDataResponse(builder),
+                AlertsStreamDataResponse(emptyMap()),
+                now,
+                RouteCardData.Context.NearbyTransit,
+            )
+        val stopCardData =
+            StopCardData.fromRouteCardData(checkNotNull(routeCardData), sortByDistanceFrom = null)
+
+        composeTestRule.setContent {
+            Column {
+                StopCardList(
+                    stopCardData = stopCardData,
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { _, _ -> },
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("SR"))
+        composeTestRule.onNodeWithText("SR").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Green Line D", ignoreCase = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Head Sign").assertIsDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testRouteCardListShowsEmptyView() {
+        loadKoinMocks()
+        composeTestRule.setContent {
+            Column {
+                StopCardList(
+                    stopCardData = emptyList(),
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { _, _ -> },
+                )
+            }
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            hasText("This would be the empty view")
+        )
+        composeTestRule.onNodeWithText("This would be the empty view").assertIsDisplayed()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun testOpenStopDetails(): Unit = runBlocking {
+        val routeCardData =
+            RouteCardData.routeCardsForStopList(
+                listOf(sampleStop.id),
+                globalResponse,
+                Position(0.0, 0.0),
+                ScheduleResponse(builder),
+                predictions = PredictionsStreamDataResponse(builder),
+                AlertsStreamDataResponse(emptyMap()),
+                now,
+                RouteCardData.Context.NearbyTransit,
+            )
+        val stopCardData =
+            StopCardData.fromRouteCardData(checkNotNull(routeCardData), sortByDistanceFrom = null)
+
+        var clickedStopId: String? = null
+        composeTestRule.setContent {
+            Column {
+                StopCardList(
+                    stopCardData = stopCardData,
+                    emptyView = { Text("This would be the empty view") },
+                    global = globalResponse,
+                    now = EasternTimeInstant.now(),
+                    isFavorite = { false },
+                    onOpenStopDetails = { stopId, _ -> clickedStopId = stopId },
+                )
+            }
+        }
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("SR"))
+        composeTestRule.onNodeWithText("SR").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        assertEquals(clickedStopId, sampleStop.id)
+    }
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardTest.kt
@@ -1,0 +1,62 @@
+package com.mbta.tid.mbta_app.android.component.stopCard
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.StopCardData
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import org.junit.Rule
+import org.junit.Test
+
+class StopCardTest {
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testNearbyCard() {
+        val now = EasternTimeInstant.now()
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop { name = "Stop" }
+        val route =
+            objects.route {
+                longName = "Route"
+                type = RouteType.LIGHT_RAIL
+            }
+
+        composeTestRule.setContent {
+            StopCard(
+                StopCardData(
+                    stop,
+                    listOf(
+                        RouteCardData.Leaf(
+                            LineOrRoute.Route(route),
+                            stop,
+                            Direction(0, route),
+                            emptyList(),
+                            emptySet(),
+                            emptyList(),
+                            emptyList(),
+                            true,
+                            true,
+                            null,
+                            emptyList(),
+                            RouteCardData.Context.Favorites,
+                        )
+                    ),
+                ),
+                GlobalResponse(objects),
+                now,
+                isFavorite = { false },
+            ) { _, _ ->
+            }
+        }
+
+        composeTestRule.onNodeWithText(route.label, ignoreCase = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DirectionLabel.kt
@@ -35,13 +35,16 @@ fun directionNameFormatted(direction: Direction) =
 fun DirectionTo(
     direction: Direction,
     textColor: Color,
+    routeNamePrefix: String? = null,
     onlyServingOppositeDirection: Boolean = false,
 ) {
     Text(
-        stringResource(
-            if (onlyServingOppositeDirection) R.string.only_direction_to else R.string.directionTo,
-            stringResource(directionNameFormatted(direction)),
-        ),
+        routeNamePrefix?.let { "$it " }.orEmpty() +
+            stringResource(
+                if (onlyServingOppositeDirection) R.string.only_direction_to
+                else R.string.directionTo,
+                stringResource(directionNameFormatted(direction)),
+            ),
         color = textColor,
         modifier = Modifier.placeholderIfLoading(),
         style = if (onlyServingOppositeDirection) Typography.footnoteItalic else Typography.footnote,
@@ -78,14 +81,15 @@ fun DirectionLabel(
     textColor: Color = LocalContentColor.current,
     showDestination: Boolean = true,
     pillDecoration: PillDecoration? = null,
+    routeNamePrefix: String? = null,
     onlyServingOppositeDirection: Boolean = false,
 ) {
     val destination = direction.destination
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
         if (!showDestination) {
-            DirectionTo(direction, textColor, onlyServingOppositeDirection)
+            DirectionTo(direction, textColor, routeNamePrefix, onlyServingOppositeDirection)
         } else if (destination != null) {
-            DirectionTo(direction, textColor, onlyServingOppositeDirection)
+            DirectionTo(direction, textColor, routeNamePrefix, onlyServingOppositeDirection)
             DestinationLabel(destination, textColor, pillDecoration)
         } else {
             DestinationLabel(direction, textColor, pillDecoration)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCard.kt
@@ -36,7 +36,7 @@ fun RouteCardContainer(
 
         data.stopData.forEach {
             if (showStopHeader) {
-                StopSubheader(it)
+                StopSubheader(it, includeIcon = false)
             }
 
             departureContent(it)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheader.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheader.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,15 +27,18 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.Stop
 import com.mbta.tid.mbta_app.repositories.Settings
 
 @Composable
-fun StopSubheader(data: RouteCardData.RouteStopData) {
+fun StopSubheader(stop: Stop, elevatorAlerts: List<Alert>, includeIcon: Boolean) {
     val showStationAccessibility = SettingsCache.get(Settings.StationAccessibility)
-    val isWheelchairAccessible = data.stop.isWheelchairAccessible
+    val isWheelchairAccessible = stop.isWheelchairAccessible
     val showInaccessible = showStationAccessibility && !isWheelchairAccessible
-    val showElevatorAlerts = showStationAccessibility && data.hasElevatorAlerts
+    val showElevatorAlerts = showStationAccessibility && elevatorAlerts.isNotEmpty()
 
     Row(
         Modifier.background(colorResource(id = R.color.fill2))
@@ -43,13 +47,23 @@ fun StopSubheader(data: RouteCardData.RouteStopData) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
+        if (includeIcon) {
+            Image(
+                painterResource(
+                    if (stop.locationType == LocationType.STATION) R.drawable.mbta_logo
+                    else R.drawable.stop_bus
+                ),
+                null,
+                Modifier.width(24.dp),
+            )
+        }
         Column(
             modifier = Modifier.height(IntrinsicSize.Min).padding(start = 8.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
             horizontalAlignment = Alignment.Start,
         ) {
             Text(
-                text = data.stop.name,
+                text = stop.name,
                 modifier = Modifier.placeholderIfLoading().fillMaxWidth(),
                 overflow = TextOverflow.Visible,
                 style = Typography.callout,
@@ -87,8 +101,8 @@ fun StopSubheader(data: RouteCardData.RouteStopData) {
                             else
                                 pluralStringResource(
                                     R.plurals.elevator_closure_count,
-                                    data.elevatorAlerts.size,
-                                    data.elevatorAlerts.size,
+                                    elevatorAlerts.size,
+                                    elevatorAlerts.size,
                                 ),
                         modifier = Modifier.placeholderIfLoading().fillMaxWidth(),
                         textAlign = TextAlign.Start,
@@ -100,4 +114,9 @@ fun StopSubheader(data: RouteCardData.RouteStopData) {
             }
         }
     }
+}
+
+@Composable
+fun StopSubheader(data: RouteCardData.RouteStopData, includeIcon: Boolean) {
+    StopSubheader(data.stop, data.elevatorAlerts, includeIcon)
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/LoadingStopCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/LoadingStopCard.kt
@@ -1,0 +1,25 @@
+package com.mbta.tid.mbta_app.android.component.stopCard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.mbta.tid.mbta_app.android.util.modifiers.loading
+import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.mbta.tid.mbta_app.model.StopCardData
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+
+@Composable
+fun LoadingStopCard() {
+    val placeholderRouteData = LoadingPlaceholders.nearbyRoute()
+    val placeholderStopData =
+        StopCardData.fromRouteCardData(listOf(placeholderRouteData), sortByDistanceFrom = null)
+    Column(modifier = Modifier.loading(withShimmer = false)) {
+        StopCard(
+            placeholderStopData.first(),
+            null,
+            EasternTimeInstant.now(),
+            { false },
+            { _, _ -> },
+        )
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCard.kt
@@ -1,0 +1,187 @@
+package com.mbta.tid.mbta_app.android.component.stopCard
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.android.component.DirectionLabel
+import com.mbta.tid.mbta_app.android.component.DirectionRowView
+import com.mbta.tid.mbta_app.android.component.HaloSeparator
+import com.mbta.tid.mbta_app.android.component.HeadsignRowView
+import com.mbta.tid.mbta_app.android.component.NavDrilldownRow
+import com.mbta.tid.mbta_app.android.component.PillDecoration
+import com.mbta.tid.mbta_app.android.component.RoutePill
+import com.mbta.tid.mbta_app.android.component.RoutePillType
+import com.mbta.tid.mbta_app.android.component.routeCard.StopSubheader
+import com.mbta.tid.mbta_app.android.component.routeCard.WorldCupBlurb
+import com.mbta.tid.mbta_app.android.generated.drawableByName
+import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
+import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
+import com.mbta.tid.mbta_app.model.LeafFormat
+import com.mbta.tid.mbta_app.model.LineOrRoute
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.StopCardData
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.UpcomingFormat
+import com.mbta.tid.mbta_app.model.WorldCupService
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import org.koin.compose.koinInject
+
+@Composable
+fun StopCardContainer(
+    modifier: Modifier = Modifier,
+    data: StopCardData,
+    departureContent: @Composable (StopCardData) -> Unit,
+) {
+    Column(modifier.haloContainer(1.dp).semantics { testTag = "StopCard" }) {
+        StopSubheader(data.stop, data.elevatorAlerts, includeIcon = true)
+
+        departureContent(data)
+    }
+}
+
+@Composable
+fun StopCard(
+    data: StopCardData,
+    globalData: GlobalResponse?,
+    now: EasternTimeInstant,
+    isFavorite: (RouteStopDirection) -> Boolean?,
+    onOpenStopDetails: (String, StopDetailsFilter) -> Unit,
+) {
+    StopCardContainer(
+        data = data,
+        departureContent = {
+            Departures(
+                it,
+                globalData,
+                now,
+                { routeStopDirection -> isFavorite(routeStopDirection) },
+            ) { leaf ->
+                onOpenStopDetails(
+                    it.stop.id,
+                    StopDetailsFilter(leaf.lineOrRoute.id, leaf.direction.id),
+                )
+            }
+        },
+    )
+}
+
+@Composable
+fun Departures(
+    stopData: StopCardData,
+    globalData: GlobalResponse?,
+    now: EasternTimeInstant,
+    isFavorite: (RouteStopDirection) -> Boolean?,
+    analytics: Analytics = koinInject(),
+    onClick: (RouteCardData.Leaf) -> Unit,
+) {
+    Column {
+        stopData.data.withIndex().forEach { (index, leaf) ->
+            fun analyticsTappedDeparture(leafFormat: LeafFormat) {
+                val format = (leafFormat as? LeafFormat.Single)?.format
+                val noTrips = (format as? UpcomingFormat.NoTrips)?.noTripsFormat
+                analytics.tappedDeparture(
+                    leaf.lineOrRoute.id,
+                    stopData.stop.id,
+                    isFavorite(leaf.routeStopDirection) ?: false,
+                    leaf.alertsHere().isNotEmpty(),
+                    leaf.lineOrRoute.type,
+                    noTrips,
+                )
+            }
+
+            val formatted = leaf.format(now, globalData)
+            val direction = leaf.direction
+
+            NavDrilldownRow(
+                onClick = {
+                    onClick(leaf)
+                    analyticsTappedDeparture(formatted)
+                },
+                onClickLabel = stringResource(R.string.open_for_more_arrivals),
+                modifier = Modifier.padding(vertical = 10.dp, horizontal = 16.dp),
+            ) { modifier ->
+                val branchedNoRoutePills =
+                    formatted is LeafFormat.Branched &&
+                        formatted.branchRows.all { it.route == null }
+                if (branchedNoRoutePills) {
+                    RoutePill(
+                        (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                        (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                        RoutePillType.Fixed,
+                    )
+                }
+                Column(
+                    modifier = modifier,
+                    horizontalAlignment = Alignment.Start,
+                    verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
+                ) {
+                    when {
+                        leaf.lineOrRoute.id == WorldCupService.route.id -> {
+                            WorldCupBlurb(
+                                leaf,
+                                TripRouteAccents(leaf.lineOrRoute.sortRoute),
+                                offerDetails = false,
+                            )
+                        }
+                        formatted is LeafFormat.Single -> {
+                            DirectionRowView(
+                                direction.copy(
+                                    destination = formatted.headsign ?: direction.destination
+                                ),
+                                formatted.format,
+                                pillDecoration =
+                                    PillDecoration.OnRow(
+                                        formatted.route ?: leaf.lineOrRoute.sortRoute
+                                    ),
+                            )
+                        }
+                        formatted is LeafFormat.Branched -> {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                formatted.warningAlert?.let { warningAlert ->
+                                    Image(
+                                        painterResource(drawableByName(warningAlert.iconName)),
+                                        stringResource(R.string.alert),
+                                        modifier =
+                                            Modifier.placeholderIfLoading().padding(end = 8.dp),
+                                    )
+                                }
+                                DirectionLabel(
+                                    direction,
+                                    showDestination = false,
+                                    routeNamePrefix =
+                                        leaf.lineOrRoute.name.takeIf { !branchedNoRoutePills },
+                                )
+                            }
+                            for (branch in formatted.branchRows) {
+                                HeadsignRowView(
+                                    branch.headsign,
+                                    branch.format,
+                                    pillDecoration = branch.route?.let { PillDecoration.OnRow(it) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (index < stopData.data.lastIndex) {
+                HaloSeparator()
+            }
+        }
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardList.kt
@@ -1,0 +1,345 @@
+package com.mbta.tid.mbta_app.android.component.stopCard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.analytics.Analytics
+import com.mbta.tid.mbta_app.analytics.MockAnalytics
+import com.mbta.tid.mbta_app.android.component.ScrollSeparatorLazyColumn
+import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
+import com.mbta.tid.mbta_app.android.util.SettingsCache
+import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.Direction
+import com.mbta.tid.mbta_app.model.LineOrRoute
+import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RoutePattern
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.RouteType
+import com.mbta.tid.mbta_app.model.StopCardData
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
+import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
+import com.mbta.tid.mbta_app.model.response.GlobalResponse
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import com.mbta.tid.mbta_app.utils.TestData
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+@Composable
+fun ColumnScope.StopCardList(
+    stopCardData: List<StopCardData>?,
+    emptyView: @Composable () -> Unit,
+    global: GlobalResponse?,
+    now: EasternTimeInstant,
+    isFavorite: (RouteStopDirection) -> Boolean,
+    onOpenStopDetails: (String, StopDetailsFilter?) -> Unit,
+) {
+    val contentPadding = PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp)
+    val verticalArrangement = Arrangement.spacedBy(14.dp)
+    val horizontalAlignment = Alignment.CenterHorizontally
+    if (stopCardData == null) {
+        CompositionLocalProvider(IsLoadingSheetContents provides true) {
+            ScrollSeparatorLazyColumn(
+                contentPadding = contentPadding,
+                verticalArrangement = verticalArrangement,
+                horizontalAlignment = horizontalAlignment,
+                userScrollEnabled = false,
+            ) {
+                items(5) { LoadingStopCard() }
+            }
+        }
+    } else if (stopCardData.isEmpty()) {
+        Column(
+            Modifier.verticalScroll(rememberScrollState()).padding(8.dp).weight(1f),
+            verticalArrangement = Arrangement.Center,
+        ) {
+            emptyView()
+        }
+    } else {
+        ScrollSeparatorLazyColumn(
+            contentPadding = contentPadding,
+            verticalArrangement = verticalArrangement,
+            horizontalAlignment = horizontalAlignment,
+        ) {
+            items(stopCardData) { StopCard(it, global, now, isFavorite, onOpenStopDetails) }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun StopCardListPreview() {
+    val now = EasternTimeInstant.now()
+    val objects = TestData.clone("StopCardListPreview")
+
+    val ruggles = objects.getStop("place-rugg")
+    val tremontAtMelneaCass =
+        objects.stop {
+            id = "1227"
+            locationType = LocationType.STOP
+            name = "Tremont St @ Melnea Cass Blvd"
+            wheelchairBoarding = WheelchairBoardingStatus.ACCESSIBLE
+        }
+    val boylston = objects.getStop("place-boyls")
+    val ol = LineOrRoute.Route(objects.getRoute("Orange"))
+    val olSouthboundPattern = objects.getRoutePattern("Orange-3-0")
+    val olNorthboundPattern = objects.getRoutePattern("Orange-3-1")
+    val gl =
+        LineOrRoute.Line(
+            objects.getLine("line-Green"),
+            setOf(
+                objects.getRoute("Green-B"),
+                objects.getRoute("Green-C"),
+                objects.getRoute("Green-D"),
+                objects.getRoute("Green-E"),
+            ),
+        )
+    val bus43 =
+        LineOrRoute.Route(
+            objects.route {
+                id = "43"
+                color = "FFC72C"
+                directionNames = listOf("Outbound", "Inbound")
+                directionDestinations = listOf("Ruggles Station", "Park Street Station")
+                shortName = "43"
+                textColor = "000000"
+                type = RouteType.BUS
+            }
+        )
+    val bus43Inbound =
+        objects.routePattern(bus43.route) {
+            directionId = 1
+            sortOrder = 504301000
+            typicality = RoutePattern.Typicality.Typical
+            representativeTrip {
+                headsign = "Park St & Tremont St"
+                stopIds = listOf("17869", "1227", "10000")
+            }
+        }
+
+    val global = GlobalResponse(objects)
+
+    val olSouthboundLeaf =
+        RouteCardData.Leaf(
+            ol,
+            ruggles,
+            Direction(0, ol.route),
+            listOf(olSouthboundPattern),
+            ruggles.childStopIds.toSet(),
+            upcomingTrips =
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(olSouthboundPattern)
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(olSouthboundPattern)
+                            departureTime = now + 11.minutes
+                        }
+                    ),
+                ),
+            alertsHere = emptyList(),
+            allDataLoaded = true,
+            hasSchedulesToday = true,
+            subwayServiceStartTime = null,
+            alertsDownstream = listOf(objects.alert { effect = Alert.Effect.Suspension }),
+            RouteCardData.Context.Favorites,
+        )
+
+    val olNorthboundLeaf =
+        RouteCardData.Leaf(
+            ol,
+            ruggles,
+            Direction(1, ol.route),
+            listOf(olNorthboundPattern),
+            ruggles.childStopIds.toSet(),
+            upcomingTrips =
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(olNorthboundPattern)
+                            departureTime = now + 6.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(olNorthboundPattern)
+                            departureTime = now + 14.minutes
+                        }
+                    ),
+                ),
+            alertsHere = emptyList(),
+            allDataLoaded = true,
+            hasSchedulesToday = true,
+            subwayServiceStartTime = null,
+            alertsDownstream = emptyList(),
+            RouteCardData.Context.Favorites,
+        )
+
+    val bus43RugglesLeaf =
+        RouteCardData.Leaf(
+            bus43,
+            ruggles,
+            Direction(1, bus43.route),
+            listOf(bus43Inbound),
+            ruggles.childStopIds.toSet(),
+            upcomingTrips =
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 22.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 56.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.schedule {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 12.hours
+                        }
+                    ),
+                ),
+            alertsHere = emptyList(),
+            allDataLoaded = true,
+            hasSchedulesToday = true,
+            subwayServiceStartTime = null,
+            alertsDownstream = emptyList(),
+            RouteCardData.Context.Favorites,
+        )
+
+    val bus43TremontAtMelneaCassLeaf =
+        RouteCardData.Leaf(
+            bus43,
+            tremontAtMelneaCass,
+            Direction(1, bus43.route),
+            listOf(bus43Inbound),
+            setOf(tremontAtMelneaCass.id),
+            upcomingTrips =
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 25.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 59.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.schedule {
+                            trip = objects.trip(bus43Inbound)
+                            departureTime = now + 12.hours
+                        }
+                    ),
+                ),
+            alertsHere = emptyList(),
+            allDataLoaded = true,
+            hasSchedulesToday = true,
+            subwayServiceStartTime = null,
+            alertsDownstream = emptyList(),
+            RouteCardData.Context.Favorites,
+        )
+
+    val glWestboundLeaf =
+        RouteCardData.Leaf(
+            gl,
+            boylston,
+            Direction("West", null, 0),
+            listOf(
+                objects.getRoutePattern("Green-B-812-0"),
+                objects.getRoutePattern("Green-C-832-0"),
+                objects.getRoutePattern("Green-D-855-0"),
+                objects.getRoutePattern("Green-E-886-0"),
+            ),
+            boylston.childStopIds.toSet(),
+            upcomingTrips =
+                listOf(
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(objects.getRoutePattern("Green-C-832-0"))
+                            departureTime = now + 3.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(objects.getRoutePattern("Green-B-812-0"))
+                            departureTime = now + 5.minutes
+                        }
+                    ),
+                    objects.upcomingTrip(
+                        objects.prediction {
+                            trip = objects.trip(objects.getRoutePattern("Green-D-855-0"))
+                            departureTime = now + 10.minutes
+                        }
+                    ),
+                ),
+            alertsHere = emptyList(),
+            allDataLoaded = true,
+            hasSchedulesToday = true,
+            subwayServiceStartTime = null,
+            alertsDownstream = emptyList(),
+            RouteCardData.Context.Favorites,
+        )
+
+    try {
+        stopKoin()
+    } catch (_: Exception) {}
+    startKoin {
+        modules(
+            module {
+                single<Analytics> { MockAnalytics() }
+                single {
+                    SettingsCache(
+                        MockSettingsRepository(
+                            mapOf(
+                                Settings.FavoritesByStop to true,
+                                Settings.StationAccessibility to true,
+                            )
+                        )
+                    )
+                }
+            }
+        )
+    }
+    Column {
+        StopCardList(
+            listOf(
+                StopCardData(ruggles, listOf(olSouthboundLeaf, olNorthboundLeaf, bus43RugglesLeaf)),
+                StopCardData(tremontAtMelneaCass, listOf(bus43TremontAtMelneaCassLeaf)),
+                StopCardData(boylston, listOf(glWestboundLeaf)),
+            ),
+            emptyView = {},
+            global,
+            now,
+            isFavorite = { true },
+            onOpenStopDetails = { _, _ -> },
+        )
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/FavoritesView.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.favorites
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
@@ -23,9 +24,12 @@ import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.NavTextButton
 import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
+import com.mbta.tid.mbta_app.android.component.stopCard.StopCardList
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.contrastTranslucent
 import com.mbta.tid.mbta_app.android.util.timer
+import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.StopDetailsFilter
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.routeDetailsPage.RouteDetailsContext
@@ -57,6 +61,7 @@ fun FavoritesView(
     val state by favoritesViewModel.models.collectAsState()
 
     val notificationsEnabled = SettingsCache.get(Settings.Notifications)
+    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     fun onAddFavorites() {
         favoritesViewModel.setIsFirstExposureToNewFavorites(false)
@@ -118,6 +123,20 @@ fun FavoritesView(
     }
 
     val routeCardData = state.routeCardData
+    val stopCardData = state.stopCardData
+
+    val chosenCardData = if (groupByStop) stopCardData else routeCardData
+
+    val emptyView: @Composable ColumnScope.() -> Unit = {
+        NoFavoritesView(::onAddFavorites)
+        Spacer(Modifier.weight(1f))
+    }
+    val isFavorite = { rsd: RouteStopDirection ->
+        (state.favorites?.keys ?: emptySet()).contains(rsd)
+    }
+    val onOpenStopDetails = { stopId: String, filter: StopDetailsFilter? ->
+        openSheetRoute(SheetRoutes.StopDetails(stopId, filter, null))
+    }
 
     Column {
         SheetHeader(
@@ -130,7 +149,7 @@ fun FavoritesView(
                 ),
             rightActionContents = {
                 Row(Modifier, Arrangement.spacedBy(8.dp), Alignment.CenterVertically) {
-                    if (!routeCardData.isNullOrEmpty()) {
+                    if (!chosenCardData.isNullOrEmpty()) {
                         ActionButton(
                             ActionButtonKind.Plus,
                             colors = ButtonDefaults.contrastTranslucent(),
@@ -156,18 +175,24 @@ fun FavoritesView(
 
         ErrorBanner(errorBannerViewModel, modifier = Modifier.padding(top = 8.dp))
         DebugView(content = {})
-        RouteCardList(
-            routeCardData = routeCardData,
-            emptyView = {
-                NoFavoritesView(::onAddFavorites)
-                Spacer(Modifier.weight(1f))
-            },
-            global = globalResponse,
-            now = now,
-            isFavorite = { rsd -> (state.favorites?.keys ?: emptySet()).contains(rsd) },
-            onOpenStopDetails = { stopId, filter ->
-                openSheetRoute(SheetRoutes.StopDetails(stopId, filter, null))
-            },
-        )
+        if (groupByStop) {
+            StopCardList(
+                stopCardData = stopCardData,
+                emptyView = { emptyView() },
+                global = globalResponse,
+                now = now,
+                isFavorite = isFavorite,
+                onOpenStopDetails = onOpenStopDetails,
+            )
+        } else {
+            RouteCardList(
+                routeCardData = routeCardData,
+                emptyView = { emptyView() },
+                global = globalResponse,
+                now = now,
+                isFavorite = isFavorite,
+                onOpenStopDetails = onOpenStopDetails,
+            )
+        }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -62,6 +62,7 @@ import com.mbta.tid.mbta_app.android.component.SheetHeader
 import com.mbta.tid.mbta_app.android.component.routeCard.LoadingRouteCard
 import com.mbta.tid.mbta_app.android.component.routeCard.StopSubheader
 import com.mbta.tid.mbta_app.android.component.routeCard.TransitHeader
+import com.mbta.tid.mbta_app.android.component.stopCard.LoadingStopCard
 import com.mbta.tid.mbta_app.android.favorites.NoFavoritesView
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
 import com.mbta.tid.mbta_app.android.util.SettingsCache
@@ -73,8 +74,10 @@ import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.android.util.modifiers.placeholderIfLoading
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.LeafFormat
+import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.RouteStopDirection
+import com.mbta.tid.mbta_app.model.StopCardData
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
@@ -97,6 +100,7 @@ fun EditFavoritesPage(
     val state by favoritesViewModel.models.collectAsState()
     val resources = LocalResources.current
     val currentLocale = stringResource(R.string.current_locale)
+    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     val removeToastText = stringResource(R.string.favorites_toast_remove)
     val removeToastFallbackText = stringResource(R.string.favorites_toast_remove_fallback)
@@ -111,10 +115,14 @@ fun EditFavoritesPage(
     // to make deletion animations work nicely, we persist the first staticRouteCardData we saw, and
     // then we visually hide things that are no longer in the favorites
     var firstStaticRouteCardData by remember { mutableStateOf<List<RouteCardData>?>(null) }
+    var firstStaticStopCardData by remember { mutableStateOf<List<StopCardData>?>(null) }
     val firstDataFavorites =
-        firstStaticRouteCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
+        if (groupByStop)
+            firstStaticStopCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
+        else firstStaticRouteCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
     val currentDataFavorites =
-        state.staticRouteCardData.orEmpty().flatMap { it.routeStopDirections }
+        if (groupByStop) state.staticStopCardData.orEmpty().flatMap { it.routeStopDirections }
+        else state.staticRouteCardData.orEmpty().flatMap { it.routeStopDirections }
     val removedFavorites = firstDataFavorites - currentDataFavorites
     // to avoid breaking creation, we reset the staticRouteCardData if anything appears that we
     // didn’t already know about
@@ -124,6 +132,13 @@ fun EditFavoritesPage(
                 !firstDataFavorites.containsAll(currentDataFavorites))
     ) {
         firstStaticRouteCardData = state.staticRouteCardData
+    }
+    if (
+        state.staticStopCardData != null &&
+            (firstStaticStopCardData == null ||
+                !firstDataFavorites.containsAll(currentDataFavorites))
+    ) {
+        firstStaticStopCardData = state.staticStopCardData
     }
 
     LaunchedEffect(Unit) { favoritesViewModel.setContext(FavoritesViewModel.Context.Edit) }
@@ -136,60 +151,73 @@ fun EditFavoritesPage(
             navCallbacks = navCallbacks,
             buttonColors = ButtonDefaults.key(),
         )
-        EditFavoritesList(
-            state.favorites,
-            firstStaticRouteCardData,
-            removedFavorites,
-            global,
-            deleteFavorite = { deletedFavorite ->
-                val deletedSettings = state.favorites?.get(deletedFavorite) ?: FavoriteSettings()
-                favoritesViewModel.updateFavorites(
-                    mapOf(deletedFavorite to null),
-                    EditFavoritesContext.Favorites,
-                    deletedFavorite.direction,
-                    fcmToken,
-                    currentLocale,
-                )
+        val deleteFavorite: (RouteStopDirection) -> Unit = { deletedFavorite ->
+            val deletedSettings = state.favorites?.get(deletedFavorite) ?: FavoriteSettings()
+            favoritesViewModel.updateFavorites(
+                mapOf(deletedFavorite to null),
+                EditFavoritesContext.Favorites,
+                deletedFavorite.direction,
+                fcmToken,
+                currentLocale,
+            )
 
-                toastViewModel.showToast(
-                    ToastViewModel.Toast(
-                        getToastLabel(deletedFavorite),
-                        duration = ToastViewModel.Duration.Short,
-                        action =
-                            ToastViewModel.ToastAction.Custom(
-                                actionLabel = removeToastUndoButtonText,
-                                onAction = {
-                                    favoritesViewModel.updateFavorites(
-                                        mapOf(deletedFavorite to deletedSettings),
-                                        EditFavoritesContext.Favorites,
-                                        deletedFavorite.direction,
-                                        fcmToken,
-                                        currentLocale,
-                                    )
-                                    toastViewModel.hideToast()
-                                },
-                            ),
-                    )
+            toastViewModel.showToast(
+                ToastViewModel.Toast(
+                    getToastLabel(deletedFavorite),
+                    duration = ToastViewModel.Duration.Short,
+                    action =
+                        ToastViewModel.ToastAction.Custom(
+                            actionLabel = removeToastUndoButtonText,
+                            onAction = {
+                                favoritesViewModel.updateFavorites(
+                                    mapOf(deletedFavorite to deletedSettings),
+                                    EditFavoritesContext.Favorites,
+                                    deletedFavorite.direction,
+                                    fcmToken,
+                                    currentLocale,
+                                )
+                                toastViewModel.hideToast()
+                            },
+                        ),
                 )
-            },
-            editFavorite = { selectedFavorite ->
-                openModalWithCloseCallback(
-                    ModalRoutes.SaveFavorite(
-                        selectedFavorite.route,
-                        selectedFavorite.stop,
-                        selectedFavorite.direction,
-                        EditFavoritesContext.Favorites,
-                    )
-                ) {
-                    favoritesViewModel.reloadFavorites()
-                }
-            },
-        )
+            )
+        }
+        val editFavorite: (RouteStopDirection) -> Unit = { selectedFavorite ->
+            openModalWithCloseCallback(
+                ModalRoutes.SaveFavorite(
+                    selectedFavorite.route,
+                    selectedFavorite.stop,
+                    selectedFavorite.direction,
+                    EditFavoritesContext.Favorites,
+                )
+            ) {
+                favoritesViewModel.reloadFavorites()
+            }
+        }
+        if (groupByStop) {
+            EditFavoritesList(
+                state.favorites,
+                firstStaticStopCardData,
+                removedFavorites,
+                global,
+                deleteFavorite = deleteFavorite,
+                editFavorite = editFavorite,
+            )
+        } else {
+            EditFavoritesListGroupedByRoute(
+                state.favorites,
+                firstStaticRouteCardData,
+                removedFavorites,
+                global,
+                deleteFavorite = deleteFavorite,
+                editFavorite = editFavorite,
+            )
+        }
     }
 }
 
 @Composable
-private fun EditFavoritesList(
+private fun EditFavoritesListGroupedByRoute(
     favorites: Map<RouteStopDirection, FavoriteSettings>?,
     routeCardData: List<RouteCardData>?,
     removedFavorites: Set<RouteStopDirection>,
@@ -233,11 +261,13 @@ private fun EditFavoritesList(
                             stopData.data.any { leaf ->
                                 !removedFavorites.contains(leaf.routeStopDirection)
                             }
-                        AnimatedVisibility(visible = visible) { StopSubheader(stopData) }
+                        AnimatedVisibility(visible = visible) {
+                            StopSubheader(stopData, includeIcon = false)
+                        }
 
                         FavoriteDepartures(
                             favorites,
-                            stopData,
+                            stopData.data,
                             removedFavorites,
                             global,
                             { leaf -> deleteFavorite(leaf.routeStopDirection) },
@@ -258,9 +288,70 @@ private fun EditFavoritesList(
 }
 
 @Composable
+private fun EditFavoritesList(
+    favorites: Map<RouteStopDirection, FavoriteSettings>?,
+    stopCardData: List<StopCardData>?,
+    removedFavorites: Set<RouteStopDirection>,
+    global: GlobalResponse?,
+    deleteFavorite: (RouteStopDirection) -> Unit,
+    editFavorite: (RouteStopDirection) -> Unit,
+) {
+    val notificationsFlag = SettingsCache.get(Settings.Notifications)
+
+    val displayedFavorites =
+        stopCardData?.filter { data -> !removedFavorites.containsAll(data.routeStopDirections) }
+
+    if (displayedFavorites == null) {
+        CompositionLocalProvider(IsLoadingSheetContents provides true) {
+            ScrollSeparatorLazyColumn(
+                contentPadding =
+                    PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                items(5) { LoadingStopCard() }
+                item { Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
+            }
+        }
+    } else if (displayedFavorites.isEmpty()) {
+        ScrollSeparatorColumn(Modifier.padding(8.dp).navigationBarsPadding(), Arrangement.Center) {
+            NoFavoritesView({}, false)
+        }
+    } else {
+        ScrollSeparatorLazyColumn(
+            contentPadding = PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            items(displayedFavorites, key = { it.stop.id }) {
+                Column(Modifier.animateItem().haloContainer(1.dp)) {
+                    StopSubheader(it.stop, it.elevatorAlerts, includeIcon = true)
+
+                    FavoriteDepartures(
+                        favorites,
+                        it.data,
+                        removedFavorites,
+                        global,
+                        { leaf -> deleteFavorite(leaf.routeStopDirection) },
+                    ) { leaf ->
+                        val selectedFavorite = leaf.routeStopDirection
+                        if (notificationsFlag) {
+                            editFavorite(selectedFavorite)
+                        } else {
+                            deleteFavorite(selectedFavorite)
+                        }
+                    }
+                }
+            }
+            item { Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
+        }
+    }
+}
+
+@Composable
 private fun FavoriteDepartures(
     favorites: Map<RouteStopDirection, FavoriteSettings>?,
-    stopData: RouteCardData.RouteStopData,
+    leaves: List<RouteCardData.Leaf>,
     removedFavorites: Set<RouteStopDirection>,
     globalData: GlobalResponse?,
     onDrag: (RouteCardData.Leaf) -> Unit,
@@ -269,7 +360,7 @@ private fun FavoriteDepartures(
     val notificationsFlag = SettingsCache.get(Settings.Notifications)
 
     Column {
-        stopData.data.withIndex().forEach { (index, leaf) ->
+        leaves.withIndex().forEach { (index, leaf) ->
             val formatted = leaf.format(EasternTimeInstant.now(), globalData)
             val direction = leaf.direction
             val overriddenClickLabel = stringResource(R.string.delete)
@@ -337,6 +428,11 @@ private fun FavoriteDepartures(
                                     }
                                 }
                     ) {
+                        RoutePill(
+                            (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                            (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                            type = RoutePillType.Fixed,
+                        )
                         when (formatted) {
                             is LeafFormat.Single -> {
                                 Column(
@@ -351,11 +447,11 @@ private fun FavoriteDepartures(
                                     ) {
                                         DirectionLabel(
                                             direction,
+                                            modifier = Modifier.weight(1f),
                                             pillDecoration =
                                                 formatted.route?.let {
                                                     PillDecoration.OnDirectionDestination(it)
                                                 },
-                                            modifier = Modifier.weight(1f),
                                         )
                                         rightContent()
                                     }
@@ -383,7 +479,7 @@ private fun FavoriteDepartures(
                     }
                 }
 
-                if (index < stopData.data.lastIndex) {
+                if (index < leaves.lastIndex) {
                     HaloSeparator()
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -358,6 +358,7 @@ private fun FavoriteDepartures(
     onClick: (RouteCardData.Leaf) -> Unit,
 ) {
     val notificationsFlag = SettingsCache.get(Settings.Notifications)
+    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     Column {
         leaves.withIndex().forEach { (index, leaf) ->
@@ -428,11 +429,13 @@ private fun FavoriteDepartures(
                                     }
                                 }
                     ) {
-                        RoutePill(
-                            (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
-                            (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
-                            type = RoutePillType.Fixed,
-                        )
+                        if (groupByStop) {
+                            RoutePill(
+                                (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                                (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                                type = RoutePillType.Fixed,
+                            )
+                        }
                         when (formatted) {
                             is LeafFormat.Single -> {
                                 Column(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
@@ -16,6 +16,7 @@ val SharedString.value: String
                 stringResource(R.string.resources_link_mticket)
             SharedString.DebugMode -> stringResource(R.string.feature_flag_debug_mode)
             SharedString.FareInformation -> stringResource(R.string.resources_link_fare_info)
+            SharedString.FavoritesByStop -> "Group favorites by stop"
             SharedString.FeatureFlagsSection -> stringResource(R.string.more_section_feature_flags)
             SharedString.ForceNotificationsBeta -> "Reset and force notifications beta"
             SharedString.MapDisplay -> stringResource(R.string.setting_toggle_map_display)

--- a/iosApp/iosApp/ComponentViews/DirectionLabel.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionLabel.swift
@@ -48,15 +48,15 @@ struct DirectionLabel: View {
     @ViewBuilder
     func directionTo(_ direction: Direction) -> some View {
         let routeNamePrefix = if let routeNamePrefix { "\(routeNamePrefix) " } else { "" }
-        Text(routeNamePrefix + NSLocalizedString("\(DirectionLabel.directionNameFormatted(direction)) to",
-                                                 comment: """
-                                                 Label the direction a list of arrivals is for.
-                                                 Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.
-                                                 For example, "[Northbound] to [Alewife]"
-                                                 """))
-                                                 .font(Typography.footnote)
-                                                 .textCase(.none)
-                                                 .multilineTextAlignment(.leading)
+        let directionTo = String(format: NSLocalizedString("%@ to", comment: """
+        Label the direction a list of arrivals is for.
+        Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.
+        For example, "[Northbound] to [Alewife]"
+        """), Self.directionNameFormatted(direction))
+        Text(routeNamePrefix + directionTo)
+            .font(Typography.footnote)
+            .textCase(.none)
+            .multilineTextAlignment(.leading)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/ComponentViews/DirectionLabel.swift
+++ b/iosApp/iosApp/ComponentViews/DirectionLabel.swift
@@ -15,17 +15,20 @@ struct DirectionLabel: View {
     let showDestination: Bool
     let pillDecoration: PredictionRowView.PillDecoration
     let isTitle: Bool
+    let routeNamePrefix: String?
 
     init(
         direction: Direction,
         showDestination: Bool = true,
         pillDecoration: PredictionRowView.PillDecoration = .none,
-        isTitle: Bool = false
+        isTitle: Bool = false,
+        routeNamePrefix: String? = nil,
     ) {
         self.direction = direction
         self.showDestination = showDestination
         self.pillDecoration = pillDecoration
         self.isTitle = isTitle
+        self.routeNamePrefix = routeNamePrefix
     }
 
     private static let localizedDirectionNames: [String: String] = [
@@ -44,15 +47,16 @@ struct DirectionLabel: View {
 
     @ViewBuilder
     func directionTo(_ direction: Direction) -> some View {
-        Text("\(DirectionLabel.directionNameFormatted(direction)) to",
-             comment: """
-             Label the direction a list of arrivals is for.
-             Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.
-             For example, "[Northbound] to [Alewife]"
-             """)
-             .font(Typography.footnote)
-             .textCase(.none)
-             .multilineTextAlignment(.leading)
+        let routeNamePrefix = if let routeNamePrefix { "\(routeNamePrefix) " } else { "" }
+        Text(routeNamePrefix + NSLocalizedString("\(DirectionLabel.directionNameFormatted(direction)) to",
+                                                 comment: """
+                                                 Label the direction a list of arrivals is for.
+                                                 Possible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.
+                                                 For example, "[Northbound] to [Alewife]"
+                                                 """))
+                                                 .font(Typography.footnote)
+                                                 .textCase(.none)
+                                                 .multilineTextAlignment(.leading)
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/ComponentViews/StopCard/LoadingStopCard.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/LoadingStopCard.swift
@@ -1,0 +1,31 @@
+//
+//  LoadingStopCard.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct LoadingStopCard: View {
+    @ObserveInjection var inject
+    var body: some View {
+        let placeholderRouteData = LoadingPlaceholders.shared.nearbyRoute()
+        let placeholderStopData = StopCardData.companion.fromRouteCardData(
+            routeCardData: [placeholderRouteData],
+            sortByDistanceFrom: nil
+        )
+        if let stopData = placeholderStopData.first {
+            StopCard(
+                cardData: stopData,
+                global: nil,
+                now: EasternTimeInstant.now(),
+                isFavorite: { _ in false },
+                pushNavEntry: { _ in }
+            )
+            .enableInjection()
+        }
+    }
+}

--- a/iosApp/iosApp/ComponentViews/StopCard/StopCard.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/StopCard.swift
@@ -1,0 +1,139 @@
+//
+//  StopCard.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopCardContainer<Content: View>: View {
+    @ObserveInjection var inject
+    let cardData: StopCardData
+    let departureContent: (StopCardData) -> Content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            StopCardStopHeader(data: cardData)
+            departureContent(cardData)
+        }
+        .background(Color.fill3)
+        .withRoundedBorder()
+        .enableInjection()
+    }
+}
+
+struct StopCard: View {
+    @ObserveInjection var inject
+    let cardData: StopCardData
+    let global: GlobalResponse?
+    let now: EasternTimeInstant
+    let isFavorite: (RouteStopDirection) -> Bool
+    let pushNavEntry: (SheetNavigationStackEntry) -> Void
+
+    @EnvironmentObject var settingsCache: SettingsCache
+    var showStationAccessibility: Bool { settingsCache.get(.stationAccessibility) }
+
+    @ScaledMetric private var modeIconHeight: CGFloat = 24
+
+    var body: some View {
+        StopCardContainer(cardData: cardData) { stopData in
+            StopCardDepartures(
+                stopData: stopData,
+                global: global,
+                now: now,
+                isFavorite: isFavorite,
+                pushNavEntry: pushNavEntry
+            )
+        }
+        .enableInjection()
+    }
+}
+
+struct StopCardDepartures: View {
+    @ObserveInjection var inject
+    var analytics: Analytics = AnalyticsProvider.shared
+    let stopData: StopCardData
+    let global: GlobalResponse?
+    let now: EasternTimeInstant
+    let isFavorite: (RouteStopDirection) -> Bool
+    let pushNavEntry: (SheetNavigationStackEntry) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(stopData.data.enumerated()), id: \.element) { index, leaf in
+                let formatted = leaf.format(now: now, globalData: global)
+                SheetNavigationLink(
+                    value: .stopDetails(
+                        stopId: stopData.stop.id,
+                        stopFilter: .init(
+                            routeId: leaf.lineOrRoute.id,
+                            directionId: leaf.direction.id
+                        ),
+                        tripFilter: nil
+                    ),
+                    action: { entry in
+                        pushNavEntry(entry)
+                        analyticsTappedDeparture(leaf: leaf, formatted: formatted)
+                    },
+                    showChevron: true
+                ) {
+                    let branchedNoRoutePills = (formatted as? LeafFormat.Branched)?.branchRows
+                        .allSatisfy { $0.route == nil } ?? false
+                    if branchedNoRoutePills {
+                        RoutePill(
+                            route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                            line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                            type: .fixed
+                        )
+                    }
+                    if leaf.lineOrRoute.id == WorldCupService.shared.route.id {
+                        WorldCupBlurb(
+                            leaf: leaf,
+                            routeAccents: .init(route: leaf.lineOrRoute.sortRoute),
+                            offerDetails: false
+                        )
+                    } else {
+                        StopCardDirection(
+                            direction: leaf.direction,
+                            formatted: formatted,
+                            lineOrRoute: leaf.lineOrRoute
+                        )
+                    }
+                }
+                .tint(.fill3)
+                .padding(.leading, 16)
+                .padding(.trailing, 8)
+                .padding(.vertical, 10)
+                .accessibilityHint(Text("Open for more arrivals"))
+                if index < stopData.data.count - 1 {
+                    HaloSeparator()
+                }
+            }
+        }
+        .enableInjection()
+    }
+
+    private func analyticsTappedDeparture(leaf: RouteCardData.Leaf, formatted: LeafFormat) {
+        let upcoming: UpcomingFormat? = switch onEnum(of: formatted) {
+        case let .single(single): single.format
+        default: nil
+        }
+        let noTrips: UpcomingFormat.NoTripsFormat? = switch onEnum(of: upcoming) {
+        case let .noTrips(formatted): formatted.noTripsFormat
+        default: nil
+        }
+        analytics.tappedDeparture(
+            routeId: leaf.lineOrRoute.id,
+            stopId: stopData.stop.id,
+            pinned: isFavorite(RouteStopDirection(route: leaf.lineOrRoute.id,
+                                                  stop: stopData.stop.id,
+                                                  direction: leaf.direction.id)),
+            alert: leaf.alertsHere(tripId: nil).count > 0,
+            routeType: leaf.lineOrRoute.type,
+            noTrips: noTrips
+        )
+    }
+}

--- a/iosApp/iosApp/ComponentViews/StopCard/StopCardDirection.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/StopCardDirection.swift
@@ -1,0 +1,74 @@
+//
+//  StopCardDirection.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopCardDirection: View {
+    @ObserveInjection var inject
+
+    let direction: Direction
+    let formatted: LeafFormat
+    let lineOrRoute: LineOrRoute
+
+    var body: some View {
+        switch onEnum(of: formatted) {
+        case let .branched(branched):
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .center) {
+                    if let warningAlert = branched.warningAlert {
+                        Image(warningAlert.iconName)
+                            .accessibilityLabel("Alert")
+                            .frame(width: 18, height: 18)
+                    }
+                    let noRoutePills = branched.branchRows.allSatisfy { $0.route == nil }
+                    DirectionLabel(
+                        direction: direction,
+                        showDestination: false,
+                        routeNamePrefix: noRoutePills ? nil : lineOrRoute.name
+                    ).foregroundStyle(Color.text)
+                }
+                ForEach(branched.branchRows) { branchRow in
+                    let pillDecoration: PredictionRowView.PillDecoration = if let route = branchRow
+                        .route { .onRow(route: route) } else { .none }
+                    HeadsignRowView(
+                        headsign: branchRow.headsign,
+                        predictions: branchRow.format,
+                        pillDecoration: pillDecoration
+                    )
+                }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityInputLabels(Set([
+                DirectionLabel.directionNameFormatted(direction),
+                direction.destination,
+            ] +
+                Set(branched.branchRows.map(\.headsign)))
+                .compactMap { text in if let text { Text(text) } else { nil }})
+            .enableInjection()
+
+        case let .single(single):
+            let destination = single.headsign == nil || single.headsign?.isEmpty == true
+                ? direction.destination
+                : single.headsign
+            DirectionRowView(
+                direction: .init(
+                    name: direction.name,
+                    destination: destination,
+                    id: direction.id
+                ),
+                predictions: single.format,
+                pillDecoration: .onRow(route: single.route ?? lineOrRoute.sortRoute)
+            )
+            .accessibilityElement(children: .combine)
+            .accessibilityInputLabels(Set([DirectionLabel.directionNameFormatted(direction), destination])
+                .compactMap { text in if let text { Text(text) } else { nil }})
+            .enableInjection()
+        }
+    }
+}

--- a/iosApp/iosApp/ComponentViews/StopCard/StopCardList.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/StopCardList.swift
@@ -1,0 +1,252 @@
+//
+//  StopCardList.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2025 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopCardList<EmptyView: View>: View {
+    @ObserveInjection var inject
+
+    let stopCardData: [StopCardData]?
+    @ViewBuilder let emptyView: () -> EmptyView
+    let global: GlobalResponse?
+    let now: Date
+    let isFavorite: (RouteStopDirection) -> Bool
+    let pushNavEntry: (SheetNavigationStackEntry) -> Void
+
+    var body: some View {
+        if let stopCardData, !stopCardData.isEmpty {
+            HaloScrollView {
+                LazyVStack(alignment: .center, spacing: 18) {
+                    ForEach(stopCardData, id: \.stop.id) { stopCardData in
+                        StopCard(
+                            cardData: stopCardData,
+                            global: global,
+                            now: now.toEasternInstant(),
+                            isFavorite: isFavorite,
+                            pushNavEntry: pushNavEntry
+                        )
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+            }
+            .enableInjection()
+        } else if let stopCardData, stopCardData.isEmpty {
+            HaloScrollView {
+                VStack {
+                    emptyView()
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+            }
+            .enableInjection()
+        } else {
+            ScrollView([]) {
+                LazyVStack(alignment: .center, spacing: 14) {
+                    ForEach(0 ..< 5) { _ in
+                        LoadingStopCard()
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+                .loadingPlaceholder(withShimmer: false)
+            }
+            .enableInjection()
+        }
+    }
+}
+
+#Preview {
+    let now = EasternTimeInstant.now()
+    let objects = TestData.clone(namespace: "StopCardListPreview")
+
+    let ruggles = objects.getStop(id: "place-rugg")
+    let tremontAtMelneaCass = objects.stop { stop in
+        stop.id = "1227"
+        stop.locationType = .stop
+        stop.name = "Tremont St @ Melnea Cass Blvd"
+        stop.wheelchairBoarding = .accessible
+    }
+    let boylston = objects.getStop(id: "place-boyls")
+    let ol = LineOrRoute.route(objects.getRoute(id: "Orange"))
+    let olSouthboundPattern = objects.getRoutePattern(id: "Orange-3-0")
+    let olNorthboundPattern = objects.getRoutePattern(id: "Orange-3-1")
+    let gl = LineOrRoute.line(
+        objects.getLine(id: "line-Green"),
+        [
+            objects.getRoute(id: "Green-B"),
+            objects.getRoute(id: "Green-C"),
+            objects.getRoute(id: "Green-D"),
+            objects.getRoute(id: "Green-E")
+        ]
+    )
+    let bus43 = LineOrRoute.route(objects.route { route in
+        route.id = "43"
+        route.color = "FFC72C"
+        route.directionNames = ["Outbound", "Inbound"]
+        route.directionDestinations = ["Ruggles Station", "Park Street Station"]
+        route.shortName = "43"
+        route.textColor = "000000"
+        route.type = .bus
+    })
+    let bus43Inbound = objects.routePattern(route: bus43.route) { routePattern in
+        routePattern.directionId = 1
+        routePattern.sortOrder = 504_301_000
+        routePattern.typicality = .typical
+        routePattern.representativeTrip { trip in
+            trip.headsign = "Park St & Tremont St"
+            trip.stopIds = ["17869", "1227", "10000"]
+        }
+    }
+
+    let olSouthboundLeaf = RouteCardData.Leaf(
+        lineOrRoute: ol,
+        stop: ruggles,
+        direction: .init(directionId: 0, route: ol.route),
+        routePatterns: [olSouthboundPattern],
+        stopIds: Set(ruggles.childStopIds),
+        upcomingTrips: [
+            objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: olSouthboundPattern)
+                prediction.departureTime = now.plus(minutes: 3)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: olSouthboundPattern)
+                prediction.departureTime = now.plus(minutes: 11)
+            })
+        ],
+        alertsHere: [],
+        allDataLoaded: true,
+        hasSchedulesToday: true,
+        subwayServiceStartTime: nil,
+        alertsDownstream: [objects.alert { $0.effect = .suspension }],
+        context: .favorites
+    )
+
+    let olNorthboundLeaf = RouteCardData.Leaf(
+        lineOrRoute: ol,
+        stop: ruggles,
+        direction: .init(directionId: 1, route: ol.route),
+        routePatterns: [olNorthboundPattern],
+        stopIds: Set(ruggles.childStopIds),
+        upcomingTrips: [
+            objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: olNorthboundPattern)
+                prediction.departureTime = now.plus(minutes: 6)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: olNorthboundPattern)
+                prediction.departureTime = now.plus(minutes: 14)
+            })
+        ],
+        alertsHere: [],
+        allDataLoaded: true,
+        hasSchedulesToday: true,
+        subwayServiceStartTime: nil,
+        alertsDownstream: [],
+        context: .favorites
+    )
+
+    let bus43RugglesLeaf = RouteCardData.Leaf(
+        lineOrRoute: bus43,
+        stop: ruggles,
+        direction: .init(directionId: 1, route: bus43.route),
+        routePatterns: [bus43Inbound],
+        stopIds: Set(ruggles.childStopIds),
+        upcomingTrips: [
+            objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: bus43Inbound)
+                prediction.departureTime = now.plus(minutes: 22)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: bus43Inbound)
+                prediction.departureTime = now.plus(minutes: 56)
+            }), objects.upcomingTrip(schedule: objects.schedule { schedule in
+                schedule.trip = objects.trip(routePattern: bus43Inbound)
+                schedule.departureTime = now.plus(hours: 12)
+            })
+        ],
+        alertsHere: [],
+        allDataLoaded: true,
+        hasSchedulesToday: true,
+        subwayServiceStartTime: nil,
+        alertsDownstream: [],
+        context: .favorites
+    )
+
+    let bus43TremontAtMelneaCassLeaf = RouteCardData.Leaf(
+        lineOrRoute: bus43,
+        stop: tremontAtMelneaCass,
+        direction: .init(directionId: 1, route: bus43.route),
+        routePatterns: [bus43Inbound],
+        stopIds: [tremontAtMelneaCass.id],
+        upcomingTrips: [
+            objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: bus43Inbound)
+                prediction.departureTime = now.plus(minutes: 25)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: bus43Inbound)
+                prediction.departureTime = now.plus(minutes: 59)
+            }), objects.upcomingTrip(schedule: objects.schedule { schedule in
+                schedule.trip = objects.trip(routePattern: bus43Inbound)
+                schedule.departureTime = now.plus(hours: 12)
+            })
+        ],
+        alertsHere: [],
+        allDataLoaded: true,
+        hasSchedulesToday: true,
+        subwayServiceStartTime: nil,
+        alertsDownstream: [],
+        context: .favorites
+    )
+
+    let glWestboundLeaf = RouteCardData.Leaf(
+        lineOrRoute: gl,
+        stop: boylston,
+        direction: .init(name: "West", destination: nil, id: 0),
+        routePatterns: [
+            objects.getRoutePattern(id: "Green-B-812-0"),
+            objects.getRoutePattern(id: "Green-C-832-0"),
+            objects.getRoutePattern(id: "Green-D-855-0"),
+            objects.getRoutePattern(id: "Green-E-886-0")
+        ],
+        stopIds: Set(boylston.childStopIds),
+        upcomingTrips: [
+            objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: objects.getRoutePattern(id: "Green-C-832-0"))
+                prediction.departureTime = now.plus(minutes: 3)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: objects.getRoutePattern(id: "Green-B-812-0"))
+                prediction.departureTime = now.plus(minutes: 5)
+            }), objects.upcomingTrip(prediction: objects.prediction { prediction in
+                prediction.trip = objects.trip(routePattern: objects.getRoutePattern(id: "Green-D-855-0"))
+                prediction.departureTime = now.plus(minutes: 10)
+            })
+        ],
+        alertsHere: [],
+        allDataLoaded: true,
+        hasSchedulesToday: true,
+        subwayServiceStartTime: nil,
+        alertsDownstream: [],
+        context: .favorites
+    )
+
+    VStack {
+        StopCardList(
+            stopCardData: [
+                .init(stop: ruggles, data: [olSouthboundLeaf, olNorthboundLeaf, bus43RugglesLeaf]),
+                .init(stop: tremontAtMelneaCass, data: [bus43TremontAtMelneaCassLeaf]),
+                .init(stop: boylston, data: [glWestboundLeaf])
+            ],
+            emptyView: {},
+            global: .init(objects: objects),
+            now: now.toNSDateLosingTimeZone(),
+            isFavorite: { _ in true },
+            pushNavEntry: { _ in }
+        )
+    }
+    .withFixedSettings([.favoritesByStop: true, .stationAccessibility: true])
+}

--- a/iosApp/iosApp/ComponentViews/StopCard/StopCardStopHeader.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/StopCardStopHeader.swift
@@ -1,0 +1,72 @@
+//
+//  StopCardStopHeader.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Shared
+import SwiftUI
+
+struct StopCardStopHeader: View {
+    @ObserveInjection var inject
+    let data: StopCardData
+
+    @EnvironmentObject var settingsCache: SettingsCache
+    var showStationAccessibility: Bool { settingsCache.get(.stationAccessibility) }
+
+    var elevatorAlerts: Int { data.elevatorAlerts.count }
+    var showInaccessible: Bool { showStationAccessibility && !data.stop.isWheelchairAccessible }
+    var showElevatorAlerts: Bool { showStationAccessibility && !data.elevatorAlerts.isEmpty }
+
+    var body: some View {
+        HStack {
+            (data.stop.locationType == .stop ? Image(.mapStopCloseBUS) : Image(.mbtaLogo))
+                .resizable()
+                .scaledToFit()
+                .frame(width: 24, height: 24)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(data.stop.name)
+                    .font(Typography.callout)
+                    .foregroundStyle(Color.text)
+
+                if showInaccessible || showElevatorAlerts {
+                    HStack(spacing: 5) {
+                        if showElevatorAlerts {
+                            Image(.accessibilityIconAlert)
+                                .accessibilityHidden(true)
+                        } else if showInaccessible {
+                            Image(.accessibilityIconNotAccessible)
+                                .accessibilityHidden(true)
+                                .tag("wheelchair_not_accessible")
+                        }
+                        Group {
+                            if showInaccessible {
+                                Text(
+                                    "Not accessible",
+                                    comment: "Header displayed when station is not wheelchair accessible"
+                                )
+                            } else {
+                                Text(
+                                    "\(elevatorAlerts, specifier: "%ld") elevators closed",
+                                    comment: "Header displayed when elevators are not working at a station"
+                                )
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .multilineTextAlignment(.leading)
+                        .font(Typography.footnoteSemibold)
+                        .foregroundColor(Color.accessibility)
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.fill2)
+        .enableInjection()
+    }
+}

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2726,7 +2726,6 @@
     },
     "%@ to" : {
       "comment" : "Label the direction a list of arrivals is for.\nPossible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.\nFor example, \"[Northbound] to [Alewife]\"",
-      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -2726,6 +2726,7 @@
     },
     "%@ to" : {
       "comment" : "Label the direction a list of arrivals is for.\nPossible values include Northbound, Southbound, Inbound, Outbound, Eastbound, Westbound.\nFor example, \"[Northbound] to [Alewife]\"",
+      "extractionState" : "stale",
       "localizations" : {
         "es" : {
           "stringUnit" : {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -26,6 +26,8 @@ struct EditFavoritesPage: View {
     @ObservedObject var fcmTokenContainer = FcmTokenContainer.shared
     @EnvironmentObject var settingsCache: SettingsCache
 
+    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
+
     let inspection = Inspection<Self>()
 
     func deleteAndToast(_ rsd: RouteStopDirection) {
@@ -86,13 +88,23 @@ struct EditFavoritesPage: View {
                     navCallbacks: navCallbacks,
                     closeText: NSLocalizedString("Done", comment: "Button text for closing flow")
                 )
-                EditFavoritesList(
-                    favorites: favoritesState,
-                    routeCardData: favoritesVMState.staticRouteCardData,
-                    global: globalResponse,
-                    deleteFavorite: deleteAndToast,
-                    onOpenEditModal: onOpenEditModal,
-                )
+                if groupByStop {
+                    EditFavoritesList(
+                        favorites: favoritesState,
+                        stopCardData: favoritesVMState.staticStopCardData,
+                        global: globalResponse,
+                        deleteFavorite: deleteAndToast,
+                        onOpenEditModal: onOpenEditModal,
+                    )
+                } else {
+                    EditFavoritesListGroupedByRoute(
+                        favorites: favoritesState,
+                        routeCardData: favoritesVMState.staticRouteCardData,
+                        global: globalResponse,
+                        deleteFavorite: deleteAndToast,
+                        onOpenEditModal: onOpenEditModal,
+                    )
+                }
             }
             .onAppear {
                 viewModel.setContext(context: FavoritesViewModel.ContextEdit())
@@ -120,7 +132,7 @@ struct EditFavoritesPage: View {
     }
 }
 
-struct EditFavoritesList: View {
+struct EditFavoritesListGroupedByRoute: View {
     @ObserveInjection var inject
     let favorites: [RouteStopDirection: FavoriteSettings?]
     let routeCardData: [RouteCardData]?
@@ -141,7 +153,7 @@ struct EditFavoritesList: View {
                         ) { stopData in
                             FavoriteDepartures(
                                 favorites: favorites,
-                                stopData: stopData,
+                                leaves: stopData.data,
                                 globalData: global
                             ) { leaf in
                                 if settingsCache.get(.notifications) {
@@ -182,10 +194,71 @@ struct EditFavoritesList: View {
     }
 }
 
+struct EditFavoritesList: View {
+    @ObserveInjection var inject
+    let favorites: [RouteStopDirection: FavoriteSettings?]
+    let stopCardData: [StopCardData]?
+    let global: GlobalResponse?
+    let deleteFavorite: (RouteStopDirection) -> Void
+    let onOpenEditModal: (RouteStopDirection) -> Void
+
+    @EnvironmentObject var settingsCache: SettingsCache
+
+    var body: some View {
+        if let stopCardData, !stopCardData.isEmpty {
+            HaloScrollView {
+                LazyVStack(alignment: .center, spacing: 14) {
+                    ForEach(stopCardData, id: \.stop.id) { cardData in
+                        StopCardContainer(
+                            cardData: cardData
+                        ) { stopData in
+                            FavoriteDepartures(
+                                favorites: favorites,
+                                leaves: stopData.data,
+                                globalData: global
+                            ) { leaf in
+                                if settingsCache.get(.notifications) {
+                                    onOpenEditModal(leaf.routeStopDirection)
+                                } else {
+                                    deleteFavorite(leaf.routeStopDirection)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+                .frame(maxHeight: .infinity, alignment: .top)
+            }
+        }
+
+        else if stopCardData != nil {
+            HaloScrollView {
+                NoFavoritesView()
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 16)
+            }
+        }
+
+        else {
+            ScrollView([]) {
+                LazyVStack(alignment: .center, spacing: 14) {
+                    ForEach(0 ..< 5) { _ in
+                        LoadingStopCard()
+                    }
+                }
+                .padding(.vertical, 4)
+                .padding(.horizontal, 16)
+                .loadingPlaceholder()
+            }
+        }
+    }
+}
+
 struct FavoriteDepartures: View {
     @ObserveInjection var inject
     let favorites: [RouteStopDirection: FavoriteSettings?]
-    let stopData: RouteCardData.RouteStopData
+    let leaves: [RouteCardData.Leaf]
     let globalData: GlobalResponse?
     let onClick: (RouteCardData.Leaf) -> Void
 
@@ -193,12 +266,17 @@ struct FavoriteDepartures: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(stopData.data.enumerated().sorted(by: { $0.offset < $1.offset }), id: \.element.id) { index, leaf in
+            ForEach(leaves.enumerated().sorted(by: { $0.offset < $1.offset }), id: \.element.id) { index, leaf in
                 let formatted = leaf.format(now: EasternTimeInstant.now(), globalData: globalData)
                 let direction: Direction = leaf.direction
                 let favoriteSettings: FavoriteSettings? = favorites[leaf.routeStopDirection] ?? nil
 
                 HStack(alignment: .center, spacing: 0) {
+                    RoutePill(
+                        route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                        line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                        type: .fixed
+                    )
                     switch onEnum(of: formatted) {
                     case let .single(single):
                         HStack(alignment: .center, spacing: 8) {
@@ -234,7 +312,7 @@ struct FavoriteDepartures: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
 
-                if index < stopData.data.endIndex {
+                if index < leaves.endIndex {
                     HaloSeparator()
                 }
             }

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -263,6 +263,7 @@ struct FavoriteDepartures: View {
     let onClick: (RouteCardData.Leaf) -> Void
 
     @EnvironmentObject var settingsCache: SettingsCache
+    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -272,11 +273,13 @@ struct FavoriteDepartures: View {
                 let favoriteSettings: FavoriteSettings? = favorites[leaf.routeStopDirection] ?? nil
 
                 HStack(alignment: .center, spacing: 0) {
-                    RoutePill(
-                        route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
-                        line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
-                        type: .fixed
-                    )
+                    if groupByStop {
+                        RoutePill(
+                            route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                            line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                            type: .fixed
+                        )
+                    }
                     switch onEnum(of: formatted) {
                     case let .single(single):
                         HStack(alignment: .center, spacing: 8) {

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -23,6 +23,7 @@ struct FavoritesView: View {
 
     @EnvironmentObject var settingsCache: SettingsCache
     var notificationsEnabled: Bool { settingsCache.get(.notifications) }
+    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
 
     @State var globalData: GlobalResponse?
     var globalRepository = RepositoryDI().global
@@ -44,7 +45,9 @@ struct FavoritesView: View {
                 title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"),
                 navCallbacks: .init(onBack: nil, onClose: nil, backButtonPresentation: .floating),
                 rightActionContents: {
-                    if let routeCardData = favoritesVMState.routeCardData, !routeCardData.isEmpty {
+                    if let chosenCardData: [Any] = groupByStop ? favoritesVMState.stopCardData : favoritesVMState
+                        .routeCardData,
+                        !chosenCardData.isEmpty {
                         ActionButton(kind: .plus, circleColor: Color.translucentContrast, action: { onAddStops() })
                         NavTextButton(
                             string: NSLocalizedString("Edit", comment: "Button text to enter edit favorites flow"),
@@ -68,22 +71,26 @@ struct FavoritesView: View {
 
             ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
             DebugView { EmptyView() }
-            RouteCardList(
-                routeCardData: favoritesVMState.routeCardData,
-                emptyView: {
-                    NoFavoritesView(
-                        onAddStops: {
-                            onAddStops()
-                        }
-                    )
-                    .frame(maxWidth: .infinity)
-                },
-                global: globalData,
-                now: now,
-                isFavorite: { rsd in favoritesVMState.favorites?.contains(where: { rsd == $0.key }) ?? false },
-                pushNavEntry: { navManager.pushNavEntry($0) },
-                showStopHeader: true
-            )
+            if groupByStop {
+                StopCardList(
+                    stopCardData: favoritesVMState.stopCardData,
+                    emptyView: { emptyView() },
+                    global: globalData,
+                    now: now,
+                    isFavorite: { isFavorite($0) },
+                    pushNavEntry: { navManager.pushNavEntry($0) }
+                )
+            } else {
+                RouteCardList(
+                    routeCardData: favoritesVMState.routeCardData,
+                    emptyView: { emptyView() },
+                    global: globalData,
+                    now: now,
+                    isFavorite: { isFavorite($0) },
+                    pushNavEntry: { navManager.pushNavEntry($0) },
+                    showStopHeader: true
+                )
+            }
         }
         .global($globalData, errorKey: .companion.fromSheetTypes(sheetTypes: [.favorites], id: "FavoritesView"))
         .onAppear {
@@ -143,6 +150,19 @@ struct FavoritesView: View {
             onBackground: { favoritesVM.setActive(active: false, wasSentToBackground: true) }
         )
         .enableInjection()
+    }
+
+    @ViewBuilder private func emptyView() -> some View {
+        NoFavoritesView(
+            onAddStops: {
+                onAddStops()
+            }
+        )
+        .frame(maxWidth: .infinity)
+    }
+
+    private func isFavorite(_ rsd: RouteStopDirection) -> Bool {
+        favoritesVMState.favorites?.contains(where: { rsd == $0.key }) ?? false
     }
 
     func showFirstTimeToast() {

--- a/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
+++ b/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
@@ -37,6 +37,7 @@ extension SharedString {
                 "Fare Information",
                 comment: "Label for a More page link to fare information on MBTA.com"
             )
+        case .favoritesByStop: "Group favorites by stop"
         case .featureFlagsSection:
             NSLocalizedString(
                 "Feature Flags",

--- a/iosApp/iosAppTests/Views/StopCardTests.swift
+++ b/iosApp/iosAppTests/Views/StopCardTests.swift
@@ -1,0 +1,156 @@
+//
+//  StopCardTests.swift
+//  iosApp
+//
+//  Created by Melody Horn on 6/25/26.
+//  Copyright © 2026 MBTA. All rights reserved.
+//
+
+import Foundation
+@testable import iosApp
+import Shared
+import SwiftUI
+import ViewInspector
+import XCTest
+
+final class StopCardTests: XCTestCase {
+    func testRoutePill() throws {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let route = objects.route { route in
+            route.shortName = "66"
+            route.type = .bus
+        }
+
+        let stopCardData = StopCardData(
+            stop: stop,
+            data: [.init(
+                lineOrRoute: .route(route),
+                stop: stop,
+                direction: .init(directionId: 0, route: route),
+                routePatterns: [],
+                stopIds: [],
+                upcomingTrips: [],
+                alertsHere: [],
+                allDataLoaded: true,
+                hasSchedulesToday: true,
+                subwayServiceStartTime: nil,
+                alertsDownstream: [],
+                context: .favorites
+            )]
+        )
+
+        let sut = StopCard(
+            cardData: stopCardData,
+            global: .init(objects: objects),
+            now: EasternTimeInstant.now(),
+            isFavorite: { _ in false },
+            pushNavEntry: { _ in }
+        ).withFixedSettings([:])
+
+        XCTAssertNotNil(try sut.inspect().find(text: "66"))
+    }
+
+    func testStopHeader() throws {
+        let objects = ObjectCollectionBuilder()
+
+        let route = objects.route { route in
+            route.longName = "1"
+            route.type = .bus
+        }
+        let stop = objects.stop { stop in
+            stop.name = "Stop Name"
+        }
+
+        let sut = StopCard(
+            cardData: .init(
+                stop: stop,
+                data: [.init(
+                    lineOrRoute: .route(route),
+                    stop: stop,
+                    direction: .init(directionId: 0, route: route),
+                    routePatterns: [],
+                    stopIds: [],
+                    upcomingTrips: [],
+                    alertsHere: [],
+                    allDataLoaded: true,
+                    hasSchedulesToday: true,
+                    subwayServiceStartTime: nil,
+                    alertsDownstream: [],
+                    context: .favorites
+                )]
+            ),
+            global: .init(objects: objects),
+            now: EasternTimeInstant.now(),
+            isFavorite: { _ in false },
+            pushNavEntry: { _ in }
+        ).withFixedSettings([:])
+        XCTAssertNotNil(try sut.inspect().find(text: stop.name))
+    }
+
+    func testShowsDepartures() throws {
+        let objects = ObjectCollectionBuilder()
+
+        let route = objects.route { route in
+            route.longName = "1"
+            route.type = .bus
+        }
+        let pattern = objects.routePattern(route: route) { _ in }
+        let stop = objects.stop { stop in
+            stop.name = "Stop Name"
+        }
+
+        let sut = StopCard(
+            cardData: .init(
+                stop: stop,
+                data: [.init(
+                    lineOrRoute: .route(route), stop: stop,
+                    direction: .init(name: "Inbound", destination: "", id: 0), routePatterns: [pattern],
+                    stopIds: [stop.id],
+                    upcomingTrips: [], alertsHere: [], allDataLoaded: true,
+                    hasSchedulesToday: true, subwayServiceStartTime: nil, alertsDownstream: [],
+                    context: .favorites
+                )]
+            ),
+            global: .init(objects: objects),
+            now: EasternTimeInstant.now(),
+            isFavorite: { _ in false },
+            pushNavEntry: { _ in }
+        ).withFixedSettings([:])
+        XCTAssertNotNil(try sut.inspect().find(StopCardDepartures.self))
+        XCTAssertNotNil(try sut.inspect().find(text: "Inbound to"))
+    }
+
+    func testBranchDisrupted() throws {
+        let data = RouteCardPreviewData()
+        let cardData = try XCTUnwrap(StopCardData.companion.fromRouteCardData(
+            routeCardData: [data.GL5()],
+            sortByDistanceFrom: nil
+        ).first)
+        let sut = StopCard(
+            cardData: cardData,
+            global: data.global,
+            now: data.now,
+            isFavorite: { _ in false },
+            pushNavEntry: { _ in }
+        ).withFixedSettings([:])
+        XCTAssertNotNil(try sut.inspect().find(StopCardDepartures.self))
+        let westDirection = try sut.inspect().find(text: "Green Line Westbound to")
+            .find(StopCardDirection.self, relation: .parent)
+        XCTAssertNotNil(westDirection)
+        XCTAssertNotNil(try westDirection.find(text: "3 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Cleveland Circle"))
+        XCTAssertNotNil(try westDirection.find(text: "5 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Boston College"))
+        XCTAssertNotNil(try westDirection.find(text: "Shuttle Bus")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Riverside"))
+
+        let eastDirection = try sut.inspect().find(text: "Green Line Eastbound to")
+            .find(StopCardDirection.self, relation: .parent)
+        XCTAssertNotNil(eastDirection)
+        XCTAssertNotNil(try eastDirection.find(text: "6 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Government Center"))
+        XCTAssertNotNil(try eastDirection.find(text: "12 min")
+            .find(HeadsignRowView.self, relation: .parent).find(text: "Government Center"))
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -40,6 +40,7 @@ public enum class Settings(
     public val override: Boolean? = null,
 ) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
+    FavoritesByStop(booleanPreferencesKey("favorites_by_stop")),
     HideMaps(booleanPreferencesKey("hide_maps")),
     Notifications(booleanPreferencesKey("notifications")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
@@ -6,6 +6,7 @@ public enum class SharedString {
     CommuterRailAndFerryTickets,
     DebugMode,
     FareInformation,
+    FavoritesByStop,
     FeatureFlagsSection,
     ForceNotificationsBeta,
     MapDisplay,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
@@ -118,6 +118,10 @@ public class MoreViewModel(
                                 }
                             },
                         ),
+                        MoreItem.Toggle(
+                            label = SharedString.FavoritesByStop,
+                            settings = Settings.FavoritesByStop,
+                        ),
                     ),
             ),
             MoreSection(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -38,6 +38,7 @@ internal class SettingsRepositoryTest : KoinTest {
         assertEquals(
             mapOf(
                 Settings.DevDebugMode to true,
+                Settings.FavoritesByStop to false,
                 Settings.HideMaps to false,
                 Settings.Notifications to false,
                 Settings.SearchRouteResults to false,


### PR DESCRIPTION
### Summary

_Ticket:_ [Group favorites by stop | Favorites View UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215746862487051)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This diff would be somewhat smaller if we weren’t using a feature flag to keep both code paths around, but since we are, it’s unreasonably large, sorry.

|Android|iOS|
|-------|---|
|<img width="1080" height="2400" alt="Screenshot_20260625_154406" src="https://github.com/user-attachments/assets/7630fd82-c1d2-4a18-a219-a006e065c284" />|<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-06-25 at 15 45 15" src="https://github.com/user-attachments/assets/50e43bc8-5ed1-48ef-8ae9-cab751eb2856" />|

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
- [x] All user-facing strings added to strings resource in alphabetical order
- [x] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Copied unit tests from RouteCard for new StopCard.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
