### PR TITLE
fix: Clean up channel connection logic

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/ChannelOwner.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -114,8 +115,9 @@ internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
             handleJoinResult(result)
         }
 
-        disconnect()
         CoroutineScope(dispatcher).launch {
+            // Wait for the disconnect to finish before attempting to connect
+            disconnect().join()
             connectLock.withLock {
                 val channel = socket.getChannel(spec.topic, spec.params)
 
@@ -166,8 +168,11 @@ internal class AsymmetricChannelOwner<JoinData : Any, MessageData : Any>(
         }
     }
 
-    fun disconnect() {
-        channel?.detach()
-        channel = null
-    }
+    fun disconnect(): Job =
+        CoroutineScope(dispatcher).launch {
+            connectLock.withLock {
+                channel?.detach()
+                channel = null
+            }
+        }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.viewModel.composeStateHelpers
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -44,7 +43,6 @@ internal fun subscribeToPredictions(
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     ) {
-        predictionsRepository.disconnect()
         if (stopIds != null && active) {
             predictionsRepository.connect(stopIds, errorKey, onJoin, onMessage)
         }
@@ -82,15 +80,14 @@ internal fun subscribeToPredictions(
         }
     }
 
-    DisposableEffect(stopIds, active) {
-        connect(stopIds, active, ::onJoin, ::onMessage)
-        onDispose {
-            predictionsRepository.disconnect()
+    LaunchedEffect(stopIds, active) {
+        if (active) {
             if (loadedStopIds != stopIds) {
                 predictions = null
                 loadedStopIds = null
             }
-        }
+            connect(stopIds, active, ::onJoin, ::onMessage)
+        } else predictionsRepository.disconnect()
     }
 
     LaunchedEffect(predictions) { if (active) checkStale() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToTripPredictions.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.viewModel.composeStateHelpers
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,13 +40,13 @@ internal fun subscribeToTripPredictions(
     val tripId = tripFilter?.tripId
 
     var predictions: PredictionsStreamDataResponse? by remember { mutableStateOf(null) }
+    var loadedTripId: String? by remember { mutableStateOf(null) }
 
     fun connect(
         tripId: String?,
         active: Boolean,
         onReceive: (ApiResult<PredictionsStreamDataResponse>) -> Unit,
     ) {
-        tripPredictionsRepository.disconnect()
         if (tripId != null && active) {
             tripPredictionsRepository.connect(tripId, errorKey, onReceive)
         }
@@ -58,6 +57,7 @@ internal fun subscribeToTripPredictions(
         when (message) {
             is ApiResult.Ok -> {
                 predictions = message.data
+                loadedTripId = tripId
             }
             is ApiResult.Error ->
                 println("Trip predictions stream failed to join: ${message.message}")
@@ -79,11 +79,11 @@ internal fun subscribeToTripPredictions(
         }
     }
 
-    DisposableEffect(tripId, active) {
-        predictions = null
-
-        connect(tripId, active, ::onReceive)
-        onDispose { tripPredictionsRepository.disconnect() }
+    LaunchedEffect(tripId, active) {
+        if (active) {
+            if (loadedTripId != tripId) predictions = null
+            connect(tripId, active, ::onReceive)
+        } else tripPredictionsRepository.disconnect()
     }
 
     LaunchedEffect(predictions) { checkStale() }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToVehicle.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.viewModel.composeStateHelpers
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,7 +31,6 @@ internal fun subscribeToVehicle(
     val errorKey = errorKey.withSuffix("subscribeToVehicle")
 
     fun connect(vehicleId: String?, onReceive: (ApiResult<VehicleStreamDataResponse>) -> Unit) {
-        vehicleRepository.disconnect()
         if (active) vehicleId?.let { vehicleRepository.connect(it, errorKey, onReceive) }
     }
 
@@ -70,11 +69,17 @@ internal fun subscribeToVehicle(
         }
     }
 
-    DisposableEffect(vehicleId, active) {
-        vehicle = null
-        lastResponseStale = false
-        connect(vehicleId, ::onReceive)
-        onDispose { vehicleRepository.disconnect() }
+    LaunchedEffect(vehicleId, active) {
+        if (active) {
+            if (vehicle?.id != vehicleId) {
+                vehicle = null
+                lastResponseStale = false
+            }
+            connect(vehicleId, ::onReceive)
+        } else {
+            lastResponseStale = false
+            vehicleRepository.disconnect()
+        }
     }
 
     return VehicleSubscriptionResponse(vehicle, lastResponseStale)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
@@ -73,20 +73,32 @@ class AlertsRepositoryTests {
         alertsRepo.connect(onReceive = {})
         advanceUntilIdle()
         verify { alertsRepo.disconnect() }
+        advanceUntilIdle()
         verify { channel.detach() }
     }
 
     @Test
-    fun testChannelClearedOnLeave() {
+    fun testChannelClearedOnLeave() = runTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val alertsRepo = AlertsRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
-        every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
-        alertsRepo.channel = socket.getChannel(topic = AlertsChannel.topic, params = emptyMap())
+        val alertsRepo =
+            AlertsRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
+        every { socket.getChannel(any(), any()) } returns mock(MockMode.autofill)
+        val channel = socket.getChannel(topic = AlertsChannel.topic, params = emptyMap())
+        every { channel.detach() } returns mock(MockMode.autofill)
+
+        alertsRepo.channel = channel
         assertNotNull(alertsRepo.channel)
 
         alertsRepo.disconnect()
+        advanceUntilIdle()
+        verify { channel.detach() }
         assertNull(alertsRepo.channel)
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/PredictionsRepositoryTests.kt
@@ -137,8 +137,10 @@ class PredictionsRepositoryTests : KoinTest {
         assertNotNull(predictionsRepo.channel)
 
         predictionsRepo.disconnect()
+        advanceUntilIdle()
 
         verify { channel.detach() }
+        assertNull(predictionsRepo.channel)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/VehiclesRepositoryTest.kt
@@ -63,20 +63,33 @@ class VehiclesRepositoryTest : KoinTest {
     }
 
     @Test
-    fun testChannelClearedOnLeave() {
+    fun testChannelClearedOnLeave() = runTest {
         val socket = mock<PhoenixSocket>(MockMode.autofill)
         val debugRepo = MockDebugRepository()
         val errorBannerRepo = MockErrorBannerStateRepository()
-        val vehiclesRepo = VehiclesRepository(socket, debugRepo, errorBannerRepo, Dispatchers.IO)
-        every { socket.getChannel(any(), any()) } returns mock<PhoenixChannel>(MockMode.autofill)
-        vehiclesRepo.channel =
+        val vehiclesRepo =
+            VehiclesRepository(
+                socket,
+                debugRepo,
+                errorBannerRepo,
+                StandardTestDispatcher(testScheduler),
+            )
+        every { socket.getChannel(any(), any()) } returns mock(MockMode.autofill)
+
+        val channel =
             socket.getChannel(
                 topic = VehiclesOnRouteChannel(emptyList(), 0).topic,
                 params = emptyMap(),
             )
+        every { channel.detach() } returns mock(MockMode.autofill)
+
+        vehiclesRepo.channel = channel
+
         assertNotNull(vehiclesRepo.channel)
 
         vehiclesRepo.disconnect()
+        advanceUntilIdle()
+        verify { channel.detach() }
         assertNull(vehiclesRepo.channel)
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
@@ -183,11 +183,11 @@ class StopDetailsViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             awaitItemSatisfying { it.routeData is StopDetailsViewModel.RouteData.Unfiltered }
             assertEquals(1, predictionLoadCount)
-            assertEquals(1, predictionDisconnectCount)
+            assertEquals(0, predictionDisconnectCount)
             viewModel.setActive(active = false, wasSentToBackground = false)
             advanceUntilIdle()
             assertEquals(1, predictionLoadCount)
-            assertEquals(3, predictionDisconnectCount)
+            assertEquals(1, predictionDisconnectCount)
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsViewModelTest.kt
@@ -273,11 +273,11 @@ class TripDetailsViewModelTest : KoinTest {
         testViewModelFlow(viewModel).test {
             awaitItemSatisfying { it.tripData?.trip?.id == trip.id }
             assertEquals(1, predictionLoadCount)
-            assertEquals(1, predictionDisconnectCount)
+            assertEquals(0, predictionDisconnectCount)
             viewModel.setActive(active = false, wasSentToBackground = false)
             advanceUntilIdle()
             assertEquals(1, predictionLoadCount)
-            assertEquals(3, predictionDisconnectCount)
+            assertEquals(1, predictionDisconnectCount)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
### Summary

_Ticket:_ [Identify persistent shimmer loading on launch root cause](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215129545871646?focus=true)

This hopefully fixes the infinite loading issues for good. It seems like it was a combination of a few factors coming together.

Ultimately, the root cause was a race condition where the channel disconnect would sometimes be called right after the connect. We were also calling disconnect unnecessarily multiple times, partly because were using `DisposableEffect`, which was complicating the disconnect calls.

Now, we only call a single channel detach within the channel owner and the mutex before attempting to make a new connection, and we wait for the disconnection to complete before starting the new channel attach. All the `DisposableEffect` blocks are also changed to basic `LaunchedEffect` which clear existing data if the relevant params have changed, and connect on active and disconnect on inactive. This seems to be more reliable when backgrounding and changing pages.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
  ~- [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

Verified the correct behavior on Android and iOS, updated existing tests to pass, and could not reproduce the infinite loading issue after these changes.