### PR TITLE
refactor: make FormattedAlert.alert non-optional

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -341,7 +341,10 @@ class AlertCardTests {
     @Test
     fun testTripCancellationAlertCard() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Cancellation }
+        val alert = objects.alert {
+            cause = Alert.Cause.MechanicalIssue
+            effect = Alert.Effect.Cancellation
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -376,7 +379,10 @@ class AlertCardTests {
     @Test
     fun testMultipleTripSuspensionAlertCard() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Suspension }
+        val alert = objects.alert {
+            cause = Alert.Cause.Holiday
+            effect = Alert.Effect.Suspension
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -554,7 +560,10 @@ class AlertCardTests {
     @Test
     fun testTripSpecificReminder() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Cancellation }
+        val alert = objects.alert {
+            cause = Alert.Cause.MechanicalIssue
+            effect = Alert.Effect.Cancellation
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.android.assertMatches
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
 import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
@@ -32,7 +33,8 @@ class FormattedAlertTests {
                 "Porter",
                 "North Station",
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -58,7 +60,8 @@ class FormattedAlertTests {
                 "Porter",
                 "North Station",
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -79,7 +82,8 @@ class FormattedAlertTests {
                 "Porter",
                 "North Station",
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals(
@@ -100,7 +104,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -124,7 +129,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -146,7 +152,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train is suspended today due to weather", summaryString)
@@ -163,7 +170,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train will terminate at Porter today due to weather", summaryString)
@@ -181,7 +189,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -204,7 +213,8 @@ class FormattedAlertTests {
                 true,
                 Alert.Cause.Weather,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train will not stop at Porter today due to weather", summaryString)
@@ -219,7 +229,8 @@ class FormattedAlertTests {
                 AlertSummary.Location.AffectedStops(listOf("Back Bay")),
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -237,7 +248,8 @@ class FormattedAlertTests {
                 AlertSummary.Location.AffectedStops(listOf("Back Bay", "Ruggles")),
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -255,7 +267,8 @@ class FormattedAlertTests {
                 AlertSummary.Location.AffectedStops(listOf("Back Bay", "Ruggles", "Hyde Park")),
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -277,7 +290,8 @@ class FormattedAlertTests {
                 ),
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
-        val format = FormattedAlert(null, summary)
+        val alert = ObjectCollectionBuilder.Single.alert()
+        val format = FormattedAlert(alert, summary)
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -75,6 +75,7 @@ import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
@@ -373,7 +374,7 @@ private fun NotificationsBetaPage(advance: () -> Unit) {
                     }
                     val alert =
                         FormattedAlert(
-                            alert = null,
+                            alert = Single.alert(),
                             alertSummary =
                                 AlertSummary.Standard(
                                     effect = Alert.Effect.Suspension,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -214,7 +214,10 @@ fun AlertCardPreview() {
         )
 
         AlertCard(
-            ObjectCollectionBuilder.Single.alert { effect = Alert.Effect.Cancellation },
+            ObjectCollectionBuilder.Single.alert {
+                cause = Alert.Cause.Holiday
+                effect = Alert.Effect.Cancellation
+            },
             TripSpecificAlertSummary(
                 TripSpecificAlertSummary.TripFrom(
                     EasternTimeInstant(2026, Month.MARCH, 10, 22, 17),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -21,7 +21,7 @@ import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 
 data class FormattedAlert(
-    val alert: Alert?,
+    val alert: Alert,
     val alertSummary: AlertSummary?,
     @StringRes val effectRes: Int,
     @StringRes val sentenceEffectRes: Int,
@@ -34,16 +34,16 @@ data class FormattedAlert(
     val predictionReplacement: PredictionReplacement,
 ) {
     constructor(
-        alert: Alert?,
+        alert: Alert,
         alertSummary: AlertSummary? = null,
     ) : this(
         alert,
         alertSummary,
-        effectRes(alert?.effect ?: alertSummary?.effect),
-        sentenceEffectRes(alert?.effect ?: alertSummary?.effect),
-        causeRes(alert?.cause),
-        dueToCauseRes(alert?.cause ?: (alertSummary as? TripSpecificAlertSummary)?.cause),
-        predictionReplacement(alert?.effect ?: alertSummary?.effect),
+        effectRes(alert.effect),
+        sentenceEffectRes(alert.effect),
+        causeRes(alert.cause),
+        dueToCauseRes(alert.cause),
+        predictionReplacement(alert.effect),
     )
 
     fun cause(resources: Resources) = causeRes?.let { resources.getString(it) }
@@ -78,7 +78,7 @@ data class FormattedAlert(
         // Show "Single Tracking" if there is an informational delay alert with that cause
         // (Any other information severity delay alerts are never shown)
         return cause(resources)?.let {
-            if (alert?.cause == Alert.Cause.SingleTracking && alert.severity < 3) {
+            if (alert.cause == Alert.Cause.SingleTracking && alert.severity < 3) {
                 AnnotatedString.fromHtml(resources.getString(R.string.effect, it))
             } else null
         } ?: AnnotatedString.fromHtml(delaysDueToCause(resources))
@@ -86,16 +86,15 @@ data class FormattedAlert(
 
     private fun elevatorHeader(resources: Resources) =
         AnnotatedString(
-            alert
-                ?.informedEntity
-                ?.mapNotNull { alert.facilities?.get(it.facility) }
-                ?.filter { it.type == Facility.Type.Elevator }
-                ?.distinct()
-                ?.singleOrNull()
+            alert.informedEntity
+                .mapNotNull { alert.facilities?.get(it.facility) }
+                .filter { it.type == Facility.Type.Elevator }
+                .distinct()
+                .singleOrNull()
                 ?.shortName
                 ?.let { facilityName ->
                     resources.getString(R.string.alert_elevator_header, facilityName)
-                } ?: alert?.header ?: effect(resources)
+                } ?: alert.header ?: effect(resources)
         )
 
     private fun summary(resources: Resources) = summary(alertSummary, resources)
@@ -199,7 +198,7 @@ data class FormattedAlert(
             AlertCardSpec.Delay -> delayHeader(resources)
             AlertCardSpec.Basic -> summary(resources) ?: AnnotatedString.fromHtml(effect(resources))
             else -> {
-                val effect = alert?.effect ?: alertSummary?.effect
+                val effect = alert.effect
                 val isTripSpecificAlertSummary =
                     alertSummary is TripSpecificAlertSummary ||
                         alertSummary is TripShuttleAlertSummary
@@ -240,7 +239,7 @@ data class FormattedAlert(
         alertCardHeader(spec, type, LocalResources.current)
 
     fun alertCardMajorBody(resources: Resources) =
-        summary(resources) ?: AnnotatedString(alert?.header ?: "")
+        summary(resources) ?: AnnotatedString(alert.header ?: "")
 
     val alertCardMajorBody
         @Composable get() = alertCardMajorBody(LocalResources.current)
@@ -258,7 +257,7 @@ data class FormattedAlert(
 
     companion object {
         @StringRes
-        private fun effectRes(effect: Alert.Effect?) =
+        private fun effectRes(effect: Alert.Effect) =
             when (effect) {
                 Alert.Effect.AccessIssue -> R.string.access_issue
                 Alert.Effect.AdditionalService -> R.string.additional_service
@@ -293,12 +292,11 @@ data class FormattedAlert(
                 Alert.Effect.Suspension -> R.string.suspension
                 Alert.Effect.TrackChange -> R.string.track_change
                 Alert.Effect.OtherEffect,
-                Alert.Effect.UnknownEffect,
-                null -> R.string.alert
+                Alert.Effect.UnknownEffect -> R.string.alert
             }
 
         @StringRes
-        private fun sentenceEffectRes(effect: Alert.Effect?) =
+        private fun sentenceEffectRes(effect: Alert.Effect) =
             when (effect) {
                 Alert.Effect.AccessIssue -> R.string.access_issue_sentence_case
                 Alert.Effect.AdditionalService -> R.string.additional_service_sentence_case
@@ -333,8 +331,7 @@ data class FormattedAlert(
                 Alert.Effect.Suspension -> R.string.service_suspended
                 Alert.Effect.TrackChange -> R.string.track_change_sentence_case
                 Alert.Effect.OtherEffect,
-                Alert.Effect.UnknownEffect,
-                null -> R.string.alert
+                Alert.Effect.UnknownEffect -> R.string.alert
             }
 
         private fun causeRes(cause: Alert.Cause?) =
@@ -462,7 +459,7 @@ data class FormattedAlert(
                 else -> null
             }
 
-        private fun predictionReplacement(effect: Alert.Effect?) =
+        private fun predictionReplacement(effect: Alert.Effect) =
             when (effect) {
                 Alert.Effect.DockClosure -> PredictionReplacement(R.string.dock_closed)
                 Alert.Effect.Shuttle ->

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -255,7 +255,10 @@ struct AlertCard: View {
             .padding(32)
 
             AlertCard(
-                alert: objects.alert { $0.effect = .cancellation },
+                alert: objects.alert {
+                    $0.cause = .mechanicalIssue
+                    $0.effect = .cancellation
+                },
                 alertSummary: TripSpecificAlertSummary(
                     tripIdentity: TripSpecificAlertSummary.TripFrom(
                         tripTime: .init(year: 2026, month: .march, day: 9, hour: 12, minute: 13, second: 0),

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -255,23 +255,26 @@ struct OnboardingScreenView: View {
                         Text("now")
                             .font(.system(size: 16))
                     }
-                    let alert = FormattedAlert(alert: nil, alertSummary: .Standard(
-                        effect: .suspension,
-                        location: AlertSummary.LocationSuccessiveStops(
-                            startStopName: "Back Bay",
-                            endStopName: "Wellington"
-                        ),
-                        timeframe: AlertSummary.TimeframeThisWeek(time: .init(
-                            year: 2026,
-                            month: .january,
-                            day: 25,
-                            hour: 12,
-                            minute: 0,
-                            second: 0
-                        )),
-                        recurrence: nil,
-                        isUpdate: false
-                    ))
+                    let alert = FormattedAlert(
+                        alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
+                        alertSummary: .Standard(
+                            effect: .suspension,
+                            location: AlertSummary.LocationSuccessiveStops(
+                                startStopName: "Back Bay",
+                                endStopName: "Wellington"
+                            ),
+                            timeframe: AlertSummary.TimeframeThisWeek(time: .init(
+                                year: 2026,
+                                month: .january,
+                                day: 25,
+                                hour: 12,
+                                minute: 0,
+                                second: 0
+                            )),
+                            recurrence: nil,
+                            isUpdate: false
+                        )
+                    )
                     Text(String(alert.alertCardMajorBody.characters[...]))
                         .font(.system(size: 16))
                         .frame(minHeight: 40) // TODO: fix

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -12,7 +12,7 @@ import Shared
 
 // swiftlint:disable:next type_body_length
 struct FormattedAlert: Equatable {
-    let alert: Alert?
+    let alert: Alert
     let alertSummary: AlertSummary?
     let effect: String
     let sentenceCaseEffect: String
@@ -21,17 +21,14 @@ struct FormattedAlert: Equatable {
     /// guarantee that the alert should replace predictions.
     let predictionReplacement: PredictionReplacement
 
-    // swiftlint:disable:next cyclomatic_complexity
-    init(alert: Alert?, alertSummary: AlertSummary? = nil) {
+    init(alert: Alert, alertSummary: AlertSummary? = nil) {
         self.alert = alert
-        let effect = alert?.effect ?? alertSummary?.effect ?? .unknownEffect
-        self.effect = "**\(effect.effectString)**"
-        sentenceCaseEffect = effect.effectSentenceCaseString
-        let cause = alert?.cause ?? (alertSummary as? TripSpecificAlertSummary)?.cause
-        dueToCause = cause?.causeLowercaseString
+        effect = "**\(alert.effect.effectString)**"
+        sentenceCaseEffect = alert.effect.effectSentenceCaseString
+        dueToCause = alert.cause?.causeLowercaseString
 
         // a handful of cases have different text when replacing predictions than in a details title
-        predictionReplacement = switch effect {
+        predictionReplacement = switch alert.effect {
         case .dockClosure: .init(text: NSLocalizedString("Dock Closed", comment: "Possible alert effect"))
         case .shuttle: .init(
                 text: NSLocalizedString("Shuttle Bus", comment: "Possible alert effect"),
@@ -44,7 +41,7 @@ struct FormattedAlert: Equatable {
                 text: NSLocalizedString("Suspension", comment: "Possible alert effect"),
                 accessibilityLabel: NSLocalizedString("Service suspended", comment: "Suspension alert VoiceOver text")
             )
-        default: .init(text: effect.effectString, accessibilityLabel: nil)
+        default: .init(text: alert.effect.effectString, accessibilityLabel: nil)
         }
         self.alertSummary = alertSummary
     }
@@ -464,7 +461,7 @@ struct FormattedAlert: Equatable {
         }
         // Show "Single Tracking" if there is an informational delay alert with that cause
         // (Any other information severity delay alerts are never shown)
-        guard let alert, let cause = alert.cause?.causeString,
+        guard let cause = alert.cause?.causeString,
               alert.cause == .singleTracking,
               alert.severity < 3
         else {
@@ -474,11 +471,11 @@ struct FormattedAlert: Equatable {
     }
 
     var elevatorHeader: AttributedString {
-        let facilities = alert?.informedEntity.compactMap { entity in
-            if let facilityId = entity.facility { alert?.facilities?[facilityId] } else { nil }
+        let facilities = alert.informedEntity.compactMap { entity in
+            if let facilityId = entity.facility { alert.facilities?[facilityId] } else { nil }
         }.filter { $0.type == .elevator }
         let headerString =
-            if let facilities, let facility = Set(facilities).count == 1 ? facilities.first : nil,
+            if let facility = Set(facilities).count == 1 ? facilities.first : nil,
             let facilityName = facility.shortName {
                 String(format:
                     NSLocalizedString(
@@ -489,7 +486,7 @@ struct FormattedAlert: Equatable {
                         ex "Elevator closure (Red Line platforms to lobby)"
                         """
                     ), facilityName)
-            } else if let header = alert?.header {
+            } else if let header = alert.header {
                 header
             } else {
                 effect
@@ -503,7 +500,7 @@ struct FormattedAlert: Equatable {
         case .downstream: summary ?? AttributedString.tryMarkdown(downstreamLabel)
         case .elevator: elevatorHeader
         case .basic: summary ?? AttributedString.tryMarkdown(effect)
-        default: switch (type, alert?.effect ?? alertSummary?.effect) {
+        default: switch (type, alert.effect) {
             case (.bus, .cancellation) where alertSummary is TripSpecificAlertSummary:
                 AttributedString(NSLocalizedString("Bus cancelled", comment: ""))
             case (.ferry, .cancellation) where alertSummary is TripSpecificAlertSummary:
@@ -528,7 +525,7 @@ struct FormattedAlert: Equatable {
     }
 
     var alertCardMajorBody: AttributedString {
-        summary ?? AttributedString(alert?.header ?? "")
+        summary ?? AttributedString(alert.header ?? "")
     }
 
     struct PredictionReplacement: Equatable {

--- a/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
+++ b/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
@@ -15,7 +15,7 @@ import XCTest
 final class FormattedAlertTests: XCTestCase {
     func testTripShuttle() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.SingleTrip(
                     tripTime: .init(
@@ -42,7 +42,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testDownstreamTripShuttle() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.SingleTrip(
                     tripTime: .init(
@@ -69,7 +69,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThisTripShuttle() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.ThisTrip(
                     routeType: .commuterRail
@@ -87,7 +87,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testDownstreamTripShuttleRecurrence() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.SingleTrip(
                     tripTime: .init(
@@ -125,7 +125,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThisTripShuttleRecurrence() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: TripShuttleAlertSummary(
                 tripIdentity: TripShuttleAlertSummary.ThisTrip(
                     routeType: .commuterRail
@@ -154,7 +154,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testTripSuspension() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripFrom(
                     tripTime: .init(
@@ -182,7 +182,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThisTripSuspension() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.ThisTrip(
                     routeType: .commuterRail
@@ -201,7 +201,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testDownstreamTripSuspension() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripFrom(
                     tripTime: .init(
@@ -229,7 +229,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThisDownstreamTripSuspension() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.ThisTrip(
                     routeType: .commuterRail
@@ -248,7 +248,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testTripStopSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.TripTo(
                     tripTime: .init(
@@ -276,7 +276,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThisTripStopSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { $0.cause = .weather },
             alertSummary: TripSpecificAlertSummary(
                 tripIdentity: TripSpecificAlertSummary.ThisTrip(
                     routeType: .ferry
@@ -296,7 +296,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testOneStopSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: AlertSummary.Standard(
                 effect: .stationClosure,
                 location: AlertSummary.LocationAffectedStops(stops: ["Back Bay"]),
@@ -313,7 +313,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testTwoStopsSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: AlertSummary.Standard(
                 effect: .stationClosure,
                 location: AlertSummary.LocationAffectedStops(stops: ["Back Bay", "Ruggles"]),
@@ -330,7 +330,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testThreeStopsSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: AlertSummary.Standard(
                 effect: .stationClosure,
                 location: AlertSummary.LocationAffectedStops(stops: ["Back Bay", "Ruggles", "Hyde Park"]),
@@ -347,7 +347,7 @@ final class FormattedAlertTests: XCTestCase {
 
     func testMultipleStopsSkipped() {
         let formatted = FormattedAlert(
-            alert: nil,
+            alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
             alertSummary: AlertSummary.Standard(
                 effect: .stationClosure,
                 location: AlertSummary.LocationAffectedStops(stops: ["Back Bay", "Ruggles", "Hyde Park", "Readville"]),

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -574,6 +574,7 @@ final class AlertCardTests: XCTestCase {
     func testTripCancellationAlertCard() throws {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
+            alert.cause = .mechanicalIssue
             alert.effect = .cancellation
         }
 
@@ -614,6 +615,7 @@ final class AlertCardTests: XCTestCase {
     func testMultipleTripSuspensionAlertCard() throws {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
+            alert.cause = .holiday
             alert.effect = .suspension
         }
 
@@ -731,6 +733,7 @@ final class AlertCardTests: XCTestCase {
     func testTripSpecificReminder() throws {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
+            alert.cause = .mechanicalIssue
             alert.effect = .cancellation
         }
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

This was made optional in #1509 when we were still building notification content in the frontend; since we don’t do that, we no longer need this to be optional.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Updated tests to ensure they still pass.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
