### PR TITLE
fix?(ios): Always connect socket onAppear

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -52,6 +52,7 @@ import com.mbta.tid.mbta_app.network.PhoenixSocket
 import com.mbta.tid.mbta_app.repositories.DefaultTab
 import com.mbta.tid.mbta_app.repositories.ErrorKey
 import com.mbta.tid.mbta_app.repositories.IAccessibilityStatusRepository
+import com.mbta.tid.mbta_app.repositories.IDebugRepository
 import com.mbta.tid.mbta_app.repositories.IErrorBannerStateRepository
 import com.mbta.tid.mbta_app.repositories.ISubscriptionsRepository
 import com.mbta.tid.mbta_app.repositories.Settings
@@ -78,6 +79,7 @@ fun ContentView(
     favoritesUsecases: FavoritesUsecases = koinInject(),
     scheduleCache: ScheduleCache = koinInject(),
     errorBannerRepository: IErrorBannerStateRepository = koinInject(),
+    debugRepository: IDebugRepository = koinInject(),
     subscriptionsRepository: ISubscriptionsRepository = koinInject(),
     mapViewModel: MapViewModel = koinInject(),
     accessibilityStatusRepository: IAccessibilityStatusRepository = koinInject(),
@@ -148,10 +150,21 @@ fun ContentView(
         val errorKey = ErrorKey(setOf(), "socket")
         socket.onError { error, response ->
             scope.launch {
+                debugRepository.setSocketConnected(false)
                 errorBannerRepository.setDataError(errorKey, "$error $response") { socket.attach() }
             }
         }
-        socket.onAttach { scope.launch { errorBannerRepository.clearDataError(errorKey) } }
+        socket.onAttach {
+            scope.launch {
+                errorBannerRepository.clearDataError(errorKey)
+                debugRepository.setSocketConnected(true)
+            }
+        }
+        socket.onDetach {
+            scope.launch {
+                debugRepository.setSocketConnected(false)
+            }
+        }
     }
 
     LifecycleResumeEffect(null) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/DebugView.kt
@@ -106,6 +106,8 @@ fun DebugView(
                             Text("$trimmedKey last updated $duration ago")
                         }
                 }
+
+                Text("socket connected: ${debugState?.socketConnected}")
             }
         }
         details?.let {

--- a/iosApp/iosApp/ComponentViews/DebugView.swift
+++ b/iosApp/iosApp/ComponentViews/DebugView.swift
@@ -47,6 +47,9 @@ struct DebugView<Content: View>: View {
                                 Text(verbatim: "\(trimmedKey) last updated \(updateDuration) ago")
                             }
                         }
+                        if let socketConnected = debugState?.socketConnected {
+                            Text(verbatim: "socket connected: \(socketConnected)")
+                        }
                     }
                     .multilineTextAlignment(.leading)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -66,6 +66,9 @@ struct ContentView: View {
         } action: { height in
             contentHeight = height
         }
+        .onAppear {
+            socketProvider.socket.attach()
+        }
         .withScenePhaseHandlers(
             onActive: {
                 socketProvider.socket.attach()

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -355,7 +355,7 @@ struct OnboardingScreenView: View {
             .withScenePhaseHandlers(
                 onActive: animate,
                 onInactive: cancelAnimation,
-                onBackground: cancelAnimation,
+                onBackground: cancelAnimation
             )
     }
 

--- a/iosApp/iosApp/ProductionAppView.swift
+++ b/iosApp/iosApp/ProductionAppView.swift
@@ -49,7 +49,12 @@ struct ProductionAppView: View {
     init(socket: PhoenixSocket) {
         // Can only add error handling once koin is initialized
         var errorBannerRepository: IErrorBannerStateRepository = RepositoryDI().errorBanner
-        Self.addSocketErrorHandling(socket: socket, errorBannerRepository: errorBannerRepository)
+        var debugRepository: IDebugRepository = RepositoryDI().debug
+        Self.addSocketErrorHandling(
+            socket: socket,
+            errorBannerRepository: errorBannerRepository,
+            debugRepository: debugRepository
+        )
         // ignore updates less than 10m
         _locationDataManager = StateObject(wrappedValue: LocationDataManager(distanceFilter: 10))
         _socketProvider = StateObject(wrappedValue: SocketProvider(socket: socket))
@@ -69,10 +74,12 @@ struct ProductionAppView: View {
 
     private static func addSocketErrorHandling(
         socket: PhoenixSocket,
-        errorBannerRepository: IErrorBannerStateRepository
+        errorBannerRepository: IErrorBannerStateRepository,
+        debugRepository: IDebugRepository
     ) {
         socket.onError { error, response in
             Task {
+                try await debugRepository.setSocketConnected(isConnected: false)
                 try await errorBannerRepository.setDataError(
                     key: errorDataKey,
                     details: "\(error) \(response)",
@@ -91,6 +98,12 @@ struct ProductionAppView: View {
         socket.onAttach {
             Task {
                 try await errorBannerRepository.clearDataError(key: errorDataKey)
+                try await debugRepository.setSocketConnected(isConnected: true)
+            }
+        }
+        socket.onDetach {
+            Task {
+                try await debugRepository.setSocketConnected(isConnected: false)
             }
         }
     }

--- a/iosApp/iosApp/Utils/Modifiers/AlertsModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/AlertsModifier.swift
@@ -33,7 +33,7 @@ struct AlertsModifier: ViewModifier {
             .withScenePhaseHandlers(
                 onActive: { joinAlertsChannel() },
                 onInactive: { leaveAlertsChannel() },
-                onBackground: { leaveAlertsChannel() },
+                onBackground: { leaveAlertsChannel() }
             )
             .onDisappear {
                 leaveAlertsChannel()

--- a/iosApp/iosApp/Utils/Modifiers/ScenePhaseChangeModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/ScenePhaseChangeModifier.swift
@@ -14,7 +14,6 @@ struct ScenePhaseChangeModifier: ViewModifier {
     let onActive: () -> Void
     let onInactive: () -> Void
     let onBackground: () -> Void
-
     func body(content: Content) -> some View {
         content.onChange(of: scenePhase) { @MainActor newPhase in
             if newPhase == .active {
@@ -35,6 +34,10 @@ public extension View {
         onInactive: @escaping () -> Void = {},
         onBackground: @escaping () -> Void = {}
     ) -> some View {
-        modifier(ScenePhaseChangeModifier(onActive: onActive, onInactive: onInactive, onBackground: onBackground))
+        modifier(ScenePhaseChangeModifier(
+            onActive: onActive,
+            onInactive: onInactive,
+            onBackground: onBackground
+        ))
     }
 }

--- a/iosApp/iosApp/Utils/Modifiers/StopDetailsManageVMModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/StopDetailsManageVMModifier.swift
@@ -41,7 +41,7 @@ struct StopDetailsManageVMModifier: ViewModifier {
             .withScenePhaseHandlers(
                 onActive: { viewModel.setActive(active: true, wasSentToBackground: false) },
                 onInactive: { viewModel.setActive(active: false, wasSentToBackground: false) },
-                onBackground: { viewModel.setActive(active: false, wasSentToBackground: true) },
+                onBackground: { viewModel.setActive(active: false, wasSentToBackground: true) }
             )
             .onDisappear {
                 // Only set to inactive if the loaded filter matches the current value, this will be true

--- a/iosApp/iosApp/Utils/Modifiers/TripDetailsManageVMModifier.swift
+++ b/iosApp/iosApp/Utils/Modifiers/TripDetailsManageVMModifier.swift
@@ -44,7 +44,7 @@ struct TripDetailsManageVMModifier: ViewModifier {
             .withScenePhaseHandlers(
                 onActive: { viewModel.setActive(active: true, wasSentToBackground: false) },
                 onInactive: { viewModel.setActive(active: false, wasSentToBackground: false) },
-                onBackground: { viewModel.setActive(active: false, wasSentToBackground: true) },
+                onBackground: { viewModel.setActive(active: false, wasSentToBackground: true) }
             )
             .onReceive(timer) { _ in
                 // In some cases, the onDisappear of one stop details page can deactivate the VM after another

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -62,6 +62,21 @@ final class ContentViewTests: XCTestCase {
         wait(for: [connectedExpectation], timeout: 1)
     }
 
+    func testSocketConnectsOnAppear() {
+        let connectedExpectation = expectation(description: "Socket has connected")
+        connectedExpectation.expectedFulfillmentCount = 1
+        connectedExpectation.assertForOverFulfill = true
+
+        let fakeSocketWithExpectations = FakeSocket(connectedExpectation: connectedExpectation)
+
+        let sut = withDefaultEnvironmentObjects(sut: ContentView(contentVM: .init()),
+                                                socketProvider: SocketProvider(socket: fakeSocketWithExpectations))
+
+        ViewHosting.host(view: sut)
+
+        wait(for: [connectedExpectation], timeout: 1)
+    }
+
     func testJoinsAlerts() {
         let joinAlertsExp = expectation(description: "Alerts channel joined")
         // joins in onAppear & on active

--- a/iosApp/iosAppTests/Views/ContentViewTests.swift
+++ b/iosApp/iosAppTests/Views/ContentViewTests.swift
@@ -43,7 +43,7 @@ final class ContentViewTests: XCTestCase {
     func testReconnectsSocketAfterBackgroundingAndReactivating() throws {
         let disconnectedExpectation = expectation(description: "Socket has disconnected")
         let connectedExpectation = expectation(description: "Socket has connected")
-        connectedExpectation.expectedFulfillmentCount = 1
+        connectedExpectation.expectedFulfillmentCount = 2 // onAppear + active
         connectedExpectation.assertForOverFulfill = true
 
         let fakeSocketWithExpectations = FakeSocket(connectedExpectation: connectedExpectation,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepository.kt
@@ -10,7 +10,10 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
 
-public class DebugState(public val channelUpdates: Map<String, EasternTimeInstant> = emptyMap())
+public class DebugState(
+    public val channelUpdates: Map<String, EasternTimeInstant> = emptyMap(),
+    public val socketConnected: Boolean = false,
+)
 
 public abstract class IDebugRepository
 internal constructor(initialState: DebugState? = null, private val clock: Clock = Clock.System) :
@@ -20,6 +23,7 @@ internal constructor(initialState: DebugState? = null, private val clock: Clock 
     public val state: StateFlow<DebugState?> = flow.asStateFlow()
 
     private val channelUpdates = mutableMapOf<String, EasternTimeInstant>()
+    private var socketConnected = false
     private val mutex = Mutex()
 
     public open suspend fun setChannelSuccess(topic: String) {
@@ -36,9 +40,16 @@ internal constructor(initialState: DebugState? = null, private val clock: Clock 
         }
     }
 
+    public open suspend fun setSocketConnected(isConnected: Boolean) {
+        mutex.withLock {
+            socketConnected = isConnected
+            updateState()
+        }
+    }
+
     private fun updateState() {
         // Updates must be copied with .toMap to avoid concurrent modification exceptions in the UI
-        flow.value = DebugState(channelUpdates.toMap())
+        flow.value = DebugState(channelUpdates.toMap(), socketConnected)
     }
 }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
@@ -54,7 +54,6 @@ class DebugRepositoryTests {
         val clock = MockClock(now.instant, TestTimeSource())
         val repo = DebugRepository(clock = clock)
 
-        assertFalse(repo.state.value?.socketConnected!!)
         repo.setSocketConnected(true)
         assertTrue(repo.state.value?.socketConnected!!)
         repo.setSocketConnected(false)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/DebugRepositoryTests.kt
@@ -5,7 +5,9 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlin.time.TestTimeSource
 import kotlinx.coroutines.runBlocking
 import org.koin.core.context.stopKoin
@@ -44,5 +46,18 @@ class DebugRepositoryTests {
         repo.clearChannelStatus("topic1")
 
         assertEquals(mapOf("topic2" to now), repo.state.value?.channelUpdates)
+    }
+
+    @Test
+    fun `setSocketConnected toggling`() = runBlocking {
+        val now = EasternTimeInstant.now()
+        val clock = MockClock(now.instant, TestTimeSource())
+        val repo = DebugRepository(clock = clock)
+
+        assertFalse(repo.state.value?.socketConnected!!)
+        repo.setSocketConnected(true)
+        assertTrue(repo.state.value?.socketConnected!!)
+        repo.setSocketConnected(false)
+        assertFalse(repo.state.value?.socketConnected!!)
     }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [another pass at "infinite shimmer loading"](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216832169039078?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

This attempts to fix the infinite shimmer issue by considering if there is some condition under which we don't call `socket.attach` when the app is launched. 

Currently, we only call `socket.attach` in an `onChange(of: scenePhase)`. The swift docs say: "How you interpret the value depends on where it’s read from. If you read the phase from inside a View instance, you obtain a value that reflects the phase of the scene that contains the view." In my local testing, the `ContentView` always went from inactive => active on launch which would trigger the socket to attach. The inner `NearbyView` always started out as active. What if there are some conditions under which `ContentView` always starts out as active? 

We previously called `socket.attach` in both the `onChange` and `onAppear`, but that was leading to some race conditions that caused crashes. That behavior [has since changed](https://github.com/davidstump/SwiftPhoenixClient/pull/260#discussion_r1759634122) and should be fixed in SwiftPhoenixClient. 

This also adds information about socket connection to the debug view so that if we continue to have reports of this issue we can see the socket status.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added some unit tests 
* Ran locally to see DebugView looks as expected
<img width="45%" height="1596" alt="image" src="https://github.com/user-attachments/assets/52399e17-47b6-4943-a555-2fb158aeade1" /><img width="45%" height="755" alt="image" src="https://github.com/user-attachments/assets/8e7daed0-8810-408a-a08a-8be31ea7fa8b" />



<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
