### PR TITLE
fix: Prevent onboarding advancement on double tap

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -94,7 +94,7 @@ import org.koin.mp.KoinPlatformTools
 @Composable
 fun OnboardingScreenView(
     screen: OnboardingScreen,
-    advance: () -> Unit,
+    advance: (OnboardingScreen) -> Unit,
     locationDataManager: LocationDataManager,
     skipLocationDialogue: Boolean = false,
     settingsCache: SettingsCache = koinInject(),
@@ -102,17 +102,17 @@ fun OnboardingScreenView(
     var sharingLocation by rememberSaveable { mutableStateOf(false) }
     val permissions =
         locationDataManager.rememberPermissions(
-            onPermissionsResult = {
+            onPermissionsResult = { result ->
                 // This only fires after the permissions state has changed
-                if (sharingLocation) {
-                    advance()
+                if (sharingLocation && result.isNotEmpty()) {
+                    advance(OnboardingScreen.Location)
                 }
             }
         )
 
     fun shareLocation() {
         if (skipLocationDialogue || permissions.permissions.any { it.status.isGranted }) {
-            advance()
+            advance(OnboardingScreen.Location)
         } else {
             sharingLocation = true
             permissions.launchMultiplePermissionRequest()
@@ -169,7 +169,7 @@ fun OnboardingScreenView(
                     Spacer(modifier = Modifier.height(16.dp))
                     OnboardingPieces.KeyButton(
                         R.string.onboarding_feedback_advance,
-                        onClick = advance,
+                        onClick = { advance(OnboardingScreen.Feedback) },
                     )
                 }
             }
@@ -196,7 +196,7 @@ fun OnboardingScreenView(
                         R.string.onboarding_continue,
                         onClick = {
                             settingsCache.set(Settings.HideMaps, localHideMapsSetting)
-                            advance()
+                            advance(OnboardingScreen.HideMaps)
                         },
                     )
                 }
@@ -231,7 +231,7 @@ fun OnboardingScreenView(
             }
         }
         OnboardingScreen.NotificationsBeta -> {
-            NotificationsBetaPage(advance)
+            NotificationsBetaPage({ advance(OnboardingScreen.NotificationsBeta) })
         }
         OnboardingScreen.StationAccessibility -> {
             OnboardingPieces.PageBox(painterResource(R.mipmap.onboarding_background_map)) {
@@ -262,7 +262,7 @@ fun OnboardingScreenView(
 
                     OnboardingPieces.KeyButton(
                         R.string.onboarding_continue,
-                        onClick = { advance() },
+                        onClick = { advance(OnboardingScreen.StationAccessibility) },
                     )
                 }
             }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/OnboardingPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/OnboardingPage.kt
@@ -2,7 +2,7 @@ package com.mbta.tid.mbta_app.android.pages
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -11,6 +11,8 @@ import com.mbta.tid.mbta_app.android.onboarding.OnboardingScreenView
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.IOnboardingRepository
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koin.compose.koinInject
 
 @Composable
@@ -22,20 +24,29 @@ fun OnboardingPage(
     onboardingRepository: IOnboardingRepository = koinInject(),
     skipLocationDialogue: Boolean = false,
 ) {
-    var selectedIndex by remember { mutableIntStateOf(0) }
+    var selectedIndex by remember { mutableStateOf<Int?>(0) }
     val coroutineScope = rememberCoroutineScope()
+    val advanceMutex = Mutex()
 
-    val screen = screens[selectedIndex]
+    val screen = selectedIndex?.let { screens[it] } ?: return
     OnboardingScreenView(
         screen,
-        {
+        { from ->
             coroutineScope.launch {
-                onboardingRepository.markOnboardingCompleted(screen)
-                if (selectedIndex < screens.size - 1) {
-                    selectedIndex += 1
-                    onAdvance()
-                } else {
-                    onFinish()
+                advanceMutex.withLock {
+                    val index = selectedIndex ?: return@launch
+                    val latestScreen = screens[index]
+                    if (from != latestScreen) return@launch
+
+                    onboardingRepository.markOnboardingCompleted(latestScreen)
+
+                    if (index < screens.lastIndex) {
+                        selectedIndex = index + 1
+                        onAdvance()
+                    } else {
+                        selectedIndex = null
+                        onFinish()
+                    }
                 }
             }
         },


### PR DESCRIPTION
### Summary

_Ticket:_ [🤖 | Accessibility onboarding step is frequently skipped after allowing location permission](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217000391129153?focus=true)

Prevent the onboarding buttons from being double tapped and advancing past the next page unintentionally. The initial double advance past the permission page was slightly different, double tapping it would call `shareLocation` multiple times, and the second `launchMultiplePermissionRequest` would trigger a call to `onPermissionsResult` with an empty result map. This can still happen, but I added a check for the empty result. If the user actually approves or denies the permission, the map will include them.

I also added the screens being advanced from to the `advance` call, and wrapped the completion call in a mutex, since it was being run in a coroutine, it was possible run it multiple times using stale values, which would mark the same page complete and advance past the next page.

### Testing

Existing unit tests pass