### PR TITLE
feat: Switch over to alerts v3 topic

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/state/SubscribeToAlertsTest.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.repositories.MockAlertsRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.usecases.AlertsUsecase
@@ -32,7 +33,8 @@ class SubscribeToAlertsTest {
 
         var connectCount = 0
         val alertsStreamDataResponse = AlertsStreamDataResponse(builder)
-        val alertsRepo = MockAlertsRepository(alertsStreamDataResponse, { connectCount += 1 })
+        val alertsRepo =
+            MockAlertsRepository(AlertsStreamUpdateResponse(builder), { connectCount += 1 })
         val alertsUsecase = AlertsUsecase(alertsRepo, MockGlobalRepository())
 
         var actualData: AlertsStreamDataResponse? = null
@@ -56,7 +58,7 @@ class SubscribeToAlertsTest {
             description = "Description 1"
         }
 
-        val alertsStreamDataResponse = AlertsStreamDataResponse(builder)
+        val alertsStreamDataResponse = AlertsStreamUpdateResponse(builder)
         val alertsRepo =
             MockAlertsRepository(
                 alertsStreamDataResponse,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/MainApplication.kt
@@ -26,10 +26,15 @@ import org.phoenixframework.Socket
 // expect val appVariant: AppVariant
 
 class MainApplication : Application() {
-    private val socket = Socket(appVariant.socketUrl, decode = ::decodeMessage)
-
     override fun onCreate() {
         super.onCreate()
+        val locale = resources.getString(R.string.current_locale)
+        val socket =
+            Socket(
+                appVariant.socketUrl,
+                params = mapOf("locale" to locale),
+                decode = ::decodeMessage,
+            )
         initKoin(
             appVariant,
             makeNativeModule(

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -96,7 +96,8 @@ struct ProductionAppView: View {
     }
 
     private static func initSocket() -> PhoenixSocket {
-        let socket = Socket(appVariant.socketUrl)
+        let locale = NSLocalizedString("key/current_locale", comment: "")
+        let socket = Socket(appVariant.socketUrl, paramsClosure: { ["locale": locale] })
 
         // decreasing default from 5s
         socket.reconnectAfter = { tries in

--- a/iosApp/iosAppTests/Utils/Modifiers/AlertsModifierTests.swift
+++ b/iosApp/iosAppTests/Utils/Modifiers/AlertsModifierTests.swift
@@ -31,7 +31,7 @@ final class AlertsModifierTests: XCTestCase {
         var repoFulfilled = false
         let mockRepos = MockRepositories()
         mockRepos.alerts = MockAlertsRepository(
-            response: updatedAlerts,
+            response: .init(remove: [], update: [:]),
             onConnect: {
                 guard !repoFulfilled else { return }
                 repoFulfilled = true

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -293,7 +293,7 @@ final class ContentViewTests: XCTestCase {
             self.disconnectExp = disconnectExp
         }
 
-        func connect(onReceive _: @escaping (ApiResult<AlertsStreamDataResponse>) -> Void) {
+        func connect(onReceive _: @escaping (ApiResult<AlertsStreamUpdateResponse>) -> Void) {
             connectExp?.fulfill()
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -5,7 +5,7 @@ import com.mbta.tid.mbta_app.cache.MockKeyedCache
 import com.mbta.tid.mbta_app.cache.ScheduleCache
 import com.mbta.tid.mbta_app.model.AppVersion
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.NearbyResponse
@@ -232,7 +232,7 @@ public class MockRepositories : IRepositories {
         selectedTripId: String? = null,
         selectedVehicleId: String? = null,
     ) {
-        alerts = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        alerts = MockAlertsRepository(AlertsStreamUpdateResponse(objects))
         global = MockGlobalRepository(GlobalResponse(objects))
         nearby = MockNearbyRepository(NearbyResponse(objects))
         predictions =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -26,6 +26,7 @@ internal constructor(
     @SerialName("informed_entity") val informedEntity: List<InformedEntity>,
     val lifecycle: Lifecycle,
     val severity: Int,
+    val summaries: List<AlertSummaryEntity>? = null,
     @SerialName("updated_at") val updatedAt: EasternTimeInstant,
     // This field is not parsed from the Alert object from the backend, it is injected from
     // global data in the AlertsUsecase if any informed entities apply to a facility.
@@ -134,6 +135,14 @@ internal constructor(
         global: GlobalResponse,
     ): AlertSummary? =
         AlertSummary.summarizing(this, stopId, directionId, patterns, atTime, upcomingTrips, global)
+
+    public fun summary(
+        routeId: Matcher<Route.Id>,
+        stopId: Matcher<String>,
+        directionId: Matcher<Int>,
+        tripId: Matcher<String>,
+    ): AlertSummaryEntity? =
+        AlertSummaryEntity.matching(summaries.orEmpty(), routeId, stopId, directionId, tripId)
 
     @Serializable
     public data class ActivePeriod

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryEntity.kt
@@ -1,0 +1,33 @@
+package com.mbta.tid.mbta_app.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class AlertSummaryEntity(
+    @SerialName("route_id") val routeId: Route.Id?,
+    @SerialName("stop_id") val stopId: String?,
+    @SerialName("trip_id") val tripId: String?,
+    @SerialName("direction_id") val directionId: Int?,
+    val summary: String?,
+) {
+    internal companion object {
+        fun matching(
+            summaries: List<AlertSummaryEntity>,
+            routeId: Matcher<Route.Id>,
+            stopId: Matcher<String>,
+            directionId: Matcher<Int>,
+            tripId: Matcher<String>,
+        ): AlertSummaryEntity? {
+            fun <T : Any> matches(expected: Matcher<T>, actual: T?): Boolean =
+                actual == null || expected.matches(actual)
+
+            return summaries.find {
+                matches(routeId, it.routeId) &&
+                    matches(stopId, it.stopId) &&
+                    matches(directionId, it.directionId) &&
+                    matches(tripId, it.tripId)
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -104,6 +104,7 @@ private constructor(
         public var header: String? = null
         public var lifecycle: Alert.Lifecycle = Alert.Lifecycle.New
         public var severity: Int = 0
+        public var summaries: List<AlertSummaryEntity>? = null
         public var updatedAt: EasternTimeInstant =
             EasternTimeInstant(Instant.fromEpochMilliseconds(0))
         public var facilities: Map<String, Facility>? = null
@@ -153,6 +154,7 @@ private constructor(
                 informedEntity,
                 lifecycle,
                 severity,
+                summaries,
                 updatedAt,
                 facilities,
             )

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/response/AlertsStreamDataResponse.kt
@@ -5,6 +5,21 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import kotlinx.serialization.Serializable
 
 @Serializable
+public data class AlertsStreamUpdateResponse(
+    internal val remove: List<String>,
+    internal val update: Map<String, Alert>,
+) {
+    public constructor(objects: ObjectCollectionBuilder) : this(emptyList(), objects.alerts.toMap())
+
+    public fun mergeInto(alertsData: AlertsStreamDataResponse?): AlertsStreamDataResponse =
+        alertsData?.let {
+            AlertsStreamDataResponse(
+                it.alerts.filter { (key, _) -> !remove.contains(key) } + update
+            )
+        } ?: AlertsStreamDataResponse(update)
+}
+
+@Serializable
 public data class AlertsStreamDataResponse(internal val alerts: Map<String, Alert>) {
     public constructor(objects: ObjectCollectionBuilder) : this(objects.alerts.toMap())
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannel.kt
@@ -1,17 +1,17 @@
 package com.mbta.tid.mbta_app.phoenix
 
 import com.mbta.tid.mbta_app.json
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 
 internal object AlertsChannel : ChannelSpec {
-    override val topic = "alerts:v2"
+    override val topic = "alerts:v3"
 
     override val updateEvent = "stream_data"
 
     override val params = emptyMap<String, Any>()
 
     @Throws(IllegalArgumentException::class)
-    fun parseMessage(payload: String): AlertsStreamDataResponse {
+    fun parseMessage(payload: String): AlertsStreamUpdateResponse {
         return json.decodeFromString(payload)
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepository.kt
@@ -1,7 +1,7 @@
 package com.mbta.tid.mbta_app.repositories
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixSocket
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.component.KoinComponent
 
 public interface IAlertsRepository {
-    public fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit)
+    public fun connect(onReceive: (ApiResult<AlertsStreamUpdateResponse>) -> Unit)
 
     public fun disconnect()
 }
@@ -23,7 +23,7 @@ internal class AlertsRepository(
     ioDispatcher: CoroutineDispatcher,
 ) : IAlertsRepository, KoinComponent {
     private val channelOwner =
-        ChannelOwner<AlertsStreamDataResponse>(
+        ChannelOwner<AlertsStreamUpdateResponse>(
             socket,
             ioDispatcher,
             debugRepository,
@@ -31,13 +31,13 @@ internal class AlertsRepository(
         )
     internal var channel: PhoenixChannel? by channelOwner::channel
 
-    override fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
+    override fun connect(onReceive: (ApiResult<AlertsStreamUpdateResponse>) -> Unit) {
         channelOwner.connect(
             AlertsChannel,
             AlertsChannel::parseMessage,
             {
                 when (it) {
-                    is ApiResult.Ok -> println("Received ${it.data.alerts.size} alerts")
+                    is ApiResult.Ok -> println("Received ${it.data.update.size} alerts")
                     else -> {}
                 }
                 onReceive(it)
@@ -54,20 +54,20 @@ internal class AlertsRepository(
 public class MockAlertsRepository
 @DefaultArgumentInterop.Enabled
 internal constructor(
-    private val result: ApiResult<AlertsStreamDataResponse>,
+    private val result: ApiResult<AlertsStreamUpdateResponse>,
     private val onConnect: () -> Unit = {},
     private val onDisconnect: () -> Unit = {},
 ) : IAlertsRepository {
     @DefaultArgumentInterop.Enabled
     public constructor(
-        response: AlertsStreamDataResponse = AlertsStreamDataResponse(emptyMap()),
+        response: AlertsStreamUpdateResponse = AlertsStreamUpdateResponse(emptyList(), emptyMap()),
         onConnect: () -> Unit = {},
         onDisconnect: () -> Unit = {},
     ) : this(ApiResult.Ok(response), onConnect, onDisconnect)
 
-    private var receiveCallback: ((ApiResult<AlertsStreamDataResponse>) -> Unit)? = null
+    private var receiveCallback: ((ApiResult<AlertsStreamUpdateResponse>) -> Unit)? = null
 
-    override fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
+    override fun connect(onReceive: (ApiResult<AlertsStreamUpdateResponse>) -> Unit) {
         receiveCallback = onReceive
         onConnect()
         onReceive(result)
@@ -77,7 +77,7 @@ internal constructor(
         onDisconnect()
     }
 
-    internal fun receiveResult(result: ApiResult<AlertsStreamDataResponse>) {
+    internal fun receiveResult(result: ApiResult<AlertsStreamUpdateResponse>) {
         receiveCallback?.let { it(result) }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecase.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.usecases
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.repositories.IAlertsRepository
 import com.mbta.tid.mbta_app.repositories.IGlobalRepository
@@ -21,17 +22,25 @@ constructor(
     private val globalUpdateDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : KoinComponent {
 
-    private var lastOkResult: ApiResult.Ok<AlertsStreamDataResponse>? = null
+    private var currentAlerts: AlertsStreamDataResponse? = null
+
     private var globalState = globalRepository.state
     private var globalUpdateJob: Job? = null
 
     public fun connect(onReceive: (ApiResult<AlertsStreamDataResponse>) -> Unit) {
-        fun injectAndReceive(result: ApiResult<AlertsStreamDataResponse>) {
+        fun injectAndReceive(result: ApiResult<AlertsStreamUpdateResponse>) {
             val injectedResult =
-                if (result is ApiResult.Ok) {
-                    lastOkResult = result
-                    result.copy(result.data.injectFacilities(globalState.value))
-                } else result
+                when (result) {
+                    is ApiResult.Ok ->
+                        ApiResult.Ok(
+                            result.data
+                                .mergeInto(currentAlerts)
+                                .also { currentAlerts = it }
+                                .injectFacilities(globalState.value)
+                        )
+
+                    is ApiResult.Error -> ApiResult.Error(result.code, result.message)
+                }
             onReceive(injectedResult)
         }
         alertsRepository.connect(::injectAndReceive)
@@ -40,8 +49,8 @@ constructor(
         globalUpdateJob =
             CoroutineScope(globalUpdateDispatcher).launch {
                 globalState.collect { global ->
-                    lastOkResult?.let { result ->
-                        onReceive(result.copy(result.data.injectFacilities(global)))
+                    currentAlerts?.let { alerts ->
+                        onReceive(ApiResult.Ok(alerts.injectFacilities(global)))
                     }
                 }
             }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
@@ -2,9 +2,10 @@ package com.mbta.tid.mbta_app.phoenix
 
 import com.mbta.tid.mbta_app.json
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteType
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -24,7 +25,8 @@ class AlertsChannelTest {
         val payload =
             json.encodeToString(
                 buildJsonObject {
-                    putJsonObject("alerts") {
+                    putJsonArray("remove") {}
+                    putJsonObject("update") {
                         putJsonObject("501047") {
                             put("id", "501047")
                             putJsonArray("active_period") {
@@ -55,7 +57,15 @@ class AlertsChannelTest {
                             }
                             put("lifecycle", "ongoing")
                             put("severity", 10)
-
+                            putJsonArray("summaries") {
+                                addJsonObject {
+                                    put("route_id", null)
+                                    put("stop_id", null)
+                                    put("direction_id", null)
+                                    put("trip_id", null)
+                                    put("summary", "Ceci n’est pas un alert")
+                                }
+                            }
                             put("updated_at", "2023-05-26T16:46:13-04:00")
                         }
                     }
@@ -65,7 +75,8 @@ class AlertsChannelTest {
         val parsed = AlertsChannel.parseMessage(payload)
 
         assertEquals(
-            AlertsStreamDataResponse(
+            AlertsStreamUpdateResponse(
+                emptyList(),
                 mapOf(
                     "501047" to
                         Alert(
@@ -98,9 +109,18 @@ class AlertsChannelTest {
                             ),
                             Alert.Lifecycle.Ongoing,
                             10,
+                            listOf(
+                                AlertSummaryEntity(
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    "Ceci n’est pas un alert",
+                                )
+                            ),
                             EasternTimeInstant(2023, Month.MAY, 26, 16, 46, 13),
                         )
-                )
+                ),
             ),
             parsed,
         )
@@ -111,7 +131,8 @@ class AlertsChannelTest {
         val payload =
             json.encodeToString(
                 buildJsonObject {
-                    putJsonObject("alerts") {
+                    putJsonArray("remove") {}
+                    putJsonObject("update") {
                         putJsonObject("501047") {
                             put("id", "501047")
                             putJsonArray("active_period") {
@@ -136,6 +157,15 @@ class AlertsChannelTest {
                             }
                             put("lifecycle", "ongoing")
                             put("severity", 10)
+                            putJsonArray("summaries") {
+                                addJsonObject {
+                                    put("route_id", null)
+                                    put("stop_id", null)
+                                    put("direction_id", null)
+                                    put("trip_id", null)
+                                    put("summary", "Ceci n’est pas un alert")
+                                }
+                            }
                             put("updated_at", "2023-05-26T16:46:13-04:00")
                         }
                     }
@@ -145,7 +175,8 @@ class AlertsChannelTest {
         val parsed = AlertsChannel.parseMessage(payload)
 
         assertEquals(
-            AlertsStreamDataResponse(
+            AlertsStreamUpdateResponse(
+                emptyList(),
                 mapOf(
                     "501047" to
                         Alert(
@@ -172,9 +203,18 @@ class AlertsChannelTest {
                             ),
                             Alert.Lifecycle.Ongoing,
                             10,
+                            listOf(
+                                AlertSummaryEntity(
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    "Ceci n’est pas un alert",
+                                )
+                            ),
                             EasternTimeInstant(2023, Month.MAY, 26, 16, 46, 13),
                         )
-                )
+                ),
             ),
             parsed,
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/AlertsRepositoryTests.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.repositories
 
 import com.mbta.tid.mbta_app.mocks.MockMessage
 import com.mbta.tid.mbta_app.model.SocketError
-import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.network.PhoenixChannel
 import com.mbta.tid.mbta_app.network.PhoenixMessage
@@ -113,7 +113,12 @@ class AlertsRepositoryTests {
         class MockChannel : PhoenixChannel {
             override fun onEvent(event: String, callback: (PhoenixMessage) -> Unit) {
                 /* no-op */
-                callback(MockMessage(subject = AlertsChannel.topic, jsonBody = "{\"alerts\": {}}"))
+                callback(
+                    MockMessage(
+                        subject = AlertsChannel.topic,
+                        jsonBody = "{\"remove\": [], \"update\": {}}",
+                    )
+                )
             }
 
             override fun onFailure(callback: (message: PhoenixMessage) -> Unit) {
@@ -137,7 +142,8 @@ class AlertsRepositoryTests {
             onReceive = { outcome ->
                 val data = outcome.dataOrThrow()
                 assertNotNull(data)
-                val expectedResponse = AlertsStreamDataResponse(alerts = emptyMap())
+                val expectedResponse =
+                    AlertsStreamUpdateResponse(remove = emptyList(), update = emptyMap())
                 assertEquals(expectedResponse, data)
             }
         )

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/usecases/AlertsUsecaseTest.kt
@@ -4,6 +4,7 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
+import com.mbta.tid.mbta_app.model.response.AlertsStreamUpdateResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.IdleGlobalRepository
@@ -31,7 +32,7 @@ class AlertsUsecaseTest {
             )
         }
 
-        val alertResponse = AlertsStreamDataResponse(objects)
+        val alertResponse = AlertsStreamUpdateResponse(objects)
         val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
         val mockAlertsRepository = MockAlertsRepository(alertResponse)
         val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
@@ -64,7 +65,7 @@ class AlertsUsecaseTest {
         }
 
         val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
-        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamUpdateResponse(objects))
         val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
 
         var result: ApiResult<AlertsStreamDataResponse>? = null
@@ -88,7 +89,7 @@ class AlertsUsecaseTest {
                 facility = facility.id,
             )
         }
-        mockAlertsRepository.receiveResult(ApiResult.Ok(AlertsStreamDataResponse(objects)))
+        mockAlertsRepository.receiveResult(ApiResult.Ok(AlertsStreamUpdateResponse(objects)))
         assertEquals(
             facility,
             (result as ApiResult.Ok<AlertsStreamDataResponse>)
@@ -120,7 +121,7 @@ class AlertsUsecaseTest {
         val alert = objects.alert {}
 
         val mockGlobalRepository = IdleGlobalRepository()
-        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamUpdateResponse(objects))
         val usecase = AlertsUsecase(mockAlertsRepository, mockGlobalRepository)
 
         var result: ApiResult<AlertsStreamDataResponse>? = null
@@ -146,7 +147,7 @@ class AlertsUsecaseTest {
             )
         }
         val mockGlobalRepository = MockGlobalRepository(GlobalResponse(objects))
-        val mockAlertsRepository = MockAlertsRepository(AlertsStreamDataResponse(objects))
+        val mockAlertsRepository = MockAlertsRepository(AlertsStreamUpdateResponse(objects))
         val usecase =
             AlertsUsecase(
                 mockAlertsRepository,


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

A finished version of #1767.

Builds on #1852 to add an `Alert.summary` that selects an `AlertSummaryEntity` based on `Matcher`s, but does not replace any summary logic.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Updated unit tests.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
