### PR TITLE
feat: removing 120 min limit cutoff

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -12,8 +12,6 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import kotlin.jvm.JvmName
 import kotlin.math.max
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -638,21 +636,12 @@ public data class RouteCardData(
                 // annoying
                 if (globalData == null) return@withContext null
 
-                val hideNonTypicalPatternsBeyondNext: Duration? =
-                    when (context) {
-                        Context.NearbyTransit -> 120.minutes
-                        Context.StopDetailsUnfiltered -> 120.minutes
-                        Context.StopDetailsFiltered,
-                        Context.Favorites -> null
-                    }
-
-                val cutoffTime = hideNonTypicalPatternsBeyondNext?.let { now + it }
                 val allDataLoaded = schedules != null
 
                 ListBuilder(allDataLoaded, context, now)
                     .addStaticStopsData(stopIds, globalData, context, alerts, favorites)
                     .addUpcomingTrips(schedules, predictions, now, globalData, alerts)
-                    .filterIrrelevantData(now, cutoffTime, context, globalData)
+                    .filterIrrelevantData(now, null, context, globalData)
                     .addAlerts(
                         alerts,
                         includeMinorAlerts = context.isStopDetails(),
@@ -1029,15 +1018,15 @@ public data class RouteCardData(
 
             val showAllPatternsWhileLoading = context.isStopDetails()
             for (entry in this.data) {
-                val (routeOrLineId, byStopId) = entry
+                val (_, byStopId) = entry
                 for (stopEntry in byStopId.stopData) {
-                    val (stopId, byDirectionId) = stopEntry
+                    val (_, byDirectionId) = stopEntry
                     val lineOrRoute = byStopId.lineOrRoute
 
                     byDirectionId.data =
                         byDirectionId.data
                             .filter {
-                                val (directionId, leafBuilder) = it
+                                val (_, leafBuilder) = it
                                 leafBuilder.shouldShow(
                                     byDirectionId.stop,
                                     filterAtTime,
@@ -1048,7 +1037,7 @@ public data class RouteCardData(
                                 )
                             }
                             .mapValues {
-                                val (directionId, leafBuilder) = it
+                                val (_, leafBuilder) = it
                                 leafBuilder.filterArrivalOnly()
                             }
                 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1184,14 +1184,20 @@ public data class RouteCardData(
             val isBus = lineOrRoute.type == RouteType.BUS
             val isSubway = lineOrRoute.isSubway
 
-            // Only take the next 2 (if bus) or 3 upcoming trips into account, since more than that
-            // can never be shown in nearby transit.
+            // Filter out trips in the past unless vehicle is at the stop or prediction has status
+            // and only take the next 2 (if bus) or 3 upcoming trips into account, since more than
+            // that can never be shown in nearby transit.
             val upcomingTripsInCutoff =
                 when (cutoffTime) {
-                    null -> this.upcomingTrips?.filter { it.isUpcoming() }
-                    else ->
-                        this.upcomingTrips?.filter { it.isUpcomingWithin(filterAtTime, cutoffTime) }
-                }?.take(if (isBus) TYPICAL_LEAF_ROWS else BRANCHING_LEAF_ROWS)
+                        null -> this.upcomingTrips?.filter { it.isUpcoming() }
+                        else -> this.upcomingTrips?.filter { it.isUpcomingWithin(cutoffTime) }
+                    }
+                    ?.filter {
+                        it.isInTheFuture(filterAtTime) ||
+                            it.isVehicleAtTheStop() ||
+                            it.doesPredictionHaveStatus()
+                    }
+                    ?.take(if (isBus) TYPICAL_LEAF_ROWS else BRANCHING_LEAF_ROWS)
 
             val hasUnseenUpcomingTrip =
                 upcomingTripsInCutoff?.any { upcomingTrip ->

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/UpcomingTrip.kt
@@ -76,19 +76,20 @@ constructor(
     /** Checks if a trip has a time */
     internal fun isUpcoming() = time != null
 
-    /**
-     * Checks if a trip exists in the near future, or the recent past if the vehicle has not yet
-     * left this stop or a custom status string is still set.
-     */
-    internal fun isUpcomingWithin(
-        currentTime: EasternTimeInstant,
-        cutoffTime: EasternTimeInstant,
-    ): Boolean =
-        time != null &&
-            time < cutoffTime &&
-            (time >= currentTime ||
-                (prediction != null &&
-                    (prediction.stopId == vehicle?.stopId || prediction.status != null)))
+    /** Checks that trip time is in the future */
+    internal fun isInTheFuture(currentTime: EasternTimeInstant) =
+        time != null && time >= currentTime
+
+    /** Check the vehicle and the prediction stop id are the same */
+    internal fun isVehicleAtTheStop() =
+        prediction != null && vehicle != null && prediction.stopId == vehicle.stopId
+
+    /** Checks prediction status */
+    internal fun doesPredictionHaveStatus() = prediction?.status?.isNotBlank() ?: false
+
+    /** Checks if a trip exists in the near future */
+    internal fun isUpcomingWithin(cutoffTime: EasternTimeInstant): Boolean =
+        time != null && time < cutoffTime
 
     override fun compareTo(other: UpcomingTrip): Int =
         nullsLast<EasternTimeInstant>().compare(time, other.time)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -2518,7 +2518,7 @@ class RouteCardDataTest {
         }
 
     @Test
-    fun `RouteCardData routeCardsForStopList hides rare direction with no predictions in next 120 min`() =
+    fun `RouteCardData routeCardsForStopList shows rare direction with no predictions in next 120 min`() =
         runBlocking {
             val objects = ObjectCollectionBuilder()
 
@@ -2595,7 +2595,24 @@ class RouteCardDataTest {
                                             subwayServiceStartTime = null,
                                             alertsDownstream = emptyList(),
                                             context = context,
-                                        )
+                                        ),
+                                        RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute1,
+                                            stop = stop1,
+                                            direction = Direction(1, route1),
+                                            routePatterns = listOf(deviationInbound),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(deviationInboundPrediction)
+                                                ),
+                                            alertsHere = emptyList(),
+                                            allDataLoaded = false,
+                                            hasSchedulesToday = false,
+                                            subwayServiceStartTime = null,
+                                            alertsDownstream = emptyList(),
+                                            context = context,
+                                        ),
                                     ),
                                 )
                             ),
@@ -3282,6 +3299,7 @@ class RouteCardDataTest {
             val objects = ObjectCollectionBuilder()
 
             val stop1 = objects.stop()
+            val stop2 = objects.stop()
 
             val route1 = objects.route()
             val route2 = objects.route()
@@ -3304,7 +3322,7 @@ class RouteCardDataTest {
                     sortOrder = 2
                     representativeTrip { headsign = "Schedule Soon" }
                 }
-            // exclude, schedule too late
+            // include, schedule too late
             val scheduleLater =
                 objects.routePattern(route2) {
                     sortOrder = 3
@@ -3330,7 +3348,7 @@ class RouteCardDataTest {
                     sortOrder = 6
                     representativeTrip { headsign = "Prediction Soon" }
                 }
-            // exclude, prediction later
+            // include, prediction later
             val predictionLater =
                 objects.routePattern(route4) {
                     sortOrder = 7
@@ -3375,9 +3393,10 @@ class RouteCardDataTest {
                     trip = objects.trip(scheduleLater)
                     departureTime = time + 121.minutes
                 }
+            // stop id has to be different to current stop otherwise is considered boarding
             val predictionPastPrediction =
                 objects.prediction {
-                    stopId = stop1.id
+                    stopId = stop2.id
                     trip = objects.trip(predictionPast)
                     departureTime = time - 1.minutes
                 }
@@ -3409,7 +3428,9 @@ class RouteCardDataTest {
                 }
 
             val lineOrRoute1 = LineOrRoute.Route(route1)
+            val lineOrRoute2 = LineOrRoute.Route(route2)
             val lineOrRoute3 = LineOrRoute.Route(route3)
+            val lineOrRoute4 = LineOrRoute.Route(route4)
             assertEquals(
                 listOf(
                     RouteCardData(
@@ -3432,6 +3453,34 @@ class RouteCardDataTest {
                                             allDataLoaded = true,
                                             hasSchedulesToday = true,
                                             subwayServiceStartTime = scheduleSoonSchedule.stopTime,
+                                            alertsDownstream = emptyList(),
+                                            context = context,
+                                        )
+                                    ),
+                                )
+                            ),
+                        time,
+                    ),
+                    RouteCardData(
+                        lineOrRoute = lineOrRoute2,
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    route2,
+                                    stop1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute2,
+                                            stop = stop1,
+                                            Direction(0, route2),
+                                            routePatterns = listOf(scheduleLater),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(objects.upcomingTrip(scheduleLaterSchedule)),
+                                            alertsHere = emptyList(),
+                                            allDataLoaded = true,
+                                            hasSchedulesToday = true,
+                                            subwayServiceStartTime = scheduleLaterSchedule.stopTime,
                                             alertsDownstream = emptyList(),
                                             context = context,
                                         )
@@ -3485,6 +3534,36 @@ class RouteCardDataTest {
                                             alertsDownstream = emptyList(),
                                             context = context,
                                         ),
+                                    ),
+                                )
+                            ),
+                        time,
+                    ),
+                    RouteCardData(
+                        lineOrRoute = lineOrRoute4,
+                        stopData =
+                            listOf(
+                                RouteCardData.RouteStopData(
+                                    route4,
+                                    stop1,
+                                    listOf(
+                                        RouteCardData.Leaf(
+                                            lineOrRoute = lineOrRoute4,
+                                            stop = stop1,
+                                            Direction(0, route4),
+                                            routePatterns = listOf(predictionLater),
+                                            stopIds = setOf(stop1.id),
+                                            upcomingTrips =
+                                                listOf(
+                                                    objects.upcomingTrip(predictionLaterPrediction)
+                                                ),
+                                            alertsHere = emptyList(),
+                                            allDataLoaded = true,
+                                            hasSchedulesToday = false,
+                                            subwayServiceStartTime = null,
+                                            alertsDownstream = emptyList(),
+                                            context = context,
+                                        )
                                     ),
                                 )
                             ),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -2534,7 +2534,6 @@ class RouteCardDataTest {
                     typicality = RoutePattern.Typicality.Typical
                     representativeTrip { headsign = "Typical Out" }
                 }
-            // should not be included because not typical and prediction beyond 120 minutes
             val deviationInbound =
                 objects.routePattern(route1) {
                     directionId = 1
@@ -2784,7 +2783,6 @@ class RouteCardDataTest {
                     typicality = RoutePattern.Typicality.Typical
                     representativeTrip { headsign = "Typical Out" }
                 }
-            // should not be included because not typical and prediction beyond 120 minutes
             val deviationOutbound =
                 objects.routePattern(route1) {
                     directionId = 0
@@ -3299,7 +3297,6 @@ class RouteCardDataTest {
             val objects = ObjectCollectionBuilder()
 
             val stop1 = objects.stop()
-            val stop2 = objects.stop()
 
             val route1 = objects.route()
             val route2 = objects.route()
@@ -3396,7 +3393,7 @@ class RouteCardDataTest {
             // stop id has to be different to current stop otherwise is considered boarding
             val predictionPastPrediction =
                 objects.prediction {
-                    stopId = stop2.id
+                    stopId = stop1.id
                     trip = objects.trip(predictionPast)
                     departureTime = time - 1.minutes
                 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Nearby - remove 120 min cutoff](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1214831841586110?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Removing the 120 min limit cutoff for trips that are schedule over 120 minutes can be displayed in the app

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Unit testing
- Checked that trips schedules over 120 min were visible
- Shared finding with the team in slack

| Before | After |
| --- | --- |
| <img width="238" height="506" alt="Screenshot_20260625_134916" src="https://github.com/user-attachments/assets/24765334-4902-4aef-abc5-28c942300671" /> | <img width="238" height="506" alt="Screenshot_20260625_120253" src="https://github.com/user-attachments/assets/1bd367c7-1310-4415-83ff-a3c3425d94cd" />  |
| <img width="238" height="506" alt="Screenshot_20260625_133943" src="https://github.com/user-attachments/assets/32ab6fc1-c268-48de-832e-83db44ead5b3" /> | <img width="238" height="506" alt="Screenshot_20260625_134132" src="https://github.com/user-attachments/assets/04fe35ad-62b8-4361-8027-a784bb1c760d" /> |

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
