### PR TITLE
Add smoke test plan to be used for validating previous ios versions

### DIFF
--- a/iosApp/iosAppSmokeTest.xctestplan
+++ b/iosApp/iosAppSmokeTest.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "13C85839-B2C7-430C-A2BF-EA3FBE5FFA0D",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "IosAppUITests\/testLaunchPerformance()",
+        "IosAppUITests\/testMapShown()",
+        "IosAppUITestsLaunchTests"
+      ],
+      "target" : {
+        "containerPath" : "container:iosApp.xcodeproj",
+        "identifier" : "C6FCE5742C7A4D59A165E213",
+        "name" : "iosAppUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -325,6 +325,7 @@ fileGroups:
   - 10 Park Plaza.gpx
   - iosApp.xctestplan
   - iosAppRetries.xctestplan
+  - iosAppSmokeTest.xctestplan
   - PrivacyInfo.xcprivacy
   - project.yml
 schemes:
@@ -360,6 +361,7 @@ schemeTemplates:
         - path: iosApp.xctestplan
           defaultPlan: true
         - path: iosAppRetries.xctestplan
+        - path: iosAppSmokeTest.xctestplan
 
     profile:
       config: ${scheme_name}Release


### PR DESCRIPTION
### Summary

_Ticket:_ [smoke test different versions of iOS](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1216219303948090?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

#### What is this PR for?
Add new test plan with only testAccessibilityNearbyToTripDetails

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

#### What testing have you done?
Ran the test plan and it only executed that test
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
