### PR TITLE
chore: clean up FavoritesByStop feature flag

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/stopCard/StopCardList.kt
@@ -316,12 +316,7 @@ private fun StopCardListPreview() {
                 single<Analytics> { MockAnalytics() }
                 single {
                     SettingsCache(
-                        MockSettingsRepository(
-                            mapOf(
-                                Settings.FavoritesByStop to true,
-                                Settings.StationAccessibility to true,
-                            )
-                        )
+                        MockSettingsRepository(mapOf(Settings.StationAccessibility to true))
                     )
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/EditFavoritesPage.kt
@@ -59,9 +59,7 @@ import com.mbta.tid.mbta_app.android.component.RoutePillType
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorColumn
 import com.mbta.tid.mbta_app.android.component.ScrollSeparatorLazyColumn
 import com.mbta.tid.mbta_app.android.component.SheetHeader
-import com.mbta.tid.mbta_app.android.component.routeCard.LoadingRouteCard
 import com.mbta.tid.mbta_app.android.component.routeCard.StopSubheader
-import com.mbta.tid.mbta_app.android.component.routeCard.TransitHeader
 import com.mbta.tid.mbta_app.android.component.stopCard.LoadingStopCard
 import com.mbta.tid.mbta_app.android.favorites.NoFavoritesView
 import com.mbta.tid.mbta_app.android.util.IsLoadingSheetContents
@@ -100,7 +98,6 @@ fun EditFavoritesPage(
     val state by favoritesViewModel.models.collectAsState()
     val resources = LocalResources.current
     val currentLocale = stringResource(R.string.current_locale)
-    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     val removeToastText = stringResource(R.string.favorites_toast_remove)
     val removeToastFallbackText = stringResource(R.string.favorites_toast_remove_fallback)
@@ -112,27 +109,15 @@ fun EditFavoritesPage(
             ?: removeToastFallbackText
     }
 
-    // to make deletion animations work nicely, we persist the first staticRouteCardData we saw, and
+    // to make deletion animations work nicely, we persist the first staticStopCardData we saw, and
     // then we visually hide things that are no longer in the favorites
-    var firstStaticRouteCardData by remember { mutableStateOf<List<RouteCardData>?>(null) }
     var firstStaticStopCardData by remember { mutableStateOf<List<StopCardData>?>(null) }
     val firstDataFavorites =
-        if (groupByStop)
-            firstStaticStopCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
-        else firstStaticRouteCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
-    val currentDataFavorites =
-        if (groupByStop) state.staticStopCardData.orEmpty().flatMap { it.routeStopDirections }
-        else state.staticRouteCardData.orEmpty().flatMap { it.routeStopDirections }
+        firstStaticStopCardData.orEmpty().flatMap { it.routeStopDirections }.toSet()
+    val currentDataFavorites = state.staticStopCardData.orEmpty().flatMap { it.routeStopDirections }
     val removedFavorites = firstDataFavorites - currentDataFavorites
-    // to avoid breaking creation, we reset the staticRouteCardData if anything appears that we
+    // to avoid breaking creation, we reset the staticStopCardData if anything appears that we
     // didn’t already know about
-    if (
-        state.staticRouteCardData != null &&
-            (firstStaticRouteCardData == null ||
-                !firstDataFavorites.containsAll(currentDataFavorites))
-    ) {
-        firstStaticRouteCardData = state.staticRouteCardData
-    }
     if (
         state.staticStopCardData != null &&
             (firstStaticStopCardData == null ||
@@ -194,97 +179,14 @@ fun EditFavoritesPage(
                 favoritesViewModel.reloadFavorites()
             }
         }
-        if (groupByStop) {
-            EditFavoritesList(
-                state.favorites,
-                firstStaticStopCardData,
-                removedFavorites,
-                global,
-                deleteFavorite = deleteFavorite,
-                editFavorite = editFavorite,
-            )
-        } else {
-            EditFavoritesListGroupedByRoute(
-                state.favorites,
-                firstStaticRouteCardData,
-                removedFavorites,
-                global,
-                deleteFavorite = deleteFavorite,
-                editFavorite = editFavorite,
-            )
-        }
-    }
-}
-
-@Composable
-private fun EditFavoritesListGroupedByRoute(
-    favorites: Map<RouteStopDirection, FavoriteSettings>?,
-    routeCardData: List<RouteCardData>?,
-    removedFavorites: Set<RouteStopDirection>,
-    global: GlobalResponse?,
-    deleteFavorite: (RouteStopDirection) -> Unit,
-    editFavorite: (RouteStopDirection) -> Unit,
-) {
-    val notificationsFlag = SettingsCache.get(Settings.Notifications)
-
-    val displayedFavorites = routeCardData?.filter { data ->
-        !removedFavorites.containsAll(data.routeStopDirections)
-    }
-
-    if (displayedFavorites == null) {
-        CompositionLocalProvider(IsLoadingSheetContents provides true) {
-            ScrollSeparatorLazyColumn(
-                contentPadding =
-                    PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(14.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                items(5) { LoadingRouteCard() }
-                item { Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
-            }
-        }
-    } else if (displayedFavorites.isEmpty()) {
-        ScrollSeparatorColumn(Modifier.padding(8.dp).navigationBarsPadding(), Arrangement.Center) {
-            NoFavoritesView({}, false)
-        }
-    } else {
-        ScrollSeparatorLazyColumn(
-            contentPadding = PaddingValues(start = 15.dp, top = 7.dp, end = 15.dp, bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            items(displayedFavorites, key = { it.id.idText }) {
-                Column(Modifier.animateItem().haloContainer(1.dp)) {
-                    TransitHeader(it.lineOrRoute) {}
-
-                    it.stopData.forEach { stopData ->
-                        val visible =
-                            stopData.data.any { leaf ->
-                                !removedFavorites.contains(leaf.routeStopDirection)
-                            }
-                        AnimatedVisibility(visible = visible) {
-                            StopSubheader(stopData, includeIcon = false)
-                        }
-
-                        FavoriteDepartures(
-                            favorites,
-                            stopData.data,
-                            removedFavorites,
-                            global,
-                            { leaf -> deleteFavorite(leaf.routeStopDirection) },
-                        ) { leaf ->
-                            val selectedFavorite = leaf.routeStopDirection
-                            if (notificationsFlag) {
-                                editFavorite(selectedFavorite)
-                            } else {
-                                deleteFavorite(selectedFavorite)
-                            }
-                        }
-                    }
-                }
-            }
-            item { Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars)) }
-        }
+        EditFavoritesList(
+            state.favorites,
+            firstStaticStopCardData,
+            removedFavorites,
+            global,
+            deleteFavorite = deleteFavorite,
+            editFavorite = editFavorite,
+        )
     }
 }
 
@@ -360,7 +262,6 @@ private fun FavoriteDepartures(
     onClick: (RouteCardData.Leaf) -> Unit,
 ) {
     val notificationsFlag = SettingsCache.get(Settings.Notifications)
-    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     Column {
         leaves.withIndex().forEach { (index, leaf) ->
@@ -424,7 +325,7 @@ private fun FavoriteDepartures(
                             Modifier.background(colorResource(R.color.fill3))
                                 .fillMaxHeight()
                                 .padding(vertical = 10.dp)
-                                .padding(horizontal = if (groupByStop) 8.dp else 16.dp)
+                                .padding(horizontal = 8.dp)
                                 .semantics(mergeDescendants = true) {
                                     role = Role.Button
                                     onClick(overriddenClickLabel) {
@@ -433,14 +334,12 @@ private fun FavoriteDepartures(
                                     }
                                 },
                     ) {
-                        if (groupByStop) {
-                            RoutePill(
-                                (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
-                                (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
-                                type = RoutePillType.Fixed,
-                                modifier = Modifier.padding(end = 8.dp),
-                            )
-                        }
+                        RoutePill(
+                            (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                            (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                            type = RoutePillType.Fixed,
+                            modifier = Modifier.padding(end = 8.dp),
+                        )
                         when (formatted) {
                             is LeafFormat.Single -> {
                                 Column(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/FavoritesPage.kt
@@ -24,7 +24,6 @@ import com.mbta.tid.mbta_app.android.component.DebugView
 import com.mbta.tid.mbta_app.android.component.ErrorBanner
 import com.mbta.tid.mbta_app.android.component.NavTextButton
 import com.mbta.tid.mbta_app.android.component.SheetHeader
-import com.mbta.tid.mbta_app.android.component.routeCard.RouteCardList
 import com.mbta.tid.mbta_app.android.component.stopCard.StopCardList
 import com.mbta.tid.mbta_app.android.favorites.NoFavoritesView
 import com.mbta.tid.mbta_app.android.favorites.NotificationsHint
@@ -68,7 +67,6 @@ fun FavoritesPage(
         nearbyTransit.viewportProvider.cameraStateFlow.collectAsStateWithLifecycle(null)
 
     val notificationsEnabled = SettingsCache.get(Settings.Notifications)
-    val groupByStop = SettingsCache.get(Settings.FavoritesByStop)
 
     fun onAddFavorites() {
         favoritesViewModel.setIsFirstExposureToNewFavorites(false)
@@ -140,10 +138,7 @@ fun FavoritesPage(
         }
     }
 
-    val routeCardData = state.routeCardData
     val stopCardData = state.stopCardData
-
-    val chosenCardData = if (groupByStop) stopCardData else routeCardData
 
     val emptyView: @Composable ColumnScope.() -> Unit = {
         NoFavoritesView(::onAddFavorites)
@@ -167,7 +162,7 @@ fun FavoritesPage(
                 ),
             rightActionContents = {
                 Row(Modifier, Arrangement.spacedBy(8.dp), Alignment.CenterVertically) {
-                    if (!chosenCardData.isNullOrEmpty()) {
+                    if (!stopCardData.isNullOrEmpty()) {
                         ActionButton(
                             ActionButtonKind.Plus,
                             colors = ButtonDefaults.contrastTranslucent(),
@@ -193,24 +188,13 @@ fun FavoritesPage(
 
         ErrorBanner(errorBannerViewModel, modifier = Modifier.padding(top = 8.dp))
         DebugView(content = {})
-        if (groupByStop) {
-            StopCardList(
-                stopCardData = stopCardData,
-                emptyView = { emptyView() },
-                global = globalResponse,
-                now = now,
-                isFavorite = isFavorite,
-                onOpenStopDetails = onOpenStopDetails,
-            )
-        } else {
-            RouteCardList(
-                routeCardData = routeCardData,
-                emptyView = { emptyView() },
-                global = globalResponse,
-                now = now,
-                isFavorite = isFavorite,
-                onOpenStopDetails = onOpenStopDetails,
-            )
-        }
+        StopCardList(
+            stopCardData = stopCardData,
+            emptyView = { emptyView() },
+            global = globalResponse,
+            now = now,
+            isFavorite = isFavorite,
+            onOpenStopDetails = onOpenStopDetails,
+        )
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -146,7 +146,6 @@ fun MorePage(
                                                 reloadPendingOnboarding()
                                             }
                                             Settings.DevDebugMode,
-                                            Settings.FavoritesByStop,
                                             Settings.HideMaps,
                                             Settings.SearchRouteResults -> {}
                                         }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
@@ -17,7 +17,6 @@ val SharedString.value: String
             SharedString.Crash -> "Crash the app"
             SharedString.DebugMode -> stringResource(R.string.feature_flag_debug_mode)
             SharedString.FareInformation -> stringResource(R.string.resources_link_fare_info)
-            SharedString.FavoritesByStop -> "Group favorites by stop"
             SharedString.FeatureFlagsSection -> stringResource(R.string.more_section_feature_flags)
             SharedString.ForceNotificationsBeta -> "Reset and force notifications beta"
             SharedString.MapDisplay -> stringResource(R.string.setting_toggle_map_display)

--- a/iosApp/iosApp/ComponentViews/StopCard/StopCardList.swift
+++ b/iosApp/iosApp/ComponentViews/StopCard/StopCardList.swift
@@ -248,5 +248,5 @@ struct StopCardList<EmptyView: View>: View {
             pushNavEntry: { _ in }
         )
     }
-    .withFixedSettings([.favoritesByStop: true, .stationAccessibility: true])
+    .withFixedSettings([.stationAccessibility: true])
 }

--- a/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
+++ b/iosApp/iosApp/Pages/Favorites/EditFavoritesPage.swift
@@ -26,8 +26,6 @@ struct EditFavoritesPage: View {
     @ObservedObject var fcmTokenContainer = FcmTokenContainer.shared
     @EnvironmentObject var settingsCache: SettingsCache
 
-    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
-
     let inspection = Inspection<Self>()
 
     func deleteAndToast(_ rsd: RouteStopDirection) {
@@ -88,23 +86,13 @@ struct EditFavoritesPage: View {
                     navCallbacks: navCallbacks,
                     closeText: NSLocalizedString("Done", comment: "Button text for closing flow")
                 )
-                if groupByStop {
-                    EditFavoritesList(
-                        favorites: favoritesState,
-                        stopCardData: favoritesVMState.staticStopCardData,
-                        global: globalResponse,
-                        deleteFavorite: deleteAndToast,
-                        onOpenEditModal: onOpenEditModal,
-                    )
-                } else {
-                    EditFavoritesListGroupedByRoute(
-                        favorites: favoritesState,
-                        routeCardData: favoritesVMState.staticRouteCardData,
-                        global: globalResponse,
-                        deleteFavorite: deleteAndToast,
-                        onOpenEditModal: onOpenEditModal,
-                    )
-                }
+                EditFavoritesList(
+                    favorites: favoritesState,
+                    stopCardData: favoritesVMState.staticStopCardData,
+                    global: globalResponse,
+                    deleteFavorite: deleteAndToast,
+                    onOpenEditModal: onOpenEditModal,
+                )
             }
             .onAppear {
                 viewModel.setContext(context: FavoritesViewModel.ContextEdit())
@@ -129,68 +117,6 @@ struct EditFavoritesPage: View {
             }
         }
         .enableInjection()
-    }
-}
-
-struct EditFavoritesListGroupedByRoute: View {
-    @ObserveInjection var inject
-    let favorites: [RouteStopDirection: FavoriteSettings?]
-    let routeCardData: [RouteCardData]?
-    let global: GlobalResponse?
-    let deleteFavorite: (RouteStopDirection) -> Void
-    let onOpenEditModal: (RouteStopDirection) -> Void
-
-    @EnvironmentObject var settingsCache: SettingsCache
-
-    var body: some View {
-        if let routeCardData, !routeCardData.isEmpty {
-            HaloScrollView {
-                LazyVStack(alignment: .center, spacing: 14) {
-                    ForEach(routeCardData) { cardData in
-                        RouteCardContainer(
-                            cardData: cardData,
-                            showStopHeader: true
-                        ) { stopData in
-                            FavoriteDepartures(
-                                favorites: favorites,
-                                leaves: stopData.data,
-                                globalData: global
-                            ) { leaf in
-                                if settingsCache.get(.notifications) {
-                                    onOpenEditModal(leaf.routeStopDirection)
-                                } else {
-                                    deleteFavorite(leaf.routeStopDirection)
-                                }
-                            }
-                        }
-                    }
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 16)
-                .frame(maxHeight: .infinity, alignment: .top)
-            }
-        }
-
-        else if routeCardData != nil {
-            HaloScrollView {
-                NoFavoritesView()
-                    .frame(maxWidth: .infinity)
-                    .padding(.top, 16)
-            }
-        }
-
-        else {
-            ScrollView([]) {
-                LazyVStack(alignment: .center, spacing: 14) {
-                    ForEach(0 ..< 5) { _ in
-                        LoadingRouteCard()
-                    }
-                }
-                .padding(.vertical, 4)
-                .padding(.horizontal, 16)
-                .loadingPlaceholder()
-            }
-        }
     }
 }
 
@@ -263,7 +189,6 @@ struct FavoriteDepartures: View {
     let onClick: (RouteCardData.Leaf) -> Void
 
     @EnvironmentObject var settingsCache: SettingsCache
-    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -273,13 +198,11 @@ struct FavoriteDepartures: View {
                 let favoriteSettings: FavoriteSettings? = favorites[leaf.routeStopDirection] ?? nil
 
                 HStack(alignment: .center, spacing: 0) {
-                    if groupByStop {
-                        RoutePill(
-                            route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
-                            line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
-                            type: .fixed
-                        ).padding(.trailing, 8)
-                    }
+                    RoutePill(
+                        route: (leaf.lineOrRoute as? LineOrRoute.Route)?.route,
+                        line: (leaf.lineOrRoute as? LineOrRoute.Line)?.line,
+                        type: .fixed
+                    ).padding(.trailing, 8)
                     switch onEnum(of: formatted) {
                     case let .single(single):
                         HStack(alignment: .center, spacing: 8) {
@@ -312,7 +235,7 @@ struct FavoriteDepartures: View {
                         }
                     }
                 }
-                .padding(.horizontal, groupByStop ? 8 : 16)
+                .padding(.horizontal, 8)
                 .padding(.vertical, 10)
 
                 if index < leaves.endIndex {

--- a/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
+++ b/iosApp/iosApp/Pages/Favorites/FavoritesView.swift
@@ -26,7 +26,6 @@ struct FavoritesView: View {
 
     @EnvironmentObject var settingsCache: SettingsCache
     var notificationsEnabled: Bool { settingsCache.get(.notifications) }
-    var groupByStop: Bool { settingsCache.get(.favoritesByStop) }
 
     @State var globalData: GlobalResponse?
     var globalRepository = RepositoryDI().global
@@ -48,9 +47,7 @@ struct FavoritesView: View {
                 title: NSLocalizedString("Favorites", comment: "Header for favorites sheet"),
                 navCallbacks: .init(onBack: nil, onClose: nil, backButtonPresentation: .floating),
                 rightActionContents: {
-                    if let chosenCardData: [Any] = groupByStop ? favoritesVMState.stopCardData : favoritesVMState
-                        .routeCardData,
-                        !chosenCardData.isEmpty {
+                    if let stopCardData = favoritesVMState.stopCardData, !stopCardData.isEmpty {
                         ActionButton(kind: .plus, circleColor: Color.translucentContrast, action: { onAddStops() })
                         NavTextButton(
                             string: NSLocalizedString("Edit", comment: "Button text to enter edit favorites flow"),
@@ -74,26 +71,14 @@ struct FavoritesView: View {
 
             ErrorBanner(errorBannerVM, padding: .init([.horizontal, .bottom], 16))
             DebugView { EmptyView() }
-            if groupByStop {
-                StopCardList(
-                    stopCardData: favoritesVMState.stopCardData,
-                    emptyView: { emptyView() },
-                    global: globalData,
-                    now: now,
-                    isFavorite: { isFavorite($0) },
-                    pushNavEntry: { navManager.pushNavEntry($0) }
-                )
-            } else {
-                RouteCardList(
-                    routeCardData: favoritesVMState.routeCardData,
-                    emptyView: { emptyView() },
-                    global: globalData,
-                    now: now,
-                    isFavorite: { isFavorite($0) },
-                    pushNavEntry: { navManager.pushNavEntry($0) },
-                    showStopHeader: true
-                )
-            }
+            StopCardList(
+                stopCardData: favoritesVMState.stopCardData,
+                emptyView: { emptyView() },
+                global: globalData,
+                now: now,
+                isFavorite: { isFavorite($0) },
+                pushNavEntry: { navManager.pushNavEntry($0) }
+            )
         }
         .global($globalData, errorKey: .companion.fromSheetTypes(sheetTypes: [.favorites], id: "FavoritesView"))
         .onAppear {

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -96,7 +96,7 @@ struct MorePage: View {
                                         }
                                     case .notifications:
                                         await reloadPendingOnboarding()
-                                    case .devDebugMode, .favoritesByStop, .hideMaps, .searchRouteResults:
+                                    case .devDebugMode, .hideMaps, .searchRouteResults:
                                         break
                                     }
                                 }

--- a/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
+++ b/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
@@ -38,7 +38,6 @@ extension SharedString {
                 "Fare Information",
                 comment: "Label for a More page link to fare information on MBTA.com"
             )
-        case .favoritesByStop: "Group favorites by stop"
         case .featureFlagsSection:
             NSLocalizedString(
                 "Feature Flags",

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -40,7 +40,6 @@ public enum class Settings(
     public val override: Boolean? = null,
 ) {
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
-    FavoritesByStop(booleanPreferencesKey("favorites_by_stop"), true),
     HideMaps(booleanPreferencesKey("hide_maps")),
     Notifications(booleanPreferencesKey("notifications")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
@@ -7,7 +7,6 @@ public enum class SharedString {
     Crash,
     DebugMode,
     FareInformation,
-    FavoritesByStop,
     FeatureFlagsSection,
     ForceNotificationsBeta,
     MapDisplay,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
@@ -118,10 +118,6 @@ public class MoreViewModel(
                                 }
                             },
                         ),
-                        MoreItem.Toggle(
-                            label = SharedString.FavoritesByStop,
-                            settings = Settings.FavoritesByStop,
-                        ),
                         MoreItem.Action(
                             label = SharedString.Crash,
                             action = {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -16,8 +16,6 @@ import org.koin.dsl.module
 import org.koin.test.KoinTest
 
 internal class SettingsRepositoryTest : KoinTest {
-    val defaultSettings = Settings.entries.associateWith { false }
-
     @AfterTest
     fun cleanup() {
         stopKoin()
@@ -38,7 +36,6 @@ internal class SettingsRepositoryTest : KoinTest {
         assertEquals(
             mapOf(
                 Settings.DevDebugMode to true,
-                Settings.FavoritesByStop to false,
                 Settings.HideMaps to false,
                 Settings.Notifications to false,
                 Settings.SearchRouteResults to false,


### PR DESCRIPTION
### Summary

_Ticket:_ [Release favorites grouped by stop](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216424151277004?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Remove the feature flag & unused code paths that relied on the flag being false

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally
* Tests already cleaned up in https://github.com/mbta/mobile_app/pull/1897

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
