### PR TITLE
fix: Missing GLX stops on the map

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
@@ -1,5 +1,6 @@
 package com.mbta.tid.mbta_app.model
 
+import com.mbta.tid.mbta_app.model.RoutePattern.Typicality
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -111,37 +112,42 @@ public data class GlobalMapData(
                             }
                         }
 
+                fun typical(pattern: RoutePattern) =
+                    pattern.isTypical() || pattern.typicality == Typicality.CanonicalOnly
+
                 val isTerminal =
-                    patterns.any { pattern ->
-                        val route = globalData.routes[pattern.routeId]
-                        if (route == null || route.type == RouteType.BUS) {
-                            // Don't mark bus terminals, only rail and ferry
-                            return@any false
+                    patterns
+                        .filter(::typical)
+                        .ifEmpty { patterns }
+                        .any { pattern ->
+                            val route = globalData.routes[pattern.routeId]
+                            if (route == null || route.type == RouteType.BUS) {
+                                // Don't mark bus terminals, only rail and ferry
+                                return@any false
+                            }
+                            val trip =
+                                globalData.trips[pattern.representativeTripId] ?: return@any false
+                            val tripIds = trip.stopIds ?: listOf()
+                            if (tripIds.size < 2) {
+                                return@any false
+                            }
+                            return@any setOf(tripIds.first(), tripIds.last())
+                                .intersect(stopIdSet)
+                                .isNotEmpty()
                         }
-                        val trip =
-                            globalData.trips[pattern.representativeTripId] ?: return@any false
-                        val tripIds = trip.stopIds ?: listOf()
-                        if (tripIds.size < 2) {
-                            return@any false
-                        }
-                        return@any setOf(tripIds.first(), tripIds.last())
-                            .intersect(stopIdSet)
-                            .isNotEmpty()
-                    }
 
                 val allRoutes = mutableSetOf<Route>()
                 val typicalRouteDirections = mutableMapOf<Route.Id, MutableSet<Int>>()
 
                 for (pattern in patterns.sorted()) {
-                    if (
-                        pattern.isTypical() ||
-                            pattern.typicality == RoutePattern.Typicality.CanonicalOnly
-                    ) {
+                    if (typical(pattern)) {
                         typicalRouteDirections
                             .getOrPut(pattern.routeId, ::mutableSetOf)
                             .add(pattern.directionId)
                     }
                     val route = globalData.routes[pattern.routeId] ?: continue
+                    // Only include non-typical patterns for bus routes
+                    if (route.type != RouteType.BUS && !typical(pattern)) continue
                     allRoutes.add(route)
                 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalMapDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/GlobalMapDataTest.kt
@@ -33,6 +33,11 @@ internal class GlobalMapDataTest {
                 id = "E"
                 locationType = LocationType.STATION
             }
+        val stopF =
+            objects.stop {
+                id = "F"
+                locationType = LocationType.STOP
+            }
 
         val routeRed =
             objects.route {
@@ -89,6 +94,11 @@ internal class GlobalMapDataTest {
                 id = "Bus1"
                 typicality = RoutePattern.Typicality.Typical
             }
+        val patternBusAtypical =
+            objects.routePattern(routeBus) {
+                id = "Bus2"
+                typicality = RoutePattern.Typicality.Atypical
+            }
         val patternCR =
             objects.routePattern(routeCR) {
                 id = "CR1"
@@ -119,6 +129,7 @@ internal class GlobalMapDataTest {
                         Pair(stopC.id, listOf(patternBus.id, patternSilver.id)),
                         Pair(stopD.id, listOf(patternSilver.id)),
                         Pair(stopE.id, listOf(patternSilver.id)),
+                        Pair(stopF.id, listOf(patternBusAtypical.id)),
                     ),
             )
 
@@ -154,9 +165,13 @@ internal class GlobalMapDataTest {
             "Route types are ordered to match the route sort order",
         )
 
-        assertTrue(
+        assertFalse(
             mapData.mapStops["A1"]!!.routeTypes.contains(MapStopRoute.BLUE),
-            "Atypical routes should be included",
+            "Atypical rail routes should not be included",
+        )
+        assertTrue(
+            mapData.mapStops["F"]!!.routeTypes.contains(MapStopRoute.BUS),
+            "Atypical bus routes should be included",
         )
         assertFalse(
             mapData.mapStops["A"]!!.routeTypes.contains(MapStopRoute.BUS),


### PR DESCRIPTION
### Summary

_Ticket:_ [Missing map icons for Medford/Tufts, Union Square, East Somerville](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216216823253886?focus=true)

These were unintentionally removed when some typicality checks were refactored away to support dynamic bus stop visibility in #1611

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

Verified that the stops now show up, and that bus stops still dynamically update when selected trip changes