### PR TITLE
refactor: subscribeToPredictions + getSchedules take sets of stops

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
@@ -21,11 +21,11 @@ import org.koin.core.qualifier.named
 
 public interface ISchedulesRepository {
     public suspend fun getSchedule(
-        stopIds: List<String>,
+        stopIds: Set<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse>
 
-    public suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse>
+    public suspend fun getSchedule(stopIds: Set<String>): ApiResult<ScheduleResponse>
 
     public suspend fun getNextSchedule(
         route: LineOrRoute,
@@ -42,7 +42,7 @@ internal class CachedSchedulesRepository(private val schedulesRepository: ISched
     private val ioDispatcher: CoroutineDispatcher by inject(named("coroutineDispatcherIO"))
 
     override suspend fun getSchedule(
-        stopIds: List<String>,
+        stopIds: Set<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse> {
         val cachedSchedules: MutableList<ScheduleResponse> = mutableListOf()
@@ -55,7 +55,7 @@ internal class CachedSchedulesRepository(private val schedulesRepository: ISched
         if (requestStopIds.isNotEmpty()) {
             val result =
                 try {
-                    schedulesRepository.getSchedule(requestStopIds, now)
+                    schedulesRepository.getSchedule(requestStopIds.toSet(), now)
                 } catch (e: Exception) {
                     return ApiResult.Error(null, e.toString())
                 }
@@ -87,7 +87,7 @@ internal class CachedSchedulesRepository(private val schedulesRepository: ISched
         return ApiResult.Ok(mergedResponse)
     }
 
-    override suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse> =
+    override suspend fun getSchedule(stopIds: Set<String>): ApiResult<ScheduleResponse> =
         getSchedule(stopIds, EasternTimeInstant.now())
 
     override suspend fun getNextSchedule(
@@ -104,7 +104,7 @@ internal class SchedulesRepository : ISchedulesRepository, KoinComponent {
     private val mobileBackendClient: MobileBackendClient by inject()
 
     override suspend fun getSchedule(
-        stopIds: List<String>,
+        stopIds: Set<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse> = ApiResult.runCatching {
         mobileBackendClient
@@ -119,7 +119,7 @@ internal class SchedulesRepository : ISchedulesRepository, KoinComponent {
             .body()
     }
 
-    override suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse> {
+    override suspend fun getSchedule(stopIds: Set<String>): ApiResult<ScheduleResponse> {
         return getSchedule(stopIds, EasternTimeInstant.now())
     }
 
@@ -154,14 +154,14 @@ internal class SchedulesRepository : ISchedulesRepository, KoinComponent {
 public class MockScheduleRepository(
     private val response: ApiResult<ScheduleResponse>,
     private val nextResponse: ApiResult<NextScheduleResponse>,
-    private val callback: (stopIds: List<String>) -> Unit = {},
+    private val callback: (stopIds: Set<String>) -> Unit = {},
 ) : ISchedulesRepository {
 
     @DefaultArgumentInterop.Enabled
     public constructor(
         scheduleResponse: ScheduleResponse = ScheduleResponse(listOf(), mapOf()),
         nextScheduleResponse: NextScheduleResponse = NextScheduleResponse(null),
-        callback: (stopIds: List<String>) -> Unit = {},
+        callback: (stopIds: Set<String>) -> Unit = {},
     ) : this(ApiResult.Ok(scheduleResponse), ApiResult.Ok(nextScheduleResponse), callback)
 
     public constructor() :
@@ -171,14 +171,14 @@ public class MockScheduleRepository(
         )
 
     override suspend fun getSchedule(
-        stopIds: List<String>,
+        stopIds: Set<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse> {
         callback(stopIds)
         return response
     }
 
-    override suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse> {
+    override suspend fun getSchedule(stopIds: Set<String>): ApiResult<ScheduleResponse> {
         callback(stopIds)
         return response
     }
@@ -195,13 +195,13 @@ public class MockScheduleRepository(
 
 public class IdleScheduleRepository : ISchedulesRepository {
     override suspend fun getSchedule(
-        stopIds: List<String>,
+        stopIds: Set<String>,
         now: EasternTimeInstant,
     ): ApiResult<ScheduleResponse> {
         return suspendCancellableCoroutine {}
     }
 
-    override suspend fun getSchedule(stopIds: List<String>): ApiResult<ScheduleResponse> {
+    override suspend fun getSchedule(stopIds: Set<String>): ApiResult<ScheduleResponse> {
         return suspendCancellableCoroutine {}
     }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModel.kt
@@ -158,10 +158,10 @@ public class FavoritesViewModel(
                         stop.id
                 }
             }
-        val schedules = getSchedules(stopIds, errorKey)
+        val schedules = getSchedules(stopIds?.toSet(), errorKey)
         val predictions =
             subscribeToPredictions(
-                stopIds,
+                stopIds?.toSet(),
                 SheetRoutes.Favorites,
                 active,
                 errorKey,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModel.kt
@@ -89,10 +89,10 @@ public class NearbyViewModel(
 
         val errorKey = ErrorKey(setOf(SheetRoutes.NearbyTransit::class), "NearbyViewModel")
         val globalData = getGlobalData(errorKey)
-        val schedules = getSchedules(stopIds, errorKey)
+        val schedules = getSchedules(stopIds?.toSet(), errorKey)
         val predictions =
             subscribeToPredictions(
-                stopIds,
+                stopIds?.toSet(),
                 SheetRoutes.NearbyTransit,
                 active,
                 errorKey,
@@ -130,7 +130,15 @@ public class NearbyViewModel(
             }
         }
 
-        LaunchedEffect(stopIds, globalData, location, schedules, predictions, alerts, now) {
+        LaunchedEffect(
+            stopIds?.toSet(),
+            globalData,
+            location,
+            schedules,
+            predictions,
+            alerts,
+            now,
+        ) {
             val resolvedStopIds = stopIds
             if (resolvedStopIds == null || globalData == null || location == null) {
                 routeCardData = null

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModel.kt
@@ -117,7 +117,7 @@ public class StopDetailsViewModel(
 
         val schedules =
             getSchedules(
-                stopIds,
+                stopIds?.toSet(),
                 errorKey,
                 schedulesRepository,
                 errorBannerRepository,
@@ -126,7 +126,7 @@ public class StopDetailsViewModel(
 
         val predictions =
             subscribeToPredictions(
-                stopIds,
+                stopIds?.toSet(),
                 filters?.let { SheetRoutes.StopDetails(it.stopId, it.stopFilter, it.tripFilter) },
                 active,
                 errorKey,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/getSchedules.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
 private fun fetchSchedules(
-    stopIds: List<String>,
+    stopIds: Set<String>,
     errorKey: ErrorKey,
     errorBannerRepository: IErrorBannerStateRepository,
     schedulesRepository: ISchedulesRepository,
@@ -48,7 +48,7 @@ private fun fetchSchedules(
 
 @Composable
 internal fun getSchedules(
-    stopIds: List<String>?,
+    stopIds: Set<String>?,
     errorKey: ErrorKey,
     schedulesRepository: ISchedulesRepository = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/composeStateHelpers/subscribeToPredictions.kt
@@ -22,7 +22,7 @@ import org.koin.compose.koinInject
 
 @Composable
 internal fun subscribeToPredictions(
-    stopIds: List<String>?,
+    stopIds: Set<String>?,
     sheetRoute: SheetRoutes?,
     active: Boolean,
     errorKey: ErrorKey,
@@ -35,16 +35,16 @@ internal fun subscribeToPredictions(
     val staleTimer by timer(checkPredictionsStaleInterval)
 
     var predictions: PredictionsByStopJoinResponse? by remember { mutableStateOf(null) }
-    var loadedStopIds: List<String>? by remember { mutableStateOf(null) }
+    var loadedStopIds: Set<String>? by remember { mutableStateOf(null) }
 
     fun connect(
-        stopIds: List<String>?,
+        stopIds: Set<String>?,
         active: Boolean,
         onJoin: (ApiResult<PredictionsByStopJoinResponse>) -> Unit,
         onMessage: (ApiResult<PredictionsByStopMessageResponse>) -> Unit,
     ) {
         if (stopIds != null && active) {
-            predictionsRepository.connect(stopIds, errorKey, onJoin, onMessage)
+            predictionsRepository.connect(stopIds.toList(), errorKey, onJoin, onMessage)
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepositoryTest.kt
@@ -87,7 +87,7 @@ class SchedulesRepositoryTest : KoinTest {
             modules(module { single { MobileBackendClient(mockEngine, AppVariant.Staging) } })
         }
         runBlocking {
-            val response = SchedulesRepository().getSchedule(stopIds = listOf("place-davis"))
+            val response = SchedulesRepository().getSchedule(stopIds = setOf("place-davis"))
             assertEquals(
                 ApiResult.Ok(
                     ScheduleResponse(
@@ -303,7 +303,7 @@ class SchedulesRepositoryTest : KoinTest {
 
         val response =
             cachedRepository.getSchedule(
-                stopIds = listOf(loadedSchedule.stopId, cachedSchedule.stopId)
+                stopIds = setOf(loadedSchedule.stopId, cachedSchedule.stopId)
             )
 
         assertEquals(
@@ -359,7 +359,7 @@ class SchedulesRepositoryTest : KoinTest {
 
         val cachedRepository = CachedSchedulesRepository(SchedulesRepository())
 
-        val response = cachedRepository.getSchedule(stopIds = listOf(cachedSchedule.stopId))
+        val response = cachedRepository.getSchedule(stopIds = setOf(cachedSchedule.stopId))
 
         assertEquals(
             ApiResult.Ok(
@@ -391,7 +391,7 @@ class SchedulesRepositoryTest : KoinTest {
 
         val cachedRepository = CachedSchedulesRepository(SchedulesRepository())
 
-        val response = cachedRepository.getSchedule(stopIds = listOf("stopId"))
+        val response = cachedRepository.getSchedule(stopIds = setOf("stopId"))
 
         assertEquals(HttpStatusCode.BadGateway.value, (response as? ApiResult.Error)?.code)
         stopKoin()

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModelTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NearbyViewModelTests.kt
@@ -11,17 +11,20 @@ import com.mbta.tid.mbta_app.model.Favorites
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteCardData
+import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.model.response.PredictionsByStopJoinResponse
 import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.repositories.MockPredictionsRepository
+import com.mbta.tid.mbta_app.repositories.NearbyRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineDispatcher
@@ -42,18 +45,21 @@ internal class NearbyViewModelTests : KoinTest {
     val objects = ObjectCollectionBuilder()
     val stop1 = objects.stop {
         id = "stop1"
-        latitude = 0.0
-        longitude = 0.0
+        latitude = 42.373362
+        longitude = -71.118956
+        vehicleType = RouteType.BUS
     }
     val stop2 = objects.stop {
         id = "stop2"
-        latitude = 1.0
-        longitude = 1.0
+        latitude = 42.373483
+        longitude = -71.119771
+        vehicleType = RouteType.BUS
     }
     val stop3 = objects.stop {
         id = "stop3"
-        latitude = -0.5
-        longitude = -0.5
+        latitude = 42.373414
+        longitude = -71.120134
+        vehicleType = RouteType.BUS
     }
     val route1 = objects.route {
         id = "route1"
@@ -430,6 +436,52 @@ internal class NearbyViewModelTests : KoinTest {
                 listOf(stop2, stop1) == it.routeCardData!!.flatMap { it.stopData }.map { it.stop }
             }
             cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `predictions not refetched when stop list stays the same`() = runTest {
+        val now = EasternTimeInstant.now()
+        val objects = objects.clone()
+        predictionsEverywhere(objects, now)
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        setUpKoin(objects, dispatcher) {
+            nearby = NearbyRepository()
+            predictions =
+                MockPredictionsRepository(
+                    connectV2Response = PredictionsByStopJoinResponse(objects),
+                    onConnectV2 = { stopIds ->
+                        if (
+                            stopIds != emptyList<String>() && stopIds != listOf(stop1.id, stop2.id)
+                        ) {
+                            fail("Stop list should not have changed. Given $stopIds")
+                        }
+                    },
+                )
+        }
+
+        val viewModel: NearbyViewModel = get()
+        viewModel.setActive(true, false)
+        viewModel.setAlerts(AlertsStreamDataResponse(emptyMap()))
+        viewModel.setNow(now)
+        viewModel.setLocation(stop1.position)
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(
+                listOf(stop1, stop2),
+                awaitItemSatisfying { it.routeCardData != null }
+                    .routeCardData!!
+                    .flatMap { it.stopData }
+                    .map { it.stop },
+            )
+            viewModel.setLocation(stop2.position)
+            advanceUntilIdle()
+            awaitItemSatisfying {
+                listOf(stop2, stop1) ==
+                    it.routeCardData!!.flatMap { it.stopData }.map { it.stop } &&
+                    it.loadedLocation == stop2.position
+            }
         }
     }
 


### PR DESCRIPTION
### Summary

_Ticket:_ No ticket

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

Split out from https://github.com/mbta/mobile_app/pull/1859. We don't need to leave / rejoin the predictions channel (or refetch schedules) when the order of nearby stops has changed. I originally did this by just sorting the `stopIds` list in nearby & favorites VMs, but @EmmaSimon pointed out that was causing issue with the route card logic which assumed the list would be sorted. 

Opted to make the calls we care about take `sets` instead. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Included unit test that we don't resubscribe to predictions in nearby VM when the order of stops changes

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
