### PR TITLE
refactor(RepositoryDI): Default to real NearbyRepository in tests

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPageTest.kt
@@ -20,7 +20,6 @@ import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
-import com.mbta.tid.mbta_app.repositories.NearbyRepository
 import com.mbta.tid.mbta_app.repositories.Settings
 import com.mbta.tid.mbta_app.routes.SheetRoutes
 import com.mbta.tid.mbta_app.viewModel.IMapViewModel
@@ -64,7 +63,6 @@ class MapAndSheetPageTest {
         val globalResponse = GlobalResponse(objects)
 
         loadKoinMocks(objects) {
-            nearby = NearbyRepository()
             settings = MockSettingsRepository(mapOf(Settings.HideMaps to true))
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/dependencyInjection/RepositoryDI.kt
@@ -8,7 +8,6 @@ import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ApiResult
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
-import com.mbta.tid.mbta_app.model.response.NearbyResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.ScheduleResponse
@@ -65,7 +64,6 @@ import com.mbta.tid.mbta_app.repositories.MockErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockGlobalRepository
 import com.mbta.tid.mbta_app.repositories.MockLastLaunchedAppVersionRepository
-import com.mbta.tid.mbta_app.repositories.MockNearbyRepository
 import com.mbta.tid.mbta_app.repositories.MockOnboardingRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
 import com.mbta.tid.mbta_app.repositories.MockRailRouteShapeRepository
@@ -234,7 +232,7 @@ public class MockRepositories : IRepositories {
     ) {
         alerts = MockAlertsRepository(AlertsStreamDataResponse(objects))
         global = MockGlobalRepository(GlobalResponse(objects))
-        nearby = MockNearbyRepository(NearbyResponse(objects))
+        nearby = NearbyRepository() // Use real nearby, will calculate based on stops in global
         predictions =
             MockPredictionsRepository(connectV2Response = PredictionsByStopJoinResponse(objects))
         railRouteShapes = MockRailRouteShapeRepository(objects)


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket, follow up to https://github.com/mbta/mobile_app/pull/1859#discussion_r3659722512

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
I thought this was going to break more tests, but turns out it was a pretty small change! Using the default `NearbyRepository` makes sense for most tests so that we realistically re-calculate the order of nearby stops when the location changes. 


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Confirm tests still pass. 

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
