### PR TITLE
doc: gotcha for xcode not using your path

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The recommendation for KMM projects is to use Android Studio for editing & runni
 - If your Gradle dependency tree has problems you need to visualize, try `./gradlew :shared:dependencies --configuration iosMainImplementationDependenciesMetadata` or `./gradlew :shared:dependencies --configuration releaseRuntimeClasspath` or `./gradlew :androidApp:dependencies --configuration stagingReleaseRuntimeClasspath`. Gradle sometimes just lies about what dependencies it’ll use, though.
 - For MBTA employees with Zscaler, if you run into an error that looks like `PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`. Check out the [issue documentation](https://app.notion.com/p/mbta-downtown-crossing/PKIX-Issues-when-building-Java-projects-25ef5d8d11ea80bd81cbd88bf531ac71) on how to solve it.
 - If an Xcode build fails because it can't locate Java Runtime, try defining `$JAVA_HOME` in the .envrc file, if you're using asdf you can add `export JAVA_HOME=$(asdf where java)` at the end of the .envrc file.
-- If an XCode build fails and it isn't using the good `PATH` from your terminal, inspect the gradle processes using `./gradlew --status` and `ps x | grep [gradle pid]` to see if one is using the incorrect version of java.
+- If an XCode build fails and it isn't using the good `PATH` from your terminal, inspect the gradle processes using `./gradlew --status` and `ps x | grep [gradle pid]` to see if one is using the incorrect version of java. You may need to change `JAVA_HOME` in your terminal (`export JAVA_HOME=$(asdf where java)`) or fix which java Android Studio is using to match.
 
 ## Running Locally
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The recommendation for KMM projects is to use Android Studio for editing & runni
 - If your Gradle dependency tree has problems you need to visualize, try `./gradlew :shared:dependencies --configuration iosMainImplementationDependenciesMetadata` or `./gradlew :shared:dependencies --configuration releaseRuntimeClasspath` or `./gradlew :androidApp:dependencies --configuration stagingReleaseRuntimeClasspath`. Gradle sometimes just lies about what dependencies it’ll use, though.
 - For MBTA employees with Zscaler, if you run into an error that looks like `PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target`. Check out the [issue documentation](https://app.notion.com/p/mbta-downtown-crossing/PKIX-Issues-when-building-Java-projects-25ef5d8d11ea80bd81cbd88bf531ac71) on how to solve it.
 - If an Xcode build fails because it can't locate Java Runtime, try defining `$JAVA_HOME` in the .envrc file, if you're using asdf you can add `export JAVA_HOME=$(asdf where java)` at the end of the .envrc file.
+- If an XCode build fails and it isn't using the good `PATH` from your terminal, inspect the gradle processes using `./gradlew --status` and `ps x | grep [gradle pid]` to see if one is using the incorrect version of java.
 
 ## Running Locally
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Documenting how to detect the issue that had broken my local builds. Thanks to the whole team for helping me debug and @boringcactus for suggesting these steps which identified my issue! 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
