### PR TITLE
feat: read FormattedAlert special cases from alert itself rather than summary

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -18,6 +18,7 @@ import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
 import com.mbta.tid.mbta_app.model.TripSpecificAlertSummary
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 import kotlinx.datetime.Month
 import org.junit.Rule
 import org.junit.Test
@@ -171,14 +172,15 @@ class AlertCardTests {
 
     @Test
     fun testUpcomingDelayAlertCard() {
+        val time = EasternTimeInstant(2025, Month.APRIL, 2, 9, 0)
         val alert =
             ObjectCollectionBuilder.Single.alert {
+                activePeriod(time, null)
                 header = "Alert header"
                 effect = Alert.Effect.Delay
                 cause = Alert.Cause.HeavyRidership
             }
 
-        val time = EasternTimeInstant(2025, Month.APRIL, 2, 9, 0)
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -190,6 +192,7 @@ class AlertCardTests {
                 AlertCardSpec.Delay,
                 routeAccents,
                 {},
+                now = time - 15.minutes,
             )
         }
 
@@ -344,6 +347,7 @@ class AlertCardTests {
         val alert = objects.alert {
             cause = Alert.Cause.MechanicalIssue
             effect = Alert.Effect.Cancellation
+            informedEntity(trip = "trip")
         }
         composeTestRule.setContent {
             AlertCard(
@@ -382,6 +386,7 @@ class AlertCardTests {
         val alert = objects.alert {
             cause = Alert.Cause.Holiday
             effect = Alert.Effect.Suspension
+            informedEntity(trip = "trip")
         }
         composeTestRule.setContent {
             AlertCard(
@@ -406,7 +411,10 @@ class AlertCardTests {
     @Test
     fun testTripShuttleAlertCard() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(trip = "trip")
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -441,7 +449,10 @@ class AlertCardTests {
     @Test
     fun testThisTripShuttleAlertCard() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(trip = "trip")
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -476,7 +487,10 @@ class AlertCardTests {
     @Test
     fun testTripStationBypassAlertCard() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.StationClosure }
+        val alert = objects.alert {
+            effect = Alert.Effect.StationClosure
+            informedEntity(trip = "trip")
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -563,6 +577,7 @@ class AlertCardTests {
         val alert = objects.alert {
             cause = Alert.Cause.MechanicalIssue
             effect = Alert.Effect.Cancellation
+            informedEntity(trip = "trip")
         }
         composeTestRule.setContent {
             AlertCard(
@@ -599,7 +614,10 @@ class AlertCardTests {
     @Test
     fun testTripShuttleRecurrence() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(trip = "trip")
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,
@@ -641,7 +659,10 @@ class AlertCardTests {
     @Test
     fun testThisTripShuttleRecurrence() {
         val objects = ObjectCollectionBuilder()
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            informedEntity(trip = "trip")
+        }
         composeTestRule.setContent {
             AlertCard(
                 alert,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -441,7 +441,7 @@ class StopDetailsFilteredDeparturesViewTest {
                         0,
                         listOf(routePatternOne, routePatternTwo),
                         now,
-                        null,
+                        listOf(UpcomingTrip(trip, schedule, prediction)),
                         globalResponse,
                     )
             )
@@ -471,7 +471,7 @@ class StopDetailsFilteredDeparturesViewTest {
         }
 
         composeTestRule.waitForIdle()
-        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Cancellation"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Bus cancelled"))
 
         composeTestRule.onNodeWithText("Trip cancelled").assertIsNotDisplayed()
         composeTestRule

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -374,7 +374,7 @@ private fun NotificationsBetaPage(advance: () -> Unit) {
                     }
                     val alert =
                         FormattedAlert(
-                            alert = Single.alert(),
+                            alert = Single.alert { effect = Alert.Effect.Suspension },
                             alertSummary =
                                 AlertSummary.Standard(
                                     effect = Alert.Effect.Suspension,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -47,6 +47,7 @@ import kotlinx.datetime.Month
 private fun TakeoverAlertCard(
     alert: Alert,
     alertSummary: AlertSummary?,
+    now: EasternTimeInstant,
     routeAccents: TripRouteAccents,
     onViewDetails: (() -> Unit)?,
     modifier: Modifier = Modifier,
@@ -82,7 +83,7 @@ private fun TakeoverAlertCard(
                     else null,
             )
             Text(
-                formattedAlert.alertCardHeader(AlertCardSpec.Takeover, routeAccents.type),
+                formattedAlert.alertCardHeader(AlertCardSpec.Takeover, routeAccents.type, now),
                 Modifier.weight(1f),
                 style = Typography.title2Bold,
             )
@@ -121,6 +122,7 @@ fun AlertCard(
     routeAccents: TripRouteAccents,
     onViewDetails: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    now: EasternTimeInstant = EasternTimeInstant.now(),
     interiorPadding: PaddingValues = PaddingValues(0.dp),
 ) {
 
@@ -128,6 +130,7 @@ fun AlertCard(
         TakeoverAlertCard(
             alert,
             alertSummary,
+            now,
             routeAccents,
             onViewDetails,
             modifier,
@@ -159,8 +162,7 @@ fun AlertCard(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 val alertState =
-                    if (alertSummary is AlertSummary.AllClear) StopAlertState.AllClear
-                    else alert.alertState
+                    if (alert.allClear(now)) StopAlertState.AllClear else alert.alertState
                 val iconSize = if (alertState == StopAlertState.AllClear) 36.dp else iconSize
                 AlertIcon(
                     alertState = alertState,
@@ -175,7 +177,7 @@ fun AlertCard(
                         else null,
                 )
                 Text(
-                    formattedAlert.alertCardHeader(cardSpec, routeAccents.type),
+                    formattedAlert.alertCardHeader(cardSpec, routeAccents.type, now),
                     Modifier.weight(1f),
                     style = Typography.callout,
                 )
@@ -217,6 +219,7 @@ fun AlertCardPreview() {
             ObjectCollectionBuilder.Single.alert {
                 cause = Alert.Cause.Holiday
                 effect = Alert.Effect.Cancellation
+                informedEntity(trip = "trip")
             },
             TripSpecificAlertSummary(
                 TripSpecificAlertSummary.TripFrom(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -65,11 +65,12 @@ data class FormattedAlert(
             resources.getString(R.string.delays_due_to_cause, resources.getString(it))
         } ?: resources.getString(R.string.delays_unknown_reason)
 
-    private fun delayHeader(resources: Resources): AnnotatedString {
+    private fun delayHeader(now: EasternTimeInstant, resources: Resources): AnnotatedString {
         if (
-            (alertSummary as? AlertSummary.Standard)?.timeframe
-                is AlertSummary.Timeframe.StartingLaterToday
+            alert.currentPeriod(now) == null &&
+                alert.nextPeriod(now)?.startServiceDate == now.serviceDate
         ) {
+            // starting later today
             summary(resources)?.let {
                 return it
             }
@@ -189,21 +190,19 @@ data class FormattedAlert(
     fun alertCardHeader(
         spec: AlertCardSpec,
         type: RouteType,
+        now: EasternTimeInstant,
         resources: Resources,
     ): AnnotatedString {
         return when (spec) {
             AlertCardSpec.Downstream ->
                 summary(resources) ?: AnnotatedString.fromHtml(downstreamEffect(resources))
             AlertCardSpec.Elevator -> elevatorHeader(resources)
-            AlertCardSpec.Delay -> delayHeader(resources)
+            AlertCardSpec.Delay -> delayHeader(now, resources)
             AlertCardSpec.Basic -> summary(resources) ?: AnnotatedString.fromHtml(effect(resources))
             else -> {
-                val effect = alert.effect
-                val isTripSpecificAlertSummary =
-                    alertSummary is TripSpecificAlertSummary ||
-                        alertSummary is TripShuttleAlertSummary
-                if (isTripSpecificAlertSummary) {
-                    when (effect) {
+                val isTripSpecific = alert.informedEntity.any { it.trip != null }
+                if (isTripSpecific) {
+                    when (alert.effect) {
                         Alert.Effect.Cancellation if type == RouteType.BUS -> R.string.bus_cancelled
 
                         Alert.Effect.Cancellation if type == RouteType.FERRY ->
@@ -235,8 +234,8 @@ data class FormattedAlert(
     }
 
     @Composable
-    fun alertCardHeader(spec: AlertCardSpec, type: RouteType) =
-        alertCardHeader(spec, type, LocalResources.current)
+    fun alertCardHeader(spec: AlertCardSpec, type: RouteType, now: EasternTimeInstant) =
+        alertCardHeader(spec, type, now, LocalResources.current)
 
     fun alertCardMajorBody(resources: Resources) =
         summary(resources) ?: AnnotatedString(alert.header ?: "")

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -13,6 +13,7 @@ private struct TakeoverAlertCard: View {
     @ObserveInjection var inject
     let alert: Shared.Alert
     let alertSummary: AlertSummary?
+    let now: EasternTimeInstant
     let routeAccents: TripRouteAccents
     let onViewDetails: (() -> Void)?
     let internalPadding: EdgeInsets
@@ -28,7 +29,7 @@ private struct TakeoverAlertCard: View {
             HStack {
                 HStack(alignment: .center, spacing: 16) {
                     // Override alert state and icon size in the case of all clear
-                    let alertState = alertSummary is AlertSummary.AllClear ? .allClear : alert.alertState
+                    let alertState = alert.allClear(atTime: now) ? .allClear : alert.alertState
                     AlertIcon(
                         alertState: alertState,
                         color: routeAccents.color,
@@ -36,7 +37,7 @@ private struct TakeoverAlertCard: View {
                     )
                     .scaledToFit()
                     .frame(width: iconSize, height: iconSize, alignment: .center)
-                    Text(formattedAlert.alertCardHeader(spec: .takeover, type: routeAccents.type))
+                    Text(formattedAlert.alertCardHeader(spec: .takeover, type: routeAccents.type, now: now))
                         .font(Typography.title2Bold)
                         .multilineTextAlignment(.leading)
                 }
@@ -75,6 +76,7 @@ struct AlertCard: View {
     let alert: Shared.Alert
     let alertSummary: AlertSummary?
     let spec: AlertCardSpec
+    let now: EasternTimeInstant
     let routeAccents: TripRouteAccents
     let onViewDetails: (() -> Void)?
     let internalPadding: EdgeInsets
@@ -88,6 +90,7 @@ struct AlertCard: View {
         alert: Shared.Alert,
         alertSummary: AlertSummary?,
         spec: AlertCardSpec,
+        now: EasternTimeInstant = .now(),
         routeAccents: TripRouteAccents,
         onViewDetails: (() -> Void)?,
         internalPadding: EdgeInsets = .init()
@@ -95,6 +98,7 @@ struct AlertCard: View {
         self.alert = alert
         self.alertSummary = alertSummary
         self.spec = spec
+        self.now = now
         self.routeAccents = routeAccents
         self.onViewDetails = onViewDetails
         self.internalPadding = internalPadding
@@ -117,7 +121,7 @@ struct AlertCard: View {
             HStack {
                 HStack(alignment: .center, spacing: 16) {
                     // Override alert state and icon size in the case of all clear
-                    let alertState = alertSummary is AlertSummary.AllClear ? .allClear : alert.alertState
+                    let alertState = alert.allClear(atTime: now) ? .allClear : alert.alertState
                     let iconSize = alertState == .allClear ? elevatorIconSize : iconSize
                     AlertIcon(
                         alertState: alertState,
@@ -126,7 +130,7 @@ struct AlertCard: View {
                     )
                     .scaledToFit()
                     .frame(width: iconSize, height: iconSize, alignment: .center)
-                    Text(formattedAlert.alertCardHeader(spec: spec, type: routeAccents.type))
+                    Text(formattedAlert.alertCardHeader(spec: spec, type: routeAccents.type, now: now))
                         .font(Typography.callout)
                         .multilineTextAlignment(.leading)
                 }
@@ -146,6 +150,7 @@ struct AlertCard: View {
         if spec == .takeover {
             TakeoverAlertCard(alert: alert,
                               alertSummary: alertSummary,
+                              now: now,
                               routeAccents: routeAccents,
                               onViewDetails: onViewDetails,
                               internalPadding: internalPadding)

--- a/iosApp/iosApp/ComponentViews/DebugView.swift
+++ b/iosApp/iosApp/ComponentViews/DebugView.swift
@@ -38,7 +38,7 @@ struct DebugView<Content: View>: View {
                                 let trimmedKey = if key.count > 25 { "\(key.prefix(25))..." } else { key }
                                 let updateDuration = if let updateTime = channelUpdates[key] {
                                     Duration(
-                                        secondsComponent: abs(now.minus(updateTime).inWholeSeconds),
+                                        secondsComponent: abs(now.minus(other: updateTime).inWholeSeconds),
                                         attosecondsComponent: 0
                                     )
                                     .formatted(.units(allowed: [.seconds], width: .narrow))

--- a/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
+++ b/iosApp/iosApp/Pages/AlertDetails/AlertDetails.swift
@@ -73,7 +73,7 @@ struct AlertDetails: View {
     }
 
     private var currentPeriod: Shared.Alert.ActivePeriod? { alert.currentPeriod(time: now) }
-    private var nextPeriod: Shared.Alert.ActivePeriod? { alert.nextPeriod(time: now, within: .max) }
+    private var nextPeriod: Shared.Alert.ActivePeriod? { alert.nextPeriod(time: now, within: .companion.INFINITE) }
     private var relevantPeriod: Shared.Alert.ActivePeriod? { currentPeriod ?? nextPeriod }
 
     static var calendar: Calendar {

--- a/iosApp/iosApp/Utils/Extensions/AlertExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/AlertExtension.swift
@@ -9,6 +9,12 @@
 import Foundation
 import Shared
 
+extension Alert {
+    func nextPeriod(time: EasternTimeInstant, within: KotlinDuration = .init(days: 1)) -> Alert.ActivePeriod? {
+        __nextPeriod(time: time, within: within.duration)
+    }
+}
+
 extension Alert.Cause {
     var causeLowercaseString: String? {
         switch self {

--- a/iosApp/iosApp/Utils/Extensions/EasternTimeInstantExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/EasternTimeInstantExtension.swift
@@ -22,10 +22,6 @@ extension EasternTimeInstant {
         toNSDateLosingTimeZone().formatted(style.inner)
     }
 
-    func minus(_ other: EasternTimeInstant) -> KotlinDuration {
-        minusToKotlinDuration(other: other)
-    }
-
     struct FormatStyle {
         let inner: Date.FormatStyle
 

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -454,9 +454,10 @@ struct FormattedAlert: Equatable {
         }
     }
 
-    var delayHeader: AttributedString {
-        if case let .standard(alertSummary) = onEnum(of: alertSummary),
-           case .startingLaterToday = onEnum(of: alertSummary.timeframe), let summary {
+    func delayHeader(now: EasternTimeInstant) -> AttributedString {
+        let startingLaterToday = alert.currentPeriod(time: now) == nil &&
+            alert.nextPeriod(time: now, within: .init(days: 1))?.startServiceDate == now.serviceDate
+        if startingLaterToday, let summary {
             return summary
         }
         // Show "Single Tracking" if there is an informational delay alert with that cause
@@ -494,30 +495,31 @@ struct FormattedAlert: Equatable {
         return AttributedString.tryMarkdown(headerString)
     }
 
-    func alertCardHeader(spec: AlertCardSpec, type: RouteType) -> AttributedString {
-        switch spec {
-        case .delay: delayHeader
+    func alertCardHeader(spec: AlertCardSpec, type: RouteType, now: EasternTimeInstant) -> AttributedString {
+        let isTripSpecific = alert.informedEntity.contains(where: { $0.trip != nil })
+        return switch spec {
+        case .delay: delayHeader(now: now)
         case .downstream: summary ?? AttributedString.tryMarkdown(downstreamLabel)
         case .elevator: elevatorHeader
         case .basic: summary ?? AttributedString.tryMarkdown(effect)
         default: switch (type, alert.effect) {
-            case (.bus, .cancellation) where alertSummary is TripSpecificAlertSummary:
+            case (.bus, .cancellation) where isTripSpecific:
                 AttributedString(NSLocalizedString("Bus cancelled", comment: ""))
-            case (.ferry, .cancellation) where alertSummary is TripSpecificAlertSummary:
+            case (.ferry, .cancellation) where isTripSpecific:
                 AttributedString(NSLocalizedString("Ferry cancelled", comment: ""))
-            case (_, .cancellation) where alertSummary is TripSpecificAlertSummary:
+            case (_, .cancellation) where isTripSpecific:
                 AttributedString(NSLocalizedString("Train cancelled", comment: ""))
-            case (_, .shuttle) where alertSummary is TripShuttleAlertSummary:
+            case (_, .shuttle) where isTripSpecific:
                 AttributedString(NSLocalizedString("Shuttle bus", comment: ""))
-            case (.bus, .suspension) where alertSummary is TripSpecificAlertSummary:
+            case (.bus, .suspension) where isTripSpecific:
                 AttributedString(NSLocalizedString("Bus suspended", comment: ""))
-            case (.ferry, .suspension) where alertSummary is TripSpecificAlertSummary:
+            case (.ferry, .suspension) where isTripSpecific:
                 AttributedString(NSLocalizedString("Ferry suspended", comment: ""))
-            case (_, .suspension) where alertSummary is TripSpecificAlertSummary:
+            case (_, .suspension) where isTripSpecific:
                 AttributedString(NSLocalizedString("Train suspended", comment: ""))
-            case (_, .stationClosure) where alertSummary is TripSpecificAlertSummary,
-                 (_, .stopClosure) where alertSummary is TripSpecificAlertSummary,
-                 (_, .dockClosure) where alertSummary is TripSpecificAlertSummary:
+            case (_, .stationClosure) where isTripSpecific,
+                 (_, .stopClosure) where isTripSpecific,
+                 (_, .dockClosure) where isTripSpecific:
                 AttributedString(NSLocalizedString("Stop skipped", comment: ""))
             default: AttributedString.tryMarkdown(effect)
             }

--- a/iosApp/iosApp/Utils/Modifiers/BackgroundTimerModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/BackgroundTimerModifier.swift
@@ -18,7 +18,7 @@ struct BackgroundTimerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content.withScenePhaseHandlers(onActive: {
             let now = EasternTimeInstant.now()
-            if let backgroundTime, now.minus(backgroundTime).inWholeSeconds >= backgroundSeconds {
+            if let backgroundTime, now.minus(other: backgroundTime).inWholeSeconds >= backgroundSeconds {
                 action()
             }
             backgroundTime = nil

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -376,12 +376,9 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
             setStopFilter: { _ in },
             setTripFilter: { _ in },
             leaf: leaf,
-            alertSummaries: [alert.id: AlertSummary.Standard(
+            alertSummaries: [alert.id: TripSpecificAlertSummary(
+                tripIdentity: TripSpecificAlertSummary.ThisTrip(routeType: route.type),
                 effect: .cancellation,
-                location: AlertSummary.LocationSingleStop(stopName: stop.name),
-                timeframe: nil,
-                recurrence: nil,
-                isUpdate: false
             )],
             selectedDirection: .init(name: nil, destination: nil, id: 0),
             favorite: false,
@@ -392,7 +389,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
             navManager: .init(),
         ).environmentObject(ViewportProvider()).withFixedSettings([:])
 
-        XCTAssertNotNil(try sut.inspect().find(text: "Cancellation"))
+        XCTAssertNotNil(try sut.inspect().find(text: "Bus cancelled"))
         XCTAssertThrowsError(try sut.inspect().find(text: "Trip cancelled"))
         XCTAssertThrowsError(try sut.inspect()
             .find(text: "This trip has been cancelled. We’re sorry for the inconvenience."))

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -415,11 +415,6 @@ final class AlertCardTests: XCTestCase {
 
     func testUpcomingDelayAlertCard() throws {
         let objects = ObjectCollectionBuilder()
-        let alert = objects.alert { alert in
-            alert.effect = .delay
-            alert.cause = .accident
-            alert.header = "Test header"
-        }
 
         let time = EasternTimeInstant(
             year: 2025,
@@ -429,6 +424,13 @@ final class AlertCardTests: XCTestCase {
             minute: 0,
             second: 0
         )
+
+        let alert = objects.alert { alert in
+            alert.activePeriod(start: time, end: nil)
+            alert.effect = .delay
+            alert.cause = .accident
+            alert.header = "Test header"
+        }
 
         let sut = AlertCard(
             alert: alert,
@@ -443,6 +445,7 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: false
             ),
             spec: .delay,
+            now: time.minus(minutes: 15),
             routeAccents: .init(),
             onViewDetails: {}
         )
@@ -576,6 +579,7 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.cause = .mechanicalIssue
             alert.effect = .cancellation
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(
@@ -617,6 +621,7 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.cause = .holiday
             alert.effect = .suspension
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(
@@ -645,6 +650,7 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .shuttle
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(
@@ -692,6 +698,7 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .stationClosure
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(
@@ -735,6 +742,7 @@ final class AlertCardTests: XCTestCase {
         let alert = objects.alert { alert in
             alert.cause = .mechanicalIssue
             alert.effect = .cancellation
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(
@@ -776,6 +784,7 @@ final class AlertCardTests: XCTestCase {
         let objects = ObjectCollectionBuilder()
         let alert = objects.alert { alert in
             alert.effect = .shuttle
+            alert.informedEntity(trip: "trip")
         }
 
         let sut = AlertCard(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Alert.kt
@@ -3,6 +3,8 @@ package com.mbta.tid.mbta_app.model
 import com.mbta.tid.mbta_app.model.RoutePattern.Typicality
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.ShouldRefineInSwift
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlinx.datetime.DayOfWeek
@@ -343,6 +345,8 @@ internal constructor(
      * Gets an active period which is not currently active but which will start in the next 24
      * hours.
      */
+    @OptIn(ExperimentalObjCRefinement::class)
+    @ShouldRefineInSwift
     public fun nextPeriod(time: EasternTimeInstant, within: Duration = 24.hours): ActivePeriod? =
         activePeriod.firstOrNull {
             it.start > time && (within == Duration.INFINITE || it.start <= time + within)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/EasternTimeInstant.kt
@@ -1,6 +1,8 @@
 package com.mbta.tid.mbta_app.utils
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import kotlin.experimental.ExperimentalObjCRefinement
+import kotlin.native.HiddenFromObjC
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -79,12 +81,9 @@ private constructor(internal val instant: Instant, public val local: LocalDateTi
     public operator fun minus(duration: Duration): EasternTimeInstant =
         EasternTimeInstant(instant - duration)
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     public operator fun minus(other: EasternTimeInstant): Duration = instant - other.instant
-
-    // Durations become Int64s of half nanoseconds in Swift,
-    // so we need this awkward wrapper to easily get specific units
-    public fun minusToKotlinDuration(other: EasternTimeInstant): KotlinDuration =
-        KotlinDuration(instant - other.instant)
 
     override fun compareTo(other: EasternTimeInstant): Int {
         return this.instant.compareTo(other.instant)
@@ -134,14 +133,4 @@ private constructor(internal val instant: Instant, public val local: LocalDateTi
         public fun now(clock: Clock = Clock.System): EasternTimeInstant =
             EasternTimeInstant(clock.now())
     }
-}
-
-public class KotlinDuration(public val duration: Duration) {
-    public val inWholeDays: Long = duration.inWholeDays
-    public val inWholeHours: Long = duration.inWholeHours
-    public val inWholeMicroseconds: Long = duration.inWholeMicroseconds
-    public val inWholeMilliseconds: Long = duration.inWholeMilliseconds
-    public val inWholeMinutes: Long = duration.inWholeMinutes
-    public val inWholeNanoseconds: Long = duration.inWholeNanoseconds
-    public val inWholeSeconds: Long = duration.inWholeSeconds
 }

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/KotlinDuration.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/KotlinDuration.kt
@@ -1,0 +1,37 @@
+package com.mbta.tid.mbta_app.utils
+
+import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Durations become opaque Int64s in Swift, so this class represents a Kotlin Duration in a way
+ * that’s legible and constructible from Swift
+ */
+public class KotlinDuration(public val duration: Duration) {
+    @DefaultArgumentInterop.Enabled
+    public constructor(
+        days: Int = 0,
+        hours: Int = 0,
+        minutes: Int = 0,
+        seconds: Int = 0,
+    ) : this(days.days + hours.hours + minutes.minutes + seconds.seconds)
+
+    public val inWholeDays: Long = duration.inWholeDays
+    public val inWholeHours: Long = duration.inWholeHours
+    public val inWholeMicroseconds: Long = duration.inWholeMicroseconds
+    public val inWholeMilliseconds: Long = duration.inWholeMilliseconds
+    public val inWholeMinutes: Long = duration.inWholeMinutes
+    public val inWholeNanoseconds: Long = duration.inWholeNanoseconds
+    public val inWholeSeconds: Long = duration.inWholeSeconds
+
+    public companion object {
+        public val INFINITE: KotlinDuration = KotlinDuration(Duration.INFINITE)
+    }
+}
+
+public fun EasternTimeInstant.minus(other: EasternTimeInstant): KotlinDuration =
+    KotlinDuration(instant - other.instant)


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

When we were generating structured `AlertSummary`s in the frontend, we didn’t need to repeat that logic to check if an alert is trip-specific or upcoming later today, but as we prepare to stop doing that, we do need to copy that logic in.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Added an assertion that the old code and the new code produce the same results, and fixed tests where that assertion failed.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
