### PR TITLE
Fix: skipping most leaf filters for non-NearbyTransit context

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1180,19 +1180,6 @@ public data class RouteCardData(
             if (this.allDataLoaded == false && showAllPatternsWhileLoading) return true
             val isBus = lineOrRoute.type == RouteType.BUS
 
-            // If we don’t have any upcoming trips to tell us whether or not service is
-            // arrival-only, trust the typical-last-stop-on-route-pattern state.
-            val isArrivalOnly =
-                this.isLastStopOnRoutePattern(stop, globalData) &&
-                    (this.upcomingTrips?.isArrivalOnly() ?: true)
-
-            // Filter out arrival-only stops when context is different from Nearby
-            // transit to show service ended, closed stops and other leafs on any
-            // of the other contexts.
-            if (context != Context.NearbyTransit) {
-                return !isArrivalOnly
-            }
-
             // Filter out trips in the past unless vehicle is at the stop or prediction has status
             // and only take the next 2 (if bus) or 3 upcoming trips into account, since more than
             // that can never be shown in nearby transit.
@@ -1208,6 +1195,23 @@ public data class RouteCardData(
                     }
                     ?.take(if (isBus) TYPICAL_LEAF_ROWS else BRANCHING_LEAF_ROWS)
 
+            // If we don’t have any upcoming trips to tell us whether or not service is
+            // arrival-only, trust the typical-last-stop-on-route-pattern state.
+            val isArrivalOnly =
+                this.isLastStopOnRoutePattern(stop, globalData) &&
+                    (this.upcomingTrips?.isArrivalOnly() ?: true)
+
+            // Typical shuttle with no service today
+            val shuttleWithNoServiceToday =
+                upcomingTripsInCutoff.orEmpty().isEmpty() && lineOrRoute.isShuttle
+
+            // Filter out arrival-only stops when context is different from Nearby
+            // transit to show service ended, closed stops and other leafs on any
+            // of the other contexts.
+            if (context != Context.NearbyTransit) {
+                return !isArrivalOnly && !shuttleWithNoServiceToday
+            }
+
             val hasUnseenUpcomingTrip =
                 upcomingTripsInCutoff?.any { upcomingTrip ->
                     upcomingTrip.trip.routePatternId?.let {
@@ -1221,10 +1225,6 @@ public data class RouteCardData(
                 routePatterns?.any {
                     (patternsNotSeenAtEarlierStops?.contains(it.id) ?: false) && it.isTypical()
                 } ?: false
-
-            // Typical shuttle with no service today
-            val shuttleWithNoServiceToday =
-                upcomingTrips.orEmpty().isEmpty() && lineOrRoute.isShuttle
 
             return (hasUnseenTypicalPattern || hasUnseenUpcomingTrip) &&
                 !(isArrivalOnly) &&

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteCardData.kt
@@ -1179,7 +1179,19 @@ public data class RouteCardData(
         ): Boolean {
             if (this.allDataLoaded == false && showAllPatternsWhileLoading) return true
             val isBus = lineOrRoute.type == RouteType.BUS
-            val isSubway = lineOrRoute.isSubway
+
+            // If we don’t have any upcoming trips to tell us whether or not service is
+            // arrival-only, trust the typical-last-stop-on-route-pattern state.
+            val isArrivalOnly =
+                this.isLastStopOnRoutePattern(stop, globalData) &&
+                    (this.upcomingTrips?.isArrivalOnly() ?: true)
+
+            // Filter out arrival-only stops when context is different from Nearby
+            // transit to show service ended, closed stops and other leafs on any
+            // of the other contexts.
+            if (context != Context.NearbyTransit) {
+                return !isArrivalOnly
+            }
 
             // Filter out trips in the past unless vehicle is at the stop or prediction has status
             // and only take the next 2 (if bus) or 3 upcoming trips into account, since more than
@@ -1205,12 +1217,6 @@ public data class RouteCardData(
                     } ?: true
                 } ?: false
 
-            // If we don’t have any upcoming trips to tell us whether or not service is
-            // arrival-only, trust the typical-last-stop-on-route-pattern state.
-            val shouldBeFilteredAsArrivalOnly =
-                this.isLastStopOnRoutePattern(stop, globalData) &&
-                    (this.upcomingTrips?.isArrivalOnly() ?: true)
-
             val hasUnseenTypicalPattern =
                 routePatterns?.any {
                     (patternsNotSeenAtEarlierStops?.contains(it.id) ?: false) && it.isTypical()
@@ -1221,7 +1227,7 @@ public data class RouteCardData(
                 upcomingTrips.orEmpty().isEmpty() && lineOrRoute.isShuttle
 
             return (hasUnseenTypicalPattern || hasUnseenUpcomingTrip) &&
-                !(shouldBeFilteredAsArrivalOnly) &&
+                !(isArrivalOnly) &&
                 !(shuttleWithNoServiceToday)
         }
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/FavoritesViewModelTest.kt
@@ -517,8 +517,12 @@ internal class FavoritesViewModelTest : KoinTest {
                 FavoritesViewModel.State(
                     awaitingPredictionsAfterBackground = false,
                     favorites = favoritesAfter.routeStopDirection,
-                    routeCardData = emptyList(),
-                    stopCardData = emptyList(),
+                    routeCardData = expectedStaticDataAfter,
+                    stopCardData =
+                        StopCardData.fromRouteCardData(
+                            expectedStaticDataAfter,
+                            sortByDistanceFrom = stop1.position,
+                        ),
                     staticRouteCardData = expectedStaticDataAfter,
                     staticStopCardData =
                         StopCardData.fromRouteCardData(
@@ -909,24 +913,11 @@ internal class FavoritesViewModelTest : KoinTest {
             listOf(routeCard1Data, routeCard2Data.copy(stopData = listOf(stop2Data)))
 
         testViewModelFlow(viewModel).test {
-            assertEquals(
-                FavoritesViewModel.State(
-                    awaitingPredictionsAfterBackground = false,
-                    favorites = favoritesBefore.routeStopDirection,
-                    routeCardData = emptyList(),
-                    stopCardData = emptyList(),
-                    staticRouteCardData = expectedStaticDataBefore,
-                    staticStopCardData =
-                        StopCardData.fromRouteCardData(
-                            expectedStaticDataBefore,
-                            sortByDistanceFrom = stop3.position,
-                        ),
-                    loadedLocation = stop3.position,
-                ),
-                awaitItemSatisfying {
-                    it.routeCardData != null && it.staticRouteCardData == expectedStaticDataBefore
-                },
-            )
+            awaitItemSatisfying {
+                it.routeCardData != null &&
+                    it.staticRouteCardData == expectedStaticDataBefore &&
+                    it.favorites == favoritesBefore.routeStopDirection
+            }
             viewModel.setContext(FavoritesViewModel.Context.Edit)
             favoritesRepo.setFavorites(favoritesAfter)
             viewModel.reloadFavorites()


### PR DESCRIPTION
### Summary

_Ticket:_ [fix: Silver Hill Inbound to North Station infinite load](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217028574714848?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Fix: skipping most leaf filters for non-NearbyTransit context

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
- Looked for silver hill station and showed service ended
- Looked at stop Hyde Park Avenue @ West St
  - It shows bus 33 service ended but doesn't show it on nearby transit 
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216177259246985