### PR TITLE
refactor: pull Matcher out of Alert.InformedEntity

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.model.Alert.InformedEntity.Matcher
 import com.mbta.tid.mbta_app.model.RoutePattern.Typicality
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -66,7 +65,7 @@ internal constructor(
      */
     public fun tripSpecificSignificance(trip: String): AlertSignificance? {
 
-        if (this.anyInformedEntitySatisfies { checkTripStrict(trip) }) {
+        if (this.anyInformedEntity { it.trip == trip }) {
             if (effect == Effect.Cancellation) {
                 return AlertSignificance.Major
             } else {
@@ -301,158 +300,25 @@ internal constructor(
             @SerialName("using_wheelchair") UsingWheelchair,
         }
 
-        internal sealed class Matcher<out T> {
-            data class Data<T>(val value: T) : Matcher<T>()
-
-            data object Wildcard : Matcher<Nothing>()
-        }
-
-        internal fun appliesTo(
-            directionId: Matcher<Int> = Matcher.Wildcard,
-            facilityId: Matcher<String> = Matcher.Wildcard,
-            routeId: Matcher<Route.Id> = Matcher.Wildcard,
-            routeType: Matcher<RouteType> = Matcher.Wildcard,
-            stopId: Matcher<String> = Matcher.Wildcard,
-            tripId: Matcher<String> = Matcher.Wildcard,
+        internal fun matches(
+            activity: Matcher<Activity> = Matcher.Wildcard(),
+            directionId: Matcher<Int> = Matcher.Wildcard(),
+            facilityId: Matcher<String> = Matcher.Wildcard(),
+            routeId: Matcher<Route.Id> = Matcher.Wildcard(),
+            routeType: Matcher<RouteType> = Matcher.Wildcard(),
+            stopId: Matcher<String> = Matcher.Wildcard(),
+            tripId: Matcher<String> = Matcher.Wildcard(),
         ): Boolean {
-            fun <T> matches(expected: Matcher<T>, actual: T?): Boolean =
-                when (expected) {
-                    is Matcher.Data -> actual == null || expected.value == actual
-                    Matcher.Wildcard -> true
-                }
+            fun <T : Any> matches(expected: Matcher<T>, actual: T?): Boolean =
+                actual == null || expected.matches(actual)
 
-            return matches(directionId, this.directionId) &&
+            return activities.any { matches(activity, it) } &&
+                matches(directionId, this.directionId) &&
                 matches(facilityId, this.facility) &&
                 matches(routeId, this.route) &&
                 matches(routeType, this.routeType) &&
                 matches(stopId, this.stop) &&
                 matches(tripId, this.trip)
-        }
-
-        /** A more expressive way to represent a set of constraints than [appliesTo]. */
-        internal inner class PredicateBuilder {
-            var isSatisfied = true
-
-            fun checkActivity(activity: Activity) {
-                if (!isSatisfied) return
-                if (activity !in this@InformedEntity.activities) {
-                    isSatisfied = false
-                }
-            }
-
-            fun checkActivityIn(vararg activities: Activity) = checkActivityIn(activities.toList())
-
-            fun checkActivityIn(activities: Collection<Activity>) {
-                if (!isSatisfied) return
-                if (!this@InformedEntity.activities.any { it in activities }) {
-                    isSatisfied = false
-                }
-            }
-
-            fun checkDirection(directionId: Matcher<Int>) {
-                if (!isSatisfied) return
-                if (this@InformedEntity.directionId == null) return
-                when (directionId) {
-                    Matcher.Wildcard -> return
-                    is Matcher.Data<Int> -> {
-                        if (this@InformedEntity.directionId != directionId.value) {
-                            isSatisfied = false
-                        }
-                    }
-                }
-            }
-
-            fun checkRoute(route: Route) {
-                checkRoute(route.id, route.type)
-            }
-
-            fun checkRoute(routeId: Route.Id, routeType: RouteType) {
-                if (!isSatisfied) return
-                checkRouteType(Matcher.Data(routeType))
-                checkRouteIdIn(listOf(routeId))
-            }
-
-            fun checkRouteIdIn(routeIds: Collection<Route.Id>) {
-                if (!isSatisfied) return
-                if (this@InformedEntity.route == null) return
-                if (this@InformedEntity.route !in routeIds) {
-                    isSatisfied = false
-                }
-            }
-
-            fun checkRouteType(routeType: Matcher<RouteType>) {
-                if (!isSatisfied) return
-                when (routeType) {
-                    Matcher.Wildcard -> return
-
-                    is Matcher.Data -> {
-                        if (this@InformedEntity.routeType == null) return
-                        if (this@InformedEntity.routeType != routeType.value) {
-                            isSatisfied = false
-                        }
-                    }
-                }
-            }
-
-            fun checkStop(stopId: Matcher<String>) {
-                if (!isSatisfied) return
-                when (stopId) {
-                    Matcher.Wildcard -> return
-
-                    is Matcher.Data -> {
-                        if (this@InformedEntity.stop == null) return
-                        if (this@InformedEntity.stop != stopId.value) {
-                            isSatisfied = false
-                        }
-                    }
-                }
-            }
-
-            fun checkStopIn(stopIds: Matcher<Collection<String>>) {
-                if (!isSatisfied) return
-                if (this@InformedEntity.stop == null) return
-                when (stopIds) {
-                    Matcher.Wildcard -> return
-                    is Matcher.Data -> {
-                        if (this@InformedEntity.stop !in stopIds.value) {
-                            isSatisfied = false
-                        }
-                    }
-                }
-            }
-
-            fun checkTrip(tripId: Matcher<String>) {
-                if (!isSatisfied) return
-                when (tripId) {
-                    Matcher.Wildcard -> return
-                    is Matcher.Data<*> -> {
-                        if (this@InformedEntity.trip == null) return
-                        if (this@InformedEntity.trip != tripId.value) {
-                            isSatisfied = false
-                        }
-                    }
-                }
-            }
-
-            fun checkTripStrict(tripId: String) {
-                if (!isSatisfied) return
-                if (this@InformedEntity.trip != tripId) {
-                    isSatisfied = false
-                }
-            }
-
-            fun checkNullTrip() {
-                if (!isSatisfied) return
-                if (this@InformedEntity.trip != null) {
-                    isSatisfied = false
-                }
-            }
-        }
-
-        internal fun satisfies(block: PredicateBuilder.() -> Unit): Boolean {
-            val builder = PredicateBuilder()
-            builder.block()
-            return builder.isSatisfied
         }
     }
 
@@ -489,9 +355,17 @@ internal constructor(
     internal fun anyInformedEntity(predicate: (InformedEntity) -> Boolean) =
         informedEntity.any(predicate)
 
-    internal fun anyInformedEntitySatisfies(
-        predicateBuilder: InformedEntity.PredicateBuilder.() -> Unit
-    ) = informedEntity.any { it.satisfies(predicateBuilder) }
+    internal fun anyInformedEntityMatches(
+        activity: Matcher<InformedEntity.Activity> = Matcher.Wildcard(),
+        directionId: Matcher<Int> = Matcher.Wildcard(),
+        facilityId: Matcher<String> = Matcher.Wildcard(),
+        routeId: Matcher<Route.Id> = Matcher.Wildcard(),
+        routeType: Matcher<RouteType> = Matcher.Wildcard(),
+        stopId: Matcher<String> = Matcher.Wildcard(),
+        tripId: Matcher<String> = Matcher.Wildcard(),
+    ) = informedEntity.any {
+        it.matches(activity, directionId, facilityId, routeId, routeType, stopId, tripId)
+    }
 
     internal fun matchingEntities(predicate: (InformedEntity) -> Boolean) =
         informedEntity.filter(predicate)
@@ -577,14 +451,14 @@ internal constructor(
         ): List<Alert> {
             return alerts
                 .filter { alert ->
-                    alert.anyInformedEntitySatisfies {
-                        checkActivity(InformedEntity.Activity.Board)
-                        checkDirection(Matcher.Data(directionId))
-                        checkRouteIdIn(routeIds)
-                        checkRouteType(Matcher.Data(routeType))
-                        checkStopIn(stopIds?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
-                        checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
-                    }
+                    alert.anyInformedEntityMatches(
+                        activity = Matcher.Data(InformedEntity.Activity.Board),
+                        directionId = Matcher.Data(directionId),
+                        routeId = Matcher.AnyOf(routeIds),
+                        routeType = Matcher.Data(routeType),
+                        stopId = stopIds?.let { Matcher.AnyOf(it) } ?: Matcher.Wildcard(),
+                        tripId = tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard(),
+                    )
                 }
                 .distinct()
         }
@@ -602,12 +476,10 @@ internal constructor(
             return alerts
                 .filter {
                     it.effect == Effect.ElevatorClosure &&
-                        it.anyInformedEntity { entity ->
-                            entity.activities.contains(InformedEntity.Activity.UsingWheelchair) &&
-                                stopIds.any { stopId ->
-                                    entity.appliesTo(stopId = InformedEntity.Matcher.Data(stopId))
-                                }
-                        }
+                        it.anyInformedEntityMatches(
+                            activity = Matcher.Data(InformedEntity.Activity.UsingWheelchair),
+                            stopId = Matcher.AnyOf(stopIds),
+                        )
                 }
                 .distinct()
         }
@@ -645,14 +517,16 @@ internal constructor(
             val relevantAlerts =
                 alerts
                     .filter {
-                        it.anyInformedEntitySatisfies {
-                            checkActivityIn(
-                                InformedEntity.Activity.Exit,
-                                InformedEntity.Activity.Ride,
-                            )
-                            checkDirection(Matcher.Data(trip.directionId))
-                            checkRoute(trip.routeId, routeType)
-                        }
+                        it.anyInformedEntityMatches(
+                            activity =
+                                Matcher.AnyOf(
+                                    InformedEntity.Activity.Exit,
+                                    InformedEntity.Activity.Ride,
+                                ),
+                            directionId = Matcher.Data(trip.directionId),
+                            routeId = Matcher.Data(trip.routeId),
+                            routeType = Matcher.Data(routeType),
+                        )
                     }
                     .toList()
 
@@ -660,9 +534,7 @@ internal constructor(
             val targetStopAlertIds =
                 relevantAlerts
                     .filter {
-                        it.anyInformedEntitySatisfies {
-                            checkStopIn(Matcher.Data(targetStopWithChildren))
-                        }
+                        it.anyInformedEntityMatches(stopId = Matcher.AnyOf(targetStopWithChildren))
                     }
                     .map { it.id }
                     .toSet()
@@ -670,7 +542,7 @@ internal constructor(
             val downstreamStops = stopIds.subList(indexOfTargetStopInPattern + 1, stopIds.size)
             val tripAlerts = downstreamStops.flatMap { stop ->
                 relevantAlerts.filter {
-                    it.anyInformedEntitySatisfies { checkStop(Matcher.Data(stop)) } &&
+                    it.anyInformedEntityMatches(stopId = Matcher.Data(stop)) &&
                         !targetStopAlertIds.contains(it.id)
                 }
             }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStop.kt
@@ -42,15 +42,12 @@ public class AlertAssociatedStop internal constructor(internal val stop: Stop) {
                 if (greenRoutes.contains(pattern.routeId) && !pattern.isTypical()) continue
                 relevantAlerts =
                     nullStopAlerts.filter { alert ->
-                        alert.anyInformedEntity {
-                            it.appliesTo(
-                                stopId = Alert.InformedEntity.Matcher.Data(stop.id),
-                                routeId = Alert.InformedEntity.Matcher.Data(pattern.routeId),
-                                routeType = Alert.InformedEntity.Matcher.Data(route.type),
-                                directionId =
-                                    Alert.InformedEntity.Matcher.Data(pattern.directionId),
-                            )
-                        }
+                        alert.anyInformedEntityMatches(
+                            stopId = Matcher.Data(stop.id),
+                            routeId = Matcher.Data(pattern.routeId),
+                            routeType = Matcher.Data(route.type),
+                            directionId = Matcher.Data(pattern.directionId),
+                        )
                     } + relevantAlerts
             }
 
@@ -186,14 +183,12 @@ private fun statesForPattern(
 
     val matchingAlert =
         serviceAlerts.find { alert ->
-            alert.anyInformedEntity {
-                it.appliesTo(
-                    stopId = Alert.InformedEntity.Matcher.Data(stop.id),
-                    routeId = Alert.InformedEntity.Matcher.Data(pattern.routeId),
-                    routeType = Alert.InformedEntity.Matcher.Data(route.type),
-                    directionId = Alert.InformedEntity.Matcher.Data(pattern.directionId),
-                )
-            }
+            alert.anyInformedEntityMatches(
+                stopId = Matcher.Data(stop.id),
+                routeId = Matcher.Data(pattern.routeId),
+                routeType = Matcher.Data(route.type),
+                directionId = Matcher.Data(pattern.directionId),
+            )
         } ?: return StopAlertState.Normal
     if (matchingAlert.effect == Alert.Effect.Shuttle) {
         return StopAlertState.Shuttle

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummary.kt
@@ -436,12 +436,13 @@ public sealed class AlertSummary {
                         val stopIdsOnPattern =
                             stopIds
                                 ?.filter { stopOnTrip ->
-                                    alert.anyInformedEntitySatisfies {
+                                    alert.anyInformedEntityMatches(
                                         // `affectedStops` only includes parent stops, here we check
                                         // if the child stops on each pattern are affected
-                                        checkStop(Alert.InformedEntity.Matcher.Data(stopOnTrip))
-                                        checkRoute(pattern.routeId, routeType)
-                                    }
+                                        stopId = Matcher.Data(stopOnTrip),
+                                        routeId = Matcher.Data(pattern.routeId),
+                                        routeType = Matcher.Data(routeType),
+                                    )
                                 }
                                 ?.mapNotNull { global.stops[it]?.resolveParent(global)?.id }
 
@@ -465,9 +466,9 @@ public sealed class AlertSummary {
 
         private fun matchesWholeRoute(alert: Alert, routeId: Route.Id, directionId: Int): Boolean =
             alert.anyInformedEntity {
-                it.appliesTo(
-                    directionId = Alert.InformedEntity.Matcher.Data(directionId),
-                    routeId = Alert.InformedEntity.Matcher.Data(routeId),
+                it.matches(
+                    directionId = Matcher.Data(directionId),
+                    routeId = Matcher.Data(routeId),
                 ) && it.trip == null && it.stop == null && it.facility == null
             }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Matcher.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Matcher.kt
@@ -1,0 +1,19 @@
+package com.mbta.tid.mbta_app.model
+
+public sealed class Matcher<T : Any> {
+    public data class Data<T : Any>(val value: T) : Matcher<T>() {
+        override fun matches(actual: T) = actual == this.value
+    }
+
+    public data class AnyOf<T : Any>(val values: Collection<T>) : Matcher<T>() {
+        public constructor(vararg values: T) : this(values.toList())
+
+        override fun matches(actual: T) = actual in this.values
+    }
+
+    public class Wildcard<T : Any> : Matcher<T>() {
+        override fun matches(actual: T) = true
+    }
+
+    internal abstract fun matches(actual: T): Boolean
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.model.Alert.InformedEntity.Matcher
 import com.mbta.tid.mbta_app.model.UpcomingFormat.NoTripsFormat
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
@@ -163,8 +162,7 @@ public data class RouteCardData(
         private fun majorAlertAffectingAllTrips(atTime: EasternTimeInstant) =
             alertsHere.firstOrNull {
                 it.significance(atTime) >= AlertSignificance.Major &&
-                    (it.informedEntity.isEmpty() ||
-                        it.anyInformedEntitySatisfies { checkNullTrip() })
+                    (it.informedEntity.isEmpty() || it.anyInformedEntity { it.trip == null })
             }
 
         /**
@@ -179,20 +177,20 @@ public data class RouteCardData(
                 (it.significance(atTime) < AlertSignificance.Major &&
                     it.significance(atTime) >= AlertSignificance.Secondary) ||
                     (it.significance(atTime) == AlertSignificance.Major &&
-                        !it.anyInformedEntitySatisfies { checkNullTrip() })
+                        !it.anyInformedEntity { it.trip == null })
             } ?: alertsDownstream.firstOrNull()
 
         public fun alertsHere(tripId: String? = null): List<Alert> = alertsHere.filter { alert ->
-            alert.anyInformedEntitySatisfies {
-                checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
-            }
+            alert.anyInformedEntityMatches(
+                tripId = tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard()
+            )
         }
 
         public fun alertsDownstream(tripId: String? = null): List<Alert> =
             alertsDownstream.filter { alert ->
-                alert.anyInformedEntitySatisfies {
-                    checkTrip(tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard)
-                }
+                alert.anyInformedEntityMatches(
+                    tripId = tripId?.let { Matcher.Data(it) } ?: Matcher.Wildcard()
+                )
             }
 
         private data class PotentialService(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopList.kt
@@ -489,15 +489,13 @@ constructor(val trip: Trip, val stops: List<Entry>, val startTerminalEntry: Entr
             val alert =
                 alertsData?.alerts?.values?.find { alert ->
                     (entryTime?.let { alert.isActive(it) } ?: true) &&
-                        alert.anyInformedEntity {
-                            it.appliesTo(
-                                directionId = Alert.InformedEntity.Matcher.Data(directionId),
-                                routeId = Alert.InformedEntity.Matcher.Data(route.id),
-                                routeType = Alert.InformedEntity.Matcher.Data(entryRouteType),
-                                stopId = Alert.InformedEntity.Matcher.Data(entry.stopId),
-                                tripId = Alert.InformedEntity.Matcher.Data(tripId),
-                            )
-                        } &&
+                        alert.anyInformedEntityMatches(
+                            directionId = Matcher.Data(directionId),
+                            routeId = Matcher.Data(route.id),
+                            routeType = Matcher.Data(entryRouteType),
+                            stopId = Matcher.Data(entry.stopId),
+                            tripId = Matcher.Data(tripId),
+                        ) &&
                         // there's no UI yet for secondary alerts in trip details
                         (entryTime?.let { alert.significance(it) }
                             ?: alert.intrinsicSignificance) >= AlertSignificance.Major

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponse.kt
@@ -7,6 +7,7 @@ import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RoutePattern
@@ -206,8 +207,11 @@ internal constructor(
 
     public fun getAlertAffectedStops(alert: Alert?, routes: List<Route>?): List<Stop>? {
         if (alert == null || routes == null) return null
-        val routeEntities = routes.flatMap { route ->
-            alert.matchingEntities { entity -> entity.satisfies { checkRoute(route) } }
+        val routeEntities = alert.matchingEntities { entity ->
+            entity.matches(
+                routeId = Matcher.AnyOf(routes.map { it.id }),
+                routeType = Matcher.AnyOf(routes.map { it.type }),
+            )
         }
         val parentStops = routeEntities.mapNotNull {
             this.stops[it.stop]?.resolveParent(this.stops)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -1109,7 +1109,7 @@ class AlertTest {
     }
 
     @Test
-    fun `anyInformedEntitySatisfies checkRoute`() {
+    fun `anyInformedEntityMatches route`() {
         val objects = ObjectCollectionBuilder()
 
         val alert = objects.alert {
@@ -1119,9 +1119,17 @@ class AlertTest {
             )
         }
 
-        assertTrue(alert.anyInformedEntitySatisfies { checkRoute(Route.Id("1"), RouteType.BUS) })
+        assertTrue(
+            alert.anyInformedEntityMatches(
+                routeId = Matcher.Data(Route.Id("1")),
+                routeType = Matcher.Data(RouteType.BUS),
+            )
+        )
         assertFalse(
-            alert.anyInformedEntitySatisfies { checkRoute(Route.Id("CR"), RouteType.COMMUTER_RAIL) }
+            alert.anyInformedEntityMatches(
+                routeId = Matcher.Data(Route.Id("CR")),
+                routeType = Matcher.Data(RouteType.COMMUTER_RAIL),
+            )
         )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/GlobalResponseTest.kt
@@ -308,7 +308,7 @@ class GlobalResponseTest {
         val route = objects.route()
         lateinit var childStop: Stop
         val parentStation = objects.stop { childStop = childStop() }
-        val alert = objects.alert { informedEntity(listOf(), stop = childStop.id) }
+        val alert = objects.alert { informedEntity(stop = childStop.id) }
 
         val affectedStops = GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route))
         assertEquals(affectedStops, listOf(parentStation))
@@ -324,9 +324,9 @@ class GlobalResponseTest {
         val stop2 = objects.stop()
         val stop3 = objects.stop()
         val alert = objects.alert {
-            informedEntity(listOf(), stop = stop1.id)
-            informedEntity(listOf(), route = route1.id.idText, stop = stop2.id)
-            informedEntity(listOf(), route = route2.id.idText, stop = stop3.id)
+            informedEntity(stop = stop1.id)
+            informedEntity(route = route1.id.idText, stop = stop2.id)
+            informedEntity(route = route2.id.idText, stop = stop3.id)
         }
 
         val affectedStops = GlobalResponse(objects).getAlertAffectedStops(alert, listOf(route1))
@@ -342,10 +342,10 @@ class GlobalResponseTest {
         val stop1 = objects.stop()
         val stop2 = objects.stop()
         val alert = objects.alert {
-            informedEntity(listOf(), route = route1.id.idText, stop = stop1.id)
-            informedEntity(listOf(), route = route1.id.idText, stop = stop2.id)
-            informedEntity(listOf(), route = route2.id.idText, stop = stop1.id)
-            informedEntity(listOf(), route = route2.id.idText, stop = stop2.id)
+            informedEntity(route = route1.id.idText, stop = stop1.id)
+            informedEntity(route = route1.id.idText, stop = stop2.id)
+            informedEntity(route = route2.id.idText, stop = stop1.id)
+            informedEntity(route = route2.id.idText, stop = stop2.id)
         }
 
         val affectedStops =


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

If we’re going to use `Matcher` for selecting alert summaries, this seems like a reasonable move, and with `AnyOf` it lets us simplify a few things.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
