### PR TITLE
Fix: Favorite stop on the opposite direction when trying to favorite …

### DIFF
--- a/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
+++ b/iosApp/iosApp/ComponentViews/SaveFavoritesFlow.swift
@@ -139,7 +139,7 @@ struct SaveFavoritesFlow: View {
             .saveFavorite(
                 routeId: lineOrRoute.id,
                 stopId: stop.id,
-                selectedDirection: selectedDirection,
+                selectedDirection: directions.count == 1 ? directions[0].id : selectedDirection,
                 context: context
             )
         )

--- a/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
+++ b/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
@@ -273,6 +273,40 @@ final class SaveFavoritesFlowTest: XCTestCase {
         )
     }
 
+    func testOpensSavePageWhenNotificationsFlagIsOnForLastStopMultiDirection() {
+        let onCloseExp = XCTestExpectation(description: "On close called")
+        let onPushNavExp = XCTestExpectation(description: "Navigation pushed")
+        var pushedNav: SheetNavigationStackEntry?
+
+        let route = ObjectCollectionBuilder().route { route in
+            route.type = RouteType.bus
+        }
+
+        let sut = SaveFavoritesFlow(
+            lineOrRoute: LineOrRoute.route(route),
+            stop: stop,
+            directions: [direction0],
+            selectedDirection: 1,
+            context: EditFavoritesContext.favorites,
+            global: .init(objects: .init()),
+            isFavorite: { _ in false },
+            updateFavorites: { _ in XCTFail("Favorites should not be updated automatically") },
+            onClose: { onCloseExp.fulfill() },
+            pushNavEntry: { entry in
+                pushedNav = entry
+                onPushNavExp.fulfill()
+            },
+        )
+
+        ViewHosting.host(view: sut.withFixedSettings([.notifications: true]))
+
+        wait(for: [onCloseExp, onPushNavExp], timeout: 2)
+        XCTAssertEqual(
+            pushedNav,
+            .saveFavorite(routeId: route.id, stopId: stop.id, selectedDirection: 0, context: .favorites)
+        )
+    }
+
     @MainActor
     func testOpensSavePageWhenNotificationsFlagIsOnForMultiDirection() {
         let onCloseExp = XCTestExpectation(description: "On close called")


### PR DESCRIPTION
…last stop

### Summary

_Ticket:_ [[Bug from research session] Users can favorite last stop on the line](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1216432722216134?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Favorite stop on the opposite direction when trying to favorite last stop

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Ran unit tests and added one

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->

<img width="230" height="500" alt="Untitled" src="https://github.com/user-attachments/assets/278bc669-1839-47e4-ac59-d0650e24459e" />
