### PR TITLE
Decrease the caching time on ResponseCache to 10 min

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/cache/ResponseCache.kt
@@ -9,7 +9,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.etag
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.TimeSource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,7 +46,7 @@ internal class ResponseCache<T : Any>(
 
         inline fun <reified T : Any> create(
             cacheKey: String,
-            maxAge: Duration = 1.hours,
+            maxAge: Duration = 10.minutes,
             invalidationKey: String? = null,
         ) = ResponseCache<T>(cacheKey, maxAge, json.serializersModule.serializer(), invalidationKey)
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Try decreasing cache time for frontend data](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1215146071911222?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Decrease the caching time on ResponseCache to 10 min

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Ran load testing =>[splunk link to backend dashboards](https://mbta.splunkcloud.com/en-US/app/search/tony_another_dashboard?tab=layout_1&form.global_env=mobile-app-backend-dev-orange-application)
 - Number of instances increased to 4
 - Max requests were 500 in a minute which is much more than what we have in prod (on the same period we got around 20 in prod)
 - Latency and memory usage got quite high on peek

I think a safe outcome should be to reduce it to 10 min and monitor the outcome but open to feedback on how to calculate numbers


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
