### PR TITLE
Fix symphony infinite loading

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredView.kt
@@ -180,7 +180,11 @@ fun StopDetailsFilteredView(
 
         val allPatternsForStop: List<RoutePattern> = global.getPatternsFor(stopId, lineOrRoute)
         val directions: List<Direction> =
-            lineOrRoute.directions(global, stop, allPatternsForStop.filter { it.isTypical() })
+            lineOrRoute.directions(
+                global,
+                stop,
+                allPatternsForStop.filter { it.isTypical() || it.isCanonicalOnly() },
+            )
 
         val availableDirections = directions.filter {
             !stop.isLastStopForAllPatterns(it.id, allPatternsForStop, global)

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredView.swift
@@ -156,7 +156,7 @@ struct StopDetailsFilteredView: View {
             globalData: global,
             stop: stop,
             patterns: allPatternsForStop.filter { pattern in
-                pattern.isTypical()
+                pattern.isTypical() || pattern.isCanonicalOnly()
             }
         )
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/GlobalMapData.kt
@@ -1,6 +1,5 @@
 package com.mbta.tid.mbta_app.model
 
-import com.mbta.tid.mbta_app.model.RoutePattern.Typicality
 import com.mbta.tid.mbta_app.model.response.AlertsStreamDataResponse
 import com.mbta.tid.mbta_app.model.response.GlobalResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -113,7 +112,7 @@ public data class GlobalMapData(
                         }
 
                 fun typical(pattern: RoutePattern) =
-                    pattern.isTypical() || pattern.typicality == Typicality.CanonicalOnly
+                    pattern.isTypical() || pattern.isCanonicalOnly()
 
                 val isTerminal =
                     patterns
@@ -151,6 +150,9 @@ public data class GlobalMapData(
                     allRoutes.add(route)
                 }
 
+                val categorizedAlerts: MutableMap<MapStopRoute, StopAlertState> =
+                    alertsByStop?.get(stop.id)?.stateByRoute?.toMutableMap() ?: mutableMapOf()
+
                 val mapRouteList = mutableListOf<MapStopRoute>()
                 val categorizedRoutes = mutableMapOf<MapStopRoute, List<Route>>()
 
@@ -160,12 +162,13 @@ public data class GlobalMapData(
                         mapRouteList += category
                     }
                     categorizedRoutes[category] = (categorizedRoutes[category] ?: listOf()) + route
-                }
-
-                var categorizedAlerts: Map<MapStopRoute, StopAlertState>? = null
-                if (alertsByStop != null) {
-                    val alertsHere = alertsByStop[stop.id]
-                    categorizedAlerts = alertsHere?.stateByRoute ?: emptyMap()
+                    if (
+                        globalData.getPatternsFor(stop.id).all { pattern ->
+                            pattern.isCanonicalOnly()
+                        }
+                    ) {
+                        categorizedAlerts[category] = StopAlertState.Suspension
+                    }
                 }
 
                 if (mapRouteList == listOf(MapStopRoute.SILVER, MapStopRoute.BUS)) {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1213,7 +1213,8 @@ public data class RouteCardData(
 
             val hasUnseenTypicalPattern =
                 routePatterns?.any {
-                    (patternsNotSeenAtEarlierStops?.contains(it.id) ?: false) && it.isTypical()
+                    (patternsNotSeenAtEarlierStops?.contains(it.id) ?: false) && it.isTypical() ||
+                        it.isCanonicalOnly()
                 } ?: false
 
             // Typical shuttle with no service today

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RoutePattern.kt
@@ -33,6 +33,14 @@ internal constructor(
      */
     public fun isTypical(): Boolean = typicality == null || typicality == Typicality.Typical
 
+    /**
+     * Checks if this pattern is [Typicality.CanonicalOnly].
+     *
+     * If any typicality is unknown, the route should be shown, and so this will return true.
+     */
+    public fun isCanonicalOnly(): Boolean =
+        typicality == null || typicality == Typicality.CanonicalOnly
+
     override fun compareTo(other: RoutePattern): Int = sortOrder.compareTo(other.sortOrder)
 
     internal data class PatternsForStop(


### PR DESCRIPTION
### Summary

_Ticket:_ [Fix: symphony unfiltered stop details infinite loads](https://app.asana.com/1/15492006741476/project/1215456342910576/task/1216541870968243?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Fix symphony infinite loading

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Tested locally
  - Checked that other stations didn't appeared as closed that weren't previously closed
  - Checked a few CR stations and they had the same info as before the change
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
