### PR TITLE
fix: Prevent missing route shapes on loop routes

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
@@ -184,7 +184,11 @@ public object RouteFeaturesBuilder {
         val firstStop = stopsById?.get(firstStopId) ?: return null
         val lastStopId = segment.stopIds.lastOrNull() ?: return null
         val lastStop = stopsById.get(lastStopId) ?: return null
-        val lineSegment = fullLineString.slice(start = firstStop.position, stop = lastStop.position)
+        // Loop routes can begin and end at the same stop, but slicing by identical positions
+        // produces an empty line, so if there's a loop, always draw the full shape
+        val lineSegment =
+            if (firstStopId == lastStopId) fullLineString
+            else fullLineString.slice(start = firstStop.position, stop = lastStop.position)
         return RouteLineData(
             id = segment.id,
             sourceRoutePatternId = segment.sourceRoutePatternId,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -186,6 +186,55 @@ class RouteFeaturesBuilderTest {
     }
 
     @Test
+    fun `uses full shape for loop segment`() = runBlocking {
+        val loopRouteData =
+            listOf(
+                MapFriendlyRouteResponse.RouteWithSegmentedShapes(
+                    routeId = MapTestDataHelper.routeRed.id,
+                    segmentedShapes =
+                        listOf(
+                            SegmentedRouteShape(
+                                sourceRoutePatternId = MapTestDataHelper.patternRed10.id,
+                                sourceRouteId = MapTestDataHelper.patternRed10.routeId,
+                                directionId = MapTestDataHelper.patternRed10.directionId,
+                                routeSegments =
+                                    listOf(
+                                        RouteSegment(
+                                            id = "loop-segment",
+                                            sourceRoutePatternId =
+                                                MapTestDataHelper.patternRed10.id,
+                                            sourceRouteId = MapTestDataHelper.patternRed10.routeId,
+                                            stopIds =
+                                                listOf(
+                                                    MapTestDataHelper.stopAlewife.id,
+                                                    MapTestDataHelper.stopDavis.id,
+                                                    MapTestDataHelper.stopAlewife.id,
+                                                ),
+                                            otherPatternsByStopId = emptyMap(),
+                                        )
+                                    ),
+                                shape = MapTestDataHelper.shapeRedC1,
+                            )
+                        ),
+                )
+            )
+
+        val routeSources =
+            RouteFeaturesBuilder.generateRouteSources(
+                routeData = loopRouteData,
+                stopsById =
+                    mapOf(
+                        MapTestDataHelper.stopAlewife.id to MapTestDataHelper.stopAlewife,
+                        MapTestDataHelper.stopDavis.id to MapTestDataHelper.stopDavis,
+                    ),
+                alertsByStop = emptyMap(),
+            )
+
+        val geometry = routeSources.single().features.features.single().geometry
+        assertEquals(LineString(Polyline.decode(MapTestDataHelper.shapeRedC1.polyline!!)), geometry)
+    }
+
+    @Test
     fun `transforms shapes with stops`() {
         val now = EasternTimeInstant.now()
 


### PR DESCRIPTION
### Summary

_Ticket:_ [Some ferry route shapes don't appear on the map](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216540341278354?focus=true)

Turns out that slicing a shape on the same point just deletes the shape entirely.

### Testing

Added a unit test for the loop route case