### PR TITLE
feat(EditFavoritesPage): Pill padding when grouped by stop

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -417,23 +417,26 @@ private fun FavoriteDepartures(
                     }
 
                     Row(
+                        verticalAlignment = Alignment.CenterVertically,
                         modifier =
                             Modifier.background(colorResource(R.color.fill3))
                                 .fillMaxHeight()
-                                .padding(vertical = 10.dp, horizontal = 16.dp)
+                                .padding(vertical = 10.dp)
+                                .padding(horizontal = if (groupByStop) 8.dp else 16.dp)
                                 .semantics(mergeDescendants = true) {
                                     role = Role.Button
                                     onClick(overriddenClickLabel) {
                                         onClick(leaf)
                                         true
                                     }
-                                }
+                                },
                     ) {
                         if (groupByStop) {
                             RoutePill(
                                 (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
                                 (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
                                 type = RoutePillType.Fixed,
+                                modifier = Modifier.padding(end = 8.dp),
                             )
                         }
                         when (formatted) {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -278,7 +278,7 @@ struct FavoriteDepartures: View {
                             route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
                             line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
                             type: .fixed
-                        )
+                        ).padding(.trailing, 8)
                     }
                     switch onEnum(of: formatted) {
                     case let .single(single):
@@ -312,7 +312,8 @@ struct FavoriteDepartures: View {
                         }
                     }
                 }
-                .padding(.horizontal, 16)
+                .padding(.leading, 8)
+                .padding(.trailing, 16)
                 .padding(.vertical, 10)
 
                 if index < leaves.endIndex {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -312,8 +312,7 @@ struct FavoriteDepartures: View {
                         }
                     }
                 }
-                .padding(.leading, groupByStop ? 8 : 16)
-                .padding(.trailing, 16)
+                .padding(.horizontal, groupByStop ? 8 : 16)
                 .padding(.vertical, 10)
 
                 if index < leaves.endIndex {

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -312,7 +312,7 @@ struct FavoriteDepartures: View {
                         }
                     }
                 }
-                .padding(.leading, 8)
+                .padding(.leading, groupByStop ? 8 : 16)
                 .padding(.trailing, 16)
                 .padding(.vertical, 10)
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Group favorites by stop | Edit Favorites View](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215746862487056?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

The Edit Favorites page was already mostly done for group by stop - this just adjusts some padding. 

Note: The AC of the ticket includes "Remove old routeCardData structure from the Favorites VM", but since we are using a feature flag I don't think we actually want to do that at this point.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
 ~ - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?

Ran locally to check padding
<img width="45%" height="1578" alt="image" src="https://github.com/user-attachments/assets/9d542426-4671-4a21-91dd-ede3ef8208ac" /><img width="45%" height="1510" alt="image" src="https://github.com/user-attachments/assets/a35e9991-afe9-4676-a559-a7a48ab32b50" />

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
