### PR TITLE
fix: Add shared checks and unit tests to older ios test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,18 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
       GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
+  test-older-ios:
+    name: tests on older iOS version
+    permissions:
+      contents: read
+    needs: check-changes
+    uses: ./.github/workflows/test-older-ios.yaml
+    with:
+      skip-everything: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.ios == 'false' }}
+    secrets:
+      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+      FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
+      GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
   build-android:
     name: Build for Android
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,18 +62,6 @@ jobs:
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
       GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
-  test-older-ios:
-    name: tests on older iOS version
-    permissions:
-      contents: read
-    needs: check-changes
-    uses: ./.github/workflows/test-older-ios.yaml
-    with:
-      skip-everything: ${{ github.event_name == 'pull_request' && needs.check-changes.outputs.ios == 'false' }}
-    secrets:
-      SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-      FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
-      GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
   build-android:
     name: Build for Android
     permissions:

--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -62,7 +62,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
-          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
+          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
       - name: Get second latest iOS version
         if: ${{ !inputs.skip-everything }}
         id: ios_versions

--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -1,9 +1,20 @@
 name: iOS tests on older iOS version
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
+    inputs:
+      skip-everything:
+        description: "Skips all the individual steps so the job passes quickly"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      SENTRY_DSN:
+        required: true
+      FIREBASE_KEY:
+        required: true
+      GOOGLE_APP_ID_IOS:
+        required: true
 
 jobs:
   test-older-ios:
@@ -28,6 +39,16 @@ jobs:
           bundle exec pod install
           popd
           bundle exec ./gradlew :shared:podInstallSyntheticIos
+      - name: shared checks & unit tests
+        if: ${{ !inputs.skip-everything }}
+        run: ./gradlew shared:iosSimulatorArm64Test
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure() && !inputs.skip-everything
+        with:
+          name: ios-shared-reports
+          path: shared/build/reports
       - name: Add build environment variables
         if: ${{ !inputs.skip-everything }}
         run: |

--- a/.github/workflows/test-older-ios.yaml
+++ b/.github/workflows/test-older-ios.yaml
@@ -1,20 +1,9 @@
 name: iOS tests on older iOS version
 
 on:
-  workflow_call:
-    inputs:
-      skip-everything:
-        description: "Skips all the individual steps so the job passes quickly"
-        required: false
-        default: false
-        type: boolean
-    secrets:
-      SENTRY_DSN:
-        required: true
-      FIREBASE_KEY:
-        required: true
-      GOOGLE_APP_ID_IOS:
-        required: true
+  push:
+    branches:
+      - main
 
 jobs:
   test-older-ios:
@@ -24,15 +13,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        if: ${{ !inputs.skip-everything }}
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-        if: ${{ !inputs.skip-everything }}
         with:
           for: ios-test
       - name: Install CocoaPods dependencies
-        if: ${{ !inputs.skip-everything }}
         run: |
           ./gradlew :shared:generateDummyFramework
           pushd iosApp
@@ -40,17 +26,15 @@ jobs:
           popd
           bundle exec ./gradlew :shared:podInstallSyntheticIos
       - name: shared checks & unit tests
-        if: ${{ !inputs.skip-everything }}
         run: ./gradlew shared:iosSimulatorArm64Test
         env:
           GH_TOKEN: ${{ github.token }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure() && !inputs.skip-everything
+        if: failure()
         with:
           name: ios-shared-reports
           path: shared/build/reports
       - name: Add build environment variables
-        if: ${{ !inputs.skip-everything }}
         run: |
           {
             echo "export SENTRY_DSN=${SENTRY_DSN}"
@@ -62,16 +46,14 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ENVIRONMENT: staging
           FIREBASE_KEY: ${{ secrets.FIREBASE_KEY }}
-          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS }}
+          GOOGLE_APP_ID_IOS: ${{ secrets.GOOGLE_APP_ID_IOS_STAGING }}
       - name: Get second latest iOS version
-        if: ${{ !inputs.skip-everything }}
         id: ios_versions
         run: |
           DEVICES=$(xcrun simctl list devices | awk '/^-- iOS/ {v=$3; next} v && /iPhone/ {print $1, $2, $3, "("v")"; v=""}' | sort -r | awk -F'[(.]' '!seen[$1]++')
           SECOND_LATEST_DEVICE=$(echo "$DEVICES" | head -n 2 | tail -n 1)
           echo "SECOND_LATEST_DEVICE=$SECOND_LATEST_DEVICE" >> $GITHUB_OUTPUT
       - name: Run emulator smoke tests
-        if: ${{ !inputs.skip-everything }}
         run: |
           bundle exec fastlane ios smoke_test \
             xcodebuild_formatter:"xcbeautify --quieter --is-ci --renderer github-actions" \
@@ -79,7 +61,7 @@ jobs:
         env:
           IOS_DEVICE: ${{ steps.ios_versions.outputs.SECOND_LATEST_DEVICE }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure() && !inputs.skip-everything
+        if: failure()
         with:
           name: ios-ios-results
           path: fastlane/test_output/*


### PR DESCRIPTION
### Summary

_Ticket:_ [smoke test different versions of iOS](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216219303948090?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Fix failing older ios test workflow

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- It passed when I added it to CI workflow => https://github.com/mbta/mobile_app/actions/runs/30401859599/job/90418408350

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
