### PR TITLE
fix: Remove landmark reordering

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapLayerManager.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/MapLayerManager.kt
@@ -5,7 +5,6 @@ import android.graphics.drawable.BitmapDrawable
 import android.util.Log
 import com.mapbox.geojson.FeatureCollection
 import com.mapbox.maps.GeoJSONSourceData
-import com.mapbox.maps.LayerPosition
 import com.mapbox.maps.MapboxMap
 import com.mapbox.maps.extension.style.layers.Layer as MapboxLayer
 import com.mapbox.maps.extension.style.layers.addLayer
@@ -120,19 +119,6 @@ class MapLayerManager(val map: MapboxMap, val context: Context) : IMapLayerManag
                 for (layer in oldLayers) {
                     if (layer.startsWith(RouteLayerGenerator.routeLayerId)) {
                         map.removeStyleLayer(layer)
-                    }
-                }
-                for (landmarkLayer in landmarkLayerIds) {
-                    if (map.styleLayerExists(landmarkLayer)) {
-                        try {
-                            // Make sure landmark icons aren't drawn below route lines
-                            map.moveStyleLayer(
-                                landmarkLayer,
-                                LayerPosition(routeAnchorLayerId, null, null),
-                            )
-                        } catch (_: Exception) {
-                            println("Failed to move landmark layer $landmarkLayer above routes")
-                        }
                     }
                 }
             }


### PR DESCRIPTION
### Summary

_Ticket:_ [Sentry | Cannot find layer with id 'puck-anchor-layer'](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216115941490135?focus=true)

This is no longer necessary after anchor layers are defined in Mapbox studio.

### Testing

Tested on staging with new Mapbox layer ordering, verified that the landmark icons show up as expected