### PR TITLE
fix: Remove route last stop added to favorites

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -40,6 +40,7 @@ internal enum class RemovalReason {
     MissingRoute,
     MissingStop,
     MissingDirection,
+    LastStopForRoute,
 }
 
 @OptIn(ExperimentalObjCRefinement::class)
@@ -174,23 +175,25 @@ public class FavoritesViewModel(
         ): Map<RouteStopDirection, RemovalReason> =
             favorites
                 .mapNotNull { rsd ->
-                    val lineOrRoute = global.getLineOrRoute(rsd.route)
-                    val routeExists = lineOrRoute != null
-                    val stopExists = global.getStop(rsd.stop) != null
-                    val directionExists =
-                        lineOrRoute?.let {
-                            global.getPatternsFor(rsd.stop, it).any { pattern ->
-                                pattern.directionId == rsd.direction
-                            }
-                        } ?: false
-                    val removalReason =
-                        when {
-                            !routeExists -> RemovalReason.MissingRoute
-                            !stopExists -> RemovalReason.MissingStop
-                            !directionExists -> RemovalReason.MissingDirection
-                            else -> null
+                    val lineOrRoute =
+                        global.getLineOrRoute(rsd.route)
+                            ?: return@mapNotNull rsd to RemovalReason.MissingRoute
+                    val stop =
+                        global.getStop(rsd.stop)
+                            ?: return@mapNotNull rsd to RemovalReason.MissingStop
+
+                    val patterns = global.getPatternsFor(rsd.stop, lineOrRoute)
+
+                    if (
+                        patterns.none { pattern ->
+                            pattern.directionId == rsd.direction
                         }
-                    return@mapNotNull removalReason?.let { rsd to removalReason }
+                    )
+                        return@mapNotNull rsd to RemovalReason.MissingDirection
+
+                    if (stop.isLastStopForAllPatterns(rsd.direction, patterns, global))
+                        return@mapNotNull rsd to RemovalReason.LastStopForRoute
+                    return@mapNotNull null
                 }
                 .toMap()
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -958,6 +958,12 @@ internal class FavoritesViewModelTest : KoinTest {
     @Test
     fun `clears stale favorites when stop is missing`() = runTest {
         val now = EasternTimeInstant.now()
+        objects.routePattern(route1) {
+            directionId = 0
+            representativeTrip {
+                stopIds = listOf(stop1.id, stop2.id)
+            }
+        }
 
         val favoritesBefore = buildFavorites {
             routeStopDirection(route1.id, stop1.id, 0)
@@ -993,6 +999,12 @@ internal class FavoritesViewModelTest : KoinTest {
     @Test
     fun `clears stale favorites when route is missing`() = runTest {
         val now = EasternTimeInstant.now()
+        objects.routePattern(route1) {
+            directionId = 0
+            representativeTrip {
+                stopIds = listOf(stop1.id, stop2.id)
+            }
+        }
 
         val favoritesBefore = buildFavorites {
             routeStopDirection(route1.id, stop1.id, 0)
@@ -1032,9 +1044,12 @@ internal class FavoritesViewModelTest : KoinTest {
         val objects = ObjectCollectionBuilder()
         val route = objects.route()
         val stop = objects.stop()
+        val lastStop = objects.stop()
         objects.routePattern(route) {
             directionId = 0
-            representativeTrip { stopIds = listOf(stop.id) }
+            representativeTrip {
+                stopIds = listOf(stop.id, lastStop.id)
+            }
         }
 
         val favoritesBefore = buildFavorites {
@@ -1063,6 +1078,55 @@ internal class FavoritesViewModelTest : KoinTest {
             awaitItemSatisfying { it.favorites == favoritesBefore.routeStopDirection }
             viewModel.clearStaleFavorites("")
             awaitItemSatisfying { it.favorites == favoritesAfter.routeStopDirection }
+            advanceUntilIdle()
+            assertEquals("Clearing stale favorites", sentryMessage)
+        }
+    }
+
+    @Test
+    fun `clears stale favorites when stop the last one`() = runTest {
+        val now = EasternTimeInstant.now()
+
+        objects.routePattern(route1) {
+            directionId = 0
+            representativeTrip {
+                stopIds = listOf(stop1.id, stop2.id)
+            }
+        }
+
+        val favoritesBefore = buildFavorites {
+            routeStopDirection(route1.id, stop1.id, 0)
+            routeStopDirection(route1.id, stop2.id, 0)
+        }
+        val favoritesAfter = buildFavorites { routeStopDirection(route1.id, stop1.id, 0) }
+
+        val favoritesRepo = MockFavoritesRepository(favorites = favoritesBefore)
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        var sentryMessage: String? = null
+        val sentryRepo = MockSentryRepository(onCaptureMessageWithDetails = { sentryMessage = it })
+        setUpKoin(objects, dispatcher) {
+            favorites = favoritesRepo
+            sentry = sentryRepo
+        }
+
+        val viewModel: FavoritesViewModel = get()
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+        viewModel.setNow(now)
+        viewModel.setLocation(stop1.position)
+
+        testViewModelFlow(viewModel).test {
+            awaitItemSatisfying { it.favorites == favoritesBefore.routeStopDirection }
+            viewModel.clearStaleFavorites("")
+            awaitItemSatisfying {
+                it.favorites == favoritesAfter.routeStopDirection &&
+                    it.staticStopCardData?.size == 2
+            }
+            awaitItemSatisfying {
+                it.favorites == favoritesAfter.routeStopDirection &&
+                    it.staticStopCardData?.size == 1
+            }
             advanceUntilIdle()
             assertEquals("Clearing stale favorites", sentryMessage)
         }


### PR DESCRIPTION
### Summary

_Ticket:_ [Handle last stops added to favorites + added notifications](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216668177080239?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Remove route last stop added to favorites

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Reverted the change to add last stop to favorites and tested it disappears after this change

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
