### PR TITLE
fix: actually group swift dependencies that need grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,9 +46,9 @@ updates:
     groups:
       firebase:
         patterns:
-          - "firebase/*"
-          - "google/*"
-          - "googleads/*"
+          - "github.com/firebase/*"
+          - "github.com/google/*"
+          - "github.com/googleads/*"
       mapbox:
         patterns:
-          - "mapbox/*"
+          - "github.com/mapbox/*"


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix SwiftPM updates in Dependabot](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215606746972642)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

#1824 didn’t actually work.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Not realistically testable.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
