### PR TITLE
refactor: make alert builder default to always active

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsPageTest.kt
@@ -8,8 +8,6 @@ import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
-import com.mbta.tid.mbta_app.utils.EasternTimeInstant
-import kotlin.time.Duration.Companion.seconds
 import org.junit.Rule
 import org.junit.Test
 
@@ -46,10 +44,7 @@ class AlertDetailsPageTest {
 
         val route = objects.route { longName = "Orange Line" }
 
-        val now = EasternTimeInstant.now()
-
         val alert = objects.alert {
-            activePeriod(now - 5.seconds, now + 5.seconds)
             description = "Long description"
             cause = Alert.Cause.Fire
             effect = Alert.Effect.Suspension

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/alertDetails/AlertDetailsTest.kt
@@ -222,7 +222,6 @@ class AlertDetailsTest {
         val now = EasternTimeInstant.now()
 
         val alert = objects.alert {
-            activePeriod(now - 5.minutes, now + 5.minutes)
             cause = Alert.Cause.UnrulyPassenger
             effect = Alert.Effect.StopClosure
             effectName = "Closure"
@@ -254,7 +253,6 @@ class AlertDetailsTest {
         val stop3 = objects.stop { name = "Stop 3" }
 
         val alert = objects.alert {
-            activePeriod(now - 5.minutes, now + 5.minutes)
             cause = Alert.Cause.UnrulyPassenger
             effect = Alert.Effect.StopClosure
             effectName = "Closure"
@@ -304,7 +302,6 @@ class AlertDetailsTest {
         val stop = objects.stop { name = "Stop" }
 
         val alert = objects.alert {
-            activePeriod(now - 5.minutes, now + 5.minutes)
             cause = Alert.Cause.UnrulyPassenger
             effect = Alert.Effect.Suspension
             effectName = "Suspension"
@@ -336,7 +333,6 @@ class AlertDetailsTest {
         val stop = objects.stop { name = "Stop" }
 
         val alert = objects.alert {
-            activePeriod(now - 5.minutes, now + 5.minutes)
             cause = Alert.Cause.Maintenance
             effect = Alert.Effect.ElevatorClosure
             effectName = "Elevator Closure"

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/NearbyTransitViewTest.kt
@@ -36,7 +36,6 @@ import com.mbta.tid.mbta_app.viewModel.MockNearbyViewModel
 import com.mbta.tid.mbta_app.viewModel.NearbyViewModel
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import org.junit.Rule
 import org.junit.Test
 import org.koin.compose.koinInject
@@ -376,7 +375,6 @@ class NearbyTransitViewTest : KoinTest {
         val harvardNorthbound = objects.getStop("70068")
         val centralNorthbound = objects.getStop("70070")
         val alert = objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             effect = Alert.Effect.Suspension
             informedEntity(
                 activities =

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -18,7 +18,6 @@ import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
 import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.days
 import kotlinx.datetime.Month
 import org.junit.Rule
 import org.junit.Test
@@ -282,11 +281,10 @@ class AlertCardTests {
 
     @Test
     fun testAllClearAlertCard() {
-        val now = EasternTimeInstant.now()
         val objects = ObjectCollectionBuilder()
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(now - 3.days, now - 1.days)
+            allClear()
         }
         composeTestRule.setContent {
             AlertCard(
@@ -311,11 +309,9 @@ class AlertCardTests {
 
     @Test
     fun testUpdateAlertCard() {
-        val now = EasternTimeInstant.now()
         val objects = ObjectCollectionBuilder()
         val alert = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(now - 3.days, now + 3.days)
         }
         composeTestRule.setContent {
             AlertCard(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -42,7 +42,6 @@ import com.mbta.tid.mbta_app.viewModel.MockStopDetailsViewModel
 import com.mbta.tid.mbta_app.viewModel.StopDetailsViewModel
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Month
 import org.junit.Before
@@ -396,7 +395,6 @@ class StopDetailsFilteredDeparturesViewTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Cancellation
-            activePeriod(now - 5.seconds, now + 5.seconds)
             informedEntity(
                 directionId = 0,
                 route = route.id.idText,
@@ -533,7 +531,6 @@ class StopDetailsFilteredDeparturesViewTest {
     fun testShowsSuspension(): Unit = runBlocking {
         val now = EasternTimeInstant.now()
         val alert = builder.alert {
-            activePeriod(now - 5.seconds, now + 5.seconds)
             effect = Alert.Effect.Suspension
             header = "Fuchsia Line suspended from Here to There"
             informedEntity(directionId = 0, route = route.id.idText, stop = stop.id)
@@ -619,7 +616,6 @@ class StopDetailsFilteredDeparturesViewTest {
         val tripPattern = objects.routePatterns["Green-D-855-0"]!!
 
         val alert = objects.alert {
-            activePeriod(now - 5.seconds, now + 20.minutes)
             effect = Alert.Effect.Shuttle
             header = "Green line shuttle on B and C branches"
             informedEntity(directionId = 0, route = routeB.id.idText, stop = "71151")
@@ -698,7 +694,6 @@ class StopDetailsFilteredDeparturesViewTest {
     @Test
     fun testShowsDownstreamAlert(): Unit = runBlocking {
         val alert = builder.alert {
-            activePeriod(now - 5.seconds, now + 5.seconds)
             effect = Alert.Effect.Suspension
             informedEntity(directionId = 0, route = route.id.idText, stop = downstreamStop.id)
         }
@@ -774,7 +769,6 @@ class StopDetailsFilteredDeparturesViewTest {
                 listOf(Alert.InformedEntity.Activity.UsingWheelchair),
                 stop = stop.id,
             )
-            activePeriod(now - 30.minutes, null)
         }
 
         val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)
@@ -830,7 +824,6 @@ class StopDetailsFilteredDeparturesViewTest {
     fun testShowsSubwayDelayAlert(): Unit = runBlocking {
         val now = EasternTimeInstant.now()
         val alert = builder.alert {
-            activePeriod(now - 5.seconds, now + 5.seconds)
             effect = Alert.Effect.Delay
             header = "Delays alert header"
             cause = Alert.Cause.HeavyRidership

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredViewTest.kt
@@ -34,7 +34,6 @@ import com.mbta.tid.mbta_app.viewModel.StopDetailsViewModel
 import com.mbta.tid.mbta_app.viewModel.StopDetailsViewModel.RouteData
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -258,7 +257,6 @@ class StopDetailsFilteredViewTest {
             effect = Alert.Effect.ElevatorClosure
             header = "Elevator Alert Header"
             informedEntity(listOf(Alert.InformedEntity.Activity.UsingWheelchair), stop = stop.id)
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
         }
 
         val filterState = StopDetailsFilter(routeId = route.id, directionId = 0)

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesViewTest.kt
@@ -22,7 +22,6 @@ import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.NavigationCallbacks
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -192,7 +191,6 @@ class StopDetailsUnfilteredRoutesViewTest {
     fun testShowsElevatorAlertsWhenGroupedByDirection(): Unit = runBlocking {
         val alert = Single.alert {
             header = "Elevator alert"
-            activePeriod(start = EasternTimeInstant(Instant.DISTANT_PAST), end = null)
             effect = Alert.Effect.ElevatorClosure
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.UsingWheelchair),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripDetailsViewTest.kt
@@ -152,7 +152,6 @@ class TripDetailsViewTest {
         objects.alert {
             cause = Alert.Cause.Parade
             effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(5.minutes), now.plus(30.minutes))
             informedEntity(directionId = 0, route = route.id.idText, stop = downstreamStop.id)
         }
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -24,7 +24,6 @@ import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.Month
 import org.junit.Rule
@@ -303,7 +302,7 @@ class TripStopRowTest {
         testEntry =
             entry(
                 accessibleStop,
-                listOf(objects.alert { activePeriod(now.minus(20.minutes), now.plus(20.minutes)) }),
+                listOf(objects.alert {}),
             )
         composeTestRule
             .onNodeWithTag("wheelchair_not_accessible", useUnmergedTree = true)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -220,12 +220,7 @@ private fun TripStopRowPreview() {
                             predictionStop = objects.stop { platformCode = "1" },
                             vehicle = null,
                             routes = emptyList(),
-                            elevatorAlerts =
-                                listOf(
-                                    objects.alert {
-                                        activePeriod(now.minus(20.minutes), now.plus(20.minutes))
-                                    }
-                                ),
+                            elevatorAlerts = listOf(objects.alert {}),
                         ),
                     trip,
                     now,
@@ -345,15 +340,7 @@ private fun TripStopRowDisruptionsPreview() {
                                 predictionStop = objects.stop { platformCode = "1" },
                                 vehicle = null,
                                 routes = emptyList(),
-                                elevatorAlerts =
-                                    listOf(
-                                        objects.alert {
-                                            activePeriod(
-                                                now.minus(20.minutes),
-                                                now.plus(20.minutes),
-                                            )
-                                        }
-                                    ),
+                                elevatorAlerts = listOf(objects.alert {}),
                             ),
                         trip,
                         now,

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -411,10 +411,6 @@ struct AlertDetails: View {
             "Elevator 804 (Government Center & North lobby to Tremont Street, Winter Street)"
                 + "unavailable on Thu Feb 6 due to maintenance"
         alert.cause = .maintenance
-        alert.activePeriod(
-            start: now.minus(hours: 3 * 24),
-            end: nil
-        )
         alert.description_ =
             """
             To exit, travel down the Winter St concourse towards Downtown Crossing. At the end of the concourse, exit \

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -175,14 +175,7 @@ struct TripStopRow: View {
                 predictionStop: objects.stop { $0.platformCode = "1" },
                 vehicle: nil,
                 routes: [],
-                elevatorAlerts: [
-                    objects.alert {
-                        $0.activePeriod(
-                            start: now.minus(minutes: 20),
-                            end: now.plus(minutes: 20)
-                        )
-                    },
-                ]
+                elevatorAlerts: [objects.alert { _ in }]
             ),
             trip: trip,
             now: now,

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsPageTests.swift
@@ -51,7 +51,6 @@ final class AlertDetailsPageTests: XCTestCase {
         let now = EasternTimeInstant.now()
 
         let alert = objects.alert { alert in
-            alert.activePeriod(start: now.minus(seconds: 5), end: now.plus(seconds: 5))
             alert.description_ = "Long description"
             alert.cause = .fire
             alert.effect = .stopClosure

--- a/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/AlertDetails/AlertDetailsTests.swift
@@ -28,7 +28,6 @@ final class AlertDetailsTests: XCTestCase {
         let now = EasternTimeInstant(year: 2025, month: .july, day: 28, hour: 15, minute: 32, second: 0)
 
         let alert = objects.alert { alert in
-            alert.activePeriod(start: now.minus(seconds: 5), end: now.plus(seconds: 5))
             alert.description_ = "Long description"
             alert.cause = .unrulyPassenger
             alert.effect = .stopClosure
@@ -143,10 +142,6 @@ final class AlertDetailsTests: XCTestCase {
         let now = EasternTimeInstant.now()
 
         let alert = objects.alert { alert in
-            alert.activePeriod(
-                start: now.minus(seconds: 5),
-                end: now.plus(seconds: 5)
-            )
             alert.cause = .unrulyPassenger
             alert.effect = .stopClosure
             alert.effectName = "Closure"
@@ -168,10 +163,6 @@ final class AlertDetailsTests: XCTestCase {
         let stop3 = objects.stop { stop in stop.name = "Stop 3" }
 
         let alert = objects.alert { alert in
-            alert.activePeriod(
-                start: now.minus(seconds: 5),
-                end: now.plus(seconds: 5)
-            )
             alert.cause = .unrulyPassenger
             alert.effect = .stopClosure
             alert.effectName = "Closure"
@@ -209,10 +200,6 @@ final class AlertDetailsTests: XCTestCase {
         let now = EasternTimeInstant.now()
 
         let alert = objects.alert { alert in
-            alert.activePeriod(
-                start: now.minus(seconds: 5),
-                end: now.plus(seconds: 5)
-            )
             alert.cause = .maintenance
             alert.effect = .elevatorClosure
             alert.updatedAt = now.minus(seconds: 100)
@@ -230,10 +217,6 @@ final class AlertDetailsTests: XCTestCase {
         let now = EasternTimeInstant.now()
 
         let alert = objects.alert { alert in
-            alert.activePeriod(
-                start: now.minus(seconds: 5),
-                end: now.plus(seconds: 5)
-            )
             alert.cause = .freightTrainInterference
             alert.effect = .serviceChange
             alert.updatedAt = now.minus(seconds: 100)
@@ -255,10 +238,6 @@ final class AlertDetailsTests: XCTestCase {
             alert.effect = .elevatorClosure
             alert.header = "Elevator 123 (Foo to Bar) unavailable due to demonstration"
             alert.cause = .demonstration
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: nil
-            )
             alert.informedEntity(
                 activities: [.usingWheelchair],
                 directionId: nil,

--- a/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
+++ b/iosApp/iosAppTests/Pages/NearbyTransit/NearbyTransitViewTests.swift
@@ -301,7 +301,6 @@ final class NearbyTransitViewTests: XCTestCase {
 
         let harvardNorthbound = objects.getStop(id: "70068")
         let alert = objects.alert { alert in
-            alert.activePeriod(start: .init(instant: .companion.DISTANT_PAST), end: nil)
             alert.effect = .suspension
             alert.informedEntity(activities: [.board, .exit, .ride], stop: harvardNorthbound.id)
         }

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -360,7 +360,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 stop: stop.id,
                 trip: trip1.id
             )
-            alert.activePeriod(start: now.minus(minutes: 30), end: nil)
         }
         let leaf = makeLeaf(
             route: route,
@@ -438,10 +437,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .suspension
             alert.header = "Fuchsia Line suspended from Here to There"
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
             alert.informedEntity(stop: stop.id)
         }
 
@@ -498,10 +493,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .suspension
             alert.header = "Fuchsia Line suspended from Here to There"
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
             alert.informedEntity(stop: stop.id)
         }
 
@@ -633,7 +624,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 stop: stop.id,
                 trip: nil
             )
-            alert.activePeriod(start: now.minus(minutes: 30), end: nil)
         }
         let trip = objects.upcomingTrip(prediction: objects.prediction { prediction in
             prediction.trip = objects.trip { $0.headsign = "A" }
@@ -721,9 +711,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         let route = objects.route { _ in }
         let alert = objects.alert { alert in
             alert.effect = .delay
-            alert.activePeriod(
-                start: .init(year: 2000, month: .january, day: 1, hour: 0, minute: 0, second: 0), end: nil
-            )
             alert.header = "Delay header"
             alert.cause = .heavyRidership
             alert.severity = 10
@@ -787,10 +774,6 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
 
         let alert =
             objects.alert { alert in
-                alert.activePeriod(
-                    start: now.minus(seconds: 5),
-                    end: now.plus(seconds: 100)
-                )
                 alert.effect = .shuttle
                 alert.header = "Green line shuttle on B and C branches"
                 alert.informedEntity(

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsUnfilteredViewTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsUnfilteredViewTests.swift
@@ -182,7 +182,6 @@ import XCTest
     func testShowsElevatorAlertsWhenGroupedByDirection() async throws {
         let alert = try XCTUnwrap(builder?.clone().alert { alert in
             alert.header = "Elevator alert"
-            alert.activePeriod(start: Date(timeIntervalSince1970: 0).toEasternInstant(), end: nil)
             alert.effect = .elevatorClosure
             alert.informedEntity(
                 activities: [.usingWheelchair],

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -295,12 +295,7 @@ final class TripStopRowTests: XCTestCase {
         let stopEntry = TripDetailsStopList.Entry(
             stop: stop, stopSequence: 0, disruption: nil,
             schedule: schedule, prediction: prediction,
-            vehicle: nil, routes: [route], elevatorAlerts: [objects.alert {
-                $0.activePeriod(
-                    start: now.minus(minutes: 20),
-                    end: now.plus(minutes: 20)
-                )
-            }]
+            vehicle: nil, routes: [route], elevatorAlerts: [objects.alert { _ in }]
         )
 
         let row = TripStopRow(

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -23,10 +23,6 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .suspension
             alert.header = "Test header"
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let exp = XCTestExpectation(description: "Detail button pressed")
@@ -261,10 +257,6 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .detour
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let exp = XCTestExpectation(description: "Card pressed")
@@ -313,10 +305,6 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .serviceChange
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let exp = XCTestExpectation(description: "Card pressed")
@@ -344,10 +332,6 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.effect = .elevatorClosure
             alert.header = "Elevator header"
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let exp = XCTestExpectation(description: "Card pressed")
@@ -384,10 +368,6 @@ final class AlertCardTests: XCTestCase {
                 facility: facility.id
             )
             alert.facilities = [facility.id: facility]
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let exp = XCTestExpectation(description: "Card pressed")
@@ -519,10 +499,7 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .suspension
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.minus(hours: 1 * 24)
-            )
+            alert.allClear()
         }
         let exp = XCTestExpectation(description: "Card pressed")
         let sut = AlertCard(
@@ -559,10 +536,6 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .shuttle
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
         let exp = XCTestExpectation(description: "Card pressed")
         let sut = AlertCard(

--- a/iosApp/iosAppTests/Views/AlertListContainerTests.swift
+++ b/iosApp/iosAppTests/Views/AlertListContainerTests.swift
@@ -37,10 +37,6 @@ final class AlertListContainerTests: XCTestCase {
 
         let downstreamAlert = objects.alert { alert in
             alert.effect = .serviceChange
-            alert.activePeriod(
-                start: now.minus(hours: 3 * 24),
-                end: now.plus(hours: 3 * 24)
-            )
         }
 
         let sut = AlertListContainer(displayAlerts: .init(highPriority: [.init(alert: highAlert, isDownstream: false)],

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/ObjectCollectionBuilder.kt
@@ -94,7 +94,8 @@ private constructor(
 
     public inner class AlertBuilder : ObjectBuilder<Alert> {
         public var id: String = objectId()
-        public var activePeriod: MutableList<Alert.ActivePeriod> = mutableListOf()
+        public var activePeriod: List<Alert.ActivePeriod> =
+            listOf(Alert.ActivePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null))
         public var cause: Alert.Cause? = null
         public var description: String? = null
         public var durationCertainty: Alert.DurationCertainty = Alert.DurationCertainty.Known
@@ -110,7 +111,16 @@ private constructor(
         public var facilities: Map<String, Facility>? = null
 
         public fun activePeriod(start: EasternTimeInstant, end: EasternTimeInstant?) {
-            activePeriod.add(Alert.ActivePeriod(start, end))
+            val newActivePeriod = Alert.ActivePeriod(start, end)
+            if (activePeriod.singleOrNull()?.start?.instant == Instant.DISTANT_PAST) {
+                activePeriod = listOf(newActivePeriod)
+            } else {
+                activePeriod += newActivePeriod
+            }
+        }
+
+        public fun allClear() {
+            activePeriod = emptyList()
         }
 
         @DefaultArgumentInterop.Enabled

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/RouteCardPreviewData.kt
@@ -14,7 +14,6 @@ import com.mbta.tid.mbta_app.model.UpcomingTrip
 import com.mbta.tid.mbta_app.model.WheelchairBoardingStatus
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.atTime
 
@@ -66,11 +65,9 @@ public open class RouteCardPreviewData {
     private val bowAtWarren = objects.getStop("26131")
     private val shuttleAlert = objects.alert {
         effect = Alert.Effect.Shuttle
-        activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
     }
     private val suspensionAlert = objects.alert {
         effect = Alert.Effect.Suspension
-        activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
     }
     private val context = RouteCardData.Context.NearbyTransit
 
@@ -722,7 +719,6 @@ public open class RouteCardPreviewData {
             )
         val wickfordShuttle = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(
@@ -1074,7 +1070,6 @@ public open class RouteCardPreviewData {
     public fun GL5(): RouteCardData {
         val kenmoreShuttleToRiverside = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(
@@ -1125,7 +1120,6 @@ public open class RouteCardPreviewData {
     public fun GL6(): RouteCardData {
         val boylstonShuttleToRiverside = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(
@@ -1176,7 +1170,6 @@ public open class RouteCardPreviewData {
 
         val shuttleAllBranches = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -18,7 +18,6 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.GreenLineTestHelper
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.runBlocking
 import org.maplibre.spatialk.geojson.LineString
 import org.maplibre.spatialk.turf.misc.slice
@@ -98,7 +97,6 @@ class RouteFeaturesBuilderTest {
         val redAlert = objects.alert {
             id = "a1"
             effect = Alert.Effect.Shuttle
-            activePeriod(start = now - 1.seconds, end = null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board),
                 route = MapTestDataHelper.routeRed.id.idText,
@@ -196,7 +194,6 @@ class RouteFeaturesBuilderTest {
         val redAlert = objects.alert {
             id = "a1"
             effect = Alert.Effect.Shuttle
-            activePeriod(start = now - 1.seconds, end = null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board),
                 route = MapTestDataHelper.routeRed.id.idText,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertAssociatedStopTest.kt
@@ -4,7 +4,6 @@ import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Instant
 
 class AlertAssociatedStopTest {
     @Test
@@ -19,7 +18,6 @@ class AlertAssociatedStopTest {
             platform2 = childStop()
         }
         val alert = objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             effect = Alert.Effect.Shuttle
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
@@ -76,7 +74,6 @@ class AlertAssociatedStopTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity(route = route.id.idText, routeType = route.type)
         }
 
@@ -118,7 +115,6 @@ class AlertAssociatedStopTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity(route = null, routeType = RouteType.FERRY)
         }
 
@@ -144,7 +140,6 @@ class AlertAssociatedStopTest {
         val stop = objects.stop()
         val trip = objects.trip()
         val alert = objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             effect = Alert.Effect.Cancellation
             informedEntity(
                 listOf(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryTest.kt
@@ -393,7 +393,6 @@ class AlertSummaryTest {
         val now = EasternTimeInstant.now()
         val alert = objects.alert {
             effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             durationCertainty = Alert.DurationCertainty.Estimated
         }
 
@@ -409,7 +408,6 @@ class AlertSummaryTest {
         val now = EasternTimeInstant.now()
         val alert = objects.alert {
             effect = Alert.Effect.StopClosure
-            activePeriod(now.minus(1.hours), null)
         }
 
         val alertSummary =
@@ -618,7 +616,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             informedEntity(route = route.id.idText, stop = childStop?.id)
         }
 
@@ -660,7 +657,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stop in successiveStops) {
                 informedEntity(route = route.id.idText, stop = stop.id)
             }
@@ -712,7 +708,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stop in successiveStops) {
                 informedEntity(route = route.id.idText, stop = stop.id)
             }
@@ -772,7 +767,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stop in (listOf(firstStop) + trunkStops + branch1Stops + branch2Stops)) {
                 informedEntity(route = route.id.idText, stop = stop.id)
             }
@@ -843,7 +837,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stop in (listOf(lastStop) + trunkStops + branch1Stops + branch2Stops)) {
                 informedEntity(route = route.id.idText, stop = stop.id)
             }
@@ -913,7 +906,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stop in objects.stops.values) {
                 informedEntity(route = route.id.idText, stop = stop.id)
             }
@@ -982,7 +974,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stopId in listOf("70150", "70148", "70212")) {
                 informedEntity(route = route.id.idText, stop = stopId)
             }
@@ -1063,7 +1054,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             for (stopId in
                 listOf(trunkAlertingStop, bStop, cStop).flatMap {
                     listOf(it.id) + it.childStopIds
@@ -1273,7 +1263,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             updatedAt = now.minus(1.minutes)
             for (stop in successiveStops) {
                 informedEntity(route = route.id.idText, stop = stop.id)
@@ -1367,7 +1356,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Unknown
-            activePeriod(now.minus(1.hours), null)
             informedEntity(route = route.id.idText, routeType = route.type)
         }
 
@@ -1410,7 +1398,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
             durationCertainty = Alert.DurationCertainty.Unknown
-            activePeriod(now.minus(1.hours), null)
             stopIds.forEach {
                 informedEntity(route = route.id.idText, routeType = route.type, stop = it)
             }
@@ -1457,7 +1444,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.StopClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), null)
             routes.forEach { informedEntity(route = it.id.idText, routeType = it.type) }
         }
 
@@ -1511,7 +1497,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.StopClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), null)
             stops.forEach { (id, stops) ->
                 if (id == "trunk") {
                     routes.forEach { route ->
@@ -1568,7 +1553,6 @@ class AlertSummaryTest {
         val alert = objects.alert {
             effect = Alert.Effect.StopClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), null)
 
             informedEntity(route = "Green-C", routeType = RouteType.LIGHT_RAIL)
         }
@@ -1604,7 +1588,6 @@ class AlertSummaryTest {
         val pattern = objects.routePattern(route) {}
         val trip = objects.trip(pattern) {}
         val alert = objects.alert {
-            activePeriod(now - 2.hours, now + 2.hours)
             cause = Alert.Cause.Weather
             effect = Alert.Effect.Suspension
             informedEntity(trip = trip.id)
@@ -1645,7 +1628,6 @@ class AlertSummaryTest {
         val trip1 = objects.trip(pattern) {}
         val trip2 = objects.trip(pattern) {}
         val alert = objects.alert {
-            activePeriod(now - 2.hours, now + 2.hours)
             cause = Alert.Cause.IceInHarbor
             effect = Alert.Effect.Cancellation
             informedEntity(trip = trip1.id)
@@ -1694,7 +1676,6 @@ class AlertSummaryTest {
             }
         val trip = objects.trip(pattern) {}
         val alert = objects.alert {
-            activePeriod(now - 2.hours, now + 2.hours)
             effect = Alert.Effect.Shuttle
             informedEntity(stop = stop1.id, trip = trip.id)
             informedEntity(stop = stop2.id, trip = trip.id)
@@ -1735,7 +1716,6 @@ class AlertSummaryTest {
         val pattern = objects.routePattern(route) {}
         val trip = objects.trip(pattern) { headsign = "Stoughton" }
         val alert = objects.alert {
-            activePeriod(now - 2.hours, now + 2.hours)
             cause = Alert.Cause.UnknownCause
             effect = Alert.Effect.StationClosure
             informedEntity(stop = stop2.id, trip = trip.id)
@@ -1887,7 +1867,6 @@ class AlertSummaryTest {
         val stopClosureAlert = objects.alert {
             effect = Alert.Effect.StopClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             informedEntity(route = route.id.idText, stop = childStop?.id)
         }
 
@@ -1905,7 +1884,6 @@ class AlertSummaryTest {
         val stationClosureAlert = objects.alert {
             effect = Alert.Effect.StationClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.plus(1.hours))
             informedEntity(route = route.id.idText, stop = childStop?.id)
         }
 
@@ -1955,7 +1933,7 @@ class AlertSummaryTest {
         val stopClosureAlert = objects.alert {
             effect = Alert.Effect.StopClosure
             durationCertainty = Alert.DurationCertainty.Estimated
-            activePeriod(now.minus(1.hours), now.minus(5.minutes))
+            allClear()
             informedEntity(route = route.id.idText, stop = childStop?.id)
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/AlertTest.kt
@@ -9,7 +9,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
@@ -950,7 +949,6 @@ class AlertTest {
 
         val shawmutClosureAlert = objects.alert {
             effect = Alert.Effect.StationClosure
-            activePeriod(time - 1.seconds, null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                 route = route.id.idText,
@@ -960,7 +958,6 @@ class AlertTest {
 
         val ashmontShuttleAlert = objects.alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(time - 1.seconds, null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                 route = route.id.idText,
@@ -970,7 +967,6 @@ class AlertTest {
         val alewifeShuttleAlert = objects.alert {
             id = "alewife_alert_id"
             effect = Alert.Effect.Shuttle
-            activePeriod(time - 1.seconds, null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                 route = route.id.idText,
@@ -981,7 +977,6 @@ class AlertTest {
         val parkShuttleAlert = objects.alert {
             id = "park_alert_id"
             effect = Alert.Effect.Shuttle
-            activePeriod(time - 1.seconds, null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Ride),
                 route = route.id.idText,
@@ -1057,12 +1052,9 @@ class AlertTest {
                 }
             }
 
-        val time = EasternTimeInstant.now()
-
         val canonicalOnlyStopAlert = objects.alert {
             id = "alert_id"
             effect = Alert.Effect.StopClosure
-            activePeriod(time - 10.seconds, null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
                 route = route.id.idText,
@@ -1099,10 +1091,10 @@ class AlertTest {
         val now = EasternTimeInstant.now()
         val objects = ObjectCollectionBuilder()
         val active = objects.alert {
-            activePeriod = mutableListOf(Alert.ActivePeriod(now - 5.minutes, now + 5.minutes))
+            activePeriod(now - 5.minutes, now + 5.minutes)
         }
         val allClear = objects.alert {
-            activePeriod = mutableListOf(Alert.ActivePeriod(now - 10.minutes, now - 5.minutes))
+            activePeriod(now - 10.minutes, now - 5.minutes)
         }
         assertFalse { active.allClear(now) }
         assertTrue { allClear.allClear(now) }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertTest.kt
@@ -19,25 +19,22 @@ class DisplayAlertTest {
     val hereMajorNow = objects.alert {
         id = "hereMajorNow"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     val hereElevatorNow = objects.alert {
         id = "hereElevatorNow"
         effect = Effect.ElevatorClosure
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     val hereMajorLater = objects.alert {
         id = "hereMajorLater"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
 
     val downstreamMajorNow = objects.alert {
         id = "downstreamMajorNow"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     @Test
@@ -55,7 +52,6 @@ class DisplayAlertTest {
         val tripAlert = objects.alert {
             id = "hereForTargetTrip"
             effect = Effect.Shuttle
-            activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(
@@ -77,7 +73,6 @@ class DisplayAlertTest {
         val tripAlert = objects.alert {
             id = "hereForTargetTrip"
             effect = Effect.Cancellation
-            activePeriod(now.minus(10.minutes), null)
             informedEntity(
                 trip = "trip1",
                 activities =
@@ -97,7 +92,6 @@ class DisplayAlertTest {
             val majorAlert = objects.alert {
                 id = "hereForTargetTrip"
                 effect = Effect.Shuttle
-                activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(
@@ -121,7 +115,7 @@ class DisplayAlertTest {
         val tripAlert = objects.alert {
             id = "hereForTargetTrip"
             effect = Effect.Shuttle
-            activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(5.hours), null))
+            activePeriod(now.plus(5.hours), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertsTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/DisplayAlertsTest.kt
@@ -17,63 +17,58 @@ class DisplayAlertsTest {
     val hereMajorNow = objects.alert {
         id = "hereMajorNow"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
     val hereMinorNow = objects.alert {
         id = "hereMinorNow"
         effect = Effect.TrackChange
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     val hereElevatorNow = objects.alert {
         id = "hereElevatorNow"
         effect = Effect.ElevatorClosure
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     val hereMajorLater = objects.alert {
         id = "hereMajorLater"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
     val hereMinorLater = objects.alert {
         id = "hereMinorLater"
         effect = Effect.TrackChange
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
 
     val hereElevatorLater = objects.alert {
         id = "hereElevatorLater"
         effect = Effect.ElevatorClosure
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
 
     val downstreamMajorNow = objects.alert {
         id = "downstreamMajorNow"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
     val downstreamMinorNow = objects.alert {
         id = "downstreamMinorNow"
         effect = Effect.TrackChange
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.minus(10.minutes), null))
     }
 
     val downstreamMajorLater = objects.alert {
         id = "downstreamMajorLater"
         effect = Effect.Shuttle
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
     val downstreamMinorLater = objects.alert {
         id = "downstreamMinorLater"
         effect = Effect.TrackChange
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(10.minutes), null))
+        activePeriod(now.plus(10.minutes), null)
     }
 
     val downstreamMinorEvenLater = objects.alert {
         id = "downstreamMinorEvenLater"
         effect = Effect.TrackChange
-        activePeriod = mutableListOf(Alert.ActivePeriod(now.plus(20.minutes), null))
+        activePeriod(now.plus(20.minutes), null)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/PatternSortingTest.kt
@@ -5,7 +5,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import org.maplibre.spatialk.geojson.Position
 
 class PatternSortingTest {
@@ -63,7 +62,6 @@ class PatternSortingTest {
                     listOf(
                         objects.alert {
                             effect = Alert.Effect.Suspension
-                            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                         }
                     )
                 else emptyList(),

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataLeafTest.kt
@@ -10,7 +10,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.Month
@@ -32,7 +31,6 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
         }
 
         assertEquals(
@@ -81,7 +79,6 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.ServiceChange
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
         }
 
         val context: RouteCardData.Context = anyEnumValue()
@@ -133,7 +130,6 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
         }
 
         assertEquals(
@@ -179,7 +175,6 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity =
                 mutableListOf(
                     Alert.InformedEntity(
@@ -361,7 +356,6 @@ class RouteCardDataLeafTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.ServiceChange
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
         }
 
         assertEquals(
@@ -593,7 +587,6 @@ class RouteCardDataLeafTest {
                 departureTime = now + 2.minutes
             }
             val alert = objects.alert {
-                activePeriod(now.minus(1.hours), now.plus(1.hours))
                 effect = Alert.Effect.Shuttle
                 cause = Alert.Cause.Maintenance
                 informedEntity(
@@ -1277,7 +1270,6 @@ class RouteCardDataLeafTest {
 
             val alert = objects.alert {
                 effect = Alert.Effect.Suspension
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     RedLine.stopsBraintreeBranchSouth
                         .map {
@@ -1383,7 +1375,6 @@ class RouteCardDataLeafTest {
 
             val alert = objects.alert {
                 effect = Alert.Effect.Suspension
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     RedLine.stopsBraintreeBranchSouth
                         .map {
@@ -2745,7 +2736,6 @@ class RouteCardDataLeafTest {
                 }
             val alert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(
@@ -2839,7 +2829,6 @@ class RouteCardDataLeafTest {
             }
             val alert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(
@@ -2921,7 +2910,6 @@ class RouteCardDataLeafTest {
 
             val alert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(
@@ -3023,7 +3011,6 @@ class RouteCardDataLeafTest {
             val now = EasternTimeInstant.now()
             val alert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(
@@ -3133,7 +3120,6 @@ class RouteCardDataLeafTest {
             val now = EasternTimeInstant.now()
             val alert = objects.alert {
                 effect = Alert.Effect.Suspension
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteCardDataTest.kt
@@ -1618,19 +1618,16 @@ class RouteCardDataTest {
         }
 
         val alertB = objects.alert {
-            activePeriod(now - 15.minutes, null)
             effect = Alert.Effect.Delay
             informedEntity(route = greenB.id.idText, routeType = RouteType.LIGHT_RAIL)
             severity = 5
         }
         val alertC = objects.alert {
-            activePeriod(now - 15.minutes, null)
             effect = Alert.Effect.Delay
             informedEntity(route = "Green-C", routeType = RouteType.LIGHT_RAIL)
             severity = 5
         }
         val alertE = objects.alert {
-            activePeriod(now - 15.minutes, null)
             effect = Alert.Effect.Delay
             informedEntity(route = "Green-E", routeType = RouteType.LIGHT_RAIL)
             severity = 5
@@ -5546,7 +5543,6 @@ class RouteCardDataTest {
 
             val shawmutShuttleAlert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(
                         Alert.InformedEntity.Activity.Board,
@@ -5559,7 +5555,6 @@ class RouteCardDataTest {
 
             val ashmontShuttleAlert = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(
                         Alert.InformedEntity.Activity.Board,
@@ -5573,7 +5568,6 @@ class RouteCardDataTest {
             val parkShuttleAlert = objects.alert {
                 id = "park_shuttle_alert"
                 effect = Alert.Effect.Shuttle
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(
                         Alert.InformedEntity.Activity.Board,
@@ -5587,7 +5581,6 @@ class RouteCardDataTest {
             val parkElevatorAlert = objects.alert {
                 id = "park_elevator_alert"
                 effect = Alert.Effect.ElevatorClosure
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(Alert.InformedEntity.Activity.UsingWheelchair),
                     route = route.id.idText,
@@ -5697,7 +5690,6 @@ class RouteCardDataTest {
 
             val southStationTrackChangeAlert = objects.alert {
                 effect = Alert.Effect.TrackChange
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(
                         Alert.InformedEntity.Activity.Board,
@@ -5710,7 +5702,6 @@ class RouteCardDataTest {
 
             val providenceTrackChangeAlert = objects.alert {
                 effect = Alert.Effect.TrackChange
-                activePeriod(time - 1.seconds, null)
                 informedEntity(
                     listOf(
                         Alert.InformedEntity.Activity.Board,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
@@ -5,7 +5,6 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single.stop
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Instant
 
 class RouteSegmentTest {
 
@@ -74,7 +73,6 @@ class RouteSegmentTest {
                     listOf(
                         alert {
                             effect = Alert.Effect.Shuttle
-                            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                             informedEntity(
                                 route = "sourceRoute",
                                 routeType = RouteType.HEAVY_RAIL,
@@ -83,7 +81,6 @@ class RouteSegmentTest {
                         },
                         alert {
                             effect = Alert.Effect.Delay
-                            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                             informedEntity(
                                 route = "sourceRoute",
                                 routeType = RouteType.HEAVY_RAIL,
@@ -129,7 +126,6 @@ class RouteSegmentTest {
                             listOf(
                                 alert {
                                     effect = Alert.Effect.Shuttle
-                                    activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                                     informedEntity(
                                         route = "sourceRoute",
                                         routeType = RouteType.HEAVY_RAIL,
@@ -138,7 +134,6 @@ class RouteSegmentTest {
                                 },
                                 alert {
                                     effect = Alert.Effect.Suspension
-                                    activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                                     informedEntity(
                                         route = "sourceRoute",
                                         routeType = RouteType.HEAVY_RAIL,
@@ -218,7 +213,6 @@ class RouteSegmentTest {
                     listOf(
                         alert {
                             effect = Alert.Effect.Shuttle
-                            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                             informedEntity(
                                 route = "sourceRoute",
                                 routeType = RouteType.HEAVY_RAIL,
@@ -251,7 +245,6 @@ class RouteSegmentTest {
 
         val alert = alert {
             effect = Alert.Effect.Shuttle
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             informedEntity(routeType = RouteType.LIGHT_RAIL, route = "Mattapan")
         }
 
@@ -593,7 +586,6 @@ class RouteSegmentTest {
                 listOf(
                     alert {
                         this.effect = effect
-                        activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                         informedEntity(
                             route = routeId.idText,
                             routeType = RouteType.HEAVY_RAIL,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripDetailsStopListTest.kt
@@ -8,7 +8,6 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Instant
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Month
 
@@ -84,7 +83,6 @@ class TripDetailsStopListTest {
             block: ObjectCollectionBuilder.AlertBuilder.() -> Unit = {},
         ) = objects.alert {
             this.effect = effect
-            this.activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
             block()
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/UpcomingTripTest.kt
@@ -13,7 +13,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 class UpcomingTripTest {
     class DisplayTest {
@@ -318,7 +317,6 @@ class UpcomingTripTest {
             val route = objects.route()
             val shuttle = objects.alert {
                 effect = Alert.Effect.Shuttle
-                activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), null)
                 informedEntity =
                     mutableListOf(
                         Alert.InformedEntity(

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponseTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/response/NearbyResponseTest.kt
@@ -7,7 +7,6 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Instant
 import org.maplibre.spatialk.geojson.Position
 import org.maplibre.spatialk.turf.measurement.offset
 import org.maplibre.spatialk.units.Bearing
@@ -83,7 +82,6 @@ class NearbyResponseTest {
         }
 
         objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
                 stop = stop1.id,
@@ -113,7 +111,6 @@ class NearbyResponseTest {
         }
 
         objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
                 stop = stop1.id,
@@ -144,7 +141,6 @@ class NearbyResponseTest {
         }
 
         objects.alert {
-            activePeriod(EasternTimeInstant(Instant.DISTANT_PAST), end = null)
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board, Alert.InformedEntity.Activity.Exit),
                 stop = stop1.id,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -676,7 +676,6 @@ internal class FavoritesViewModelTest : KoinTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(now - 10.minutes, now + 10.minutes)
             informedEntity(stop = stop1.id)
             informedEntity(stop = stop2.id)
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/MapViewModelTests.kt
@@ -44,7 +44,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.fail
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
@@ -382,8 +381,6 @@ internal class MapViewModelTests : KoinTest {
             }
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod =
-                mutableListOf(Alert.ActivePeriod(EasternTimeInstant.now().minus(5.hours), null))
             informedEntity = informedEntities.toMutableList()
         }
 
@@ -435,8 +432,6 @@ internal class MapViewModelTests : KoinTest {
             }
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod =
-                mutableListOf(Alert.ActivePeriod(EasternTimeInstant.now().minus(5.hours), null))
             informedEntity = informedEntities.toMutableList()
         }
 
@@ -583,7 +578,7 @@ internal class MapViewModelTests : KoinTest {
         val alertCreationTime = clock.startTime + 1.seconds
         objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod = mutableListOf(Alert.ActivePeriod(alertCreationTime, null))
+            activePeriod(alertCreationTime, null)
             informedEntity = informedEntities.toMutableList()
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModelTests.kt
@@ -368,7 +368,6 @@ internal class NearbyViewModelTests : KoinTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(now - 10.minutes, now + 10.minutes)
             informedEntity(stop = stop1.id)
             informedEntity(stop = stop2.id)
         }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/TripDetailsPageViewModelTest.kt
@@ -151,7 +151,6 @@ class TripDetailsPageViewModelTest : KoinTest {
 
         val alert = objects.alert {
             effect = Alert.Effect.Suspension
-            activePeriod(EasternTimeInstant.now() - 1.hours, null)
             informedEntity(route = route.id.idText, stop = alertStop.id)
         }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

The fact that alerts default to all clear is counterintuitive (and makes some of the summary-related changes more confusing). Most of the time, we want alerts to be active, so this seems like a more natural behavior.

If I had known that it would take most of the day to check every single created alert and see whether it needs to actually set its active period or if it can just use the default, I would not have done that, but I thought it would not take most of the day, so I did it.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Checked that all tests still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
