### PR TITLE
Filter out arrival only atypical routes

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1211,8 +1211,11 @@ public data class RouteCardData(
             // If we don’t have any upcoming trips to tell us whether or not service is
             // arrival-only, trust the typical-last-stop-on-route-pattern state.
             val shouldBeFilteredAsArrivalOnly =
-                this.isTypicalLastStopOnRoutePattern(stop, globalData) &&
-                    (this.upcomingTrips?.isArrivalOnly() ?: true)
+                this.isLastStopOnRoutePattern(
+                    stop,
+                    globalData,
+                    listOf(RoutePattern.Typicality.Typical, RoutePattern.Typicality.Atypical),
+                ) && (this.upcomingTrips?.isArrivalOnly() ?: true)
 
             val hasUnseenTypicalPattern =
                 routePatterns?.any {
@@ -1228,12 +1231,13 @@ public data class RouteCardData(
                 !(shuttleWithNoServiceToday)
         }
 
-        private fun isTypicalLastStopOnRoutePattern(
+        private fun isLastStopOnRoutePattern(
             stop: Stop,
             globalData: GlobalResponse,
+            typicalityList: List<RoutePattern.Typicality>,
         ): Boolean {
             return this.routePatterns
-                ?.filter { it.typicality == RoutePattern.Typicality.Typical }
+                ?.filter { typicalityList.contains(it.typicality) }
                 ?.map { it.representativeTripId }
                 ?.takeUnless { it.isEmpty() }
                 ?.all { representativeTripId ->

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1211,11 +1211,8 @@ public data class RouteCardData(
             // If we don’t have any upcoming trips to tell us whether or not service is
             // arrival-only, trust the typical-last-stop-on-route-pattern state.
             val shouldBeFilteredAsArrivalOnly =
-                this.isLastStopOnRoutePattern(
-                    stop,
-                    globalData,
-                    listOf(RoutePattern.Typicality.Typical, RoutePattern.Typicality.Atypical),
-                ) && (this.upcomingTrips?.isArrivalOnly() ?: true)
+                this.isLastStopOnRoutePattern(stop, globalData) &&
+                    (this.upcomingTrips?.isArrivalOnly() ?: true)
 
             val hasUnseenTypicalPattern =
                 routePatterns?.any {
@@ -1231,15 +1228,12 @@ public data class RouteCardData(
                 !(shuttleWithNoServiceToday)
         }
 
-        private fun isLastStopOnRoutePattern(
-            stop: Stop,
-            globalData: GlobalResponse,
-            typicalityList: List<RoutePattern.Typicality>,
-        ): Boolean {
+        private fun isLastStopOnRoutePattern(stop: Stop, globalData: GlobalResponse): Boolean {
             return this.routePatterns
-                ?.filter { typicalityList.contains(it.typicality) }
+                ?.filter { it.typicality == RoutePattern.Typicality.Typical }
+                ?.ifEmpty { this.routePatterns }
+                ?.takeIf { it.isNotEmpty() }
                 ?.map { it.representativeTripId }
-                ?.takeUnless { it.isEmpty() }
                 ?.all { representativeTripId ->
                     val representativeTrip = globalData.trips[representativeTripId]
                     val lastStopIdInPattern =


### PR DESCRIPTION
### Summary

_Ticket:_ [Filter out arrival-only trips for stops that only serve non-typical trips](https://app.asana.com/1/15492006741476/project/1205425564113216/task/1216302146592360?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Filter out arrival only atypical routes

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing


What testing have you done?
- Tested that atypical routes are being filtered out after the change

| Before | After |
| -- | -- |
| <img width="240" height="524" alt="IMG_0001" src="https://github.com/user-attachments/assets/c0f31335-1712-4783-bb1d-425f271b2532" /> | <img width="240" height="524" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-08 at 11 39 25" src="https://github.com/user-attachments/assets/45d82e2a-d10f-4ee4-9fab-4c159491a596" /> |


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
