### PR TITLE
Include GOOGLE_APP_ID_IOS and rename test output

### DIFF
--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -41,7 +41,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
-          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
+          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
       - name: Get second latest iOS version
         if: ${{ !inputs.skip-everything }}
         id: ios_versions
@@ -61,4 +61,4 @@ jobs:
         if: failure() && !inputs.skip-everything
         with:
           name: ios-ios-results
-          path: fastlane/smoke_test_output/*
+          path: fastlane/test_output/*


### PR DESCRIPTION
### Summary

_Ticket:_ [smoke test different versions of iOS](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1216219303948090?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
- Follow up since the last execution failed => https://github.com/mbta/mobile_app/pull/1879

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Can't really test locally

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
