### PR TITLE
fix: Filter out vehicles 1+ hours stale

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -26,6 +26,8 @@ import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.MockRouteCardDataViewModel
 import com.mbta.tid.mbta_app.viewModel.RouteCardDataViewModel
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -206,5 +208,90 @@ class SubscribeToVehiclesTest {
 
         composeTestRule.waitUntilDefaultTimeout { connectProps == Pair(line.id, 0) }
         composeTestRule.waitUntilDefaultTimeout { listOf(vehicle2) == vehicles }
+    }
+
+    @Test
+    fun testFiltersStaleVehicles() = runTest {
+        val objects = ObjectCollectionBuilder()
+
+        val route = objects.route {}
+
+        val now = EasternTimeInstant.now()
+        val vehicle1 =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                routeId = route.id.idText
+                updatedAt = now.minus(10.seconds)
+            }
+        val vehicle2 =
+            objects.vehicle {
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                routeId = route.id.idText
+                updatedAt = now.minus(10.minutes)
+            }
+
+        var connectProps: Pair<LineOrRoute.Id, Int>? = null
+
+        val vehiclesRepo =
+            MockVehiclesRepository(
+                VehiclesStreamDataResponse(mapOf(vehicle1.id to vehicle1, vehicle2.id to vehicle2)),
+                onConnect = { routeId, directionId -> connectProps = Pair(routeId, directionId) },
+            )
+
+        val dataRoute = LineOrRoute.Route(route)
+        val stop = objects.stop()
+        val routeCardData =
+            listOf(
+                RouteCardData(
+                    lineOrRoute = dataRoute,
+                    stopData =
+                        listOf(
+                            RouteCardData.RouteStopData(
+                                dataRoute,
+                                stop,
+                                listOf(
+                                    RouteCardData.Leaf(
+                                        dataRoute,
+                                        stop,
+                                        Direction(0, route),
+                                        listOf(),
+                                        setOf(stop.id),
+                                        listOf(
+                                            UpcomingTrip(objects.trip { routeId = route.id.idText })
+                                        ),
+                                        emptyList(),
+                                        true,
+                                        true,
+                                        null,
+                                        emptyList(),
+                                        RouteCardData.Context.StopDetailsFiltered,
+                                    )
+                                ),
+                            )
+                        ),
+                    at = EasternTimeInstant.now(),
+                )
+            )
+
+        var vehicles: List<Vehicle> = emptyList()
+
+        val stateFilter = mutableStateOf(StopDetailsFilter(route.id, 0))
+
+        val routeCardDataVM =
+            MockRouteCardDataViewModel(RouteCardDataViewModel.State(routeCardData))
+
+        composeTestRule.setContent {
+            val filter by remember { stateFilter }
+            vehicles =
+                subscribeToVehicles(
+                    filter,
+                    ErrorKey(setOf(), "error"),
+                    routeCardDataVM,
+                    vehiclesRepo,
+                )
+        }
+
+        composeTestRule.waitUntilDefaultTimeout { connectProps == Pair(route.id, 0) }
+        composeTestRule.waitUntilDefaultTimeout { listOf(vehicle1) == vehicles }
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToVehiclesTest.kt
@@ -26,7 +26,7 @@ import com.mbta.tid.mbta_app.repositories.MockVehiclesRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.viewModel.MockRouteCardDataViewModel
 import com.mbta.tid.mbta_app.viewModel.RouteCardDataViewModel
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -227,7 +227,7 @@ class SubscribeToVehiclesTest {
             objects.vehicle {
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
                 routeId = route.id.idText
-                updatedAt = now.minus(10.minutes)
+                updatedAt = now.minus(2.hours)
             }
 
         var connectProps: Pair<LineOrRoute.Id, Int>? = null

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/state/subscribeToVehicles.kt
@@ -95,5 +95,6 @@ fun subscribeToVehicles(
                 ?: response.vehicles
         }
         ?.values
+        ?.filter { !it.isStale() }
         ?.toList() ?: emptyList()
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.hours
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.maplibre.spatialk.geojson.Position
@@ -82,7 +82,7 @@ public data class Vehicle(
     public val hasCarLevelCrowding: Boolean =
         carriages.orEmpty().any { it.occupancyStatus != Vehicle.OccupancyStatus.NoDataAvailable }
 
-    private val staleThreshold = 5.minutes
+    private val staleThreshold = 1.hours
 
     public fun isStale(): Boolean = EasternTimeInstant.now().minus(updatedAt) > staleThreshold
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Vehicle.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.maplibre.spatialk.geojson.Position
@@ -80,6 +81,10 @@ public data class Vehicle(
 
     public val hasCarLevelCrowding: Boolean =
         carriages.orEmpty().any { it.occupancyStatus != Vehicle.OccupancyStatus.NoDataAvailable }
+
+    private val staleThreshold = 5.minutes
+
+    public fun isStale(): Boolean = EasternTimeInstant.now().minus(updatedAt) > staleThreshold
 
     override fun toString(): String = "Vehicle(id=$id)"
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getTripData.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.mbta.tid.mbta_app.model.Trip
 import com.mbta.tid.mbta_app.model.TripDetailsPageFilter
-import com.mbta.tid.mbta_app.model.Vehicle
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.TripSchedulesResponse
 import com.mbta.tid.mbta_app.model.stopDetailsPage.TripData
@@ -90,7 +89,7 @@ internal fun getTripData(
     var trip: Trip? by remember { mutableStateOf(null) }
     var tripSchedules: TripSchedulesResponse? by remember { mutableStateOf(null) }
     var tripPredictions: PredictionsStreamDataResponse? by remember { mutableStateOf(null) }
-    var vehicle: Vehicle? by remember { mutableStateOf(null) }
+    var vehicleResponse: VehicleSubscriptionResponse? by remember { mutableStateOf(null) }
     var tripLoading: Boolean by remember { mutableStateOf(true) }
 
     var result: TripData? by remember { mutableStateOf(null) }
@@ -104,7 +103,7 @@ internal fun getTripData(
         trip = null
         tripSchedules = null
         tripPredictions = null
-        vehicle = null
+        vehicleResponse = null
         tripLoading = true
     }
 
@@ -116,7 +115,7 @@ internal fun getTripData(
             params,
             {
                 tripLoading = false
-                if (trip == null && vehicle != null) {
+                if (trip == null && vehicleResponse?.vehicle != null) {
                     CoroutineScope(coroutineDispatcher).launch {
                         errorBannerRepository.clearDataError(fetchTripErrorKey(errorKey))
                     }
@@ -130,7 +129,7 @@ internal fun getTripData(
             tripId,
             params,
             {
-                if (trip == null && vehicle != null) {
+                if (trip == null && vehicleResponse?.vehicle != null) {
                     CoroutineScope(coroutineDispatcher).launch {
                         errorBannerRepository.clearDataError(fetchTripSchedulesErrorKey(errorKey))
                     }
@@ -157,7 +156,7 @@ internal fun getTripData(
             )
         else null
 
-    vehicle =
+    vehicleResponse =
         subscribeToVehicle(
             tripFilter?.vehicleId,
             errorKey,
@@ -181,25 +180,33 @@ internal fun getTripData(
         }
     }
 
-    LaunchedEffect(vehicle) {
+    LaunchedEffect(vehicleResponse) {
         // If a trip is not loaded but the vehicle has updated, try loading the trip again
         if (!shouldTryLoadingTrip && active) {
             tripFilter?.tripId?.let { tripId -> fetchStaticData(tripId) }
         }
     }
 
-    LaunchedEffect(tripFilter, trip, tripSchedules, tripPredictions, vehicle, context) {
+    LaunchedEffect(tripFilter, trip, tripSchedules, tripPredictions, vehicleResponse, context) {
         val resolvedTrip = trip
         result =
             if (
                 tripFilter != null &&
                     resolvedTrip != null &&
                     resolvedTrip.id == tripFilter.tripId &&
-                    (tripFilter.vehicleId == null || tripFilter.vehicleId == vehicle?.id)
+                    (tripFilter.vehicleId == null ||
+                        tripFilter.vehicleId == vehicleResponse?.vehicle?.id ||
+                        vehicleResponse?.lastResponseStale == true)
             ) {
-                TripData(tripFilter, resolvedTrip, tripSchedules, tripPredictions, vehicle)
-            } else if (tripFilter != null && vehicle != null && !tripLoading) {
-                TripData(tripFilter, null, null, null, vehicle)
+                TripData(
+                    tripFilter,
+                    resolvedTrip,
+                    tripSchedules,
+                    tripPredictions,
+                    vehicleResponse?.vehicle,
+                )
+            } else if (tripFilter != null && vehicleResponse?.vehicle != null && !tripLoading) {
+                TripData(tripFilter, null, null, null, vehicleResponse?.vehicle)
             } else {
                 null
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -12,6 +12,8 @@ import com.mbta.tid.mbta_app.model.response.VehicleStreamDataResponse
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
+import io.sentry.kotlin.multiplatform.Sentry
+import io.sentry.kotlin.multiplatform.protocol.Breadcrumb
 import org.koin.compose.koinInject
 
 public data class VehicleSubscriptionResponse(val vehicle: Vehicle?, val lastResponseStale: Boolean)
@@ -37,8 +39,25 @@ internal fun subscribeToVehicle(
         when (message) {
             is ApiResult.Ok ->
                 message.data.vehicle?.let {
-                    if (it.isStale()) lastResponseStale = true
-                    else {
+                    if (it.isStale()) {
+                        lastResponseStale = true
+                        Sentry.captureMessage("Stale vehicle received") { scope ->
+                            scope.addBreadcrumb(
+                                Breadcrumb(
+                                    message = "Vehicle significantly out of date",
+                                    data =
+                                        mutableMapOf(
+                                            "id" to it.id,
+                                            "updatedAt" to it.updatedAt,
+                                            "routeId" to (it.routeId?.idText ?: "nil"),
+                                            "tripId" to (it.tripId ?: "nil"),
+                                            "stopId" to (it.stopId ?: "nil"),
+                                            "currentStatus" to it.currentStatus,
+                                        ),
+                                )
+                            )
+                        }
+                    } else {
                         vehicle = it
                         lastResponseStale = false
                     }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -14,6 +14,8 @@ import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.IVehicleRepository
 import org.koin.compose.koinInject
 
+public data class VehicleSubscriptionResponse(val vehicle: Vehicle?, val lastResponseStale: Boolean)
+
 @Composable
 internal fun subscribeToVehicle(
     vehicleId: String?,
@@ -21,8 +23,9 @@ internal fun subscribeToVehicle(
     active: Boolean,
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
     vehicleRepository: IVehicleRepository = koinInject(),
-): Vehicle? {
+): VehicleSubscriptionResponse {
     var vehicle: Vehicle? by remember { mutableStateOf(null) }
+    var lastResponseStale: Boolean by remember { mutableStateOf(false) }
     val errorKey = errorKey.withSuffix("subscribeToVehicle")
 
     fun connect(vehicleId: String?, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit) {
@@ -32,19 +35,28 @@ internal fun subscribeToVehicle(
 
     fun onReceive(message: ApiResult<VehicleStreamDataResponse>) {
         when (message) {
-            is ApiResult.Ok -> vehicle = message.data.vehicle
+            is ApiResult.Ok ->
+                message.data.vehicle?.let {
+                    if (it.isStale()) lastResponseStale = true
+                    else {
+                        vehicle = it
+                        lastResponseStale = false
+                    }
+                }
             is ApiResult.Error -> {
                 println("Vehicle stream failed to join: ${message.message}")
                 vehicle = null
+                lastResponseStale = false
             }
         }
     }
 
     DisposableEffect(vehicleId, active) {
         vehicle = null
+        lastResponseStale = false
         connect(vehicleId, ::onReceive)
         onDispose { vehicleRepository.disconnect() }
     }
 
-    return vehicle
+    return VehicleSubscriptionResponse(vehicle, lastResponseStale)
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
@@ -27,7 +27,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.hours
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
@@ -160,7 +160,7 @@ class TripDetailsViewModelTest : KoinTest {
             objects.vehicle {
                 this.tripId = trip.id
                 currentStatus = Vehicle.CurrentStatus.StoppedAt
-                updatedAt = now.minus(10.minutes)
+                updatedAt = now.minus(2.hours)
             }
 
         var vehicleLoaded = false

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
@@ -19,6 +19,7 @@ import com.mbta.tid.mbta_app.repositories.MockPinnedRoutesRepository
 import com.mbta.tid.mbta_app.repositories.MockTripPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockTripRepository
 import com.mbta.tid.mbta_app.repositories.MockVehicleRepository
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.TestData
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -26,6 +27,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterIsInstance
@@ -143,6 +145,54 @@ class TripDetailsViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             awaitItemSatisfying {
                 it.tripData?.tripFilter == filters && it.tripData.vehicle == vehicle
+            }
+            assertTrue(vehicleLoaded)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun testLoadsStaleVehicle() = runTest {
+        val now = EasternTimeInstant.now()
+        val objects = TestData.clone()
+        val trip = objects.trip {}
+        val vehicle =
+            objects.vehicle {
+                this.tripId = trip.id
+                currentStatus = Vehicle.CurrentStatus.StoppedAt
+                updatedAt = now.minus(10.minutes)
+            }
+
+        var vehicleLoaded = false
+
+        val tripRepo =
+            MockTripRepository(
+                tripSchedulesResponse =
+                    TripSchedulesResponse.Schedules(listOf(objects.schedule { this.trip = trip })),
+                tripResponse = TripResponse(trip),
+            )
+        val vehicleRepo =
+            MockVehicleRepository(
+                { vehicleLoaded = true },
+                outcome = ApiResult.Ok(VehicleStreamDataResponse(vehicle)),
+            )
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        setUpKoin(objects, dispatcher) {
+            this.trip = tripRepo
+            this.vehicle = vehicleRepo
+        }
+
+        val viewModel: TripDetailsViewModel = get()
+        val filters = TripDetailsPageFilter(trip.id, vehicle.id, Route.Id(""), 0, "", 0)
+        viewModel.setFilters(filters)
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+
+        testViewModelFlow(viewModel).test {
+            awaitItemSatisfying {
+                it.tripData?.tripFilter == filters &&
+                    it.tripData.vehicle == null &&
+                    it.tripData.trip == trip
             }
             assertTrue(vehicleLoaded)
             cancelAndIgnoreRemainingEvents()


### PR DESCRIPTION
### Summary

_Ticket:_ [Bus detour | Trip details flipping between two stops](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215301341188345?focus=true)

Possible fix for the issues we saw with incorrect vehicle stop data sneaking into trip details. While testing, I saw rail vehicles >10 minutes stale several times, almost always at the end of a line, presumably being taken out of service or waiting to start a new trip, which seems appropriate to hide. There was at least once or twice where I saw a mid trip stale vehicle, these will now be shown as the "location not available yet" state until a new update is received. I never saw any stale bus or CR data. A 1 hour threshold should never apply to vehicles stopped for normal reasons during regular service.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Added new tests for updated behavior