### PR TITLE
Add smoke test to test-ios workflow

### DIFF
--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -63,13 +63,39 @@ jobs:
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
           GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
+      - name: Get latest two iOS versions
+        if: ${{ !inputs.skip-everything }}
+        id: ios_versions
+        run: |
+          DEVICES=$(xcrun simctl list devices | awk '/^-- iOS/ {v=$3; next} v && /iPhone/ {print $1, $2, $3, "("v")"; v=""}' | sort -r | awk -F'[(.]' '!seen[$1]++')
+          LATEST_DEVICE=$(echo "$DEVICES" | head -n 1)
+          SECOND_LATEST_DEVICE=$(echo "$DEVICES" | head -n 2 | tail -n 1)
+          echo "LATEST_DEVICE=$LATEST_DEVICE" >> $GITHUB_OUTPUT
+          echo "SECOND_LATEST_DEVICE=$SECOND_LATEST_DEVICE" >> $GITHUB_OUTPUT
       - name: Run emulator tests
         if: ${{ !inputs.skip-everything }}
         run: |
           bundle exec fastlane ios test \
-            xcodebuild_formatter:"xcbeautify --renderer github-actions"
+            xcodebuild_formatter:"xcbeautify --renderer github-actions" \
+            device:"${IOS_DEVICE}"
+        env:
+          IOS_DEVICE: ${{ steps.ios_versions.outputs.LATEST_DEVICE }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && !inputs.skip-everything
         with:
           name: ios-ios-results
           path: fastlane/test_output/*
+
+      - name: Run emulator smoke tests
+        if: ${{ !inputs.skip-everything }}
+        run: |
+          bundle exec fastlane ios smoke_test \
+            xcodebuild_formatter:"xcbeautify --renderer github-actions" \
+            device:"${IOS_DEVICE}"
+        env:
+          IOS_DEVICE: ${{ steps.ios_versions.outputs.SECOND_LATEST_DEVICE }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure() && !inputs.skip-everything
+        with:
+          name: ios-ios-results
+          path: fastlane/smoke_test_output/*

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -68,7 +68,7 @@ jobs:
         id: ios_versions
         run: |
           DEVICES=$(xcrun simctl list devices | awk '/^-- iOS/ {v=$3; next} v && /iPhone/ {print $1, $2, $3, "("v")"; v=""}' | sort -r | awk -F'[(.]' '!seen[$1]++')
-          SECOND_LATEST_DEVICE=$(echo "$DEVICES" | head -n 2 | tail -n 1)
+          LATEST_DEVICE=$(echo "$DEVICES" | head -n 1)
           echo "LATEST_DEVICE=$LATEST_DEVICE" >> $GITHUB_OUTPUT
       - name: Run emulator tests
         if: ${{ !inputs.skip-everything }}

--- a/.github/workflows/test-ios.yaml
+++ b/.github/workflows/test-ios.yaml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ !inputs.skip-everything }}
         run: |
           bundle exec fastlane ios test \
-            xcodebuild_formatter:"xcbeautify --renderer github-actions" \
+            xcodebuild_formatter:"xcbeautify --quieter --is-ci --renderer github-actions" \
             device:"${IOS_DEVICE}"
         env:
           IOS_DEVICE: ${{ steps.ios_versions.outputs.LATEST_DEVICE }}

--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -53,7 +53,7 @@ jobs:
         if: ${{ !inputs.skip-everything }}
         run: |
           bundle exec fastlane ios smoke_test \
-            xcodebuild_formatter:"xcbeautify --renderer github-actions" \
+            xcodebuild_formatter:"xcbeautify --quieter --is-ci --renderer github-actions" \
             device:"${IOS_DEVICE}"
         env:
           IOS_DEVICE: ${{ steps.ios_versions.outputs.SECOND_LATEST_DEVICE }}

--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -1,24 +1,13 @@
-name: iOS tests
+name: iOS tests on older iOS version
 
 on:
-  workflow_call:
-    inputs:
-      skip-everything:
-        description: "Skips all the individual steps so the job passes quickly"
-        required: false
-        default: false
-        type: boolean
-    secrets:
-      SENTRY_DSN:
-        required: true
-      FIREBASE_KEY:
-        required: true
-      GOOGLE_APP_ID_IOS:
-        required: true
+  push:
+    branches:
+      - main
 
 jobs:
-  test-ios:
-    name: Test for iOS
+  test-older-ios:
+    name: Test for older iOS
     runs-on: macos-15-xlarge
     permissions:
       contents: read
@@ -39,16 +28,6 @@ jobs:
           bundle exec pod install
           popd
           bundle exec ./gradlew :shared:podInstallSyntheticIos
-      - name: shared checks & unit tests
-        if: ${{ !inputs.skip-everything }}
-        run: ./gradlew shared:iosSimulatorArm64Test
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure() && !inputs.skip-everything
-        with:
-          name: ios-shared-reports
-          path: shared/build/reports
       - name: Add build environment variables
         if: ${{ !inputs.skip-everything }}
         run: |
@@ -63,23 +42,23 @@ jobs:
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
           GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
-      - name: Get latest two iOS versions
+      - name: Get second latest iOS version
         if: ${{ !inputs.skip-everything }}
         id: ios_versions
         run: |
           DEVICES=$(xcrun simctl list devices | awk '/^-- iOS/ {v=$3; next} v && /iPhone/ {print $1, $2, $3, "("v")"; v=""}' | sort -r | awk -F'[(.]' '!seen[$1]++')
           SECOND_LATEST_DEVICE=$(echo "$DEVICES" | head -n 2 | tail -n 1)
-          echo "LATEST_DEVICE=$LATEST_DEVICE" >> $GITHUB_OUTPUT
-      - name: Run emulator tests
+          echo "SECOND_LATEST_DEVICE=$SECOND_LATEST_DEVICE" >> $GITHUB_OUTPUT
+      - name: Run emulator smoke tests
         if: ${{ !inputs.skip-everything }}
         run: |
-          bundle exec fastlane ios test \
+          bundle exec fastlane ios smoke_test \
             xcodebuild_formatter:"xcbeautify --renderer github-actions" \
             device:"${IOS_DEVICE}"
         env:
-          IOS_DEVICE: ${{ steps.ios_versions.outputs.LATEST_DEVICE }}
+          IOS_DEVICE: ${{ steps.ios_versions.outputs.SECOND_LATEST_DEVICE }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure() && !inputs.skip-everything
         with:
           name: ios-ios-results
-          path: fastlane/test_output/*
+          path: fastlane/smoke_test_output/*

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -217,7 +217,7 @@ platform :ios do
       device: options[:device]&.strip || 'iPhone 16 (26.2)',
       testplan: 'iosAppRetries',
       output_directory: options[:output_directory],
-      include_simulator_logs: true,
+      include_simulator_logs: false,
       xcodebuild_formatter: options[:xcodebuild_formatter],
       result_bundle: true,
       number_of_retries: 3,
@@ -233,7 +233,7 @@ platform :ios do
       device: options[:device]&.strip || 'iPhone 15 (17.4)',
       testplan: 'iosAppSmokeTest',
       output_directory: options[:output_directory],
-      include_simulator_logs: true,
+      include_simulator_logs: false,
       xcodebuild_formatter: options[:xcodebuild_formatter],
       result_bundle: true,
       number_of_retries: 3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,7 +220,8 @@ platform :ios do
       include_simulator_logs: true,
       xcodebuild_formatter: options[:xcodebuild_formatter],
       result_bundle: true,
-      number_of_retries: 3
+      number_of_retries: 3,
+      parallel_testing: true
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,8 +220,7 @@ platform :ios do
       include_simulator_logs: false,
       xcodebuild_formatter: options[:xcodebuild_formatter],
       result_bundle: true,
-      number_of_retries: 3,
-      parallel_testing: true
+      number_of_retries: 3
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,8 +214,23 @@ platform :ios do
     run_tests(
       workspace: 'iosApp/iosApp.xcworkspace',
       scheme: 'Staging',
-      device: 'iPhone 16 (26.2)',
+      device: options[:device]&.strip || 'iPhone 16 (26.2)',
       testplan: 'iosAppRetries',
+      output_directory: options[:output_directory],
+      include_simulator_logs: true,
+      xcodebuild_formatter: options[:xcodebuild_formatter],
+      result_bundle: true,
+      number_of_retries: 3
+    )
+  end
+
+  desc 'Run smoke tests'
+  lane :smoke_test do |options|
+    run_tests(
+      workspace: 'iosApp/iosApp.xcworkspace',
+      scheme: 'Staging',
+      device: options[:device]&.strip || 'iPhone 15 (17.4)',
+      testplan: 'iosAppSmokeTest',
       output_directory: options[:output_directory],
       include_simulator_logs: true,
       xcodebuild_formatter: options[:xcodebuild_formatter],

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -79,6 +79,14 @@ and for "No profile for team '...' matching '...' found: Xcode couldn't find any
 
 Run tests
 
+### ios smoke_test
+
+```sh
+[bundle exec] fastlane ios smoke_test
+```
+
+Run smoke tests
+
 ### ios build
 
 ```sh

--- a/iosApp/iosAppRetries.xctestplan
+++ b/iosApp/iosAppRetries.xctestplan
@@ -19,7 +19,6 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "skippedTests" : [
         "FavoritesModifierTests\/testLoadsFromRepo()",
         "HomeMapViewTests\/testFollowsPuckWhenUserLocationIsKnown()",
@@ -32,7 +31,6 @@
       }
     },
     {
-      "parallelizable" : true,
       "skippedTests" : [
         "EndToEndOpenStopDetailsTest\/testOpenStopDetails()",
         "HomeMapViewUITests\/testRecentersToUserLocation()",

--- a/iosApp/iosAppRetries.xctestplan
+++ b/iosApp/iosAppRetries.xctestplan
@@ -19,6 +19,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "FavoritesModifierTests\/testLoadsFromRepo()",
         "HomeMapViewTests\/testFollowsPuckWhenUserLocationIsKnown()",
@@ -31,6 +32,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "EndToEndOpenStopDetailsTest\/testOpenStopDetails()",
         "HomeMapViewUITests\/testRecentersToUserLocation()",

--- a/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
+++ b/iosApp/iosAppTests/Pages/Settings/MorePageTests.swift
@@ -88,7 +88,7 @@ final class MorePageTests: XCTestCase {
 
     @MainActor func testLinksExist() async {
         let sut = MorePage(highlight: nil)
-        let exp = sut.inspection.inspect(after: 2) { view in
+        let exp = sut.inspection.inspect(after: 0) { view in
             try XCTAssertNotNil(view.find(text: "Send App Feedback"))
             try XCTAssertNotNil(view.find(text: "Trip Planner"))
             try XCTAssertNotNil(view.find(text: "Fare Information"))
@@ -101,7 +101,7 @@ final class MorePageTests: XCTestCase {
 
         ViewHosting.host(view: sut.withFixedSettings([:]))
 
-        await fulfillment(of: [exp], timeout: 5)
+        await fulfillment(of: [exp], timeout: 3)
     }
 
     @MainActor func testShowsBuildNumberOnTap() {


### PR DESCRIPTION
This change also checks for the latest iOS/iPhone versions and picks the latest two

### Summary

_Ticket:_ [smoke test different versions of iOS](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1216219303948090?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
- Add smoke test to test-ios workflow
iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

Will rely on the workflows for the PR

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
