### PR TITLE
test(Android): make tests more robust on real devices

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -158,33 +158,23 @@ spotless {
         custom(
             "use custom default wait timeout in android UI tests",
             object : Serializable, FormatterFunc.NeedsFile {
-                override fun applyWithFile(text: String, file: File): String {
-                    if (
-                        !file.path.contains("androidTest") ||
-                            file.name == "ComposeTestRuleExtension.kt" ||
-                            file.name == "RetryableComposeTestRule.kt"
+                val replacements =
+                    mapOf(
+                        "waitUntil(" to "waitUntilDefaultTimeout(",
+                        "waitUntil {" to "waitUntilDefaultTimeout {",
+                        "waitUntilAtLeastOneExists(" to "waitUntilAtLeastOneExistsDefaultTimeout(",
+                        "waitUntilDoesNotExist(" to "waitUntilDoesNotExistDefaultTimeout(",
+                        "waitUntilExactlyOneExists(" to "waitUntilExactlyOneExistsDefaultTimeout(",
+                        "waitUntilNodeCount(" to "waitUntilNodeCountDefaultTimeout(",
+                        ".assertIsDisplayed()" to ".assertCanBeDisplayed()",
                     )
+
+                override fun applyWithFile(text: String, file: File): String {
+                    if (!file.path.contains("androidTest") || file.path.contains("testUtils"))
                         return text
-                    val lines = text.lines()
-                    for (line in lines.withIndex()) {
-                        for (fnText in
-                            arrayOf(
-                                "waitUntil(",
-                                "waitUntil {",
-                                "waitUntilAtLeastOneExists(",
-                                "waitUntilDoesNotExist(",
-                                "waitUntilExactlyOneExists(",
-                                "waitUntilNodeCount(",
-                            )) {
-                            val column = line.value.indexOf(fnText, 0, false)
-                            if (column != -1) {
-                                throw IllegalStateException(
-                                    "${file.path}:${line.index + 1}:${column + 1} calls $fnText. Replace with ${fnText.dropLast(1)}DefaultTimeout to prevent CI flakiness."
-                                )
-                            }
-                        }
-                    }
-                    return text
+                    return replacements
+                        .toList()
+                        .fold(text, { text, (bad, good) -> text.replace(bad, good) })
                 }
             },
         )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/ContentViewTests.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -13,6 +12,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.rule.GrantPermissionRule
 import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.LocalLocationClient
@@ -59,10 +59,10 @@ class ContentViewTests : KoinTest {
         }
 
         composeTestRule.onNodeWithText("More").performClick()
-        composeTestRule.onNodeWithText("MBTA Go").assertIsDisplayed()
+        composeTestRule.onNodeWithText("MBTA Go").assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText("Nearby").performClick()
-        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertCanBeDisplayed()
     }
 
     @Test
@@ -79,7 +79,7 @@ class ContentViewTests : KoinTest {
             }
         }
 
-        composeTestRule.onNode(hasText("Favorites") and isHeading()).assertIsDisplayed()
+        composeTestRule.onNode(hasText("Favorites") and isHeading()).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Nearby").performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Nearby Transit"))
         assertEquals(DefaultTab.Nearby, repo.defaultTab)
@@ -117,7 +117,7 @@ class ContentViewTests : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add your favorites"))
         composeTestRule
             .onNodeWithText("Now save your frequently used stops", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -15,6 +15,9 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatformTools
 
+fun assertMatches(regex: Regex, actual: String) =
+    assert(regex.matches(actual)) { "$actual does not match $regex" }
+
 /**
  * Loads mock repositories into the global Koin instance for use in tests, based on the given
  * [objects] by default but with whatever overridden repositories are provided.

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/TestUtils.kt
@@ -1,15 +1,5 @@
 package com.mbta.tid.mbta_app.android
 
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toPixelMap
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.captureToImage
 import com.mbta.tid.mbta_app.analytics.Analytics
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.dependencyInjection.MockRepositories
@@ -18,100 +8,12 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.network.MockPhoenixSocket
 import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.viewModel.viewModelModule
-import kotlin.math.abs
 import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import org.junit.Assert.fail
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatformTools
-
-fun hasClickActionLabel(expected: String?) =
-    SemanticsMatcher("has click action label $expected") { node ->
-        node.config.getOrNull(SemanticsActions.OnClick)?.label == expected
-    }
-
-fun hasTextMatching(regex: Regex): SemanticsMatcher {
-    val propertyName = "${SemanticsProperties.Text.name} + ${SemanticsProperties.EditableText.name}"
-    return SemanticsMatcher("$propertyName matches $regex") {
-        val isInEditableTextValue =
-            it.config.getOrNull(SemanticsProperties.EditableText)?.text?.matches(regex) ?: false
-        val isInTextValue =
-            it.config.getOrNull(SemanticsProperties.Text)?.any { item -> item.text.matches(regex) }
-                ?: false
-        isInEditableTextValue || isInTextValue
-    }
-}
-
-fun hasContentDescriptionMatching(regex: Regex): SemanticsMatcher {
-    val propertyName = SemanticsProperties.ContentDescription.name
-    return SemanticsMatcher("$propertyName matches $regex") {
-        it.config.getOrNull(SemanticsProperties.ContentDescription)?.any { item ->
-            item.matches(regex)
-        } ?: false
-    }
-}
-
-fun hasRole(role: Role) =
-    SemanticsMatcher("has role $role") { node ->
-        node.config.getOrNull(SemanticsProperties.Role) == role
-    }
-
-fun SemanticsNodeInteraction.assertContentDescriptionMatches(regex: Regex) =
-    assert(hasContentDescriptionMatching(regex))
-
-@OptIn(ExperimentalStdlibApi::class)
-private fun colorToHex(color: Color): String {
-    fun valToHex(value: Float): String {
-        val byteValue = (value * 255).toInt().toByte()
-        return byteValue.toHexString(HexFormat.UpperCase)
-    }
-    return "#${valToHex(color.red)}${valToHex(color.green)}${valToHex(color.blue)}"
-}
-
-private fun Color.isGrey(): Boolean =
-    abs(this.red - this.green) < 0.01 && abs(this.green - this.blue) < 0.01
-
-/**
- * It's difficult to determine if a view hierarchy contains the correct image when the image is
- * semantically invisible, but it's easy to capture a screenshot of the view and check it pixel by
- * pixel.
- */
-fun SemanticsNodeInteraction.assertHasColor(targetColor: Color) {
-    val pixelMap = this.captureToImage().toPixelMap()
-    val pixelCounts = mutableMapOf<Color, Int>()
-    for (x in 0.rangeUntil(pixelMap.width)) {
-        for (y in 0.rangeUntil(pixelMap.height)) {
-            val colorHere = pixelMap[x, y]
-            if (colorHere == targetColor) {
-                return
-            }
-            pixelCounts[colorHere] = pixelCounts.getOrDefault(colorHere, 0) + 1
-        }
-    }
-    // never returned so did not find the target. hopefully the color that is present instead of the
-    // target is either the most common non-grey color or among the most common grey colors (the
-    // most common grey will likely be a background, though)
-    val legibleResult =
-        pixelCounts.entries
-            .groupBy(
-                { if (it.key.isGrey()) "grey" else "not grey" },
-                { colorToHex(it.key) to it.value },
-            )
-            .mapValues { it.value.sortedByDescending { it.second } }
-            .toSortedMap(
-                compareBy {
-                    when (it) {
-                        "not grey" -> 1
-                        "grey" -> 2
-                        else -> 3
-                    }
-                }
-            )
-
-    fail("Did not contain specified color, but did have $legibleResult")
-}
 
 /**
  * Loads mock repositories into the global Koin instance for use in tests, based on the given

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.alertDetails
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
@@ -83,13 +83,13 @@ class AlertDetailsPageTest {
 
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("Orange Line Suspension").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Fire").assertIsDisplayed()
-        composeTestRule.onNodeWithText("3 affected stops").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Orange Line Suspension").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Fire").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("3 affected stops").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("3 affected stops").performClick()
-        composeTestRule.onNodeWithText("Stop 1").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Stop 2").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Stop 3").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop 1").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Stop 2").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Stop 3").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Stop 1a").assertDoesNotExist()
         composeTestRule.onNodeWithText("Stop 1b").assertDoesNotExist()
         composeTestRule.onNodeWithText("Stop 2a").assertDoesNotExist()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -65,7 +65,11 @@ class AlertDetailsTest {
         composeTestRule.onNodeWithText("Red Line Suspension").assertIsDisplayed()
         composeTestRule.onNodeWithText("Unruly Passenger").assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("Wednesday, Jan 22, 10:35\\sAM")))
+            .onNode(
+                hasTextMatching(
+                    Regex("Wednesday, (Jan 22|22 Jan), 10:35\\sAM", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule.onNodeWithText("3 affected stops").assertIsDisplayed()
         composeTestRule.onNodeWithText("3 affected stops").performClick()
@@ -79,7 +83,11 @@ class AlertDetailsTest {
         // as of probably API 34, this has a U+202F Narrow No-Break Space instead of U+0020 Space,
         // so to make the test work either way we need a regex
         composeTestRule
-            .onNode(hasTextMatching(Regex("Updated: 1/22/25, 10:36\\sAM")))
+            .onNode(
+                hasTextMatching(
+                    Regex("Updated: (0?1/22|22/0?1)/25, 10:36\\sAM", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
     }
 
@@ -109,7 +117,11 @@ class AlertDetailsTest {
         }
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("Tuesday, Jul 29, 9:25\\sAM")))
+            .onNode(
+                hasTextMatching(
+                    Regex("Tuesday, (Jul 29|29 Jul), 9:25\\sAM", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
     }
 
@@ -138,9 +150,13 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Tuesday, Jul 29, start of service").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("Tuesday, (Jul 29|29 Jul), start of service")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("3:00", substring = true).assertDoesNotExist()
-        composeTestRule.onNodeWithText("Tuesday, Jul 29, end of service").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("Tuesday, (Jul 29|29 Jul), end of service")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("2:59", substring = true).assertDoesNotExist()
     }
 
@@ -385,9 +401,13 @@ class AlertDetailsTest {
         }
 
         composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Fri, Jan 23 – Sun, Jan 25").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("Fri, (Jan 23|23 Jan) – Sun, (Jan 25|25 Jan)")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
-        composeTestRule.onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test
@@ -421,7 +441,9 @@ class AlertDetailsTest {
         composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
         composeTestRule.onNodeWithText("Until further notice").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
-        composeTestRule.onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test
@@ -450,10 +472,14 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("January 23 – January 25").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("(January 23|23 January) – (January 25|25 January)")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("Sunday, Friday").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
-        composeTestRule.onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test
@@ -486,10 +512,14 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("May 4 – May 11").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("(May 4|4 May) – (May 11|11 May)")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("Weekdays").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
-        composeTestRule.onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test
@@ -519,10 +549,14 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("May 3 – May 10").assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("(May 3|3 May) – (May 10|10 May)")))
+            .assertIsDisplayed()
         composeTestRule.onNodeWithText("Weekends").assertIsDisplayed()
         composeTestRule.onNodeWithText("From").assertIsDisplayed()
-        composeTestRule.onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.alertDetails
 
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -62,24 +62,24 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Red Line Suspension").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Unruly Passenger").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Red Line Suspension").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Unruly Passenger").assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(
                     Regex("Wednesday, (Jan 22|22 Jan), 10:35\\sAM", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("3 affected stops").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("3 affected stops").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("3 affected stops").performClick()
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop3.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop3.name).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("3 affected stops").performClick()
-        composeTestRule.onNodeWithText("Full Description").assertIsDisplayed()
-        composeTestRule.onNodeWithText(alert.description!!).assertIsDisplayed()
-        composeTestRule.onNodeWithText(alert.header!!).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Full Description").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(alert.description!!).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(alert.header!!).assertCanBeDisplayed()
         // as of probably API 34, this has a U+202F Narrow No-Break Space instead of U+0020 Space,
         // so to make the test work either way we need a regex
         composeTestRule
@@ -88,7 +88,7 @@ class AlertDetailsTest {
                     Regex("Updated: (0?1/22|22/0?1)/25, 10:36\\sAM", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -122,7 +122,7 @@ class AlertDetailsTest {
                     Regex("Tuesday, (Jul 29|29 Jul), 9:25\\sAM", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -152,11 +152,11 @@ class AlertDetailsTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("Tuesday, (Jul 29|29 Jul), start of service")))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("3:00", substring = true).assertDoesNotExist()
         composeTestRule
             .onNode(hasTextMatching(Regex("Tuesday, (Jul 29|29 Jul), end of service")))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("2:59", substring = true).assertDoesNotExist()
     }
 
@@ -186,9 +186,9 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("9:10", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("9:10", substring = true).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("11:30", substring = true).assertDoesNotExist()
-        composeTestRule.onNodeWithText("later today", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("later today", substring = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -217,7 +217,7 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Alert is no longer in effect").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Alert is no longer in effect").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Start").assertDoesNotExist()
     }
 
@@ -286,21 +286,21 @@ class AlertDetailsTest {
         }
 
         composeTestRule.onNodeWithText("3 affected stops").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Alert description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Alert description").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Affected stops:\nStop 1\nStop 2\nStop 3")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("More details").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("More details").assertCanBeDisplayed()
 
         affectedStops.value = listOf(stop1, stop2, stop3)
         composeTestRule.waitForIdle()
 
-        composeTestRule.onNodeWithText("3 affected stops").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Alert description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("3 affected stops").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Alert description").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Affected stops:\nStop 1\nStop 2\nStop 3")
             .assertDoesNotExist()
-        composeTestRule.onNodeWithText("More details").assertIsDisplayed()
+        composeTestRule.onNodeWithText("More details").assertCanBeDisplayed()
     }
 
     @Test
@@ -366,10 +366,10 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("${stop.name} Elevator Closure").assertIsDisplayed()
-        composeTestRule.onNodeWithText(alert.header!!).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Alternative path").assertIsDisplayed()
-        composeTestRule.onNodeWithText(alert.description!!).assertIsDisplayed()
+        composeTestRule.onNodeWithText("${stop.name} Elevator Closure").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(alert.header!!).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Alternative path").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(alert.description!!).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("1 affected stop").assertDoesNotExist()
     }
 
@@ -400,14 +400,14 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Daily").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("Fri, (Jan 23|23 Jan) – Sun, (Jan 25|25 Jan)")))
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("From").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -438,12 +438,12 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Daily").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Until further notice").assertIsDisplayed()
-        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Daily").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Until further notice").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("From").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -474,12 +474,12 @@ class AlertDetailsTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("(January 23|23 January) – (January 25|25 January)")))
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sunday, Friday").assertIsDisplayed()
-        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sunday, Friday").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("From").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("9:41\\sAM – 11:41\\sAM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -514,12 +514,12 @@ class AlertDetailsTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("(May 4|4 May) – (May 11|11 May)")))
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Weekdays").assertIsDisplayed()
-        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Weekdays").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("From").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -551,12 +551,12 @@ class AlertDetailsTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("(May 3|3 May) – (May 10|10 May)")))
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Weekends").assertIsDisplayed()
-        composeTestRule.onNodeWithText("From").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Weekends").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("From").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("1:38\\sPM – 3:38\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -590,7 +590,9 @@ class AlertDetailsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Starting tomorrow until further notice").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Starting tomorrow until further notice")
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -628,6 +630,6 @@ class AlertDetailsTest {
         composeTestRule
             .onNodeWithText("Starting tomorrow until further notice")
             .assertDoesNotExist()
-        composeTestRule.onNodeWithText("Until further notice").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Until further notice").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/BarAndToastScaffoldTest.kt
@@ -2,11 +2,11 @@ package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.viewModel.MockToastViewModel
 import com.mbta.tid.mbta_app.viewModel.ToastViewModel
@@ -36,10 +36,12 @@ class BarAndToastScaffoldTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilDefaultTimeout { toastShown }
-        composeTestRule.onNodeWithText("Toast message", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Toast message", useUnmergedTree = true)
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Tip: Toast message", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -60,10 +62,12 @@ class BarAndToastScaffoldTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilDefaultTimeout { toastShown }
-        composeTestRule.onNodeWithText("Toast message", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Toast message", useUnmergedTree = true)
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Toast message", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Tip:", useUnmergedTree = true, substring = true)
             .assertDoesNotExist()
@@ -99,7 +103,7 @@ class BarAndToastScaffoldTest {
         composeTestRule.waitUntilDefaultTimeout { toastShown }
         composeTestRule
             .onNodeWithText("Action", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
 
         assert(actionTapped)
@@ -125,7 +129,7 @@ class BarAndToastScaffoldTest {
         composeTestRule.waitForIdle()
         composeTestRule
             .onNodeWithContentDescription("Dismiss", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
 
         assert(closeTapped)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionLabelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionLabelTest.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Direction
 import org.junit.Rule
 import org.junit.Test
@@ -15,8 +15,8 @@ class DirectionLabelTest {
         composeTestRule.setContent {
             DirectionLabel(Direction(name = "Inbound", destination = "South Station", id = 1))
         }
-        composeTestRule.onNodeWithText("Inbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("South Station").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Inbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("South Station").assertCanBeDisplayed()
     }
 
     @Test
@@ -24,7 +24,7 @@ class DirectionLabelTest {
         composeTestRule.setContent {
             DirectionLabel(Direction(name = "East", destination = "Park St & North", id = 1))
         }
-        composeTestRule.onNodeWithText("Eastbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Park St & North").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Eastbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Park St & North").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/DirectionPickerTest.kt
@@ -1,11 +1,11 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.stopDetails.DirectionPicker
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import junit.framework.TestCase.assertTrue
@@ -34,7 +34,7 @@ class DirectionPickerTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Northbound").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Northbound").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Southbound").performClick()
         assertTrue(directionId == 1)
     }
@@ -60,7 +60,7 @@ class DirectionPickerTest {
         }
 
         composeTestRule.onNodeWithText("Northbound").assertIsNotDisplayed()
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Destination").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Destination").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/HeadsignRowViewTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.MyApplicationTheme
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.trip
@@ -45,9 +45,9 @@ class HeadsignRowViewTest {
             ),
         )
 
-        composeTestRule.onNodeWithText("Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("2 min").assertIsDisplayed()
-        composeTestRule.onNodeWithText("10 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Headsign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("2 min").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("10 min").assertCanBeDisplayed()
     }
 
     @Test
@@ -67,8 +67,8 @@ class HeadsignRowViewTest {
             ),
         )
 
-        composeTestRule.onNodeWithText("A Place").assertIsDisplayed()
-        composeTestRule.onNodeWithText("BRD").assertIsDisplayed()
+        composeTestRule.onNodeWithText("A Place").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("BRD").assertCanBeDisplayed()
     }
 
     @Test
@@ -88,9 +88,9 @@ class HeadsignRowViewTest {
             ),
         )
 
-        composeTestRule.onNodeWithText("A Place").assertIsDisplayed()
-        composeTestRule.onNodeWithText("BRD").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Alert").assertIsDisplayed()
+        composeTestRule.onNodeWithText("A Place").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("BRD").assertCanBeDisplayed()
+        composeTestRule.onNodeWithContentDescription("Alert").assertCanBeDisplayed()
     }
 
     @Test
@@ -100,8 +100,8 @@ class HeadsignRowViewTest {
             UpcomingFormat.NoTrips(UpcomingFormat.NoTripsFormat.PredictionsUnavailable),
         )
 
-        composeTestRule.onNodeWithText("Somewhere").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Somewhere").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Predictions unavailable").assertCanBeDisplayed()
     }
 
     @Test
@@ -114,9 +114,9 @@ class HeadsignRowViewTest {
             ),
         )
 
-        composeTestRule.onNodeWithText("Somewhere").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Alert").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Somewhere").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Predictions unavailable").assertCanBeDisplayed()
+        composeTestRule.onNodeWithContentDescription("Alert").assertCanBeDisplayed()
     }
 
     @Test
@@ -126,13 +126,13 @@ class HeadsignRowViewTest {
             UpcomingFormat.Disruption(alert { effect = Alert.Effect.Shuttle }, mapStopRoute = null),
         )
 
-        composeTestRule.onNodeWithText("Shuttle Bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Shuttle Bus").assertCanBeDisplayed()
     }
 
     @Test
     fun showsLoading() {
         init("Headsign", UpcomingFormat.Loading)
 
-        composeTestRule.onNodeWithContentDescription("Loading...").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Loading...").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/LocationAuthButtonTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -22,7 +22,7 @@ class LocationAuthButtonTest {
 
         composeTestRule.setContent { LocationAuthButton(locationDataManager = locationManager) }
 
-        composeTestRule.onNodeWithText("Location Services is off").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Location Services is off").assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RoutePillTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/RoutePillTest.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.android.component
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import org.junit.Rule
@@ -20,7 +20,7 @@ class RoutePillTest {
             }
 
         composeTestRule.setContent { RoutePill(busRoute, null, RoutePillType.Fixed) }
-        composeTestRule.onNodeWithContentDescription("Harvard bus").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Harvard bus").assertCanBeDisplayed()
     }
 
     @Test
@@ -32,7 +32,7 @@ class RoutePillTest {
             }
 
         composeTestRule.setContent { RoutePill(subwayRoute, null, RoutePillType.Fixed) }
-        composeTestRule.onNodeWithContentDescription("Red Line train").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Red Line train").assertCanBeDisplayed()
     }
 
     @Test
@@ -44,7 +44,7 @@ class RoutePillTest {
             }
 
         composeTestRule.setContent { RoutePill(crRoute, null, RoutePillType.Fixed) }
-        composeTestRule.onNodeWithContentDescription("Haverhill train").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Haverhill train").assertCanBeDisplayed()
     }
 
     @Test
@@ -56,6 +56,6 @@ class RoutePillTest {
             }
 
         composeTestRule.setContent { RoutePill(ferryRoute, null, RoutePillType.Fixed) }
-        composeTestRule.onNodeWithContentDescription("Charlestown Ferry").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Charlestown Ferry").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/SaveFavoritesFlowTest.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.android.component
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -9,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
@@ -301,7 +301,7 @@ class SaveFavoritesFlowTest {
             )
         }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Eastbound service only").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Eastbound service only").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Add").performClick()
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilDefaultTimeout { onCloseCalled }
@@ -463,7 +463,7 @@ class SaveFavoritesFlowTest {
             )
         }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("This stop is drop-off only").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This stop is drop-off only").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Add").assertDoesNotExist()
         composeTestRule.onNodeWithText("Okay").performClick()
         composeTestRule.waitForIdle()
@@ -488,7 +488,7 @@ class SaveFavoritesFlowTest {
             )
         }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Add Green Line at Boylston").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add Green Line at Boylston").assertCanBeDisplayed()
     }
 
     @Test
@@ -510,7 +510,7 @@ class SaveFavoritesFlowTest {
         composeTestRule.waitForIdle()
         composeTestRule
             .onNodeWithText("Add Green Line at Boylston to Favorites")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumnTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorColumnTest.kt
@@ -3,11 +3,11 @@ package com.mbta.tid.mbta_app.android.component
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollTo
+import com.mbta.tid.mbta_app.android.testUtils.assertIsAlreadyOnScreen
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -26,7 +26,7 @@ class ScrollSeparatorColumnTest {
         composeTestRule.onNodeWithTag("99").performScrollTo()
         composeTestRule.awaitIdle()
 
-        composeTestRule.onNodeWithTag("separator").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("99").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("separator").assertIsAlreadyOnScreen()
+        composeTestRule.onNodeWithTag("99").assertIsAlreadyOnScreen()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumnTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/ScrollSeparatorLazyColumnTest.kt
@@ -4,12 +4,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToNode
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -30,7 +30,7 @@ class ScrollSeparatorLazyColumnTest {
         composeTestRule.onNodeWithTag("column").performScrollToNode(hasTestTag("99"))
         composeTestRule.awaitIdle()
 
-        composeTestRule.onNodeWithTag("separator").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("99").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("separator").assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("99").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/StopDetailsFilterPillsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/StopDetailsFilterPillsTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
@@ -18,6 +17,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import com.mbta.tid.mbta_app.android.stopDetails.PillFilter
 import com.mbta.tid.mbta_app.android.stopDetails.StopDetailsFilterPills
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopDetailsFilter
@@ -75,14 +75,14 @@ class StopDetailsFilterPillsTest {
 
         composeTestRule
             .onNodeWithText("RL", ignoreCase = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionEquals("Red Line train")
             .assertIsSelected()
             .assert(onClickLabelContains("Remove"))
 
         composeTestRule
             .onNodeWithText("M", ignoreCase = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertIsNotSelected()
         composeTestRule
             .onNodeWithText(route3.shortName)
@@ -93,7 +93,7 @@ class StopDetailsFilterPillsTest {
 
         composeTestRule
             .onNodeWithText(route3.shortName)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionEquals("55 bus")
             .assertIsNotSelected()
             .assert(onClickLabelContains("Apply"))

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -90,7 +90,9 @@ class UpcomingTripViewTest {
             .onNodeWithText("Cancelled", substring = true)
             .onParent()
             .assertExists()
-            .assertContentDescriptionMatches(Regex(" arriving at 2:03\\sPM cancelled"))
+            .assertContentDescriptionMatches(
+                Regex(" arriving at 2:03\\sPM cancelled", RegexOption.IGNORE_CASE)
+            )
     }
 
     @Test
@@ -203,9 +205,11 @@ class UpcomingTripViewTest {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Time(instant, false)))
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")))
+            .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
-            .assertContentDescriptionMatches(Regex(" arriving at 2:03\\sPM"))
+            .assertContentDescriptionMatches(
+                Regex(" arriving at 2:03\\sPM", RegexOption.IGNORE_CASE)
+            )
             .assertIsDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
     }
@@ -218,9 +222,11 @@ class UpcomingTripViewTest {
         }
         composeTestRule.onNodeWithText("Last").assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")))
+            .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
-            .assertContentDescriptionMatches(Regex(" arriving at 2:03\\sPM, Last trip"))
+            .assertContentDescriptionMatches(
+                Regex(" arriving at 2:03\\sPM, Last trip", RegexOption.IGNORE_CASE)
+            )
         composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
     }
 
@@ -237,10 +243,17 @@ class UpcomingTripViewTest {
         }
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasContentDescriptionMatching(Regex("train arriving at 2:03\\sPM, All aboard")))
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("train arriving at 2:03\\sPM, All aboard", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
@@ -261,12 +274,18 @@ class UpcomingTripViewTest {
         }
         composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
-                    Regex("train arriving at 2:03\\sPM, All aboard, Last trip")
+                    Regex(
+                        "train arriving at 2:03\\sPM, All aboard, Last trip",
+                        RegexOption.IGNORE_CASE,
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -287,10 +306,17 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasContentDescriptionMatching(Regex("2:03\\sPM train delayed")))
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("2:03\\sPM train delayed", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
@@ -309,10 +335,17 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasContentDescriptionMatching(Regex("2:03\\sPM train delayed")))
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("2:03\\sPM train delayed", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
@@ -332,12 +365,15 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:09\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
-                    Regex("2:03\\sPM train delayed, arriving at 2:09\\sPM")
+                    Regex("2:03\\sPM train delayed, arriving at 2:09\\sPM", RegexOption.IGNORE_CASE)
                 )
             )
             .assertIsDisplayed()
@@ -345,7 +381,10 @@ class UpcomingTripViewTest {
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 
@@ -362,18 +401,26 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNode(
-                hasContentDescriptionMatching(Regex("2:09\\sPM train early, arriving at 2:03\\sPM"))
+                hasContentDescriptionMatching(
+                    Regex("2:09\\sPM train early, arriving at 2:03\\sPM", RegexOption.IGNORE_CASE)
+                )
             )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:09\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 
@@ -394,7 +441,10 @@ class UpcomingTripViewTest {
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
-                    Regex("and 2:03\\sPM train delayed, arriving at 2:09\\sPM")
+                    Regex(
+                        "and 2:03\\sPM train delayed, arriving at 2:09\\sPM",
+                        RegexOption.IGNORE_CASE,
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -402,10 +452,16 @@ class UpcomingTripViewTest {
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:09\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 
@@ -423,12 +479,18 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
-                    Regex("and 2:09\\sPM train early, arriving at 2:03\\sPM")
+                    Regex(
+                        "and 2:09\\sPM train early, arriving at 2:03\\sPM",
+                        RegexOption.IGNORE_CASE,
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -436,7 +498,10 @@ class UpcomingTripViewTest {
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:09\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 
@@ -450,9 +515,11 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")))
+            .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
-            .assertContentDescriptionMatches(Regex(" arriving at 2:03\\sPM scheduled"))
+            .assertContentDescriptionMatches(
+                Regex(" arriving at 2:03\\sPM scheduled", RegexOption.IGNORE_CASE)
+            )
             .assertIsDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertDoesNotExist()
     }
@@ -467,9 +534,11 @@ class UpcomingTripViewTest {
         }
         composeTestRule.onNodeWithText("Last").assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:03\\sPM")))
+            .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
-            .assertContentDescriptionMatches(Regex(" arriving at 2:03\\sPM scheduled, Last trip"))
+            .assertContentDescriptionMatches(
+                Regex(" arriving at 2:03\\sPM scheduled, Last trip", RegexOption.IGNORE_CASE)
+            )
         composeTestRule.onNodeWithTag("lastScheduleIndicator").assertIsDisplayed()
     }
 
@@ -487,11 +556,18 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:14\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule.onNodeWithText("Delayed", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
-            .onNode(hasContentDescriptionMatching(Regex("2:14\\sPM train delayed")))
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("2:14\\sPM train delayed", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
@@ -512,10 +588,17 @@ class UpcomingTripViewTest {
         }
         composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:14\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule
-            .onNode(hasContentDescriptionMatching(Regex("2:14\\sPM train delayed, Last trip")))
+            .onNode(
+                hasContentDescriptionMatching(
+                    Regex("2:14\\sPM train delayed, Last trip", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
         composeTestRule
             .onNodeWithTag("lastScheduleIndicator", useUnmergedTree = true)
@@ -536,13 +619,19 @@ class UpcomingTripViewTest {
             )
         }
         composeTestRule
-            .onNode(hasTextMatching(Regex("2:14\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
         composeTestRule.onNodeWithText("Anomalous", useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
-                    Regex("train arriving at 2:14\\sPM scheduled, Anomalous")
+                    Regex(
+                        "train arriving at 2:14\\sPM scheduled, Anomalous",
+                        RegexOption.IGNORE_CASE,
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -728,7 +817,9 @@ class UpcomingTripViewTest {
                 )
             )
         }
-        composeTestRule.onNode(hasTextMatching(Regex("^First 9:41\\sAM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("^First 9:41\\sAM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.component
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertContentDescriptionContains
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -11,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.onRoot
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.assertContentDescriptionMatches
 import com.mbta.tid.mbta_app.android.testUtils.assertHasColor
 import com.mbta.tid.mbta_app.android.testUtils.hasContentDescriptionMatching
@@ -40,9 +40,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("Test")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("Test", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -52,12 +52,12 @@ class UpcomingTripViewTest {
                 UpcomingTripViewState.Some(TripInstantDisplay.Overridden("Test", true))
             )
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Test")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("Test, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -102,9 +102,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("Now")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving now", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -112,12 +112,12 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Now(true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Now")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving now, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -127,10 +127,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("BRD")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("boarding now", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -138,12 +138,12 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Boarding(true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("BRD")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("boarding now, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -153,10 +153,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 1 min", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -164,12 +164,12 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Approaching(true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("1 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 1 min, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -179,10 +179,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("ARR")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving now", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -190,12 +190,12 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Arriving(true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("ARR")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving now, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -206,12 +206,12 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionMatches(
                 Regex(" arriving at 2:03\\sPM", RegexOption.IGNORE_CASE)
             )
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -220,14 +220,14 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Time(instant, true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionMatches(
                 Regex(" arriving at 2:03\\sPM, Last trip", RegexOption.IGNORE_CASE)
             )
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -247,18 +247,18 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("train arriving at 2:03\\sPM, All aboard", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("All aboard", useUnmergedTree = true).assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("All aboard", useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -272,13 +272,13 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
@@ -288,10 +288,10 @@ class UpcomingTripViewTest {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -310,17 +310,17 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:03\\sPM train delayed", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -339,17 +339,17 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:03\\sPM train delayed", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -369,23 +369,23 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:03\\sPM train delayed, arriving at 2:09\\sPM", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -405,23 +405,23 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:09\\sPM train early, arriving at 2:03\\sPM", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -447,22 +447,22 @@ class UpcomingTripViewTest {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -483,7 +483,7 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
@@ -493,16 +493,16 @@ class UpcomingTripViewTest {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:09\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -516,11 +516,11 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionMatches(
                 Regex(" arriving at 2:03\\sPM scheduled", RegexOption.IGNORE_CASE)
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertDoesNotExist()
     }
 
@@ -532,14 +532,14 @@ class UpcomingTripViewTest {
                 UpcomingTripViewState.Some(TripInstantDisplay.ScheduleTime(instant, true))
             )
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("2:03\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionMatches(
                 Regex(" arriving at 2:03\\sPM scheduled, Last trip", RegexOption.IGNORE_CASE)
             )
-        composeTestRule.onNodeWithTag("lastScheduleIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("lastScheduleIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -560,15 +560,15 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Delayed", useUnmergedTree = true).assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Delayed", useUnmergedTree = true).assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:14\\sPM train delayed", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertDoesNotExist()
@@ -586,23 +586,23 @@ class UpcomingTripViewTest {
                 routeType = RouteType.COMMUTER_RAIL,
             )
         }
-        composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last", useUnmergedTree = true).assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
                     Regex("2:14\\sPM train delayed, Last trip", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("lastScheduleIndicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -623,8 +623,8 @@ class UpcomingTripViewTest {
                 hasTextMatching(Regex("2:14\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Anomalous", useUnmergedTree = true).assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Anomalous", useUnmergedTree = true).assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasContentDescriptionMatching(
@@ -634,7 +634,7 @@ class UpcomingTripViewTest {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("realtimeIndicator", useUnmergedTree = true)
             .assertDoesNotExist()
@@ -647,10 +647,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 5 min", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -658,12 +658,12 @@ class UpcomingTripViewTest {
         composeTestRule.setContent {
             UpcomingTripView(UpcomingTripViewState.Some(TripInstantDisplay.Minutes(5, true)))
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 5 min, Last trip", substring = true)
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -673,9 +673,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 hr 5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 1 hr 5 min", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -685,9 +685,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 hr")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 1 hr", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -699,9 +699,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 5 min scheduled", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertDoesNotExist()
     }
 
@@ -712,15 +712,15 @@ class UpcomingTripViewTest {
                 UpcomingTripViewState.Some(TripInstantDisplay.ScheduleMinutes(5, true))
             )
         }
-        composeTestRule.onNodeWithText("Last").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Last").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains(
                 "arriving in 5 min scheduled, Last trip",
                 substring = true,
             )
-        composeTestRule.onNodeWithTag("lastScheduleIndicator").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("lastScheduleIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -732,9 +732,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 hr 15 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("arriving in 1 hr 15 min scheduled", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithTag("realtimeIndicator").assertDoesNotExist()
     }
 
@@ -749,10 +749,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("and in 5 min", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -766,10 +766,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 hr 5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("and in 1 hr 5 min", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -783,10 +783,10 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("1 hr")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("and in 1 hr", substring = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithTag("realtimeIndicator").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("realtimeIndicator").assertCanBeDisplayed()
     }
 
     @Test
@@ -801,9 +801,9 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNodeWithText("5 min")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertContentDescriptionContains("buses arriving in 5 min", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -819,13 +819,13 @@ class UpcomingTripViewTest {
         }
         composeTestRule
             .onNode(hasTextMatching(Regex("^First 9:41\\sAM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
     fun testUpcomingTripViewWithLoading() {
         composeTestRule.setContent { UpcomingTripView(UpcomingTripViewState.Loading) }
-        composeTestRule.onNodeWithContentDescription("Loading...").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Loading...").assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/UpcomingTripViewTest.kt
@@ -11,10 +11,10 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onParent
 import androidx.compose.ui.test.onRoot
-import com.mbta.tid.mbta_app.android.assertContentDescriptionMatches
-import com.mbta.tid.mbta_app.android.assertHasColor
-import com.mbta.tid.mbta_app.android.hasContentDescriptionMatching
-import com.mbta.tid.mbta_app.android.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.assertContentDescriptionMatches
+import com.mbta.tid.mbta_app.android.testUtils.assertHasColor
+import com.mbta.tid.mbta_app.android.testUtils.hasContentDescriptionMatching
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/DeparturesTest.kt
@@ -1,12 +1,12 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
@@ -96,14 +96,14 @@ class DeparturesTest {
             Departures(stopData, GlobalResponse(objects), now, { false }) { _ -> }
         }
 
-        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
-        composeTestRule.onNodeWithText(aTrip.headsign).assertIsDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(aTrip.headsign).assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("20 min").assertIsDisplayed()
-        composeTestRule.onNodeWithText(bTrip.headsign).assertIsDisplayed()
-        composeTestRule.onNodeWithText(bTrip.headsign).assertIsDisplayed()
+        composeTestRule.onNodeWithText("20 min").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(bTrip.headsign).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(bTrip.headsign).assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithContentDescription("Alert").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Alert").assertCanBeDisplayed()
     }
 
     @Test
@@ -176,8 +176,8 @@ class DeparturesTest {
         }
 
         composeTestRule.onNodeWithText(aTrip.headsign).assertDoesNotExist()
-        composeTestRule.onNodeWithText(aSchedule.stopHeadsign!!).assertIsDisplayed()
-        composeTestRule.onNodeWithText(bTrip.headsign).assertIsDisplayed()
+        composeTestRule.onNodeWithText(aSchedule.stopHeadsign!!).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(bTrip.headsign).assertCanBeDisplayed()
     }
 
     @Test
@@ -226,7 +226,7 @@ class DeparturesTest {
             Departures(stopData, GlobalResponse(objects), now, { false }) { _ -> }
         }
 
-        composeTestRule.onNodeWithText("D").assertIsDisplayed()
+        composeTestRule.onNodeWithText("D").assertCanBeDisplayed()
     }
 
     @Test
@@ -303,7 +303,7 @@ class DeparturesTest {
             Departures(stopData, GlobalResponse(objects), now, { true }) { onClickCalled = true }
         }
 
-        composeTestRule.onNodeWithText(aTrip.headsign).assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText(aTrip.headsign).assertCanBeDisplayed().performClick()
 
         assertTrue(onClickCalled)
         assertEquals(
@@ -361,8 +361,10 @@ class DeparturesTest {
         }
         composeTestRule
             .onNodeWithText("Service from South Station to today’s World Cup match")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Boston Stadium Train ticket required").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithText("Boston Stadium Train ticket required")
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("View details").assertDoesNotExist()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardListTest.kt
@@ -3,12 +3,12 @@ package com.mbta.tid.mbta_app.android.component.routeCard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -193,14 +193,14 @@ class RouteCardListTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("1 min").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Head Sign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Head Sign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -224,7 +224,7 @@ class RouteCardListTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("This would be the empty view")
         )
-        composeTestRule.onNodeWithText("This would be the empty view").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This would be the empty view").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -257,9 +257,9 @@ class RouteCardListTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertCanBeDisplayed().performClick()
+        composeTestRule.onNodeWithText("1 min").assertCanBeDisplayed()
         assertEquals(clickedStopId, sampleStop.id)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/RouteCardTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
@@ -44,8 +44,8 @@ class RouteCardTest {
             }
         }
 
-        composeTestRule.onNodeWithText(route.label).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route.label).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
     }
 
     @Test
@@ -76,8 +76,8 @@ class RouteCardTest {
             }
         }
 
-        composeTestRule.onNodeWithText(route.label).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route.label).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
 
         composeTestRule.onNodeWithContentDescription("Star route").assertDoesNotExist()
     }
@@ -110,7 +110,7 @@ class RouteCardTest {
             }
         }
 
-        composeTestRule.onNodeWithText(route.label).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route.label).assertCanBeDisplayed()
         composeTestRule.onNodeWithText(stop.name).assertDoesNotExist()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/StopSubheaderTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
@@ -31,7 +31,7 @@ class StopSubheaderTest {
                 includeIcon = false,
             )
         }
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
     }
 
     @Test
@@ -49,7 +49,7 @@ class StopSubheaderTest {
                 includeIcon = false,
             )
         }
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
         composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertDoesNotExist()
     }
 
@@ -68,9 +68,9 @@ class StopSubheaderTest {
                 includeIcon = false,
             )
         }
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Not accessible").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Not accessible").assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("wheelchair_not_accessible").assertCanBeDisplayed()
     }
 
     @Test
@@ -113,8 +113,8 @@ class StopSubheaderTest {
                 includeIcon = false,
             )
         }
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("1 elevator closed").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("elevator_alert").assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("1 elevator closed").assertCanBeDisplayed()
+        composeTestRule.onNodeWithTag("elevator_alert").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/WorldCupBlurbTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/routeCard/WorldCupBlurbTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.component.routeCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -43,8 +43,10 @@ class WorldCupBlurbTest {
         }
         composeTestRule
             .onNodeWithText("Service from South Station to today’s World Cup match")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Boston Stadium Train ticket required").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithText("Boston Stadium Train ticket required")
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -75,8 +77,10 @@ class WorldCupBlurbTest {
         }
         composeTestRule
             .onNodeWithText("Service from today’s World Cup match to South Station")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Boston Stadium Train ticket required").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithText("Boston Stadium Train ticket required")
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -134,6 +138,6 @@ class WorldCupBlurbTest {
                 offerDetails = true,
             )
         }
-        composeTestRule.onNodeWithText("View details").assertIsDisplayed()
+        composeTestRule.onNodeWithText("View details").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/FavoriteStopCardTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.component.stopCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.utils.TestData
@@ -29,13 +29,13 @@ class FavoriteStopCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText(wellington.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("OL").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Forest Hills").assertIsDisplayed()
+        composeTestRule.onNodeWithText(wellington.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("OL").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Forest Hills").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("toggle direction")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
         composeTestRule.waitForIdle()
         assert(toggled)
@@ -73,7 +73,7 @@ class FavoriteStopCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Only Southbound to").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Only Southbound to").assertCanBeDisplayed()
     }
 
     @Test
@@ -91,6 +91,6 @@ class FavoriteStopCardTest {
         }
 
         composeTestRule.onNodeWithText("Providence/Stoughton").assertDoesNotExist()
-        composeTestRule.onNodeWithText("CR").assertIsDisplayed()
+        composeTestRule.onNodeWithText("CR").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardListTest.kt
@@ -3,12 +3,12 @@ package com.mbta.tid.mbta_app.android.component.stopCard
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -195,14 +195,14 @@ class StopCardListTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("SR"))
-        composeTestRule.onNodeWithText("SR").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("SR").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("1 min").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line D", ignoreCase = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Head Sign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line D", ignoreCase = true).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Head Sign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -226,7 +226,7 @@ class StopCardListTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("This would be the empty view")
         )
-        composeTestRule.onNodeWithText("This would be the empty view").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This would be the empty view").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -261,9 +261,9 @@ class StopCardListTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("SR"))
-        composeTestRule.onNodeWithText("SR").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed().performClick()
-        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("SR").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertCanBeDisplayed().performClick()
+        composeTestRule.onNodeWithText("1 min").assertCanBeDisplayed()
         assertEquals(clickedStopId, sampleStop.id)
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardTest.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.android.component.stopCard
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -56,7 +56,7 @@ class StopCardTest {
             }
         }
 
-        composeTestRule.onNodeWithText(route.label, ignoreCase = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route.label, ignoreCase = true).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.android.favorites
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
@@ -12,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.ModalRoutes
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.pages.EditFavoritesPage
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Direction
@@ -296,8 +296,8 @@ class EditFavoritesPageTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Downtown").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
         // Shouldn't be shown because it is not a favorite
         composeTestRule.onNodeWithText("Green Line Long Name").assertIsNotDisplayed()
@@ -333,7 +333,7 @@ class EditFavoritesPageTest : KoinTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("No stops added"))
-        composeTestRule.onNodeWithText("No stops added").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No stops added").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -390,11 +390,11 @@ class EditFavoritesPageTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Downtown").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("trashCan")[0].performClick()
         composeTestRule.awaitIdle()
@@ -411,8 +411,8 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.onNodeWithText("Downtown").assertIsNotDisplayed()
 
         // Should remain
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -477,7 +477,7 @@ class EditFavoritesPageTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("trashCan")[0].performClick()
         composeTestRule.awaitIdle()
@@ -490,7 +490,7 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
 
         composeTestRule.onNodeWithText("Sample Route").assertIsNotDisplayed()
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
         assertEquals(
             "<b>Northbound Sample Route bus</b> at <b>Sample Stop 1</b> removed from Favorites",
             displayedToast?.message,
@@ -506,8 +506,8 @@ class EditFavoritesPageTest : KoinTest {
         }
         composeTestRule.waitUntilDefaultTimeout { undo == updatedWith }
 
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
         assertNull(displayedToast)
     }
 
@@ -548,11 +548,11 @@ class EditFavoritesPageTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Downtown").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("editIcon")[0].performClick()
         composeTestRule.awaitIdle()
@@ -617,7 +617,7 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasContentDescription("notifications enabled")
         )
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Downtown").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/FavoritesViewTest.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
-import com.mbta.tid.mbta_app.android.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.util.ConstantPermissionState
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import kotlin.test.assertEquals

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
@@ -57,8 +57,12 @@ class NotificationSettingsWidgetTest {
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
         assertEquals(1, settings.value.windows.size)
-        composeTestRule.onNode(hasTextMatching(Regex("8:00\\sAM"))).assertExists()
-        composeTestRule.onNode(hasTextMatching(Regex("9:00\\sAM"))).assertExists()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("9:00\\sAM", RegexOption.IGNORE_CASE)))
+            .assertExists()
         composeTestRule.onNodeWithText("Sunday").assertIsOff()
         composeTestRule.onNodeWithText("Monday").assertIsOn()
         composeTestRule.onNodeWithText("Tuesday").assertIsOn()
@@ -69,8 +73,12 @@ class NotificationSettingsWidgetTest {
         composeTestRule.onNodeWithContentDescription("Delete").assertDoesNotExist()
         composeTestRule.onNodeWithText("Add another time period").performClick()
         assertEquals(2, settings.value.windows.size)
-        composeTestRule.onNode(hasTextMatching(Regex("12:00\\sPM"))).assertExists()
-        composeTestRule.onNode(hasTextMatching(Regex("1:00\\sPM"))).assertExists()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("12:00\\sPM", RegexOption.IGNORE_CASE)))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("1:00\\sPM", RegexOption.IGNORE_CASE)))
+            .assertExists()
         composeTestRule.onAllNodesWithText("Sunday").onLast().assertIsOn()
         composeTestRule.onAllNodesWithText("Monday").onLast().assertIsOff()
         composeTestRule.onAllNodesWithText("Tuesday").onLast().assertIsOff()
@@ -96,7 +104,9 @@ class NotificationSettingsWidgetTest {
         }
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
-        composeTestRule.onNode(hasTextMatching(Regex("8:00\\sAM"))).performClick()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
+            .performClick()
         composeTestRule.onNodeWithText("Select start time").assertExists()
         composeTestRule.onNodeWithContentDescription("7 o'clock").performClick()
         // selecting hours in this way doesn’t automatically switch to minutes for some reason
@@ -104,7 +114,9 @@ class NotificationSettingsWidgetTest {
         composeTestRule.onNodeWithContentDescription("45 minutes").performClick()
         composeTestRule.onNodeWithText("Okay").performClick()
         assertEquals(LocalTime(7, 45), settings.value.windows.single().startTime)
-        composeTestRule.onNode(hasTextMatching(Regex("9:00\\sAM"))).performClick()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("9:00\\sAM", RegexOption.IGNORE_CASE)))
+            .performClick()
         composeTestRule.onNodeWithText("Select end time").assertExists()
         composeTestRule.onNodeWithContentDescription("Time picker type toggle").performClick()
         composeTestRule.onNodeWithContentDescription("for hour").performTextReplacement("9")
@@ -152,14 +164,18 @@ class NotificationSettingsWidgetTest {
         }
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
-        composeTestRule.onNode(hasTextMatching(Regex("8:00\\sAM"))).performClick()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
+            .performClick()
         composeTestRule.onNodeWithContentDescription("10 o'clock").performClick()
         composeTestRule.onNodeWithContentDescription("Select minutes").performClick()
         composeTestRule.onNodeWithContentDescription("45 minutes").performClick()
         composeTestRule.onNodeWithText("Okay").performClick()
         assertEquals(LocalTime(10, 45), settings.value.windows.single().startTime)
         assertEquals(LocalTime(11, 45), settings.value.windows.single().endTime)
-        composeTestRule.onNode(hasTextMatching(Regex("11:45\\sAM"))).performClick()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("11:45\\sAM", RegexOption.IGNORE_CASE)))
+            .performClick()
         composeTestRule.onNodeWithContentDescription("10 o'clock").performClick()
         composeTestRule.onNodeWithContentDescription("Select minutes").performClick()
         composeTestRule.onNodeWithContentDescription("40 minutes").performClick()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
@@ -22,6 +21,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.util.ConstantPermissionState
 import com.mbta.tid.mbta_app.model.FavoriteSettings
@@ -204,6 +204,6 @@ class NotificationSettingsWidgetTest {
         composeTestRule.onNodeWithText("Allow Notifications in Settings").assertIsNotDisplayed()
         hasRequestedPermission.value = true
 
-        composeTestRule.onNodeWithText("Allow Notifications in Settings").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Allow Notifications in Settings").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/map/HomeMapViewTests.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -18,6 +17,7 @@ import com.mapbox.maps.EdgeInsets
 import com.mapbox.maps.extension.compose.animation.viewport.MapViewportState
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
@@ -188,7 +188,7 @@ class HomeMapViewTests {
         }
         composeTestRule
             .onNodeWithContentDescription("Recenter map on my location")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -228,7 +228,7 @@ class HomeMapViewTests {
                 navCallbacks = NavigationCallbacks.empty,
             )
         }
-        composeTestRule.onNodeWithText("Location Services is off").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Location Services is off").assertCanBeDisplayed()
     }
 
     @Test
@@ -404,7 +404,7 @@ class HomeMapViewTests {
         }
         composeTestRule
             .onNodeWithContentDescription("Recenter map on my location")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -449,7 +449,7 @@ class HomeMapViewTests {
                     ),
             )
         }
-        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Back").assertCanBeDisplayed()
     }
 
     @Test
@@ -540,7 +540,7 @@ class HomeMapViewTests {
                 navCallbacks = NavigationCallbacks.empty,
             )
         }
-        composeTestRule.onNodeWithTag("Empty map grid").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("Empty map grid").assertCanBeDisplayed()
         configManager.loadConfig()
         composeTestRule.onNodeWithTag("Empty map grid").assertIsNotDisplayed()
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/more/MoreSectionViewTests.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.more
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.morePage.MoreItem
 import com.mbta.tid.mbta_app.model.morePage.MoreSection
@@ -37,7 +37,7 @@ class MoreSectionViewTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Feature Flags").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Feature Flags").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Map Display").performClick()
         composeTestRule.waitForIdle()
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -35,6 +34,7 @@ import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.IMapboxConfigManager
 import com.mbta.tid.mbta_app.android.pages.MapAndSheetPage
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -353,14 +353,14 @@ class MapAndSheetPageTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasContentDescription("Mapbox Attribution")
         )
-        composeTestRule.onNodeWithContentDescription("Mapbox Attribution").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Mapbox Attribution").assertCanBeDisplayed()
 
         composeTestRule
             .onNodeWithContentDescription("Drag handle")
             .performSemanticsAction(SemanticsActions.Expand)
 
-        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Stops").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Stops").assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText("Green Line Long Name").assertExists()
         composeTestRule.onNodeWithText("Green Line Stop").assertExists()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -5,13 +5,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
@@ -286,16 +286,16 @@ class NearbyTransitViewTest : KoinTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertCanBeDisplayed()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Sample Headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("1 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Sample Headsign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("1 min").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Stop").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Green Line Head Sign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Green Line Head Sign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -345,7 +345,7 @@ class NearbyTransitViewTest : KoinTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Nearby Transit").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Nearby Transit").assertCanBeDisplayed()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
         composeTestRule.onNodeWithText("Sample Headsign").performClick()
 
@@ -374,7 +374,9 @@ class NearbyTransitViewTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("This would be the no nearby stops view")
         )
-        composeTestRule.onNodeWithText("This would be the no nearby stops view").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("This would be the no nearby stops view")
+            .assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -445,7 +447,7 @@ class NearbyTransitViewTest : KoinTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Harvard"))
-        composeTestRule.onNodeWithText("Harvard").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Harvard").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Central").assertDoesNotExist()
 
         alerts = AlertsStreamDataResponse(mapOf(alert.id to alert))

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NoNearbyStopsViewTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.nearbyTransit
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -17,10 +17,12 @@ class NoNearbyStopsViewTest {
             NoNearbyStopsView(onOpenSearch = {}, onPanToDefaultCenter = {})
         }
 
-        composeTestRule.onNodeWithText("No nearby stops").assertIsDisplayed()
-        composeTestRule.onNodeWithText("You’re outside the MBTA service area.").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Search by stop").assertIsDisplayed()
-        composeTestRule.onNodeWithText("View transit near Boston").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No nearby stops").assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithText("You’re outside the MBTA service area.")
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Search by stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("View transit near Boston").assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
-import com.mbta.tid.mbta_app.android.hasRole
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.testUtils.hasRole
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenViewTest.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.android.onboarding
 
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasText
@@ -10,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasRole
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.model.OnboardingScreen
@@ -45,7 +45,7 @@ class OnboardingScreenViewTest {
                 "We use your location to show you nearby transit options.",
                 substring = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Continue").performClick()
 
         composeTestRule.waitForIdle()
@@ -75,14 +75,14 @@ class OnboardingScreenViewTest {
 
         composeTestRule
             .onNodeWithText("Set station accessibility info preference")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText(
                 " we can show you which stations are inaccessible or have elevator closures.",
                 substring = true,
             )
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Continue").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Continue").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasText("Station Accessibility Info") and hasRole(Role.Switch))
             .performClick()
@@ -119,13 +119,13 @@ class OnboardingScreenViewTest {
             .onNodeWithText(
                 "When using TalkBack, we can hide maps to make the app easier to navigate."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         composeTestRule.waitForIdle()
 
         composeTestRule
             .onNodeWithText("Map Display")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertIsOff()
             .performClick()
 
@@ -133,7 +133,7 @@ class OnboardingScreenViewTest {
 
         composeTestRule.onNodeWithText("Map Display").assertIsOn()
 
-        composeTestRule.onNodeWithText("Continue").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Continue").assertCanBeDisplayed().performClick()
         composeTestRule.waitForIdle()
         assertTrue(savedSetting)
         assertTrue(advanced)
@@ -149,12 +149,12 @@ class OnboardingScreenViewTest {
                 locationDataManager = MockLocationDataManager(),
             )
         }
-        composeTestRule.onNodeWithText("Now get disruption notifications").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Add a Favorite stop").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Set your own schedule").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Now get disruption notifications").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Add a Favorite stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Set your own schedule").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("We’ll tell you about any problems before you go!")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Got it").performClick()
 
         composeTestRule.waitForIdle()
@@ -176,7 +176,7 @@ class OnboardingScreenViewTest {
                 "MBTA Go is in the early stages! We want your feedback" +
                     " as we continue making improvements and adding new features."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Get started").performClick()
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/ExplainerPageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/ExplainerPageTests.kt
@@ -1,11 +1,11 @@
 package com.mbta.tid.mbta_app.android.pages
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.stopDetails.TripRouteAccents
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.stopDetailsPage.ExplainerType
@@ -45,12 +45,12 @@ class ExplainerPageTests {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Finishing another trip").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Finishing another trip").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText(
                 "The train assigned to this route is currently serving another trip. We’ll show it on the route once it starts this trip."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -60,12 +60,12 @@ class ExplainerPageTests {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Prediction not available yet").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Prediction not available yet").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText(
                 "We don’t have live predictions for this trip yet, but they will appear closer to the scheduled time. If the trip is delayed or cancelled, we’ll let you know here."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -80,11 +80,11 @@ class ExplainerPageTests {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Ferry location not available yet").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Ferry location not available yet").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText(
                 "The ferry location might not be available in advance if a vehicle hasn’t been assigned yet. Once the driver starts the trip, we’ll start showing the live location."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -13,6 +12,7 @@ import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffold
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -102,11 +102,11 @@ class MapAndSheetPageTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
 
         locationDataManager.moveTo(stop2.position)
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop2.name))
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MorePageTests.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -10,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.mbta.tid.mbta_app.android.BuildConfig
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Dependency
@@ -30,7 +30,7 @@ class MorePageTests : KoinTest {
         composeTestRule.setContent { MorePage(bottomBar = {}) }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("MBTA Go").assertIsDisplayed()
+        composeTestRule.onNodeWithText("MBTA Go").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -52,8 +52,7 @@ class MorePageTests : KoinTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Settings"))
-        composeTestRule.onNodeWithText("Settings").performScrollTo()
-        composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Settings").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Map Display").assertIsOn().performClick()
 
         composeTestRule.waitForIdle()
@@ -69,21 +68,15 @@ class MorePageTests : KoinTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Send App Feedback"))
-        composeTestRule.onNodeWithText("Send App Feedback").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Trip Planner").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Fare Information").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Commuter Rail and Ferry Tickets").performScrollTo()
-        composeTestRule.onNodeWithText("Commuter Rail and Ferry Tickets").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Terms of Use").performScrollTo()
-        composeTestRule.onNodeWithText("Terms of Use").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Privacy Policy").performScrollTo()
-        composeTestRule.onNodeWithText("Privacy Policy").assertIsDisplayed()
-        composeTestRule.onNode(hasText("View Source on GitHub")).performScrollTo()
-        composeTestRule.onNodeWithText("View Source on GitHub").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Software Licenses").performScrollTo()
-        composeTestRule.onNodeWithText("Software Licenses").assertIsDisplayed()
-        composeTestRule.onNode(hasText("617-222-3200")).performScrollTo()
-        composeTestRule.onNodeWithText("617-222-3200").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Send App Feedback").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Trip Planner").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Fare Information").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Commuter Rail and Ferry Tickets").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Terms of Use").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Privacy Policy").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("View Source on GitHub").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Software Licenses").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("617-222-3200").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -99,11 +92,11 @@ class MorePageTests : KoinTest {
         composeTestRule.onNodeWithText("Software Licenses").performScrollTo()
         composeTestRule.onNodeWithText("Software Licenses").performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(dependency.name))
-        composeTestRule.onNodeWithText(dependency.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(dependency.name).assertCanBeDisplayed()
         composeTestRule.onNodeWithText(dependency.name).performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(dependency.licenseText))
-        composeTestRule.onNodeWithText(dependency.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(dependency.licenseText).assertIsDisplayed()
+        composeTestRule.onNodeWithText(dependency.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(dependency.licenseText).assertCanBeDisplayed()
     }
 
     @Test
@@ -114,6 +107,6 @@ class MorePageTests : KoinTest {
         val versionAndBuildText = "$versionText (${BuildConfig.VERSION_CODE})"
         composeTestRule.onNodeWithText(versionAndBuildText).assertDoesNotExist()
         composeTestRule.onNodeWithText(versionText).performClick()
-        composeTestRule.onNodeWithText(versionAndBuildText).assertIsDisplayed()
+        composeTestRule.onNodeWithText(versionAndBuildText).assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
@@ -1,13 +1,12 @@
 package com.mbta.tid.mbta_app.android.pages
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.Favorites
 import com.mbta.tid.mbta_app.model.RouteStopDirection
@@ -70,7 +69,7 @@ class SaveFavoritePageTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Add Favorite").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add Favorite").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Save").performClick()
         composeTestRule.waitForIdle()
         assertEquals(
@@ -94,14 +93,14 @@ class SaveFavoritePageTests {
             SaveFavoritePage(route.id, stop.id, 0, EditFavoritesContext.StopDetails, {})
         }
 
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Forest Hills").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Forest Hills").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("toggle direction")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
-        composeTestRule.onNodeWithText("Northbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Oak Grove").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Northbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Oak Grove").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Save").performClick()
         composeTestRule.waitForIdle()
         assertEquals(
@@ -129,20 +128,20 @@ class SaveFavoritePageTests {
             SaveFavoritePage(route.id, stop.id, 0, EditFavoritesContext.StopDetails, {})
         }
 
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Forest Hills").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Forest Hills").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("toggle direction")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
-        composeTestRule.onNodeWithText("Northbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Oak Grove").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Northbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Oak Grove").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("toggle direction")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Forest Hills").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Forest Hills").assertCanBeDisplayed()
     }
 
     @Test
@@ -159,7 +158,7 @@ class SaveFavoritePageTests {
             SaveFavoritePage(route.id, stop.id, 0, EditFavoritesContext.StopDetails, {})
         }
 
-        composeTestRule.onNodeWithText("Add Favorite").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add Favorite").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
         composeTestRule.onNodeWithText("Save").performClick()
         composeTestRule.waitForIdle()
@@ -224,16 +223,15 @@ class SaveFavoritePageTests {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Edit Favorite").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Edit Favorite").assertCanBeDisplayed()
         composeTestRule.onNodeWithContentDescription("toggle direction").assertDoesNotExist()
         composeTestRule
             .onNodeWithText("Get disruption notifications")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .assertIsOn()
         composeTestRule
             .onNodeWithText("Remove from Favorites")
-            .performScrollTo()
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
         composeTestRule.waitForIdle()
         assertEquals(Favorites(), favoritesSet)
@@ -251,8 +249,8 @@ class SaveFavoritePageTests {
             SaveFavoritePage(route.id, stop.id, 0, EditFavoritesContext.StopDetails, {})
         }
 
-        composeTestRule.onNodeWithText("Only Northbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Oak Grove").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Only Northbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Oak Grove").assertCanBeDisplayed()
         composeTestRule.onNodeWithContentDescription("toggle direction").assertDoesNotExist()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
@@ -1,10 +1,12 @@
 package com.mbta.tid.mbta_app.android.pages
 
+import android.os.Build
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.rule.GrantPermissionRule
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.FavoriteSettings
@@ -22,6 +24,11 @@ import org.junit.Test
 
 class SaveFavoritePageTests {
     @get:Rule val composeTestRule = createComposeRule()
+    @get:Rule
+    val runtimePermissionRule =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            GrantPermissionRule.grant(android.Manifest.permission.POST_NOTIFICATIONS)
+        else GrantPermissionRule.grant()
 
     @Test
     fun testCloses() {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/TripDetailsPageTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -10,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
@@ -108,8 +108,8 @@ class TripDetailsPageTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("Southbound to") and hasText("Forest Hills")
         )
-        composeTestRule.onNodeWithText("OL").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Southbound to").assertIsDisplayed()
+        composeTestRule.onNodeWithText("OL").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Southbound to").assertCanBeDisplayed()
         composeTestRule.onAllNodesWithText("Forest Hills").assertCountEquals(2)
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(targetStop.name))
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/promo/PromoScreenViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/promo/PromoScreenViewTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.promo
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.FeaturePromo
 import kotlin.test.assertTrue
 import org.junit.Rule
@@ -19,10 +19,10 @@ class PromoScreenViewTest {
         composeTestRule.setContent {
             PromoScreenView(FeaturePromo.EnhancedFavorites) { calledOnAdvance = true }
         }
-        composeTestRule.onNodeWithText("Add your favorites").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add your favorites").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Now save your frequently used stops", substring = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText("Got it").performClick()
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasClickActionLabel
+import com.mbta.tid.mbta_app.android.testUtils.hasClickActionLabel
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LineOrRoute

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -1,12 +1,12 @@
 package com.mbta.tid.mbta_app.android.routeDetails
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasClickActionLabel
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -64,7 +64,7 @@ class CollapsableStopListTest {
         }
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
-        composeTestRule.onNodeWithText("Less common stop").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Less common stop").assertCanBeDisplayed()
         composeTestRule.onNodeWithText(stop1.name).performClick()
         assertTrue(clicked)
     }
@@ -120,12 +120,12 @@ class CollapsableStopListTest {
         composeTestRule.onNodeWithText(stop1.name).assertIsNotDisplayed()
         composeTestRule.onNode(hasClickActionLabel("expand stops")).assertExists()
 
-        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("2 less common stops").assertCanBeDisplayed().performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
         composeTestRule.onNode(hasClickActionLabel("collapse stops")).assertExists()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("2 less common stops").assertCanBeDisplayed().performClick()
         composeTestRule.waitUntilDoesNotExistDefaultTimeout(hasText(stop1.name))
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListViewTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -12,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilNodeCountDefaultTimeout
@@ -127,24 +127,24 @@ class RouteStopListViewTest {
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
 
-        composeTestRule.onNodeWithText(mainRoute.longName).assertIsDisplayed()
+        composeTestRule.onNodeWithText(mainRoute.longName).assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Westbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Here").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Eastbound to").assertIsDisplayed()
-        composeTestRule.onNodeWithText("There").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Westbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Here").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Eastbound to").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("There").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop3.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop3.name).assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("rightSideContent for ${stop1.name}").assertIsDisplayed()
-        composeTestRule.onNodeWithText("rightSideContent for ${stop2.name}").assertIsDisplayed()
-        composeTestRule.onNodeWithText("rightSideContent for ${stop3.name}").assertIsDisplayed()
+        composeTestRule.onNodeWithText("rightSideContent for ${stop1.name}").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("rightSideContent for ${stop2.name}").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("rightSideContent for ${stop3.name}").assertCanBeDisplayed()
 
         composeTestRule
             .onNodeWithText(connectingRoute.shortName, useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText(stop2.name).performClick()
         assertEquals<List<RouteDetailsRowContext>>(
@@ -307,12 +307,12 @@ class RouteStopListViewTest {
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
 
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
         composeTestRule.onNodeWithText(stop3NonTypical.name).assertIsNotDisplayed()
-        composeTestRule.onNodeWithText("2 less common stops").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("2 less common stops").assertCanBeDisplayed().performClick()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop3NonTypical.name))
-        composeTestRule.onNodeWithText(stop4NonTypical.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop4NonTypical.name).assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -361,8 +361,8 @@ class RouteStopListViewTest {
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText(stop1.name))
 
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("2 less common stops").assertIsNotDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRootRowTest.kt
@@ -3,10 +3,10 @@ package com.mbta.tid.mbta_app.android.routePicker
 import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -30,7 +30,7 @@ class RoutePickerRootRowTest {
 
         composeTestRule.setContent { RoutePickerRootRow(LineOrRoute.Route(route)) {} }
 
-        composeTestRule.onNodeWithText("Red Line").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Red Line").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Red Line").assertHasClickAction()
     }
 
@@ -42,7 +42,7 @@ class RoutePickerRootRowTest {
 
         composeTestRule.setContent { RoutePickerRootRow(LineOrRoute.Line(line, routes)) {} }
 
-        composeTestRule.onNodeWithText("Green Line").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line").assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerRowTest.kt
@@ -1,10 +1,10 @@
 package com.mbta.tid.mbta_app.android.routePicker
 
 import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -26,7 +26,7 @@ class RoutePickerRowTest {
 
         composeTestRule.setContent { RoutePickerRow(LineOrRoute.Route(route)) {} }
 
-        composeTestRule.onNodeWithText("66").assertIsDisplayed()
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Harvard Square - Nubian Station").assertHasClickAction()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routePicker/RoutePickerViewTest.kt
@@ -2,7 +2,6 @@ package com.mbta.tid.mbta_app.android.routePicker
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
@@ -13,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LineOrRoute
@@ -53,7 +53,7 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNode(hasContentDescription("Loading")).assertIsDisplayed()
+        composeTestRule.onNode(hasContentDescription("Loading")).assertCanBeDisplayed()
     }
 
     @Test
@@ -84,8 +84,8 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Add favorite stops").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Done").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Add favorite stops").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Done").assertCanBeDisplayed()
     }
 
     @Test
@@ -108,9 +108,9 @@ class RoutePickerViewTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.onAllNodesWithText("Bus").assertCountEquals(2)
-        composeTestRule.onNodeWithText("Silver Line").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Commuter Rail").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Ferry").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Silver Line").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Commuter Rail").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Ferry").assertCanBeDisplayed()
     }
 
     @Test
@@ -136,7 +136,7 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Subway").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subway").assertCanBeDisplayed()
     }
 
     @Test
@@ -166,8 +166,8 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Red Line").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Mattapan Line").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Red Line").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Mattapan Line").assertCanBeDisplayed()
     }
 
     @Test
@@ -209,11 +209,11 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Harvard Square - Nubian Station").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Watertown Square - Harvard Station").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Harvard Square - Nubian Station").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Watertown Square - Harvard Station").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("Logan Airport Terminals - South Station")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Mattapan Line").assertIsNotDisplayed()
     }
 
@@ -250,7 +250,7 @@ class RoutePickerViewTest {
         composeTestRule.onNodeWithText("Harvard Square - Nubian Station").assertIsNotDisplayed()
         composeTestRule
             .onNodeWithText("Logan Airport Terminals - South Station")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -276,7 +276,7 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Providence/Stoughton Line").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Providence/Stoughton Line").assertCanBeDisplayed()
     }
 
     @Test
@@ -302,7 +302,7 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Lynn Ferry").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lynn Ferry").assertCanBeDisplayed()
     }
 
     @Test
@@ -450,13 +450,13 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(route71.longName).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route71.longName).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Filter routes").performClick().performTextInput("query")
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("To find stops, select a route first")
         )
-        composeTestRule.onNodeWithText(route1.longName).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route1.longName).assertCanBeDisplayed()
         composeTestRule.onNodeWithText(route71.longName).assertIsNotDisplayed()
     }
 
@@ -522,15 +522,15 @@ class RoutePickerViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(route1.longName).assertIsDisplayed()
-        composeTestRule.onNodeWithText(route71.longName).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route1.longName).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(route71.longName).assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Filter routes").performClick().performTextInput("query")
         composeTestRule.waitForIdle()
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasText("To find stops, select a route first")
         )
-        composeTestRule.onNodeWithText("No matching bus routes").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No matching bus routes").assertCanBeDisplayed()
         composeTestRule.onNodeWithText(route1.longName).assertIsNotDisplayed()
         composeTestRule.onNodeWithText(route71.longName).assertIsNotDisplayed()
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/SearchBarOverlayTest.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -15,6 +14,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.requestFocus
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilAtLeastOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -188,8 +188,8 @@ class SearchBarOverlayTest : KoinTest {
         searchNode.performTextInput("anything")
         composeTestRule.waitForIdle()
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Routes"))
-        composeTestRule.onNodeWithText("3½").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Here - There").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("3½").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Here - There").assertCanBeDisplayed().performClick()
         composeTestRule.waitUntilDefaultTimeout { navigated }
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/RouteResultsViewTest.kt
@@ -1,11 +1,11 @@
 package com.mbta.tid.mbta_app.android.search.results
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -30,8 +30,8 @@ class RouteResultsViewTest {
                 handleSearch = {},
             )
         }
-        composeTestRule.onNodeWithText(route.shortName).assertIsDisplayed()
-        composeTestRule.onNodeWithText(route.longName).assertIsDisplayed()
+        composeTestRule.onNodeWithText(route.shortName).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(route.longName).assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/StopResultsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/search/results/StopResultsViewTest.kt
@@ -1,12 +1,12 @@
 package com.mbta.tid.mbta_app.android.search.results
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RoutePillSpec
@@ -125,13 +125,13 @@ class StopResultsViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("South Station").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("South Station").assertCanBeDisplayed().performClick()
         assertTrue(handleSearchCalled)
         composeTestRule
             .onNodeWithContentDescription(
                 "serves Red Line train,Commuter Rail trains,Silver Line buses,buses"
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -196,7 +196,7 @@ class StopResultsViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Platform Stop").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("serves 4 bus,5 bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Platform Stop").assertCanBeDisplayed()
+        composeTestRule.onNodeWithContentDescription("serves 4 bus,5 bus").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -195,7 +195,11 @@ class AlertCardTests {
         }
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("Delay on Red Line starting 9:00\\sAM today")))
+            .onNode(
+                hasTextMatching(
+                    Regex("Delay on Red Line starting 9:00\\sAM today", RegexOption.IGNORE_CASE)
+                )
+            )
             .assertIsDisplayed()
     }
 
@@ -271,7 +275,7 @@ class AlertCardTests {
         }
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("Detour through 9:00\\sAM")))
+            .onNode(hasTextMatching(Regex("Detour through 9:00\\sAM", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
         composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
     }
@@ -367,7 +371,8 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "12:13\\sPM train from Ruggles is cancelled today due to mechanical issue"
+                        "12:13\\sPM train from Ruggles is cancelled today due to mechanical issue",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )
@@ -425,7 +430,8 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills"
+                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )
@@ -458,7 +464,10 @@ class AlertCardTests {
         composeTestRule
             .onNode(
                 hasTextMatching(
-                    Regex("Shuttle buses replace the 12:13\\sPM train from Ruggles to Forest Hills")
+                    Regex(
+                        "Shuttle buses replace the 12:13\\sPM train from Ruggles to Forest Hills",
+                        RegexOption.IGNORE_CASE,
+                    )
                 )
             )
             .assertIsDisplayed()
@@ -492,7 +501,8 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today"
+                        "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )
@@ -575,7 +585,8 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "12:13\\sPM train from Ruggles is cancelled tomorrow due to mechanical issue"
+                        "12:13\\sPM train from Ruggles is cancelled tomorrow due to mechanical issue",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )
@@ -616,7 +627,8 @@ class AlertCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills daily until Thursday"
+                        "12:13\\sPM train from Oak Grove is replaced by shuttle buses from Ruggles to Forest Hills daily until Thursday",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertCardSpec

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -1,11 +1,11 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
@@ -48,7 +48,7 @@ class AlertCardTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Detour ahead").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Detour ahead").assertCanBeDisplayed().performClick()
         composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
         assertTrue { onViewDetailsClicked }
     }
@@ -71,8 +71,8 @@ class AlertCardTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Suspension").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Alert header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Suspension").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Alert header").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("View details").performClick()
         assertTrue { onViewDetailsClicked }
     }
@@ -95,7 +95,7 @@ class AlertCardTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Detour").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Detour").assertCanBeDisplayed().performClick()
         composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
         assertTrue { onViewDetailsClicked }
     }
@@ -118,7 +118,7 @@ class AlertCardTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Alert header").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Alert header").assertCanBeDisplayed().performClick()
         assertTrue { onViewDetailsClicked }
     }
 
@@ -152,7 +152,7 @@ class AlertCardTests {
 
         composeTestRule
             .onNodeWithText("Elevator closure (Elevator name)")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
         assertTrue { onViewDetailsClicked }
     }
@@ -167,7 +167,7 @@ class AlertCardTests {
             }
         composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
 
-        composeTestRule.onNodeWithText("Delays due to heavy ridership").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delays due to heavy ridership").assertCanBeDisplayed()
     }
 
     @Test
@@ -200,7 +200,7 @@ class AlertCardTests {
                     Regex("Delay on Red Line starting 9:00\\sAM today", RegexOption.IGNORE_CASE)
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -213,7 +213,7 @@ class AlertCardTests {
             }
         composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
 
-        composeTestRule.onNodeWithText("Delays").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delays").assertCanBeDisplayed()
     }
 
     @Test
@@ -227,7 +227,7 @@ class AlertCardTests {
             }
         composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
 
-        composeTestRule.onNodeWithText("Single Tracking").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Single Tracking").assertCanBeDisplayed()
     }
 
     @Test
@@ -250,8 +250,8 @@ class AlertCardTests {
             )
         }
 
-        composeTestRule.onNodeWithText("Suspension").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Service suspended through Saturday").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Suspension").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Service suspended through Saturday").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Alert header").assertDoesNotExist()
         composeTestRule.onNodeWithText("View details").performClick()
     }
@@ -276,7 +276,7 @@ class AlertCardTests {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("Detour through 9:00\\sAM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Alert header").assertIsNotDisplayed()
     }
 
@@ -307,7 +307,7 @@ class AlertCardTests {
 
         composeTestRule
             .onNodeWithText("All clear: Regular service from Start Stop to End Stop")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -341,7 +341,7 @@ class AlertCardTests {
 
         composeTestRule
             .onNodeWithText("Update: Shuttle buses from Start Stop to End Stop through tomorrow")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -365,7 +365,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Train cancelled").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Train cancelled").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -376,7 +376,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -396,11 +396,11 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Train suspended").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Train suspended").assertCanBeDisplayed()
 
         composeTestRule
             .onNodeWithText("Multiple trips are suspended today due to holiday")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -424,7 +424,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Shuttle bus").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -435,7 +435,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -459,7 +459,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Shuttle bus").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -470,7 +470,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -495,7 +495,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Stop skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop skipped").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -506,7 +506,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -526,11 +526,11 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Stop Skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop Skipped").assertCanBeDisplayed()
 
         composeTestRule
             .onNodeWithText("Trains will not stop at Back Bay and Ruggles until further notice")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -550,11 +550,11 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Stop Skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Stop Skipped").assertCanBeDisplayed()
 
         composeTestRule
             .onNodeWithText("Buses will not stop at Back Bay and Ruggles until further notice")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -579,7 +579,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Train cancelled").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Train cancelled").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -590,7 +590,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -621,7 +621,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Shuttle bus").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -632,7 +632,7 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -659,7 +659,7 @@ class AlertCardTests {
                 onViewDetails = {},
             )
         }
-        composeTestRule.onNodeWithText("Shuttle bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Shuttle bus").assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
@@ -669,6 +669,6 @@ class AlertCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertListContainerTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertListContainerTest.kt
@@ -2,9 +2,9 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.RouteType
 import org.junit.Rule
@@ -28,8 +28,8 @@ class AlertListContainerTest {
             )
         }
 
-        composeTestRule.onNodeWithText("High 1").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Middle").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Low 1").assertIsDisplayed()
+        composeTestRule.onNodeWithText("High 1").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Middle").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Low 1").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
@@ -4,11 +4,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasClickActionLabel
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -53,8 +53,8 @@ class DepartureTileTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("headsign").assertIsDisplayed()
-        composeTestRule.onNodeWithText("5 min").assertIsDisplayed()
+        composeTestRule.onNodeWithText("headsign").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("5 min").assertCanBeDisplayed()
     }
 
     @Test
@@ -94,7 +94,7 @@ class DepartureTileTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("B").assertIsDisplayed()
+        composeTestRule.onNodeWithText("B").assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/DepartureTileTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasClickActionLabel
+import com.mbta.tid.mbta_app.android.testUtils.hasClickActionLabel
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripInstantDisplay

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.stopDetails
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -11,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
@@ -356,13 +356,13 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Trip cancelled").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Trip cancelled").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText("This trip has been cancelled. We’re sorry for the inconvenience.")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("route_slash_icon", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -541,7 +541,7 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Service ended").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Service ended").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -781,7 +781,7 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Service suspended", true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Service suspended", true).assertCanBeDisplayed()
     }
 
     @Test
@@ -844,7 +844,7 @@ class StopDetailsFilteredDeparturesViewTest {
         }
 
         composeTestRule.onNodeWithText("Elevator Closure").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Elevator Alert Header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Elevator Alert Header").assertCanBeDisplayed()
     }
 
     @Test
@@ -923,7 +923,7 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Delays due to heavy ridership").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Delays due to heavy ridership").assertCanBeDisplayed()
     }
 
     @Test
@@ -973,7 +973,7 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("This stop is not accessible").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This stop is not accessible").assertCanBeDisplayed()
     }
 
     @Test
@@ -1032,7 +1032,7 @@ class StopDetailsFilteredDeparturesViewTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("^Next trip on \\w+, (Dec 8|8 Dec)$")))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -1120,8 +1120,8 @@ class StopDetailsFilteredDeparturesViewTest {
             )
         }
 
-        composeTestRule.onNodeWithTag("sunrise").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Good morning!").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("sunrise").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Good morning!").assertCanBeDisplayed()
     }
 
     @Test
@@ -1256,8 +1256,10 @@ class StopDetailsFilteredDeparturesViewTest {
         }
         composeTestRule
             .onNodeWithText("Service from South Station to today’s World Cup match")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText("Boston Stadium Train ticket required").assertIsDisplayed()
-        composeTestRule.onNodeWithText("View details").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithText("Boston Stadium Train ticket required")
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("View details").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -10,8 +10,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -1031,7 +1031,7 @@ class StopDetailsFilteredDeparturesViewTest {
         }
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("^Next trip on \\w+, Dec 8$")))
+            .onNode(hasTextMatching(Regex("^Next trip on \\w+, (Dec 8|8 Dec)$")))
             .assertIsDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeaderTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredSheetHeaderTest.kt
@@ -1,12 +1,12 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -68,7 +68,7 @@ class StopDetailsFilteredSheetHeaderTest {
         composeTestRule.onNode(hasText(route.shortName)).assertExists()
         composeTestRule.onNodeWithContentDescription("Star route").assertExists()
         composeTestRule.onNodeWithContentDescription("Close").assertExists()
-        composeTestRule.onNode(hasText("at Sample Stop") and isHeading()).assertIsDisplayed()
+        composeTestRule.onNode(hasText("at Sample Stop") and isHeading()).assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredViewTest.kt
@@ -2,13 +2,13 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
@@ -313,7 +313,7 @@ class StopDetailsFilteredViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Elevator Alert Header").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Elevator Alert Header").assertCanBeDisplayed()
     }
 
     @Test
@@ -364,7 +364,7 @@ class StopDetailsFilteredViewTest {
             )
         }
 
-        composeTestRule.onNodeWithText("This stop is not accessible").assertIsDisplayed()
+        composeTestRule.onNodeWithText("This stop is not accessible").assertCanBeDisplayed()
     }
 
     @OptIn(ExperimentalTestApi::class)
@@ -421,7 +421,7 @@ class StopDetailsFilteredViewTest {
 
         composeTestRule
             .onNodeWithContentDescription("Star route")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Add"))
@@ -493,7 +493,7 @@ class StopDetailsFilteredViewTest {
 
         composeTestRule
             .onNodeWithContentDescription("Star route")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
             .performClick()
 
         composeTestRule.waitForIdle()

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
-import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.UpcomingFormat

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
@@ -48,7 +48,8 @@ class StopDetailsNoTripCardTests {
             .onNode(
                 hasTextMatching(
                     Regex(
-                        "^The first Forest Hills train is scheduled to arrive at 9:44\\sAM. We don’t have predictions to show you yet, but they’ll appear here closer to the scheduled time.$"
+                        "^The first Forest Hills train is scheduled to arrive at 9:44\\sAM. We don’t have predictions to show you yet, but they’ll appear here closer to the scheduled time.$",
+                        RegexOption.IGNORE_CASE,
                     )
                 )
             )
@@ -128,7 +129,9 @@ class StopDetailsNoTripCardTests {
         composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
         composeTestRule.onNodeWithText("Service ended").assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("^Next trip at 9:15\\sAM tomorrow$")))
+            .onNode(
+                hasTextMatching(Regex("^Next trip at 9:15\\sAM tomorrow$", RegexOption.IGNORE_CASE))
+            )
             .assertIsDisplayed()
     }
 
@@ -155,7 +158,7 @@ class StopDetailsNoTripCardTests {
         composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
         composeTestRule.onNodeWithText("No service today").assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("^Next trip at 9:15\\sAM$")))
+            .onNode(hasTextMatching(Regex("^Next trip at 9:15\\sAM$", RegexOption.IGNORE_CASE)))
             .assertIsDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsNoTripCardTests.kt
@@ -1,11 +1,11 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -42,8 +42,8 @@ class StopDetailsNoTripCardTests {
             )
         }
 
-        composeTestRule.onNodeWithTag("sunrise").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Good morning!").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("sunrise").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Good morning!").assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(
@@ -53,7 +53,7 @@ class StopDetailsNoTripCardTests {
                     )
                 )
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -70,14 +70,14 @@ class StopDetailsNoTripCardTests {
             )
         }
 
-        composeTestRule.onNodeWithTag("live_data_slash").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Predictions unavailable").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("live_data_slash").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Predictions unavailable").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithText(
                 "Service is running, but predicted arrival times aren’t available." +
                     " Check the map to see where buses are right now."
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -126,13 +126,13 @@ class StopDetailsNoTripCardTests {
                 nextScheduleResponse = NextScheduleResponse(schedule),
             )
         }
-        composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Service ended").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("route_slash_icon").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Service ended").assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("^Next trip at 9:15\\sAM tomorrow$", RegexOption.IGNORE_CASE))
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -155,10 +155,10 @@ class StopDetailsNoTripCardTests {
                 nextScheduleResponse = NextScheduleResponse(schedule),
             )
         }
-        composeTestRule.onNodeWithTag("route_slash_icon").assertIsDisplayed()
-        composeTestRule.onNodeWithText("No service today").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("route_slash_icon").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("No service today").assertCanBeDisplayed()
         composeTestRule
             .onNode(hasTextMatching(Regex("^Next trip at 9:15\\sAM$", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -2,10 +2,10 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.LocationType
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -240,6 +240,6 @@ class StopDetailsUnfilteredRoutesViewTest {
             ) {}
         }
 
-        composeTestRule.onNodeWithText("Elevator alert").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Elevator alert").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsViewTest.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isHeading
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Direction
@@ -186,7 +186,7 @@ class StopDetailsViewTest {
 
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Stop"))
 
-        composeTestRule.onNode(hasText("Sample Stop") and isHeading()).assertIsDisplayed()
+        composeTestRule.onNode(hasText("Sample Stop") and isHeading()).assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText("Sample Route").assertExists()
         composeTestRule.onNodeWithText("Sample Headsign").assertExists()
@@ -258,7 +258,7 @@ class StopDetailsViewTest {
 
         composeTestRule.onNodeWithContentDescription("Star route").assertExists()
         composeTestRule.onNodeWithContentDescription("Close").assertExists()
-        composeTestRule.onNode(hasText("at Sample Stop") and isHeading()).assertIsDisplayed()
+        composeTestRule.onNode(hasText("at Sample Stop") and isHeading()).assertCanBeDisplayed()
 
         composeTestRule.onNodeWithText("1 min").assertExists()
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -1,13 +1,13 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.analytics.MockAnalytics
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -189,8 +189,8 @@ class TripDetailsViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText(downstreamStop.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Stop skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithText(downstreamStop.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Stop skipped").assertCanBeDisplayed()
     }
 
     @Test
@@ -270,7 +270,7 @@ class TripDetailsViewTest {
 
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Follow").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Trip complete").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Trip complete").assertCanBeDisplayed()
     }
 
     @Test
@@ -304,6 +304,6 @@ class TripDetailsViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Trip not available").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Trip not available").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -2,12 +2,12 @@ package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -50,7 +50,7 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -111,7 +111,7 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Next stop", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Next stop", useUnmergedTree = true).assertCanBeDisplayed()
 
         val incomingVehicle =
             objects.vehicle {
@@ -121,7 +121,7 @@ class TripHeaderCardTest {
 
         vehicleState.value = incomingVehicle
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Approaching", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Approaching", useUnmergedTree = true).assertCanBeDisplayed()
 
         val stoppedVehicle =
             objects.vehicle {
@@ -132,7 +132,7 @@ class TripHeaderCardTest {
         vehicleState.value = stoppedVehicle
 
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Now at", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Now at", useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -164,7 +164,7 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Not crowded", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Not crowded", useUnmergedTree = true).assertCanBeDisplayed()
 
         vehicleState.value =
             objects.vehicle {
@@ -173,7 +173,9 @@ class TripHeaderCardTest {
                 occupancyStatus = Vehicle.OccupancyStatus.FewSeatsAvailable
             }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Some crowding", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Some crowding", useUnmergedTree = true)
+            .assertCanBeDisplayed()
 
         vehicleState.value =
             objects.vehicle {
@@ -182,7 +184,7 @@ class TripHeaderCardTest {
                 occupancyStatus = Vehicle.OccupancyStatus.CrushedStandingRoomOnly
             }
         composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithText("Crowded", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Crowded", useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -204,7 +206,7 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Finishing another trip").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Finishing another trip").assertCanBeDisplayed()
         composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertDoesNotExist()
     }
 
@@ -221,7 +223,7 @@ class TripHeaderCardTest {
         }
         composeTestRule
             .onNodeWithText("Location not available yet", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertDoesNotExist()
     }
 
@@ -254,7 +256,7 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithTag("stop_pin_indicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -303,17 +305,17 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithText("Waiting to depart", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithTag("stop_pin_indicator", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("4:49\\sPM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -371,7 +373,7 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Track 5", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Track 5", useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -414,14 +416,14 @@ class TripHeaderCardTest {
 
         composeTestRule
             .onNodeWithText("Scheduled to depart", useUnmergedTree = true)
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertCanBeDisplayed()
         composeTestRule
             .onNode(
                 hasTextMatching(Regex("9:48\\sAM", RegexOption.IGNORE_CASE)),
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     /*
@@ -491,7 +493,7 @@ class TripHeaderCardTest {
                 "Selected bus Approaching stop, selected stop",
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -552,10 +554,10 @@ class TripHeaderCardTest {
                 "Selected train Now at Ruggles, selected stop",
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Boarding on track 3", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -589,7 +591,7 @@ class TripHeaderCardTest {
                 "Selected bus Approaching other stop",
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -633,7 +635,7 @@ class TripHeaderCardTest {
                 "Selected bus scheduled to depart stop, selected stop",
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -679,7 +681,7 @@ class TripHeaderCardTest {
                 "Selected bus scheduled to depart other stop",
                 useUnmergedTree = true,
             )
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -723,15 +725,21 @@ class TripHeaderCardTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("Train crowding diagram").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Car 1 of 5, Not crowded").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Train crowding diagram")
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Car 1 of 5, Not crowded")
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Car 2 of 5, Some crowding")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Car 3 of 5, Crowded").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithContentDescription("Car 3 of 5, Crowded").assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Car 4 of 5, Crowding unknown")
-            .assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Car 5 of 5, Not crowded").assertIsDisplayed()
+            .assertCanBeDisplayed()
+        composeTestRule
+            .onNodeWithContentDescription("Car 5 of 5, Not crowded")
+            .assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -309,7 +309,10 @@ class TripHeaderCardTest {
             .assertIsDisplayed()
 
         composeTestRule
-            .onNode(hasTextMatching(Regex("4:49\\sPM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("4:49\\sPM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 
@@ -414,7 +417,10 @@ class TripHeaderCardTest {
             .assertIsDisplayed()
         composeTestRule.onNodeWithText(stop.name, useUnmergedTree = true).assertIsDisplayed()
         composeTestRule
-            .onNode(hasTextMatching(Regex("9:48\\sAM")), useUnmergedTree = true)
+            .onNode(
+                hasTextMatching(Regex("9:48\\sAM", RegexOption.IGNORE_CASE)),
+                useUnmergedTree = true,
+            )
             .assertIsDisplayed()
     }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripHeaderCardTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripDetailsStopList

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -98,7 +98,9 @@ class TripStopRowTest {
             )
         }
 
-        composeTestRule.onNode(hasTextMatching(Regex("3:37\\sPM"))).assertIsDisplayed()
+        composeTestRule
+            .onNode(hasTextMatching(Regex("3:37\\sPM", RegexOption.IGNORE_CASE)))
+            .assertIsDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -3,13 +3,13 @@ package com.mbta.tid.mbta_app.android.stopDetails
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
@@ -64,7 +64,7 @@ class TripStopRowTest {
             )
         }
 
-        composeTestRule.onNodeWithText(stop.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop.name).assertCanBeDisplayed()
     }
 
     @Test
@@ -100,7 +100,7 @@ class TripStopRowTest {
 
         composeTestRule
             .onNode(hasTextMatching(Regex("3:37\\sPM", RegexOption.IGNORE_CASE)))
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -141,8 +141,8 @@ class TripStopRowTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Track 2").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Boarding on track 2").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Track 2").assertCanBeDisplayed()
+        composeTestRule.onNodeWithContentDescription("Boarding on track 2").assertCanBeDisplayed()
     }
 
     @Test
@@ -184,20 +184,20 @@ class TripStopRowTest {
             )
         }
 
-        composeTestRule.onNodeWithContentDescription("stop").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("stop").assertCanBeDisplayed()
 
         selected = true
 
-        composeTestRule.onNodeWithContentDescription("stop, selected stop").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("stop, selected stop").assertCanBeDisplayed()
 
         first = true
 
         composeTestRule
             .onNodeWithContentDescription("stop, selected stop, first stop")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         selected = false
-        composeTestRule.onNodeWithContentDescription("stop, first stop").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("stop, first stop").assertCanBeDisplayed()
     }
 
     @Test
@@ -290,10 +290,10 @@ class TripStopRowTest {
 
         composeTestRule
             .onNodeWithTag("wheelchair_not_accessible", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("This stop is not accessible", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
 
         composeTestRule.onNodeWithTag("elevator_alert", useUnmergedTree = true).assertDoesNotExist()
 
@@ -311,10 +311,12 @@ class TripStopRowTest {
         composeTestRule
             .onNodeWithTag("wheelchair_not_accessible", useUnmergedTree = true)
             .assertDoesNotExist()
-        composeTestRule.onNodeWithTag("elevator_alert", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag("elevator_alert", useUnmergedTree = true)
+            .assertCanBeDisplayed()
         composeTestRule
             .onNodeWithContentDescription("This stop has 1 elevator closed", useUnmergedTree = true)
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test
@@ -359,6 +361,6 @@ class TripStopRowTest {
 
         composeTestRule
             .onNodeWithText("Shuttle buses from Roxbury Crossing to Green Street through tomorrow")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import com.mbta.tid.mbta_app.android.hasTextMatching
 import com.mbta.tid.mbta_app.android.loadKoinMocks
+import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.MapStopRoute

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -1,9 +1,9 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
@@ -140,9 +140,11 @@ class TripStopsTest {
             )
         }
 
-        composeTestRule.onNodeWithText("2 stops away", useUnmergedTree = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop3Target.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop5.name).assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("2 stops away", useUnmergedTree = true)
+            .assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop3Target.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop5.name).assertCanBeDisplayed()
     }
 
     @Test
@@ -239,9 +241,9 @@ class TripStopsTest {
             )
         }
 
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop2.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText(stop3.name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop2.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText(stop3.name).assertCanBeDisplayed()
     }
 
     @Test
@@ -427,8 +429,8 @@ class TripStopsTest {
             )
         }
 
-        composeTestRule.onNodeWithText(stop1.name).assertIsDisplayed()
-        composeTestRule.onNodeWithText("1 stop away", useUnmergedTree = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(stop1.name).assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("1 stop away", useUnmergedTree = true).assertCanBeDisplayed()
     }
 
     @Test
@@ -536,7 +538,7 @@ class TripStopsTest {
 
         composeTestRule
             .onNodeWithText("Shuttle buses at Stop C through end of service")
-            .assertIsDisplayed()
+            .assertCanBeDisplayed()
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsMatchers.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsMatchers.kt
@@ -1,0 +1,38 @@
+package com.mbta.tid.mbta_app.android.testUtils
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+
+fun hasClickActionLabel(expected: String?) =
+    SemanticsMatcher("has click action label $expected") { node ->
+        node.config.getOrNull(SemanticsActions.OnClick)?.label == expected
+    }
+
+fun hasTextMatching(regex: Regex): SemanticsMatcher {
+    val propertyName = "${SemanticsProperties.Text.name} + ${SemanticsProperties.EditableText.name}"
+    return SemanticsMatcher("$propertyName matches $regex") {
+        val isInEditableTextValue =
+            it.config.getOrNull(SemanticsProperties.EditableText)?.text?.matches(regex) ?: false
+        val isInTextValue =
+            it.config.getOrNull(SemanticsProperties.Text)?.any { item -> item.text.matches(regex) }
+                ?: false
+        isInEditableTextValue || isInTextValue
+    }
+}
+
+fun hasContentDescriptionMatching(regex: Regex): SemanticsMatcher {
+    val propertyName = SemanticsProperties.ContentDescription.name
+    return SemanticsMatcher("$propertyName matches $regex") {
+        it.config.getOrNull(SemanticsProperties.ContentDescription)?.any { item ->
+            item.matches(regex)
+        } ?: false
+    }
+}
+
+fun hasRole(role: Role) =
+    SemanticsMatcher("has role $role") { node ->
+        node.config.getOrNull(SemanticsProperties.Role) == role
+    }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsNodeInteractionExtension.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsNodeInteractionExtension.kt
@@ -4,12 +4,28 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.filter
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.onAncestors
+import androidx.compose.ui.test.performScrollTo
 import kotlin.math.abs
 import org.junit.Assert
 
 fun SemanticsNodeInteraction.assertContentDescriptionMatches(regex: Regex) =
     assert(hasContentDescriptionMatching(regex))
+
+/** Scrolls this element into view, if possible, before asserting that it is displayed. */
+fun SemanticsNodeInteraction.assertCanBeDisplayed(): SemanticsNodeInteraction {
+    if (this.onAncestors().filter(hasScrollAction()).fetchSemanticsNodes().isNotEmpty()) {
+        this.performScrollTo()
+    }
+    return this.assertIsDisplayed()
+}
+
+/** Does not scroll this element into view before asserting that it is displayed. */
+fun SemanticsNodeInteraction.assertIsAlreadyOnScreen() = assertIsDisplayed()
 
 @OptIn(ExperimentalStdlibApi::class)
 private fun colorToHex(color: Color): String {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsNodeInteractionExtension.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/testUtils/SemanticsNodeInteractionExtension.kt
@@ -1,0 +1,64 @@
+package com.mbta.tid.mbta_app.android.testUtils
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.captureToImage
+import kotlin.math.abs
+import org.junit.Assert
+
+fun SemanticsNodeInteraction.assertContentDescriptionMatches(regex: Regex) =
+    assert(hasContentDescriptionMatching(regex))
+
+@OptIn(ExperimentalStdlibApi::class)
+private fun colorToHex(color: Color): String {
+    fun valToHex(value: Float): String {
+        val byteValue = (value * 255).toInt().toByte()
+        return byteValue.toHexString(HexFormat.UpperCase)
+    }
+    return "#${valToHex(color.red)}${valToHex(color.green)}${valToHex(color.blue)}"
+}
+
+private fun Color.isGrey(): Boolean =
+    abs(this.red - this.green) < 0.01 && abs(this.green - this.blue) < 0.01
+
+/**
+ * It's difficult to determine if a view hierarchy contains the correct image when the image is
+ * semantically invisible, but it's easy to capture a screenshot of the view and check it pixel by
+ * pixel.
+ */
+fun SemanticsNodeInteraction.assertHasColor(targetColor: Color) {
+    val pixelMap = this.captureToImage().toPixelMap()
+    val pixelCounts = mutableMapOf<Color, Int>()
+    for (x in 0.rangeUntil(pixelMap.width)) {
+        for (y in 0.rangeUntil(pixelMap.height)) {
+            val colorHere = pixelMap[x, y]
+            if (colorHere == targetColor) {
+                return
+            }
+            pixelCounts[colorHere] = pixelCounts.getOrDefault(colorHere, 0) + 1
+        }
+    }
+    // never returned so did not find the target. hopefully the color that is present instead of the
+    // target is either the most common non-grey color or among the most common grey colors (the
+    // most common grey will likely be a background, though)
+    val legibleResult =
+        pixelCounts.entries
+            .groupBy(
+                { if (it.key.isGrey()) "grey" else "not grey" },
+                { colorToHex(it.key) to it.value },
+            )
+            .mapValues { it.value.sortedByDescending { it.second } }
+            .toSortedMap(
+                compareBy {
+                    when (it) {
+                        "not grey" -> 1
+                        "grey" -> 2
+                        else -> 3
+                    }
+                }
+            )
+
+    Assert.fail("Did not contain specified color, but did have $legibleResult")
+}

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtensionTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/EasternTimeInstantExtensionTests.kt
@@ -1,8 +1,8 @@
 package com.mbta.tid.mbta_app.android.util
 
+import com.mbta.tid.mbta_app.android.assertMatches
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import kotlinx.datetime.Month
 import org.junit.Test
 
@@ -11,13 +11,16 @@ class EasternTimeInstantExtensionTests {
     @Test
     fun testFormattedTime() {
         val instant = EasternTimeInstant(2026, Month.APRIL, 9, 23, 30)
-        assertTrue(Regex("11:30\\sPM").matches(instant.formattedTime()))
+        assertMatches(Regex("11:30\\sPM", RegexOption.IGNORE_CASE), instant.formattedTime())
     }
 
     @Test
     fun testFormattedShortDateShortTime() {
         val instant = EasternTimeInstant(2026, Month.APRIL, 9, 23, 30)
-        assertTrue(Regex("4/9/26, 11:30\\sPM").matches(instant.formattedShortDateShortTime()))
+        assertMatches(
+            Regex("(0?4/0?9|0?9/0?4)/26, 11:30\\sPM", RegexOption.IGNORE_CASE),
+            instant.formattedShortDateShortTime(),
+        )
     }
 
     @Test
@@ -39,15 +42,21 @@ class EasternTimeInstantExtensionTests {
     @Test
     fun testFormattedServiceDayAndDate() {
         val middayInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 11, 27)
-        assertEquals("Sunday, Jan 11", middayInstant.formattedServiceDayAndDate())
+        assertMatches(Regex("Sunday, (Jan 11|11 Jan)"), middayInstant.formattedServiceDayAndDate())
 
         val pastMidnightInstant = EasternTimeInstant(2026, Month.JANUARY, 11, 1, 23)
-        assertEquals("Saturday, Jan 10", pastMidnightInstant.formattedServiceDayAndDate())
+        assertMatches(
+            Regex("Saturday, (Jan 10|10 Jan)"),
+            pastMidnightInstant.formattedServiceDayAndDate(),
+        )
 
         val serviceThreshold = EasternTimeInstant(2026, Month.JANUARY, 11, 3, 0)
-        assertEquals("Sunday, Jan 11", serviceThreshold.formattedServiceDayAndDate())
-        assertEquals(
-            "Saturday, Jan 10",
+        assertMatches(
+            Regex("Sunday, (Jan 11|11 Jan)"),
+            serviceThreshold.formattedServiceDayAndDate(),
+        )
+        assertMatches(
+            Regex("Saturday, (Jan 10|10 Jan)"),
             serviceThreshold.formattedServiceDayAndDate(
                 EasternTimeInstant.ServiceDateRounding.BACKWARDS
             ),
@@ -57,15 +66,21 @@ class EasternTimeInstantExtensionTests {
     @Test
     fun testFormattedShortServiceDayAndDate() {
         val middayInstant = EasternTimeInstant(2025, Month.OCTOBER, 4, 4, 12)
-        assertEquals("Sat, Oct 4", middayInstant.formattedShortServiceDayAndDate())
+        assertMatches(Regex("Sat, (Oct 4|4 Oct)"), middayInstant.formattedShortServiceDayAndDate())
 
         val pastMidnightInstant = EasternTimeInstant(2025, Month.OCTOBER, 4, 1, 23)
-        assertEquals("Fri, Oct 3", pastMidnightInstant.formattedShortServiceDayAndDate())
+        assertMatches(
+            Regex("Fri, (Oct 3|3 Oct)"),
+            pastMidnightInstant.formattedShortServiceDayAndDate(),
+        )
 
         val serviceThreshold = EasternTimeInstant(2025, Month.OCTOBER, 4, 3, 0)
-        assertEquals("Sat, Oct 4", serviceThreshold.formattedShortServiceDayAndDate())
-        assertEquals(
-            "Fri, Oct 3",
+        assertMatches(
+            Regex("Sat, (Oct 4|4 Oct)"),
+            serviceThreshold.formattedShortServiceDayAndDate(),
+        )
+        assertMatches(
+            Regex("Fri, (Oct 3|3 Oct)"),
             serviceThreshold.formattedShortServiceDayAndDate(
                 EasternTimeInstant.ServiceDateRounding.BACKWARDS
             ),
@@ -75,15 +90,18 @@ class EasternTimeInstantExtensionTests {
     @Test
     fun testFormattedServiceDate() {
         val middayInstant = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 20, 20)
-        assertEquals("September 16", middayInstant.formattedServiceDate())
+        assertMatches(Regex("September 16|16 September"), middayInstant.formattedServiceDate())
 
         val pastMidnightInstant = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 2, 20)
-        assertEquals("September 15", pastMidnightInstant.formattedServiceDate())
+        assertMatches(
+            Regex("September 15|15 September"),
+            pastMidnightInstant.formattedServiceDate(),
+        )
 
         val serviceThreshold = EasternTimeInstant(2025, Month.SEPTEMBER, 16, 3, 0)
-        assertEquals("September 16", serviceThreshold.formattedServiceDate())
-        assertEquals(
-            "September 15",
+        assertMatches(Regex("September 16|16 September"), serviceThreshold.formattedServiceDate())
+        assertMatches(
+            Regex("September 15|15 September"),
             serviceThreshold.formattedServiceDate(EasternTimeInstant.ServiceDateRounding.BACKWARDS),
         )
     }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.android.util
 
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.mbta.tid.mbta_app.android.assertMatches
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.RouteType
@@ -32,10 +33,15 @@ class FormattedAlertTests {
                 "North Station",
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "Shuttle buses replace the 4:00\\sPM train from Porter to North Station"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "Shuttle buses replace the 4:00\\sPM train from Porter to North Station",
+                    RegexOption.IGNORE_CASE,
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -53,11 +59,15 @@ class FormattedAlertTests {
                 "North Station",
             )
         val format = FormattedAlert(null, summary)
-        val pattern =
-            "4:00\\sPM train from Concord is replaced by shuttle buses from Porter to North Station"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "4:00\\sPM train from Concord is replaced by shuttle buses from Porter to North Station",
+                    RegexOption.IGNORE_CASE,
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -70,10 +80,12 @@ class FormattedAlertTests {
                 "North Station",
             )
         val format = FormattedAlert(null, summary)
-        val expected = "Shuttle buses replace this train from Porter to North Station"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assertEquals(expected, summaryString)
+            assertEquals(
+                "Shuttle buses replace this train from Porter to North Station",
+                summaryString,
+            )
         }
     }
 
@@ -89,10 +101,15 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "12:13\\sPM train from Ruggles is suspended today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "12:13\\sPM train from Ruggles is suspended today due to weather",
+                    RegexOption.IGNORE_CASE,
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -108,10 +125,14 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "11:15\\sAM train from Concord will terminate at Porter today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "11:15\\s[Aa][Mm] train from Concord will terminate at Porter today due to weather"
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -126,10 +147,9 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val expected = "This train is suspended today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assertEquals(expected, summaryString)
+            assertEquals("This train is suspended today due to weather", summaryString)
         }
     }
 
@@ -144,10 +164,9 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val expected = "This train will terminate at Porter today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assertEquals(expected, summaryString)
+            assertEquals("This train will terminate at Porter today due to weather", summaryString)
         }
     }
 
@@ -163,11 +182,15 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val pattern =
-            "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "12:13\\sPM train to Stoughton will not stop at Back Bay and Ruggles today due to weather",
+                    RegexOption.IGNORE_CASE,
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -182,10 +205,9 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val format = FormattedAlert(null, summary)
-        val expected = "This train will not stop at Porter today due to weather"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assertEquals(expected, summaryString)
+            assertEquals("This train will not stop at Porter today due to weather", summaryString)
         }
     }
 
@@ -198,10 +220,12 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "Trains will not stop at Back Bay until further notice"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex("Trains will not stop at Back Bay until further notice"),
+                summaryString,
+            )
         }
     }
 
@@ -214,10 +238,12 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "Trains will not stop at Back Bay and Ruggles until further notice"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex("Trains will not stop at Back Bay and Ruggles until further notice"),
+                summaryString,
+            )
         }
     }
 
@@ -230,11 +256,14 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val format = FormattedAlert(null, summary)
-        val pattern =
-            "Trains will not stop at Back Bay, Ruggles, and Hyde Park until further notice"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex(
+                    "Trains will not stop at Back Bay, Ruggles,? and Hyde Park until further notice"
+                ),
+                summaryString,
+            )
         }
     }
 
@@ -249,10 +278,12 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val format = FormattedAlert(null, summary)
-        val pattern = "Trains will not stop at multiple stops until further notice"
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
-            assert(Regex(pattern).matches(summaryString))
+            assertMatches(
+                Regex("Trains will not stop at multiple stops until further notice"),
+                summaryString,
+            )
         }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/RouteModeLabelTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/RouteModeLabelTest.kt
@@ -6,10 +6,10 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -27,7 +27,7 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, name, type)) }
 
-        composeTestRule.onNodeWithText("1 bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("1 bus").assertCanBeDisplayed()
     }
 
     @Test
@@ -39,7 +39,7 @@ class RouteModeLabelTest {
             Text(routeModeLabel(LocalResources.current, name, type, false))
         }
 
-        composeTestRule.onNodeWithText("Red Line trains").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Red Line trains").assertCanBeDisplayed()
     }
 
     @Test
@@ -48,7 +48,7 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, name, null)) }
 
-        composeTestRule.onNodeWithText(name).assertIsDisplayed()
+        composeTestRule.onNodeWithText(name).assertCanBeDisplayed()
     }
 
     @Test
@@ -57,7 +57,7 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, null, type)) }
 
-        composeTestRule.onNodeWithText("ferry").assertIsDisplayed()
+        composeTestRule.onNodeWithText("ferry").assertCanBeDisplayed()
     }
 
     @Test
@@ -92,7 +92,7 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, route)) }
 
-        composeTestRule.onNodeWithText("Lynn Ferry").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Lynn Ferry").assertCanBeDisplayed()
     }
 
     @Test
@@ -107,7 +107,7 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, line, route)) }
 
-        composeTestRule.onNodeWithText("Green Line train").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Green Line train").assertCanBeDisplayed()
     }
 
     @Test
@@ -124,6 +124,6 @@ class RouteModeLabelTest {
 
         composeTestRule.setContent { Text(routeModeLabel(LocalResources.current, lineOrRoute)) }
 
-        composeTestRule.onNodeWithText("Silver Line bus").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Silver Line bus").assertCanBeDisplayed()
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Make android tests pass locally on device](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215072780897372)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Ran into some issues locally outside of the ones mentioned in Slack; this should take care of everything. Split into separate logical changes for easier review.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that tests pass on my physical Android phone.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
