### PR TITLE
fix: Make upcoming stop closures use AffectedStops

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -11674,6 +11674,53 @@
         }
       }
     },
+    "Ferries" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Transbordadores"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ferries"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ferry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Balsas"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Phà"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "渡轮"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "渡輪"
+          }
+        }
+      }
+    },
     "ferry" : {
       "comment" : "ferry",
       "localizations" : {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -317,7 +317,11 @@ public sealed class AlertSummary {
 
             val affectedStops = global.getAlertAffectedStops(alert, routes) ?: return null
 
-            if (alert.stopSkipped && affectedStops.isNotEmpty() && alert.isActive(atTime)) {
+            if (
+                alert.stopSkipped &&
+                    affectedStops.isNotEmpty() &&
+                    (alert.isActive(atTime) || alert.willBeActiveSoon(atTime))
+            ) {
                 return Location.AffectedStops(affectedStops.map { it.name })
             }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix template for downstream stop closure](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215459184849991?focus=true)

Related backend PR https://github.com/mbta/mobile_app_backend/pull/574

I wasn't planning to do this in the frontend since I thought the fix was more complex than this, but since it's one line I might as well. Also added a new string for ferry closures, for use on the backend.

<img width="1412" height="281" alt="Screenshot_20260701_154344" src="https://github.com/user-attachments/assets/4a48181d-990a-4837-847c-8d54d918b77a" />

iOS
- [x] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [x] Add temporary machine translations, marked "Needs Review"

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified that the text for upcoming closures was correct now, didn't bother write tests since this is being replaced soon