### PR TITLE
feat: turn on FavoritesByStop

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/EditFavoritesPageTest.kt
@@ -62,7 +62,7 @@ class EditFavoritesPageTest : KoinTest {
         directionNames = listOf("North", "South")
         directionDestinations = listOf("Downtown", "Uptown")
         longName = "Sample Route Long Name"
-        shortName = "Sample Route"
+        shortName = "66"
         textColor = "000000"
         lineId = line.id.idText
         routePatternIds = mutableListOf("pattern_1", "pattern_2")
@@ -134,13 +134,13 @@ class EditFavoritesPageTest : KoinTest {
         textColor = "FFFFFF"
     }
     val greenLineRoute = builder.route {
-        id = "route_gl"
+        id = "Green-B"
         type = RouteType.LIGHT_RAIL
         color = "008000"
         directionNames = listOf("Inbound", "Outbound")
         directionDestinations = listOf("Park Street", "Lechmere")
         longName = "Green Line Long Name"
-        shortName = "Green Line"
+        shortName = "B"
         textColor = "FFFFFF"
         lineId = greenLine.id.idText
         routePatternIds = mutableListOf("pattern_gl")
@@ -283,12 +283,12 @@ class EditFavoritesPageTest : KoinTest {
             )
         }
 
-        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("66"))
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
         // Shouldn't be shown because it is not a favorite
-        composeTestRule.onNodeWithText("Green Line Long Name").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("GL").assertIsNotDisplayed()
         composeTestRule.onNodeWithText("Green Line Stop").assertIsNotDisplayed()
     }
 
@@ -377,11 +377,11 @@ class EditFavoritesPageTest : KoinTest {
             )
         }
 
-        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("66"))
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("trashCan")[0].performClick()
@@ -395,11 +395,11 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
 
         // Should be deleted
-        composeTestRule.onNodeWithText("Sample Route").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("66").assertIsNotDisplayed()
         composeTestRule.onNodeWithText("Downtown").assertIsNotDisplayed()
 
         // Should remain
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
     }
 
@@ -465,8 +465,8 @@ class EditFavoritesPageTest : KoinTest {
             )
         }
 
-        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("66"))
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("trashCan")[0].performClick()
         composeTestRule.awaitIdle()
@@ -478,10 +478,10 @@ class EditFavoritesPageTest : KoinTest {
 
         composeTestRule.waitUntilDefaultTimeout { update == updatedWith }
 
-        composeTestRule.onNodeWithText("Sample Route").assertIsNotDisplayed()
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("66").assertIsNotDisplayed()
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
         assertEquals(
-            "<b>Northbound Sample Route bus</b> at <b>Sample Stop 1</b> removed from Favorites",
+            "<b>Northbound 66 bus</b> at <b>Sample Stop 1</b> removed from Favorites",
             displayedToast?.message,
         )
 
@@ -495,8 +495,8 @@ class EditFavoritesPageTest : KoinTest {
         }
         composeTestRule.waitUntilDefaultTimeout { undo == updatedWith }
 
-        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
         assertNull(displayedToast)
     }
 
@@ -536,11 +536,12 @@ class EditFavoritesPageTest : KoinTest {
             )
         }
 
-        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Sample Route"))
-        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("66"))
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
 
-        composeTestRule.onNodeWithText("Green Line Long Name").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("GL").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Park Street").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Green Line Stop").assertCanBeDisplayed()
 
         composeTestRule.onAllNodesWithTag("editIcon")[0].performClick()
@@ -606,7 +607,7 @@ class EditFavoritesPageTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
             hasContentDescription("notifications enabled")
         )
-        composeTestRule.onNodeWithText("Sample Route").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("66").assertCanBeDisplayed()
         composeTestRule.onNodeWithText("Downtown").assertCanBeDisplayed()
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -458,7 +458,7 @@ private fun FavoriteDepartures(
                                             modifier = Modifier.weight(1f),
                                             pillDecoration =
                                                 formatted.route?.let {
-                                                    PillDecoration.OnDirectionDestination(it)
+                                                    PillDecoration.OnRow(it)
                                                 },
                                         )
                                         rightContent()

--- a/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
+++ b/iosApp/iosAppTests/Pages/Favorites/FavoritesViewTests.swift
@@ -239,7 +239,7 @@ final class FavoritesViewTests: XCTestCase {
             viewportProvider: .init(),
         )
         let exp = sut.inspection.inspect(after: 0.2) { view in
-            XCTAssertEqual(5, view.findAll(LoadingRouteCard.self).count)
+            XCTAssertEqual(5, view.findAll(LoadingStopCard.self).count)
         }
         ViewHosting.host(view: sut.withFixedSettings([:]))
         wait(for: [exp], timeout: 2)

--- a/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
+++ b/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
@@ -56,7 +56,7 @@ final class SaveFavoritePageTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        sut.inspection.inspect(after: 0.5) { view in
+        sut.inspection.inspect(after: 1) { view in
             XCTAssertNotNil(try sut.inspect().find(text: "Alewife"))
             XCTAssertNotNil(try sut.inspect().find(text: "Northbound to"))
 
@@ -92,7 +92,7 @@ final class SaveFavoritePageTests: XCTestCase {
 
         ViewHosting.host(view: sut)
 
-        sut.inspection.inspect(after: 0.5) { view in
+        sut.inspection.inspect(after: 1) { view in
             XCTAssertNotNil(try sut.inspect().find(text: "Alewife"))
             XCTAssertNotNil(try sut.inspect().find(text: "Northbound to"))
 

--- a/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
+++ b/iosApp/iosAppTests/Views/SaveFavoritesFlowTest.swift
@@ -90,7 +90,7 @@ final class SaveFavoritesFlowTest: XCTestCase {
             pushNavEntry: { _ in },
         )
 
-        let exp = sut.inspection.inspect(after: 0.5) { view in
+        let exp = sut.inspection.inspect(after: 1) { view in
             XCTAssertNotNil(try view.find(FavoriteConfirmationDialog.self))
         }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -40,7 +40,7 @@ public enum class Settings(
     public val override: Boolean? = null,
 ) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
-    FavoritesByStop(booleanPreferencesKey("favorites_by_stop")),
+    FavoritesByStop(booleanPreferencesKey("favorites_by_stop"), true),
     HideMaps(booleanPreferencesKey("hide_maps")),
     Notifications(booleanPreferencesKey("notifications")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),


### PR DESCRIPTION
### Summary

_Ticket:_ [Release favorites grouped by stop](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216424151277004?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Turns on the feature flag. Will remove the feature flag / dead code paths after release. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
Ran locally & confirmed grouping is on by default. I also made one tiny change to remove the route branch pill in edit favorites, which was showing up only in android.
<img width="45%" height="2340" alt="image" src="https://github.com/user-attachments/assets/7c837a98-6df6-4940-bafd-d93c5766ab0d" />


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
