### PR TITLE
feat: display the summaries from the backend

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopListTest.kt
@@ -6,12 +6,14 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.android.component.StopListContext
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasClickActionLabel
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDoesNotExistDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.RouteDetailsStopList
@@ -42,6 +44,7 @@ class CollapsableStopListTest {
         composeTestRule.setContent {
             CollapsableStopList(
                 LineOrRoute.Route(mainRoute),
+                stopListContext = StopListContext.RouteDetails(Matcher.Wildcard(), 0),
                 segment =
                     RouteDetailsStopList.Segment(
                         listOf(
@@ -88,6 +91,7 @@ class CollapsableStopListTest {
         composeTestRule.setContent {
             CollapsableStopList(
                 LineOrRoute.Route(mainRoute),
+                stopListContext = StopListContext.RouteDetails(Matcher.Wildcard(), 0),
                 segment =
                     RouteDetailsStopList.Segment(
                         listOf(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -11,6 +11,7 @@ import com.mbta.tid.mbta_app.android.util.fromHex
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertCardSpec
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -42,6 +43,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 null,
+                null,
                 AlertCardSpec.Downstream,
                 routeAccents,
                 { onViewDetailsClicked = true },
@@ -64,6 +66,7 @@ class AlertCardTests {
         composeTestRule.setContent {
             AlertCard(
                 alert,
+                null,
                 null,
                 AlertCardSpec.Takeover,
                 routeAccents,
@@ -89,6 +92,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 null,
+                null,
                 AlertCardSpec.Basic,
                 routeAccents,
                 { onViewDetailsClicked = true },
@@ -111,6 +115,7 @@ class AlertCardTests {
         composeTestRule.setContent {
             AlertCard(
                 alert,
+                null,
                 null,
                 AlertCardSpec.Elevator,
                 routeAccents,
@@ -144,6 +149,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 null,
+                null,
                 AlertCardSpec.Elevator,
                 routeAccents,
                 { onViewDetailsClicked = true },
@@ -165,7 +171,9 @@ class AlertCardTests {
                 effect = Alert.Effect.Delay
                 cause = Alert.Cause.HeavyRidership
             }
-        composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
+        composeTestRule.setContent {
+            AlertCard(alert, null, null, AlertCardSpec.Delay, routeAccents, {})
+        }
 
         composeTestRule.onNodeWithText("Delays due to heavy ridership").assertCanBeDisplayed()
     }
@@ -188,6 +196,13 @@ class AlertCardTests {
                     Alert.Effect.Delay,
                     AlertSummary.Location.WholeRoute("Red Line", RouteType.HEAVY_RAIL),
                     timeframe = AlertSummary.Timeframe.StartingLaterToday(time),
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**Delay** on **Red Line** starting **9:00\u202FAM** today",
                 ),
                 AlertCardSpec.Delay,
                 routeAccents,
@@ -213,7 +228,9 @@ class AlertCardTests {
                 effect = Alert.Effect.Delay
                 cause = Alert.Cause.UnknownCause
             }
-        composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
+        composeTestRule.setContent {
+            AlertCard(alert, null, null, AlertCardSpec.Delay, routeAccents, {})
+        }
 
         composeTestRule.onNodeWithText("Delays").assertCanBeDisplayed()
     }
@@ -227,7 +244,9 @@ class AlertCardTests {
                 cause = Alert.Cause.SingleTracking
                 severity = 1
             }
-        composeTestRule.setContent { AlertCard(alert, null, AlertCardSpec.Delay, routeAccents, {}) }
+        composeTestRule.setContent {
+            AlertCard(alert, null, null, AlertCardSpec.Delay, routeAccents, {})
+        }
 
         composeTestRule.onNodeWithText("Single Tracking").assertCanBeDisplayed()
     }
@@ -246,6 +265,13 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 AlertSummary.Standard(alert.effect, null, AlertSummary.Timeframe.ThisWeek(endTime)),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**Service suspended** through Saturday",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents,
                 {},
@@ -270,6 +296,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 AlertSummary.Standard(alert.effect, null, AlertSummary.Timeframe.Time(endTime)),
+                AlertSummaryEntity(null, null, null, null, "**Detour** through 9:00\u202FAM"),
                 AlertCardSpec.Basic,
                 routeAccents,
                 {},
@@ -298,6 +325,13 @@ class AlertCardTests {
                             startStopName = "Start Stop",
                             endStopName = "End Stop",
                         )
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**All clear:** Regular service from **Start Stop** to **End Stop**",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents,
@@ -330,6 +364,13 @@ class AlertCardTests {
                     recurrence = null,
                     isUpdate = true,
                 ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**Update:** Shuttle buses from **Start Stop** to **End Stop** through tomorrow",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents,
                 onViewDetails = {},
@@ -360,6 +401,13 @@ class AlertCardTests {
                     ),
                     Alert.Effect.Cancellation,
                     cause = Alert.Cause.MechanicalIssue,
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train from **Ruggles** is cancelled today due to mechanical issue",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -396,6 +444,13 @@ class AlertCardTests {
                     Alert.Effect.Suspension,
                     cause = Alert.Cause.Holiday,
                 ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Multiple trips are suspended today due to holiday",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
                 onViewDetails = {},
@@ -426,6 +481,13 @@ class AlertCardTests {
                     ),
                     "Ruggles",
                     "Forest Hills",
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -464,6 +526,13 @@ class AlertCardTests {
                     ),
                     "Ruggles",
                     "Forest Hills",
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Shuttle buses replace the **12:13\u202FPM** train from **Ruggles** to **Forest Hills**",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -504,6 +573,13 @@ class AlertCardTests {
                     listOf("Back Bay", "Ruggles"),
                     cause = null,
                 ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
                 onViewDetails = {},
@@ -535,6 +611,13 @@ class AlertCardTests {
                     AlertSummary.Location.AffectedStops(listOf("Back Bay", "Ruggles")),
                     AlertSummary.Timeframe.UntilFurtherNotice,
                 ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
                 onViewDetails = {},
@@ -558,6 +641,13 @@ class AlertCardTests {
                     Alert.Effect.StopClosure,
                     AlertSummary.Location.AffectedStops(listOf("Back Bay", "Ruggles")),
                     AlertSummary.Timeframe.UntilFurtherNotice,
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Buses will not stop at **Back Bay** and **Ruggles** until further notice",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.BUS),
@@ -591,6 +681,13 @@ class AlertCardTests {
                     Alert.Effect.Cancellation,
                     isToday = false,
                     cause = Alert.Cause.MechanicalIssue,
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train from **Ruggles** is cancelled tomorrow due to mechanical issue",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -637,6 +734,13 @@ class AlertCardTests {
                                 )
                         ),
                 ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday",
+                ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
                 onViewDetails = {},
@@ -677,6 +781,13 @@ class AlertCardTests {
                                     EasternTimeInstant(2026, Month.MARCH, 12, 9, 18)
                                 )
                         ),
+                ),
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Shuttle buses replace this train from **Ruggles** to **Forest Hills** daily until Thursday",
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCardTests.kt
@@ -197,13 +197,7 @@ class AlertCardTests {
                     AlertSummary.Location.WholeRoute("Red Line", RouteType.HEAVY_RAIL),
                     timeframe = AlertSummary.Timeframe.StartingLaterToday(time),
                 ),
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**Delay** on **Red Line** starting **9:00\u202FAM** today",
-                ),
+                AlertSummaryEntity("**Delay** on **Red Line** starting **9:00\u202FAM** today"),
                 AlertCardSpec.Delay,
                 routeAccents,
                 {},
@@ -265,13 +259,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 AlertSummary.Standard(alert.effect, null, AlertSummary.Timeframe.ThisWeek(endTime)),
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**Service suspended** through Saturday",
-                ),
+                AlertSummaryEntity("**Service suspended** through Saturday"),
                 AlertCardSpec.Takeover,
                 routeAccents,
                 {},
@@ -296,7 +284,7 @@ class AlertCardTests {
             AlertCard(
                 alert,
                 AlertSummary.Standard(alert.effect, null, AlertSummary.Timeframe.Time(endTime)),
-                AlertSummaryEntity(null, null, null, null, "**Detour** through 9:00\u202FAM"),
+                AlertSummaryEntity("**Detour** through 9:00\u202FAM"),
                 AlertCardSpec.Basic,
                 routeAccents,
                 {},
@@ -327,11 +315,7 @@ class AlertCardTests {
                         )
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**All clear:** Regular service from **Start Stop** to **End Stop**",
+                    "**All clear:** Regular service from **Start Stop** to **End Stop**"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents,
@@ -365,11 +349,7 @@ class AlertCardTests {
                     isUpdate = true,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**Update:** Shuttle buses from **Start Stop** to **End Stop** through tomorrow",
+                    "**Update:** Shuttle buses from **Start Stop** to **End Stop** through tomorrow"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents,
@@ -403,11 +383,7 @@ class AlertCardTests {
                     cause = Alert.Cause.MechanicalIssue,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train from **Ruggles** is cancelled today due to mechanical issue",
+                    "**12:13\u202FPM** train from **Ruggles** is cancelled today due to mechanical issue"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -444,13 +420,7 @@ class AlertCardTests {
                     Alert.Effect.Suspension,
                     cause = Alert.Cause.Holiday,
                 ),
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Multiple trips are suspended today due to holiday",
-                ),
+                AlertSummaryEntity("Multiple trips are suspended today due to holiday"),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
                 onViewDetails = {},
@@ -483,11 +453,7 @@ class AlertCardTests {
                     "Forest Hills",
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**",
+                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -528,11 +494,7 @@ class AlertCardTests {
                     "Forest Hills",
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Shuttle buses replace the **12:13\u202FPM** train from **Ruggles** to **Forest Hills**",
+                    "Shuttle buses replace the **12:13\u202FPM** train from **Ruggles** to **Forest Hills**"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -574,11 +536,7 @@ class AlertCardTests {
                     cause = null,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today",
+                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -612,11 +570,7 @@ class AlertCardTests {
                     AlertSummary.Timeframe.UntilFurtherNotice,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice",
+                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -643,11 +597,7 @@ class AlertCardTests {
                     AlertSummary.Timeframe.UntilFurtherNotice,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Buses will not stop at **Back Bay** and **Ruggles** until further notice",
+                    "Buses will not stop at **Back Bay** and **Ruggles** until further notice"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.BUS),
@@ -683,11 +633,7 @@ class AlertCardTests {
                     cause = Alert.Cause.MechanicalIssue,
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train from **Ruggles** is cancelled tomorrow due to mechanical issue",
+                    "**12:13\u202FPM** train from **Ruggles** is cancelled tomorrow due to mechanical issue"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -735,11 +681,7 @@ class AlertCardTests {
                         ),
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday",
+                    "**12:13\u202FPM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),
@@ -783,11 +725,7 @@ class AlertCardTests {
                         ),
                 ),
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Shuttle buses replace this train from **Ruggles** to **Forest Hills** daily until Thursday",
+                    "Shuttle buses replace this train from **Ruggles** to **Forest Hills** daily until Thursday"
                 ),
                 AlertCardSpec.Takeover,
                 routeAccents.copy(type = RouteType.COMMUTER_RAIL),

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -401,8 +401,7 @@ class StopDetailsFilteredDeparturesViewTest {
                 stop = stop.id,
                 trip = trip.id,
             )
-            summaries =
-                listOf(AlertSummaryEntity(null, null, null, null, "This bus is cancelled today"))
+            summaries = listOf(AlertSummaryEntity("This bus is cancelled today"))
         }
 
         val globalResponse =
@@ -539,11 +538,7 @@ class StopDetailsFilteredDeparturesViewTest {
             summaries =
                 listOf(
                     AlertSummaryEntity(
-                        null,
-                        null,
-                        null,
-                        null,
-                        "**Service suspended** at **${stop.name}** through 6:45\u202FPM",
+                        "**Service suspended** at **${stop.name}** through 6:45\u202FPM"
                     )
                 )
         }
@@ -633,13 +628,7 @@ class StopDetailsFilteredDeparturesViewTest {
             informedEntity(directionId = 0, route = routeC.id.idText, stop = "70151")
             summaries =
                 listOf(
-                    AlertSummaryEntity(
-                        null,
-                        null,
-                        null,
-                        null,
-                        "**Shuttle buses** at **${stop.name}** through 6:45\u202FPM",
-                    )
+                    AlertSummaryEntity("**Shuttle buses** at **${stop.name}** through 6:45\u202FPM")
                 )
         }
         val alertResponse = AlertsStreamDataResponse(mapOf(alert.id to alert))
@@ -721,11 +710,7 @@ class StopDetailsFilteredDeparturesViewTest {
             summaries =
                 listOf(
                     AlertSummaryEntity(
-                        null,
-                        null,
-                        null,
-                        null,
-                        "**Service suspended** at **Sample Stop 2** through 6:25\u202FPM",
+                        "**Service suspended** at **Sample Stop 2** through 6:25\u202FPM"
                     )
                 )
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -15,6 +15,7 @@ import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
 import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.model.Alert
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.Direction
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LocationType
@@ -50,7 +51,7 @@ import org.junit.Test
 @OptIn(ExperimentalTestApi::class)
 class StopDetailsFilteredDeparturesViewTest {
     val builder = ObjectCollectionBuilder()
-    val now = EasternTimeInstant.now()
+    val now = EasternTimeInstant(2026, Month.JULY, 10, 9, 0)
     val route = builder.route {
         id = "route_1"
         type = RouteType.LIGHT_RAIL
@@ -400,6 +401,8 @@ class StopDetailsFilteredDeparturesViewTest {
                 stop = stop.id,
                 trip = trip.id,
             )
+            summaries =
+                listOf(AlertSummaryEntity(null, null, null, null, "This bus is cancelled today"))
         }
 
         val globalResponse =
@@ -528,11 +531,21 @@ class StopDetailsFilteredDeparturesViewTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testShowsSuspension(): Unit = runBlocking {
-        val now = EasternTimeInstant.now()
         val alert = builder.alert {
+            activePeriod(now, EasternTimeInstant(2026, Month.JULY, 10, 18, 45))
             effect = Alert.Effect.Suspension
             header = "Fuchsia Line suspended from Here to There"
             informedEntity(directionId = 0, route = route.id.idText, stop = stop.id)
+            summaries =
+                listOf(
+                    AlertSummaryEntity(
+                        null,
+                        null,
+                        null,
+                        null,
+                        "**Service suspended** at **${stop.name}** through 6:45\u202FPM",
+                    )
+                )
         }
         val alertResponse = AlertsStreamDataResponse(mapOf(alert.id to alert))
         val alertSummaries =
@@ -603,8 +616,6 @@ class StopDetailsFilteredDeparturesViewTest {
     @OptIn(ExperimentalTestApi::class)
     @Test
     fun testShowsPredictionsAndAlertOnBranchingTrunk(): Unit = runBlocking {
-        val now = EasternTimeInstant.now()
-
         val objects = TestData.clone()
         val stop = objects.getStop("place-kencl")
         val line = objects.getLine("line-Green")
@@ -615,10 +626,21 @@ class StopDetailsFilteredDeparturesViewTest {
         val tripPattern = objects.routePatterns["Green-D-855-0"]!!
 
         val alert = objects.alert {
+            activePeriod(now, EasternTimeInstant(2026, Month.JULY, 10, 18, 45))
             effect = Alert.Effect.Shuttle
             header = "Green line shuttle on B and C branches"
             informedEntity(directionId = 0, route = routeB.id.idText, stop = "71151")
             informedEntity(directionId = 0, route = routeC.id.idText, stop = "70151")
+            summaries =
+                listOf(
+                    AlertSummaryEntity(
+                        null,
+                        null,
+                        null,
+                        null,
+                        "**Shuttle buses** at **${stop.name}** through 6:45\u202FPM",
+                    )
+                )
         }
         val alertResponse = AlertsStreamDataResponse(mapOf(alert.id to alert))
 
@@ -693,8 +715,19 @@ class StopDetailsFilteredDeparturesViewTest {
     @Test
     fun testShowsDownstreamAlert(): Unit = runBlocking {
         val alert = builder.alert {
+            activePeriod(now, EasternTimeInstant(2026, Month.JULY, 10, 18, 25))
             effect = Alert.Effect.Suspension
             informedEntity(directionId = 0, route = route.id.idText, stop = downstreamStop.id)
+            summaries =
+                listOf(
+                    AlertSummaryEntity(
+                        null,
+                        null,
+                        null,
+                        null,
+                        "**Service suspended** at **Sample Stop 2** through 6:25\u202FPM",
+                    )
+                )
         }
         val alertResponse = AlertsStreamDataResponse(mapOf(alert.id to alert))
 

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -13,6 +13,7 @@ import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
@@ -321,7 +322,19 @@ class TripStopRowTest {
         val objects = ObjectCollectionBuilder()
         val stop = objects.stop()
         val route = objects.route()
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            summaries =
+                listOf(
+                    AlertSummaryEntity(
+                        null,
+                        null,
+                        null,
+                        null,
+                        "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow",
+                    )
+                )
+        }
         val summary =
             AlertSummary.Standard(
                 alert.effect,

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRowTest.kt
@@ -327,11 +327,7 @@ class TripStopRowTest {
             summaries =
                 listOf(
                     AlertSummaryEntity(
-                        null,
-                        null,
-                        null,
-                        null,
-                        "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow",
+                        "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow"
                     )
                 )
         }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onNodeWithText
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Prediction
 import com.mbta.tid.mbta_app.model.Schedule
@@ -437,7 +438,19 @@ class TripStopsTest {
         val stop2Target = objects.stop { name = "Stop B" }
         val stop3 = objects.stop { name = "Stop C" }
 
-        val alert = objects.alert { effect = Alert.Effect.Shuttle }
+        val alert = objects.alert {
+            effect = Alert.Effect.Shuttle
+            summaries =
+                listOf(
+                    AlertSummaryEntity(
+                        null,
+                        null,
+                        null,
+                        null,
+                        "**Shuttle buses** at **Stop C** through end of service",
+                    )
+                )
+        }
 
         val vehicle = objects.vehicle {
             tripId = trip.id

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopsTest.kt
@@ -441,15 +441,7 @@ class TripStopsTest {
         val alert = objects.alert {
             effect = Alert.Effect.Shuttle
             summaries =
-                listOf(
-                    AlertSummaryEntity(
-                        null,
-                        null,
-                        null,
-                        null,
-                        "**Shuttle buses** at **Stop C** through end of service",
-                    )
-                )
+                listOf(AlertSummaryEntity("**Shuttle buses** at **Stop C** through end of service"))
         }
 
         val vehicle = objects.vehicle {

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import com.mbta.tid.mbta_app.android.assertMatches
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
@@ -34,7 +35,18 @@ class FormattedAlertTests {
                 "North Station",
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Shuttle buses replace the **4:00\u202FPM** train from **Porter** to **North Station**",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -61,7 +73,18 @@ class FormattedAlertTests {
                 "North Station",
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**4:00\u202FPM** train from **Concord** is replaced by shuttle buses from **Porter** to **North Station**",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -83,7 +106,18 @@ class FormattedAlertTests {
                 "North Station",
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Shuttle buses replace this train from **Porter** to **North Station**",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals(
@@ -105,7 +139,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train from **Ruggles** is suspended today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -130,7 +175,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**11:15\u202FAM** train from **Concord** will terminate at Porter today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -153,7 +209,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "This train is suspended today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train is suspended today due to weather", summaryString)
@@ -171,7 +238,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "This train will terminate at Porter today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train will terminate at Porter today due to weather", summaryString)
@@ -190,7 +268,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -214,7 +303,18 @@ class FormattedAlertTests {
                 Alert.Cause.Weather,
             )
         val alert = ObjectCollectionBuilder.Single.alert { cause = Alert.Cause.Weather }
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "This train will not stop at **Porter** today due to weather",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertEquals("This train will not stop at Porter today due to weather", summaryString)
@@ -230,7 +330,18 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Trains will not stop at **Back Bay** until further notice",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -249,7 +360,18 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -268,7 +390,18 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Trains will not stop at **Back Bay**, **Ruggles**, and **Hyde Park** until further notice",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(
@@ -291,7 +424,18 @@ class FormattedAlertTests {
                 AlertSummary.Timeframe.UntilFurtherNotice,
             )
         val alert = ObjectCollectionBuilder.Single.alert()
-        val format = FormattedAlert(alert, summary)
+        val format =
+            FormattedAlert(
+                alert,
+                summary,
+                AlertSummaryEntity(
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Trains will not stop at **multiple stops** until further notice",
+                ),
+            )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
             assertMatches(

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/util/FormattedAlertTests.kt
@@ -40,11 +40,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Shuttle buses replace the **4:00\u202FPM** train from **Porter** to **North Station**",
+                    "Shuttle buses replace the **4:00\u202FPM** train from **Porter** to **North Station**"
                 ),
             )
         composeTestRule.setContent {
@@ -78,11 +74,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**4:00\u202FPM** train from **Concord** is replaced by shuttle buses from **Porter** to **North Station**",
+                    "**4:00\u202FPM** train from **Concord** is replaced by shuttle buses from **Porter** to **North Station**"
                 ),
             )
         composeTestRule.setContent {
@@ -111,11 +103,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Shuttle buses replace this train from **Porter** to **North Station**",
+                    "Shuttle buses replace this train from **Porter** to **North Station**"
                 ),
             )
         composeTestRule.setContent {
@@ -144,11 +132,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train from **Ruggles** is suspended today due to weather",
+                    "**12:13\u202FPM** train from **Ruggles** is suspended today due to weather"
                 ),
             )
         composeTestRule.setContent {
@@ -180,11 +164,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**11:15\u202FAM** train from **Concord** will terminate at Porter today due to weather",
+                    "**11:15\u202FAM** train from **Concord** will terminate at Porter today due to weather"
                 ),
             )
         composeTestRule.setContent {
@@ -213,13 +193,7 @@ class FormattedAlertTests {
             FormattedAlert(
                 alert,
                 summary,
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "This train is suspended today due to weather",
-                ),
+                AlertSummaryEntity("This train is suspended today due to weather"),
             )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
@@ -242,13 +216,7 @@ class FormattedAlertTests {
             FormattedAlert(
                 alert,
                 summary,
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "This train will terminate at Porter today due to weather",
-                ),
+                AlertSummaryEntity("This train will terminate at Porter today due to weather"),
             )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
@@ -273,11 +241,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today due to weather",
+                    "**12:13\u202FPM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today due to weather"
                 ),
             )
         composeTestRule.setContent {
@@ -307,13 +271,7 @@ class FormattedAlertTests {
             FormattedAlert(
                 alert,
                 summary,
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "This train will not stop at **Porter** today due to weather",
-                ),
+                AlertSummaryEntity("This train will not stop at **Porter** today due to weather"),
             )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
@@ -334,13 +292,7 @@ class FormattedAlertTests {
             FormattedAlert(
                 alert,
                 summary,
-                AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Trains will not stop at **Back Bay** until further notice",
-                ),
+                AlertSummaryEntity("Trains will not stop at **Back Bay** until further notice"),
             )
         composeTestRule.setContent {
             val summaryString = format.alertCardMajorBody(LocalResources.current).toString()
@@ -365,11 +317,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice",
+                    "Trains will not stop at **Back Bay** and **Ruggles** until further notice"
                 ),
             )
         composeTestRule.setContent {
@@ -395,11 +343,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Trains will not stop at **Back Bay**, **Ruggles**, and **Hyde Park** until further notice",
+                    "Trains will not stop at **Back Bay**, **Ruggles**, and **Hyde Park** until further notice"
                 ),
             )
         composeTestRule.setContent {
@@ -429,11 +373,7 @@ class FormattedAlertTests {
                 alert,
                 summary,
                 AlertSummaryEntity(
-                    null,
-                    null,
-                    null,
-                    null,
-                    "Trains will not stop at **multiple stops** until further notice",
+                    "Trains will not stop at **multiple stops** until further notice"
                 ),
             )
         composeTestRule.setContent {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -45,6 +45,7 @@ import com.mbta.tid.mbta_app.android.util.routeModeLabel
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertCardSpec
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
 import com.mbta.tid.mbta_app.model.SegmentAlertState
@@ -57,9 +58,24 @@ class StopPlacement(val isFirst: Boolean = false, val isLast: Boolean = false)
 
 @Serializable
 sealed class StopListContext {
-    data object Trip : StopListContext()
+    abstract val routeIdMatcher: Matcher<Route.Id>
+    abstract val directionId: Int
+    abstract val tripIdMatcher: Matcher<String>
 
-    data object RouteDetails : StopListContext()
+    data class Trip(
+        override val routeIdMatcher: Matcher<Route.Id>,
+        override val directionId: Int,
+        val tripId: String,
+    ) : StopListContext() {
+        override val tripIdMatcher: Matcher<String> = Matcher.Data(tripId)
+    }
+
+    data class RouteDetails(
+        override val routeIdMatcher: Matcher<Route.Id>,
+        override val directionId: Int,
+    ) : StopListContext() {
+        override val tripIdMatcher: Matcher<String> = Matcher.Wildcard()
+    }
 }
 
 @Composable
@@ -233,6 +249,12 @@ fun StopListRow(
                 AlertCard(
                     disruption.alert,
                     alertSummaries[disruption.alert.id],
+                    disruption.alert.summary(
+                        routeId = stopListContext.routeIdMatcher,
+                        stopId = Matcher.Data(stop.id),
+                        directionId = Matcher.Data(stopListContext.directionId),
+                        tripId = stopListContext.tripIdMatcher,
+                    ),
                     AlertCardSpec.Downstream,
                     routeAccents,
                     onViewDetails = { onOpenAlertDetails(disruption.alert) },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/component/StopListRow.kt
@@ -59,21 +59,23 @@ class StopPlacement(val isFirst: Boolean = false, val isLast: Boolean = false)
 @Serializable
 sealed class StopListContext {
     abstract val routeIdMatcher: Matcher<Route.Id>
-    abstract val directionId: Int
+    abstract val directionIdMatcher: Matcher<Int>
     abstract val tripIdMatcher: Matcher<String>
 
     data class Trip(
         override val routeIdMatcher: Matcher<Route.Id>,
-        override val directionId: Int,
+        val directionId: Int,
         val tripId: String,
     ) : StopListContext() {
+        override val directionIdMatcher: Matcher<Int> = Matcher.Data(directionId)
         override val tripIdMatcher: Matcher<String> = Matcher.Data(tripId)
     }
 
     data class RouteDetails(
         override val routeIdMatcher: Matcher<Route.Id>,
-        override val directionId: Int,
+        val directionId: Int,
     ) : StopListContext() {
+        override val directionIdMatcher: Matcher<Int> = Matcher.Data(directionId)
         override val tripIdMatcher: Matcher<String> = Matcher.Wildcard()
     }
 }
@@ -252,7 +254,7 @@ fun StopListRow(
                     disruption.alert.summary(
                         routeId = stopListContext.routeIdMatcher,
                         stopId = Matcher.Data(stop.id),
-                        directionId = Matcher.Data(stopListContext.directionId),
+                        directionId = stopListContext.directionIdMatcher,
                         tripId = stopListContext.tripIdMatcher,
                     ),
                     AlertCardSpec.Downstream,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -73,8 +73,10 @@ import com.mbta.tid.mbta_app.android.location.LocationDataManager
 import com.mbta.tid.mbta_app.android.util.FormattedAlert
 import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
+import com.mbta.tid.mbta_app.android.util.formattedServiceDay
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder.Single
 import com.mbta.tid.mbta_app.model.OnboardingScreen
 import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
@@ -387,6 +389,39 @@ private fun NotificationsBetaPage(advance: () -> Unit) {
                                         AlertSummary.Timeframe.ThisWeek(
                                             EasternTimeInstant(2026, Month.JANUARY, 25, 12, 0)
                                         ),
+                                ),
+                            alertSummaryEntity =
+                                AlertSummaryEntity(
+                                    routeId = null,
+                                    stopId = null,
+                                    directionId = null,
+                                    tripId = null,
+                                    summary =
+                                        stringResource(
+                                                R.string.alert_summary,
+                                                stringResource(R.string.service_suspended),
+                                                stringResource(
+                                                    R.string.alert_summary_location_successive,
+                                                    "Back Bay",
+                                                    "Wellington",
+                                                ),
+                                                stringResource(
+                                                    R.string.alert_summary_timeframe_this_week,
+                                                    EasternTimeInstant(
+                                                            2026,
+                                                            Month.JANUARY,
+                                                            25,
+                                                            12,
+                                                            0,
+                                                        )
+                                                        .formattedServiceDay(
+                                                            EasternTimeInstant.ServiceDateRounding
+                                                                .BACKWARDS
+                                                        ),
+                                                ),
+                                                "",
+                                            )
+                                            .replace(Regex("</?b>"), "**"),
                                 ),
                         )
                     Text(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/onboarding/OnboardingScreenView.kt
@@ -392,36 +392,31 @@ private fun NotificationsBetaPage(advance: () -> Unit) {
                                 ),
                             alertSummaryEntity =
                                 AlertSummaryEntity(
-                                    routeId = null,
-                                    stopId = null,
-                                    directionId = null,
-                                    tripId = null,
-                                    summary =
-                                        stringResource(
-                                                R.string.alert_summary,
-                                                stringResource(R.string.service_suspended),
-                                                stringResource(
-                                                    R.string.alert_summary_location_successive,
-                                                    "Back Bay",
-                                                    "Wellington",
-                                                ),
-                                                stringResource(
-                                                    R.string.alert_summary_timeframe_this_week,
-                                                    EasternTimeInstant(
-                                                            2026,
-                                                            Month.JANUARY,
-                                                            25,
-                                                            12,
-                                                            0,
-                                                        )
-                                                        .formattedServiceDay(
-                                                            EasternTimeInstant.ServiceDateRounding
-                                                                .BACKWARDS
-                                                        ),
-                                                ),
-                                                "",
-                                            )
-                                            .replace(Regex("</?b>"), "**"),
+                                    stringResource(
+                                            R.string.alert_summary,
+                                            stringResource(R.string.service_suspended),
+                                            stringResource(
+                                                R.string.alert_summary_location_successive,
+                                                "Back Bay",
+                                                "Wellington",
+                                            ),
+                                            stringResource(
+                                                R.string.alert_summary_timeframe_this_week,
+                                                EasternTimeInstant(
+                                                        2026,
+                                                        Month.JANUARY,
+                                                        25,
+                                                        12,
+                                                        0,
+                                                    )
+                                                    .formattedServiceDay(
+                                                        EasternTimeInstant.ServiceDateRounding
+                                                            .BACKWARDS
+                                                    ),
+                                            ),
+                                            "",
+                                        )
+                                        .replace(Regex("</?b>"), "**")
                                 ),
                         )
                     Text(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/CollapsableStopList.kt
@@ -37,6 +37,7 @@ import com.mbta.tid.mbta_app.model.RouteDetailsStopList
 @Composable
 fun CollapsableStopList(
     lineOrRoute: LineOrRoute,
+    stopListContext: StopListContext,
     segment: RouteDetailsStopList.Segment,
     onClick: (RouteDetailsStopList.Entry) -> Unit,
     onClickLabel: @Composable (RouteDetailsStopList.Entry) -> String? = { null },
@@ -56,7 +57,7 @@ fun CollapsableStopList(
             stop.stickConnections,
             onClick = { onClick(stop) },
             routeAccents = routeAccents,
-            stopListContext = StopListContext.RouteDetails,
+            stopListContext = stopListContext,
             modifier =
                 Modifier.minimumInteractiveComponentSize().background(colorResource(R.color.fill1)),
             connectingRoutes = stop.connectingRoutes,
@@ -119,7 +120,7 @@ fun CollapsableStopList(
                         stop.stickConnections,
                         onClick = { onClick(stop) },
                         routeAccents = routeAccents,
-                        stopListContext = StopListContext.RouteDetails,
+                        stopListContext = stopListContext,
                         modifier =
                             Modifier.minimumInteractiveComponentSize()
                                 .background(colorResource(R.color.fill1)),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/routeDetails/RouteStopListView.kt
@@ -67,6 +67,7 @@ import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LineOrRoute
 import com.mbta.tid.mbta_app.model.LoadingPlaceholders
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
@@ -398,6 +399,11 @@ private fun RouteStops(
         return
     }
 
+    val stopListContext =
+        StopListContext.RouteDetails(
+            Matcher.AnyOf(lineOrRoute.allRoutes.map { it.id }),
+            selectedDirection,
+        )
     val haloColor =
         if (lineOrRoute.type == RouteType.BUS && !silverRoutes.contains(lineOrRoute.id))
             colorResource(R.color.halo_light)
@@ -438,7 +444,7 @@ private fun RouteStops(
                         stop.stickConnections,
                         onClick = { onTapStop(stopRowContext) },
                         routeAccents = TripRouteAccents(lineOrRoute.sortRoute),
-                        stopListContext = StopListContext.RouteDetails,
+                        stopListContext = stopListContext,
                         modifier = Modifier.minimumInteractiveComponentSize().fillMaxWidth(),
                         connectingRoutes = stop.connectingRoutes,
                         onClickLabel = onClickLabel(stopRowContext),
@@ -451,6 +457,7 @@ private fun RouteStops(
             } else {
                 CollapsableStopList(
                     lineOrRoute,
+                    stopListContext,
                     segment,
                     onClick = { onTapStop(stopRowContext(it.stop)) },
                     onClickLabel = { onClickLabel(stopRowContext(it.stop)) },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -251,7 +251,7 @@ fun AlertCardPreview() {
         AlertCard(
             ObjectCollectionBuilder.Single.alert({ effect = Alert.Effect.ServiceChange }),
             null,
-            AlertSummaryEntity("**Service Change**"),
+            null,
             AlertCardSpec.Basic,
             routeAccents =
                 TripRouteAccents(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -236,11 +236,7 @@ fun AlertCardPreview() {
                 cause = Alert.Cause.Holiday,
             ),
             AlertSummaryEntity(
-                null,
-                null,
-                null,
-                null,
-                "**10:17\u202FPM** train from **Mansfield** is cancelled today due to holiday",
+                "**10:17\u202FPM** train from **Mansfield** is cancelled today due to holiday"
             ),
             AlertCardSpec.Takeover,
             routeAccents =
@@ -255,7 +251,7 @@ fun AlertCardPreview() {
         AlertCard(
             ObjectCollectionBuilder.Single.alert({ effect = Alert.Effect.ServiceChange }),
             null,
-            AlertSummaryEntity(null, null, null, null, "**Service Change**"),
+            AlertSummaryEntity("**Service Change**"),
             AlertCardSpec.Basic,
             routeAccents =
                 TripRouteAccents(
@@ -293,13 +289,7 @@ fun AlertCardPreview() {
                             cause = Alert.Cause.DrawbridgeIssue
                         }),
                         AlertSummary.Standard(effect = Alert.Effect.Delay),
-                        AlertSummaryEntity(
-                            null,
-                            null,
-                            null,
-                            null,
-                            "Delays due to drawbridge issue",
-                        ),
+                        AlertSummaryEntity("Delays due to drawbridge issue"),
                         AlertCardSpec.Delay,
                         routeAccents =
                             TripRouteAccents(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertCard.kt
@@ -36,6 +36,7 @@ import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertCardSpec
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.StopAlertState
@@ -47,6 +48,7 @@ import kotlinx.datetime.Month
 private fun TakeoverAlertCard(
     alert: Alert,
     alertSummary: AlertSummary?,
+    alertSummaryEntity: AlertSummaryEntity?,
     now: EasternTimeInstant,
     routeAccents: TripRouteAccents,
     onViewDetails: (() -> Unit)?,
@@ -56,7 +58,7 @@ private fun TakeoverAlertCard(
 
     val alertState = alert.alertState
     val iconSize = 48.dp
-    val formattedAlert = FormattedAlert(alert, alertSummary)
+    val formattedAlert = FormattedAlert(alert, alertSummary, alertSummaryEntity)
 
     Column(
         modifier =
@@ -118,6 +120,7 @@ private fun TakeoverAlertCard(
 fun AlertCard(
     alert: Alert,
     alertSummary: AlertSummary?,
+    alertSummaryEntity: AlertSummaryEntity?,
     cardSpec: AlertCardSpec,
     routeAccents: TripRouteAccents,
     onViewDetails: (() -> Unit)?,
@@ -130,6 +133,7 @@ fun AlertCard(
         TakeoverAlertCard(
             alert,
             alertSummary,
+            alertSummaryEntity,
             now,
             routeAccents,
             onViewDetails,
@@ -137,7 +141,7 @@ fun AlertCard(
             interiorPadding,
         )
     } else {
-        val formattedAlert = FormattedAlert(alert, alertSummary)
+        val formattedAlert = FormattedAlert(alert, alertSummary, alertSummaryEntity)
 
         val iconSize =
             when (cardSpec) {
@@ -205,6 +209,7 @@ fun AlertCardPreview() {
                 effect = Alert.Effect.Suspension
             }),
             null,
+            null,
             AlertCardSpec.Takeover,
             routeAccents =
                 TripRouteAccents(
@@ -230,6 +235,13 @@ fun AlertCardPreview() {
                 Alert.Effect.Cancellation,
                 cause = Alert.Cause.Holiday,
             ),
+            AlertSummaryEntity(
+                null,
+                null,
+                null,
+                null,
+                "**10:17\u202FPM** train from **Mansfield** is cancelled today due to holiday",
+            ),
             AlertCardSpec.Takeover,
             routeAccents =
                 TripRouteAccents(
@@ -243,6 +255,7 @@ fun AlertCardPreview() {
         AlertCard(
             ObjectCollectionBuilder.Single.alert({ effect = Alert.Effect.ServiceChange }),
             null,
+            AlertSummaryEntity(null, null, null, null, "**Service Change**"),
             AlertCardSpec.Basic,
             routeAccents =
                 TripRouteAccents(
@@ -259,6 +272,7 @@ fun AlertCardPreview() {
                 header =
                     "Ruggles Elevator 848 (Lobby to lower busway side platform) unavailable due to maintenance"
             }),
+            null,
             null,
             AlertCardSpec.Elevator,
             routeAccents =
@@ -279,6 +293,13 @@ fun AlertCardPreview() {
                             cause = Alert.Cause.DrawbridgeIssue
                         }),
                         AlertSummary.Standard(effect = Alert.Effect.Delay),
+                        AlertSummaryEntity(
+                            null,
+                            null,
+                            null,
+                            null,
+                            "Delays due to drawbridge issue",
+                        ),
                         AlertCardSpec.Delay,
                         routeAccents =
                             TripRouteAccents(

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertListContainer.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/AlertListContainer.kt
@@ -115,6 +115,7 @@ fun AlertListContainerPreview() {
                             effect = Alert.Effect.ServiceChange
                         }),
                         null,
+                        null,
                         AlertCardSpec.Basic,
                         routeAccents =
                             TripRouteAccents(
@@ -135,6 +136,7 @@ fun AlertListContainerPreview() {
                             header =
                                 "Ruggles Elevator 848 (Lobby to lower busway side platform) unavailable due to maintenance"
                         }),
+                        null,
                         null,
                         AlertCardSpec.Elevator,
                         routeAccents =
@@ -157,6 +159,7 @@ fun AlertListContainerPreview() {
                             effect = Alert.Effect.ServiceChange
                         }),
                         null,
+                        null,
                         AlertCardSpec.Basic,
                         routeAccents =
                             TripRouteAccents(
@@ -177,6 +180,7 @@ fun AlertListContainerPreview() {
                         ObjectCollectionBuilder.Single.alert({
                             effect = Alert.Effect.ServiceChange
                         }),
+                        null,
                         null,
                         AlertCardSpec.Basic,
                         routeAccents =

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -42,6 +42,7 @@ import com.mbta.tid.mbta_app.model.DisplayAlert
 import com.mbta.tid.mbta_app.model.DisplayAlerts
 import com.mbta.tid.mbta_app.model.Line
 import com.mbta.tid.mbta_app.model.LineOrRoute
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteCardData
 import com.mbta.tid.mbta_app.model.Stop
@@ -176,10 +177,19 @@ fun StopDetailsFilteredDeparturesView(
     @Composable
     fun AlertCard(displayAlert: DisplayAlert, summary: AlertSummary?, modifier: Modifier) {
         val spec = displayAlert.cardSpec(now, isAllServiceDisrupted, tripFilter?.tripId)
+        val summaryEntity =
+            displayAlert.alert.summary(
+                Matcher.AnyOf(lineOrRoute.allRoutes.map { it.id }),
+                Matcher.Data(stopId),
+                Matcher.Data(selectedDirection.id),
+                if (tripFilter?.tripId != null) Matcher.Data(tripFilter.tripId)
+                else Matcher.Wildcard(),
+            )
 
         AlertCard(
             displayAlert.alert,
             summary,
+            summaryEntity,
             spec,
             routeAccents,
             onViewDetails = { openAlertDetails(displayAlert.alert, spec) },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsUnfilteredRoutesView.kt
@@ -129,6 +129,7 @@ fun StopDetailsUnfilteredRoutesView(
                                                 AlertCard(
                                                     it,
                                                     null,
+                                                    null,
                                                     AlertCardSpec.Elevator,
                                                     TripRouteAccents(
                                                         color = Color.Unspecified,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/TripStopRow.kt
@@ -27,6 +27,7 @@ import com.mbta.tid.mbta_app.android.util.modifiers.DestinationPredictionBalance
 import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.AlertSummary
 import com.mbta.tid.mbta_app.model.MapStopRoute
+import com.mbta.tid.mbta_app.model.Matcher
 import com.mbta.tid.mbta_app.model.ObjectCollectionBuilder
 import com.mbta.tid.mbta_app.model.Route
 import com.mbta.tid.mbta_app.model.RouteBranchSegment
@@ -76,7 +77,7 @@ fun TripStopRow(
             ),
         onClick = { onTapLink(entry) },
         routeAccents = routeAccents,
-        stopListContext = StopListContext.Trip,
+        stopListContext = StopListContext.Trip(Matcher.Data(route.id), trip.directionId, trip.id),
         modifier = modifier,
         activeElevatorAlerts = activeElevatorAlerts.size,
         alertSummaries = alertSummaries,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/AnnotatedStringExtension.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/AnnotatedStringExtension.kt
@@ -1,0 +1,20 @@
+package com.mbta.tid.mbta_app.android.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.fromHtml
+
+fun AnnotatedString.toHtml(): String {
+    // conveniently, we only use bold
+    var result = this.text
+    for (range in this.spanStyles.asReversed()) {
+        if (range.item.fontWeight != FontWeight.Normal) {
+            result = result.replaceRange(range.end, range.end, "</b>")
+            result = result.replaceRange(range.start, range.start, "<b>")
+        }
+    }
+    return result
+}
+
+fun AnnotatedString.Companion.fromMarkdown(markdown: String) =
+    AnnotatedString.fromHtml(markdown.replace("""\*\*([^*]+)\*\*""".toRegex(), "<b>$1</b>"))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -198,11 +198,7 @@ data class FormattedAlert(
         alertSummaryEntity?.summary?.let { AnnotatedString.fromMarkdown(it) }
 
     private fun summary(resources: Resources): AnnotatedString? {
-        val calculated = summaryCalculated(resources)
         val provided = summaryProvided()
-        check(calculated == provided) {
-            "summary mismatch: ${calculated?.toHtml()} vs ${provided?.toHtml()}"
-        }
         return provided
     }
 

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/FormattedAlert.kt
@@ -14,6 +14,7 @@ import com.mbta.tid.mbta_app.model.Alert
 import com.mbta.tid.mbta_app.model.Alert.Effect
 import com.mbta.tid.mbta_app.model.AlertCardSpec
 import com.mbta.tid.mbta_app.model.AlertSummary
+import com.mbta.tid.mbta_app.model.AlertSummaryEntity
 import com.mbta.tid.mbta_app.model.Facility
 import com.mbta.tid.mbta_app.model.RouteType
 import com.mbta.tid.mbta_app.model.TripShuttleAlertSummary
@@ -23,6 +24,7 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 data class FormattedAlert(
     val alert: Alert,
     val alertSummary: AlertSummary?,
+    val alertSummaryEntity: AlertSummaryEntity?,
     @StringRes val effectRes: Int,
     @StringRes val sentenceEffectRes: Int,
     @StringRes val causeRes: Int?,
@@ -36,9 +38,11 @@ data class FormattedAlert(
     constructor(
         alert: Alert,
         alertSummary: AlertSummary? = null,
+        alertSummaryEntity: AlertSummaryEntity? = null,
     ) : this(
         alert,
         alertSummary,
+        alertSummaryEntity,
         effectRes(alert.effect),
         sentenceEffectRes(alert.effect),
         causeRes(alert.cause),
@@ -98,9 +102,12 @@ data class FormattedAlert(
                 } ?: alert.header ?: effect(resources)
         )
 
-    private fun summary(resources: Resources) = summary(alertSummary, resources)
+    private fun summaryCalculated(resources: Resources) = summaryCalculated(alertSummary, resources)
 
-    private fun summary(alertSummary: AlertSummary?, resources: Resources): AnnotatedString? =
+    private fun summaryCalculated(
+        alertSummary: AlertSummary?,
+        resources: Resources,
+    ): AnnotatedString? =
         when (alertSummary) {
             is AlertSummary.AllClear ->
                 AnnotatedString.fromHtml(
@@ -186,6 +193,18 @@ data class FormattedAlert(
             is AlertSummary.Unknown -> AnnotatedString(alertSummary.fallback)
             null -> null
         }
+
+    private fun summaryProvided(): AnnotatedString? =
+        alertSummaryEntity?.summary?.let { AnnotatedString.fromMarkdown(it) }
+
+    private fun summary(resources: Resources): AnnotatedString? {
+        val calculated = summaryCalculated(resources)
+        val provided = summaryProvided()
+        check(calculated == provided) {
+            "summary mismatch: ${calculated?.toHtml()} vs ${provided?.toHtml()}"
+        }
+        return provided
+    }
 
     fun alertCardHeader(
         spec: AlertCardSpec,

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -233,13 +233,7 @@ struct AlertCard: View {
                     recurrence: nil,
                     isUpdate: false
                 ),
-                alertSummaryEntity: .init(
-                    routeId: nil,
-                    stopId: nil,
-                    tripId: nil,
-                    directionId: nil,
-                    summary: "Shuttle buses replace service from Start to End through 4:00 PM"
-                ),
+                alertSummaryEntity: .init(summary: "Shuttle buses replace service from Start to End through 4:00 PM"),
                 spec: .takeover,
                 routeAccents: .init(color: .pink, textColor: .orange, type: .ferry),
                 onViewDetails: {}
@@ -258,10 +252,6 @@ struct AlertCard: View {
                     isUpdate: true
                 ),
                 alertSummaryEntity: .init(
-                    routeId: nil,
-                    stopId: nil,
-                    tripId: nil,
-                    directionId: nil,
                     summary: "Update: Shuttle buses replace service from Start to End through 4:00 PM"
                 ),
                 spec: .basic,
@@ -275,13 +265,7 @@ struct AlertCard: View {
                 alertSummary: AlertSummary.AllClear(
                     location: .some(AlertSummary.LocationSuccessiveStops(startStopName: "Start", endStopName: "End")),
                 ),
-                alertSummaryEntity: .init(
-                    routeId: nil,
-                    stopId: nil,
-                    tripId: nil,
-                    directionId: nil,
-                    summary: "All clear: Regular service from Start to End"
-                ),
+                alertSummaryEntity: .init(summary: "All clear: Regular service from Start to End"),
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}
@@ -300,13 +284,7 @@ struct AlertCard: View {
                         stopName: "Ruggles"
                     ), effect: .cancellation, cause: .mechanicalIssue
                 ),
-                alertSummaryEntity: .init(
-                    routeId: nil,
-                    stopId: nil,
-                    tripId: nil,
-                    directionId: nil,
-                    summary: "1:00 PM trip from Ruggles cancelled today due to mechanical issue"
-                ),
+                alertSummaryEntity: .init(summary: "1:00 PM trip from Ruggles cancelled today due to mechanical issue"),
                 spec: .takeover,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -233,7 +233,9 @@ struct AlertCard: View {
                     recurrence: nil,
                     isUpdate: false
                 ),
-                alertSummaryEntity: .init(summary: "Shuttle buses replace service from Start to End through 4:00 PM"),
+                alertSummaryEntity: .init(
+                    summary: "**Shuttle buses** from **Start** to **End** through 4:00\u{202F}PM"
+                ),
                 spec: .takeover,
                 routeAccents: .init(color: .pink, textColor: .orange, type: .ferry),
                 onViewDetails: {}
@@ -252,7 +254,7 @@ struct AlertCard: View {
                     isUpdate: true
                 ),
                 alertSummaryEntity: .init(
-                    summary: "Update: Shuttle buses replace service from Start to End through 4:00 PM"
+                    summary: "**Update:** Shuttle buses from **Start** to **End** through 4:00\u{202F}PM"
                 ),
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
@@ -265,7 +267,7 @@ struct AlertCard: View {
                 alertSummary: AlertSummary.AllClear(
                     location: .some(AlertSummary.LocationSuccessiveStops(startStopName: "Start", endStopName: "End")),
                 ),
-                alertSummaryEntity: .init(summary: "All clear: Regular service from Start to End"),
+                alertSummaryEntity: .init(summary: "**All clear:** Regular service from **Start** to **End**"),
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}
@@ -284,7 +286,9 @@ struct AlertCard: View {
                         stopName: "Ruggles"
                     ), effect: .cancellation, cause: .mechanicalIssue
                 ),
-                alertSummaryEntity: .init(summary: "1:00 PM trip from Ruggles cancelled today due to mechanical issue"),
+                alertSummaryEntity: .init(
+                    summary: "**12:13\u{202F}PM** train from **Ruggles** is cancelled today due to mechanical issue"
+                ),
                 spec: .takeover,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}

--- a/iosApp/iosApp/ComponentViews/AlertCard.swift
+++ b/iosApp/iosApp/ComponentViews/AlertCard.swift
@@ -13,6 +13,7 @@ private struct TakeoverAlertCard: View {
     @ObserveInjection var inject
     let alert: Shared.Alert
     let alertSummary: AlertSummary?
+    let alertSummaryEntity: AlertSummaryEntity?
     let now: EasternTimeInstant
     let routeAccents: TripRouteAccents
     let onViewDetails: (() -> Void)?
@@ -21,7 +22,7 @@ private struct TakeoverAlertCard: View {
     @ScaledMetric var iconSize = 48
 
     var formattedAlert: FormattedAlert {
-        FormattedAlert(alert: alert, alertSummary: alertSummary)
+        FormattedAlert(alert: alert, alertSummary: alertSummary, alertSummaryEntity: alertSummaryEntity)
     }
 
     var body: some View {
@@ -75,6 +76,7 @@ struct AlertCard: View {
     @ObserveInjection var inject
     let alert: Shared.Alert
     let alertSummary: AlertSummary?
+    let alertSummaryEntity: AlertSummaryEntity?
     let spec: AlertCardSpec
     let now: EasternTimeInstant
     let routeAccents: TripRouteAccents
@@ -89,6 +91,7 @@ struct AlertCard: View {
     init(
         alert: Shared.Alert,
         alertSummary: AlertSummary?,
+        alertSummaryEntity: AlertSummaryEntity?,
         spec: AlertCardSpec,
         now: EasternTimeInstant = .now(),
         routeAccents: TripRouteAccents,
@@ -97,6 +100,7 @@ struct AlertCard: View {
     ) {
         self.alert = alert
         self.alertSummary = alertSummary
+        self.alertSummaryEntity = alertSummaryEntity
         self.spec = spec
         self.now = now
         self.routeAccents = routeAccents
@@ -105,7 +109,7 @@ struct AlertCard: View {
     }
 
     var formattedAlert: FormattedAlert {
-        FormattedAlert(alert: alert, alertSummary: alertSummary)
+        FormattedAlert(alert: alert, alertSummary: alertSummary, alertSummaryEntity: alertSummaryEntity)
     }
 
     var iconSize: Double {
@@ -150,6 +154,7 @@ struct AlertCard: View {
         if spec == .takeover {
             TakeoverAlertCard(alert: alert,
                               alertSummary: alertSummary,
+                              alertSummaryEntity: alertSummaryEntity,
                               now: now,
                               routeAccents: routeAccents,
                               onViewDetails: onViewDetails,
@@ -176,6 +181,7 @@ struct AlertCard: View {
                     alert.effect = .suspension
                 },
                 alertSummary: nil,
+                alertSummaryEntity: nil,
                 spec: .takeover,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}
@@ -187,6 +193,7 @@ struct AlertCard: View {
                     alert.effect = .serviceChange
                 },
                 alertSummary: nil,
+                alertSummaryEntity: nil,
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "80276C"), textColor: Color(hex: "FFFFFF"), type: .commuterRail),
                 onViewDetails: {}
@@ -199,6 +206,7 @@ struct AlertCard: View {
                     alert.header = "Ruggles elevator 321 (Orange Line Platform to lobby) unavailable due to maintenance"
                 },
                 alertSummary: nil,
+                alertSummaryEntity: nil,
                 spec: .elevator,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}
@@ -225,6 +233,13 @@ struct AlertCard: View {
                     recurrence: nil,
                     isUpdate: false
                 ),
+                alertSummaryEntity: .init(
+                    routeId: nil,
+                    stopId: nil,
+                    tripId: nil,
+                    directionId: nil,
+                    summary: "Shuttle buses replace service from Start to End through 4:00 PM"
+                ),
                 spec: .takeover,
                 routeAccents: .init(color: .pink, textColor: .orange, type: .ferry),
                 onViewDetails: {}
@@ -242,6 +257,13 @@ struct AlertCard: View {
                     recurrence: nil,
                     isUpdate: true
                 ),
+                alertSummaryEntity: .init(
+                    routeId: nil,
+                    stopId: nil,
+                    tripId: nil,
+                    directionId: nil,
+                    summary: "Update: Shuttle buses replace service from Start to End through 4:00 PM"
+                ),
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
                 onViewDetails: {}
@@ -252,6 +274,13 @@ struct AlertCard: View {
                 alert: alert,
                 alertSummary: AlertSummary.AllClear(
                     location: .some(AlertSummary.LocationSuccessiveStops(startStopName: "Start", endStopName: "End")),
+                ),
+                alertSummaryEntity: .init(
+                    routeId: nil,
+                    stopId: nil,
+                    tripId: nil,
+                    directionId: nil,
+                    summary: "All clear: Regular service from Start to End"
                 ),
                 spec: .basic,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),
@@ -270,6 +299,13 @@ struct AlertCard: View {
                         routeType: .commuterRail,
                         stopName: "Ruggles"
                     ), effect: .cancellation, cause: .mechanicalIssue
+                ),
+                alertSummaryEntity: .init(
+                    routeId: nil,
+                    stopId: nil,
+                    tripId: nil,
+                    directionId: nil,
+                    summary: "1:00 PM trip from Ruggles cancelled today due to mechanical issue"
                 ),
                 spec: .takeover,
                 routeAccents: .init(color: Color(hex: "ED8B00"), textColor: Color(hex: "FFFFFF"), type: .heavyRail),

--- a/iosApp/iosApp/ComponentViews/AlertListContainer.swift
+++ b/iosApp/iosApp/ComponentViews/AlertListContainer.swift
@@ -16,6 +16,9 @@ struct AlertListContainer: View {
     let alertSummaries: [String: AlertSummary?]
     let now: EasternTimeInstant
     let isAllServiceDisrupted: Bool
+    let routeIdMatcher: Matcher<Route.Id>
+    let stopIdMatcher: Matcher<NSString>
+    let directionIdMatcher: Matcher<KotlinInt>
     let tripId: String?
     let routeAccents: TripRouteAccents
     let onRowTap: (String, AlertCardSpec) -> Void
@@ -64,17 +67,24 @@ struct AlertListContainer: View {
     @ViewBuilder
     func alertCard(_ displayAlert: DisplayAlert) -> some View {
         let alert = displayAlert.alert
+        let tripIdMatcher: Matcher<NSString> =
+            if let tripId { MatcherData(value: tripId as NSString) } else { MatcherWildcard() }
+        let summaryEntity = alert.summary(
+            routeId: routeIdMatcher,
+            stopId: stopIdMatcher,
+            directionId: directionIdMatcher,
+            tripId: tripIdMatcher,
+        )
         let spec = displayAlert.cardSpec(now: now, isAllServiceDisrupted: isAllServiceDisrupted, tripId: tripId)
 
-        if alertSummaries.keys.contains(displayAlert.id) {
-            AlertCard(
-                alert: alert,
-                alertSummary: alertSummaries[alert.id] ?? nil,
-                spec: spec,
-                routeAccents: routeAccents,
-                onViewDetails: { onRowTap(alert.id, spec) }
-            )
-        }
+        AlertCard(
+            alert: alert,
+            alertSummary: alertSummaries[alert.id] ?? nil,
+            alertSummaryEntity: summaryEntity,
+            spec: spec,
+            routeAccents: routeAccents,
+            onViewDetails: { onRowTap(alert.id, spec) }
+        )
     }
 }
 
@@ -102,6 +112,9 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                routeIdMatcher: MatcherWildcard(),
+                stopIdMatcher: MatcherWildcard(),
+                directionIdMatcher: MatcherWildcard(),
                 tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }
@@ -113,6 +126,9 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                routeIdMatcher: MatcherWildcard(),
+                stopIdMatcher: MatcherWildcard(),
+                directionIdMatcher: MatcherWildcard(),
                 tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }
@@ -124,6 +140,9 @@ struct AlertListContainer: View {
                 alertSummaries: [serviceChange.id: nil, elevator.id: nil],
                 now: now,
                 isAllServiceDisrupted: false,
+                routeIdMatcher: MatcherWildcard(),
+                stopIdMatcher: MatcherWildcard(),
+                directionIdMatcher: MatcherWildcard(),
                 tripId: nil,
                 routeAccents: .init(),
                 onRowTap: { _, _ in }

--- a/iosApp/iosApp/ComponentViews/StopListDisclosureGroup.swift
+++ b/iosApp/iosApp/ComponentViews/StopListDisclosureGroup.swift
@@ -18,12 +18,16 @@ struct StopListDisclosureGroup: DisclosureGroupStyle {
     @State var twistFactor: Float = 1
 
     func makeBody(configuration: Configuration) -> some View {
+        let haloPaddingAxis: Edge.Set = switch stopListContext {
+        case .trip: .horizontal
+        case .routeDetails: .leading
+        }
         VStack(spacing: 0) {
             Button(
                 action: { withAnimation { configuration.isExpanded.toggle() } },
                 label: {
                     ZStack(alignment: .bottom) {
-                        HaloSeparator().padding(stopListContext == .trip ? .horizontal : .leading, 7)
+                        HaloSeparator().padding(haloPaddingAxis, 7)
                         HStack(spacing: 0) {
                             if let stickConnections {
                                 RouteLineTwist(

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -20,8 +20,29 @@ struct StopPlacement {
 }
 
 enum StopListContext {
-    case trip
-    case routeDetails
+    case trip(Matcher<Route.Id>, Int32, String)
+    case routeDetails(Matcher<Route.Id>, Int32)
+
+    func routeIdMatcher() -> Matcher<Route.Id> {
+        switch self {
+        case let .trip(routeIdMatcher, _, _): routeIdMatcher
+        case let .routeDetails(routeIdMatcher, _): routeIdMatcher
+        }
+    }
+
+    func directionId() -> Int32 {
+        switch self {
+        case let .trip(_, directionId, _): directionId
+        case let .routeDetails(_, directionId): directionId
+        }
+    }
+
+    func tripIdMatcher() -> Matcher<NSString> {
+        switch self {
+        case let .trip(_, _, tripId): MatcherData(value: tripId as NSString)
+        case .routeDetails: MatcherWildcard()
+        }
+    }
 }
 
 struct StopListRow<Descriptor: View, RightSideContent: View>: View {
@@ -89,6 +110,10 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
     }
 
     var body: some View {
+        let padding: CGFloat = switch stopListContext {
+        case .trip: 7
+        case .routeDetails: 0
+        }
         VStack(spacing: 0) {
             stopRow
                 .background(background?.padding(1).clipShape(RoundedRectangle(cornerRadius: 12)))
@@ -106,6 +131,12 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                     AlertCard(
                         alert: disruption.alert,
                         alertSummary: alertSummaries[disruption.alert.id] ?? nil,
+                        alertSummaryEntity: disruption.alert.summary(
+                            routeId: stopListContext.routeIdMatcher(),
+                            stopId: MatcherData(value: stop.id as NSString),
+                            directionId: MatcherData(value: KotlinInt(value: stopListContext.directionId())),
+                            tripId: stopListContext.tripIdMatcher()
+                        ),
                         spec: .downstream,
                         routeAccents: routeAccents,
                         onViewDetails: { onOpenAlertDetails(disruption.alert) },
@@ -118,7 +149,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                 }
             }
         }
-        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, stopListContext == .trip ? 7 : 0)
+        .fixedSize(horizontal: false, vertical: true).padding(.horizontal, padding)
         .enableInjection()
     }
 

--- a/iosApp/iosApp/ComponentViews/StopListRow.swift
+++ b/iosApp/iosApp/ComponentViews/StopListRow.swift
@@ -30,10 +30,10 @@ enum StopListContext {
         }
     }
 
-    func directionId() -> Int32 {
+    func directionIdMatcher() -> Matcher<KotlinInt> {
         switch self {
-        case let .trip(_, directionId, _): directionId
-        case let .routeDetails(_, directionId): directionId
+        case let .trip(_, directionId, _): MatcherData(value: KotlinInt(value: directionId))
+        case let .routeDetails(_, directionId): MatcherData(value: KotlinInt(value: directionId))
         }
     }
 
@@ -134,7 +134,7 @@ struct StopListRow<Descriptor: View, RightSideContent: View>: View {
                         alertSummaryEntity: disruption.alert.summary(
                             routeId: stopListContext.routeIdMatcher(),
                             stopId: MatcherData(value: stop.id as NSString),
-                            directionId: MatcherData(value: KotlinInt(value: stopListContext.directionId())),
+                            directionId: stopListContext.directionIdMatcher(),
                             tripId: stopListContext.tripIdMatcher()
                         ),
                         spec: .downstream,

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -323,13 +323,7 @@ struct OnboardingScreenView: View {
                             recurrence: nil,
                             isUpdate: false
                         ),
-                        alertSummaryEntity: .init(
-                            routeId: nil,
-                            stopId: nil,
-                            tripId: nil,
-                            directionId: nil,
-                            summary: alertSummary
-                        )
+                        alertSummaryEntity: .init(summary: alertSummary)
                     )
                     Text(String(alert.alertCardMajorBody.characters[...]))
                         .font(.system(size: 16))

--- a/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
+++ b/iosApp/iosApp/Pages/Onboarding/OnboardingScreenView.swift
@@ -11,6 +11,7 @@ import Lottie
 import Shared
 import SwiftUI
 
+// swiftlint:disable:next type_body_length
 struct OnboardingScreenView: View {
     @ObserveInjection var inject
     let screen: OnboardingScreen
@@ -243,6 +244,54 @@ struct OnboardingScreenView: View {
     }
 
     @ViewBuilder private var notificationsBeta: some View {
+        let alertSummaryLocation = String(
+            format: NSLocalizedString(
+                " from **%1$@** to **%2$@**",
+                comment: """
+                Alert summary location for consecutive stops in the format of " from [Stop name] \
+                to [Other stop name]" ex. " from [Alewife] to [Harvard]" or " from [Lechmere] \
+                to [Park Street]". The leading space should be retained, because this will be \
+                added in the %2 position of the "**%1$@**%2$@%3$@" alert summary template which \
+                may or may not include a location fragment.
+                """
+            ),
+            "Back Bay",
+            "Wellington"
+        )
+        let alertSummaryTimeframe = String(
+            format: NSLocalizedString(
+                "key/alert_summary_timeframe_this_week",
+                comment: """
+                Alert summary timeframe ending on a specific day later this week. \
+                ex. " through Thursday". The weekday component is localized by the \
+                OS. The leading space should be retained, because this will be added \
+                in the %3 position of the "**%1$@**%2$@%3$@" alert summary template \
+                which may or may not include a timeframe fragment.
+                """
+            ), EasternTimeInstant(
+                year: 2026,
+                month: .january,
+                day: 25,
+                hour: 12,
+                minute: 0,
+                second: 0
+            ).coerceInServiceDay(rounding: .backwards).formatted(
+                .init().weekday(.wide)
+            )
+        )
+        let alertSummary = String(format:
+            NSLocalizedString(
+                "**%1$@**%2$@%3$@%4$@",
+                comment: """
+                Alert summary in the format of "[Alert effect][at location][through timeframe][until recurrence]", \
+                ex "[Stop closed][ at Haymarket][ through this Friday][]" or \
+                "[Service suspended][ from Alewife to Harvard][ through end of service][ daily until Friday]"
+                """
+            ),
+            Shared.Alert.Effect.suspension.effectSentenceCaseString,
+            alertSummaryLocation,
+            alertSummaryTimeframe,
+            "")
         VStack {
             HStack(spacing: 10) {
                 Image(.appIcon).resizable().scaledToFit().frame(width: 38, height: 38)
@@ -256,7 +305,7 @@ struct OnboardingScreenView: View {
                             .font(.system(size: 16))
                     }
                     let alert = FormattedAlert(
-                        alert: ObjectCollectionBuilder.Single.shared.alert { _ in },
+                        alert: ObjectCollectionBuilder.Single.shared.alert { $0.effect = .suspension },
                         alertSummary: .Standard(
                             effect: .suspension,
                             location: AlertSummary.LocationSuccessiveStops(
@@ -273,6 +322,13 @@ struct OnboardingScreenView: View {
                             )),
                             recurrence: nil,
                             isUpdate: false
+                        ),
+                        alertSummaryEntity: .init(
+                            routeId: nil,
+                            stopId: nil,
+                            tripId: nil,
+                            directionId: nil,
+                            summary: alertSummary
                         )
                     )
                     Text(String(alert.alertCardMajorBody.characters[...]))

--- a/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/CollapsableStopList.swift
@@ -13,6 +13,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
     @ObserveInjection var inject
 
     let lineOrRoute: LineOrRoute
+    let stopListContext: StopListContext
     let segment: RouteDetailsStopList.Segment
     let onClick: (RouteDetailsStopList.Entry) -> Void
     let isFirstSegment: Bool
@@ -25,6 +26,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
 
     init(
         lineOrRoute: LineOrRoute,
+        stopListContext: StopListContext,
         segment: RouteDetailsStopList.Segment,
         onClick: @escaping (RouteDetailsStopList.Entry) -> Void,
         isFirstSegment: Bool = false,
@@ -32,6 +34,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
         rightSideContent: @escaping (RouteDetailsStopList.Entry) -> RightSideContent
     ) {
         self.lineOrRoute = lineOrRoute
+        self.stopListContext = stopListContext
         self.segment = segment
         self.onClick = onClick
         self.isFirstSegment = isFirstSegment
@@ -47,7 +50,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                 stickConnections: stop.stickConnections,
                 onClick: { onClick(stop) },
                 routeAccents: .init(route: lineOrRoute.sortRoute),
-                stopListContext: .routeDetails,
+                stopListContext: stopListContext,
                 connectingRoutes: stop.connectingRoutes,
                 stopPlacement: .init(isFirst: isFirstSegment, isLast: isLastSegment),
                 descriptor: { Text("Less common stop").font(Typography.footnote).foregroundStyle(Color.text) },
@@ -65,7 +68,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                             stickConnections: stop.stickConnections,
                             onClick: { onClick(stop) },
                             routeAccents: .init(route: lineOrRoute.sortRoute),
-                            stopListContext: .routeDetails,
+                            stopListContext: stopListContext,
                             connectingRoutes: stop.connectingRoutes,
                             stopPlacement: .init(
                                 isFirst: isFirstSegment && index == segment.stops.startIndex,
@@ -106,7 +109,7 @@ struct CollapsableStopList<RightSideContent: View>: View {
                     guard let connection = $0.first, let isTwisted = $0.second else { return nil }
                     return (connection, isTwisted.boolValue)
                 },
-                context: .routeDetails,
+                context: stopListContext,
             ))
             .onReceive(inspection.notice) { inspection.visit(self, $0) }
             .enableInjection()

--- a/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
+++ b/iosApp/iosApp/Pages/RouteDetails/RouteStopListView.swift
@@ -274,6 +274,10 @@ struct RouteStopListContentView<RightSideContent: View>: View {
         }
     }
 
+    private var stopListContext: StopListContext {
+        .routeDetails(MatcherAnyOf(values: lineOrRoute.allRoutes.map(\.id)), selectedDirection)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             SheetHeader(
@@ -367,7 +371,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
                                     stickConnections: stop.stickConnections,
                                     onClick: { onTapStop(stopRowContext) },
                                     routeAccents: .init(route: lineOrRoute.sortRoute),
-                                    stopListContext: .routeDetails,
+                                    stopListContext: stopListContext,
                                     connectingRoutes: stop.connectingRoutes,
                                     stopPlacement: stopPlacement,
                                     descriptor: { EmptyView() },
@@ -377,6 +381,7 @@ struct RouteStopListContentView<RightSideContent: View>: View {
                         } else {
                             CollapsableStopList(
                                 lineOrRoute: lineOrRoute,
+                                stopListContext: stopListContext,
                                 segment: segment,
                                 onClick: { onTapStop(stopRowContext($0.stop)) },
                                 isFirstSegment: segmentIndex == stopList.segments.startIndex,

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -356,6 +356,9 @@ struct StopDetailsFilteredDepartureDetails: View {
                                alertSummaries: alertSummaries,
                                now: now,
                                isAllServiceDisrupted: isAllServiceDisrupted,
+                               routeIdMatcher: MatcherAnyOf(values: leaf.lineOrRoute.allRoutes.map(\.id)),
+                               stopIdMatcher: MatcherData(value: stopId as NSString),
+                               directionIdMatcher: MatcherData(value: .init(int: selectedDirection.id)),
                                tripId: tripFilter?.tripId,
                                routeAccents: routeAccents,
                                onRowTap: { id, spec in getAlertDetailsHandler(id, spec: spec) })

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsUnfilteredView.swift
@@ -132,6 +132,9 @@ struct StopDetailsUnfilteredView: View {
                                                        alertSummaries: summaries,
                                                        now: now,
                                                        isAllServiceDisrupted: false,
+                                                       routeIdMatcher: MatcherWildcard(),
+                                                       stopIdMatcher: MatcherData(value: stopId as NSString),
+                                                       directionIdMatcher: MatcherWildcard(),
                                                        tripId: nil,
                                                        routeAccents: .init(),
                                                        onRowTap: { id, _ in

--- a/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStopRow.swift
@@ -19,6 +19,7 @@ struct TripStopRow: View {
     var route: Route
     var routeAccents: TripRouteAccents
     var alertSummaries: [String: AlertSummary?]
+    var stopListContext: StopListContext
     var showDownstreamAlert: Bool = false
     var targeted: Bool = false
     var firstStop: Bool = false
@@ -54,7 +55,7 @@ struct TripStopRow: View {
             stickConnections: stickConnections,
             onClick: { onTapLink(stop) },
             routeAccents: routeAccents,
-            stopListContext: .trip,
+            stopListContext: stopListContext,
             activeElevatorAlerts: activeElevatorAlerts.count,
             alertSummaries: alertSummaries,
             background: background,
@@ -111,6 +112,7 @@ struct TripStopRow: View {
         route.textColor = "FFFFFF"
         route.type = .heavyRail
     }
+    let stopListContext = StopListContext.trip(MatcherData(value: red.id), trip.directionId, trip.id)
     VStack(spacing: 0) {
         TripStopRow(
             stop: .init(
@@ -138,7 +140,8 @@ struct TripStopRow: View {
             onOpenAlertDetails: { _ in },
             route: red,
             routeAccents: .init(route: red),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: stopListContext,
         )
         TripStopRow(
             stop: .init(
@@ -163,7 +166,8 @@ struct TripStopRow: View {
             onOpenAlertDetails: { _ in },
             route: red,
             routeAccents: .init(route: red),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: stopListContext
         )
         TripStopRow(
             stop: .init(
@@ -183,7 +187,8 @@ struct TripStopRow: View {
             onOpenAlertDetails: { _ in },
             route: red,
             routeAccents: .init(route: red),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: stopListContext
         )
     }
     .withFixedSettings([.stationAccessibility: true])
@@ -201,6 +206,7 @@ struct TripStopRow: View {
         route.textColor = "FFFFFF"
         route.type = .heavyRail
     }
+    let stopListContext = StopListContext.trip(MatcherData(value: red.id), trip.directionId, trip.id)
     ZStack {
         Color.fill3.padding(6)
         VStack(spacing: 0) {
@@ -231,7 +237,8 @@ struct TripStopRow: View {
                 onOpenAlertDetails: { _ in },
                 route: red,
                 routeAccents: .init(route: red),
-                alertSummaries: [:]
+                alertSummaries: [:],
+                stopListContext: stopListContext
             )
             TripStopRow(
                 stop:
@@ -257,7 +264,8 @@ struct TripStopRow: View {
                 onOpenAlertDetails: { _ in },
                 route: red,
                 routeAccents: .init(route: red),
-                alertSummaries: [:]
+                alertSummaries: [:],
+                stopListContext: stopListContext
             )
             TripStopRow(
                 stop:
@@ -280,6 +288,7 @@ struct TripStopRow: View {
                 route: red,
                 routeAccents: .init(route: red),
                 alertSummaries: [:],
+                stopListContext: stopListContext,
                 showDownstreamAlert: true
             )
         }

--- a/iosApp/iosApp/Pages/StopDetails/TripStops.swift
+++ b/iosApp/iosApp/Pages/StopDetails/TripStops.swift
@@ -71,6 +71,10 @@ struct TripStops: View {
         }
     }
 
+    var stopListContext: StopListContext {
+        .trip(MatcherData(value: route.id), stops.trip.directionId, stops.trip.id)
+    }
+
     @ViewBuilder
     func stopList(list: [TripDetailsStopList.Entry], showDownstreamAlerts: Bool = false) -> some View {
         ForEach(list, id: \.stopSequence) { stop in
@@ -83,6 +87,7 @@ struct TripStops: View {
                 route: route,
                 routeAccents: routeAccents,
                 alertSummaries: alertSummaries,
+                stopListContext: stopListContext,
                 showDownstreamAlert: showDownstreamAlerts,
                 lastStop: stop.stopSequence == stops.stops.last?.stopSequence,
                 background: Color.fill2
@@ -110,6 +115,7 @@ struct TripStops: View {
                         route: route,
                         routeAccents: routeAccents,
                         alertSummaries: alertSummaries,
+                        stopListContext: stopListContext,
                         firstStop: true,
                         background: .fill2
                     )
@@ -157,7 +163,7 @@ struct TripStops: View {
                             .frame(maxWidth: .infinity, minHeight: 56)
                         }
                     )
-                    .disclosureGroupStyle(.stopList(routeAccents: routeAccents, context: .trip))
+                    .disclosureGroupStyle(.stopList(routeAccents: routeAccents, context: stopListContext))
                 }
                 if let target, !hideTarget {
                     // If the target is the first stop and there's no vehicle,
@@ -171,6 +177,7 @@ struct TripStops: View {
                         route: route,
                         routeAccents: routeAccents,
                         alertSummaries: alertSummaries,
+                        stopListContext: stopListContext,
                         targeted: true,
                         firstStop: showFirstStopSeparately && target == stops.startTerminalEntry,
                         background: Color.fill3

--- a/iosApp/iosApp/Utils/Extensions/AttributedStringExtension.swift
+++ b/iosApp/iosApp/Utils/Extensions/AttributedStringExtension.swift
@@ -9,6 +9,11 @@
 import SwiftUI
 
 extension AttributedString {
+    static func tryMarkdown(_ optionalString: String?) -> AttributedString? {
+        guard let optionalString else { return nil }
+        return tryMarkdown(optionalString)
+    }
+
     static func tryMarkdown(_ stringWithMarkdown: String) -> AttributedString {
         do {
             return try AttributedString(markdown: stringWithMarkdown)

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -14,6 +14,7 @@ import Shared
 struct FormattedAlert: Equatable {
     let alert: Alert
     let alertSummary: AlertSummary?
+    let alertSummaryEntity: AlertSummaryEntity?
     let effect: String
     let sentenceCaseEffect: String
     let dueToCause: String?
@@ -21,7 +22,7 @@ struct FormattedAlert: Equatable {
     /// guarantee that the alert should replace predictions.
     let predictionReplacement: PredictionReplacement
 
-    init(alert: Alert, alertSummary: AlertSummary? = nil) {
+    init(alert: Alert, alertSummary: AlertSummary? = nil, alertSummaryEntity: AlertSummaryEntity? = nil) {
         self.alert = alert
         effect = "**\(alert.effect.effectString)**"
         sentenceCaseEffect = alert.effect.effectSentenceCaseString
@@ -44,6 +45,7 @@ struct FormattedAlert: Equatable {
         default: .init(text: alert.effect.effectString, accessibilityLabel: nil)
         }
         self.alertSummary = alertSummary
+        self.alertSummaryEntity = alertSummaryEntity
     }
 
     var downstreamLabel: String {
@@ -388,7 +390,13 @@ struct FormattedAlert: Equatable {
     }
 
     var summary: AttributedString? {
-        summary(alertSummary: alertSummary)
+        let summaryCalculated = summary(alertSummary: alertSummary)
+        let summaryProvided = AttributedString.tryMarkdown(alertSummaryEntity?.summary)
+        if summaryCalculated != summaryProvided {
+            debugPrint("summary mismatch", summaryCalculated, summaryProvided)
+            abort()
+        }
+        return summaryProvided ?? summaryCalculated
     }
 
     func summary(alertSummary: AlertSummary?) -> AttributedString? {

--- a/iosApp/iosApp/Utils/FormattedAlert.swift
+++ b/iosApp/iosApp/Utils/FormattedAlert.swift
@@ -390,13 +390,7 @@ struct FormattedAlert: Equatable {
     }
 
     var summary: AttributedString? {
-        let summaryCalculated = summary(alertSummary: alertSummary)
-        let summaryProvided = AttributedString.tryMarkdown(alertSummaryEntity?.summary)
-        if summaryCalculated != summaryProvided {
-            debugPrint("summary mismatch", summaryCalculated, summaryProvided)
-            abort()
-        }
-        return summaryProvided ?? summaryCalculated
+        AttributedString.tryMarkdown(alertSummaryEntity?.summary)
     }
 
     func summary(alertSummary: AlertSummary?) -> AttributedString? {

--- a/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
+++ b/iosApp/iosAppTests/Pages/RouteDetails/CollapsableStopListTests.swift
@@ -37,6 +37,7 @@ final class CollapsableStopListTests: XCTestCase {
 
         let sut = CollapsableStopList(
             lineOrRoute: .route(mainRoute),
+            stopListContext: .routeDetails(MatcherWildcard(), 0),
             segment: .init(
                 stops: [.init(stop: stop1, stopLane: .center, stickConnections: [], connectingRoutes: [])],
                 isTypical: false
@@ -73,6 +74,7 @@ final class CollapsableStopListTests: XCTestCase {
 
         let sut = CollapsableStopList(
             lineOrRoute: .route(mainRoute),
+            stopListContext: .routeDetails(MatcherWildcard(), 0),
             segment: .init(
                 stops: [.init(stop: stop1, stopLane: .center, stickConnections: [], connectingRoutes: []), .init(
                     stop: stop2,

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -360,13 +360,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 stop: stop.id,
                 trip: trip1.id
             )
-            alert.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "This bus is cancelled today"
-            )]
+            alert.summaries = [.init(summary: "This bus is cancelled today")]
         }
         let leaf = makeLeaf(
             route: route,
@@ -792,13 +786,7 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                     route: routeC.id.idText, routeType: nil,
                     stop: "70151", trip: nil
                 )
-                alert.summaries = [.init(
-                    routeId: nil,
-                    stopId: nil,
-                    tripId: nil,
-                    directionId: nil,
-                    summary: "**Shuttle buses** at **\(stop.name)**"
-                )]
+                alert.summaries = [.init(summary: "**Shuttle buses** at **\(stop.name)**")]
             }
         let alertResponse = AlertsStreamDataResponse(alerts: [alert.id: alert])
 

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -360,6 +360,13 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                 stop: stop.id,
                 trip: trip1.id
             )
+            alert.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "This bus is cancelled today"
+            )]
         }
         let leaf = makeLeaf(
             route: route,
@@ -785,6 +792,13 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
                     route: routeC.id.idText, routeType: nil,
                     stop: "70151", trip: nil
                 )
+                alert.summaries = [.init(
+                    routeId: nil,
+                    stopId: nil,
+                    tripId: nil,
+                    directionId: nil,
+                    summary: "**Shuttle buses** at **\(stop.name)**"
+                )]
             }
         let alertResponse = AlertsStreamDataResponse(alerts: [alert.id: alert])
 

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -331,13 +331,9 @@ final class TripStopRowTests: XCTestCase {
         let route = objects.route { _ in }
         let alert = objects.alert {
             $0.effect = .shuttle
-            $0.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow"
-            )]
+            $0
+                .summaries =
+                [.init(summary: "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow")]
         }
         let summary = AlertSummary.Standard(
             effect: alert.effect,

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopRowTests.swift
@@ -42,7 +42,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id)
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: stop.name))
@@ -73,7 +74,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id)
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(UpcomingTripView.self))
@@ -110,7 +112,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: .init(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id)
         ).withFixedSettings([:])
 
         XCTAssertNotNil(try sut.inspect().find(text: "Track 7"))
@@ -143,6 +146,7 @@ final class TripStopRowTests: XCTestCase {
             route: route,
             routeAccents: TripRouteAccents(route: route),
             alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
             targeted: true
         ).withFixedSettings([:])
 
@@ -160,7 +164,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
         ).withFixedSettings([:])
 
         XCTAssertThrowsError(try notTargeted.inspect().find(imageName: "stop-pin-indicator"))
@@ -193,7 +198,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
         ).withFixedSettings([:])
         XCTAssertNotNil(try basicRow.inspect().find(viewWithAccessibilityLabel: "stop"))
 
@@ -206,6 +212,7 @@ final class TripStopRowTests: XCTestCase {
             route: route,
             routeAccents: TripRouteAccents(route: route),
             alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
             targeted: true
         ).withFixedSettings([:])
         XCTAssertNotNil(try selectedRow.inspect().find(viewWithAccessibilityLabel: "stop, selected stop"))
@@ -219,6 +226,7 @@ final class TripStopRowTests: XCTestCase {
             route: route,
             routeAccents: TripRouteAccents(route: route),
             alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
             firstStop: true
         ).withFixedSettings([:])
         XCTAssertNotNil(try firstRow.inspect().find(viewWithAccessibilityLabel: "stop, first stop"))
@@ -232,6 +240,7 @@ final class TripStopRowTests: XCTestCase {
             route: route,
             routeAccents: TripRouteAccents(route: route),
             alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
             targeted: true,
             firstStop: true
         ).withFixedSettings([:])
@@ -270,7 +279,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id)
         ).withFixedSettings([.stationAccessibility: true])
         XCTAssertNotNil(try row.inspect().find(viewWithTag: "wheelchair_not_accessible"))
         XCTAssertNotNil(try row.inspect().find(viewWithAccessibilityLabel: "This stop is not accessible"))
@@ -306,7 +316,8 @@ final class TripStopRowTests: XCTestCase {
             onOpenAlertDetails: { _ in },
             route: route,
             routeAccents: TripRouteAccents(route: route),
-            alertSummaries: [:]
+            alertSummaries: [:],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id)
         ).withFixedSettings([.stationAccessibility: true])
         XCTAssertNotNil(try row.inspect().find(viewWithTag: "elevator_alert"))
         XCTAssertNotNil(try row.inspect().find(viewWithAccessibilityLabel: "This stop has 1 elevator closed"))
@@ -318,7 +329,16 @@ final class TripStopRowTests: XCTestCase {
         let stop = objects.stop { _ in }
         let trip = objects.trip { _ in }
         let route = objects.route { _ in }
-        let alert = objects.alert { $0.effect = .shuttle }
+        let alert = objects.alert {
+            $0.effect = .shuttle
+            $0.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Roxbury Crossing** to **Green Street** through tomorrow"
+            )]
+        }
         let summary = AlertSummary.Standard(
             effect: alert.effect,
             location: AlertSummary
@@ -347,6 +367,7 @@ final class TripStopRowTests: XCTestCase {
             route: route,
             routeAccents: .init(route: route),
             alertSummaries: [alert.id: summary],
+            stopListContext: .trip(MatcherData(value: route.id), trip.directionId, trip.id),
             showDownstreamAlert: true
         ).withFixedSettings([:])
 

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -365,7 +365,16 @@ final class TripStopsTests: XCTestCase {
         let stop2Target = objects.stop { $0.name = "Stop B" }
         let stop3 = objects.stop { $0.name = "Stop C" }
 
-        let alert = objects.alert { $0.effect = .shuttle }
+        let alert = objects.alert {
+            $0.effect = .shuttle
+            $0.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** at **Stop C** through end of service"
+            )]
+        }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.tripId = trip.id
@@ -463,7 +472,16 @@ final class TripStopsTests: XCTestCase {
         let stop2Target = objects.stop { $0.name = "Stop B" }
         let stop3 = objects.stop { $0.name = "Stop C" }
 
-        let alert = objects.alert { $0.effect = .stopClosure }
+        let alert = objects.alert {
+            $0.effect = .stopClosure
+            $0.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Stop closed at Stop C through end of service"
+            )]
+        }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.tripId = trip.id
@@ -561,7 +579,16 @@ final class TripStopsTests: XCTestCase {
         let stop2Target = objects.stop { $0.name = "Stop B" }
         let stop3 = objects.stop { $0.name = "Stop C" }
 
-        let alert = objects.alert { $0.effect = .stopClosure }
+        let alert = objects.alert {
+            $0.effect = .stopClosure
+            $0.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Stop closed at Stop B"
+            )]
+        }
 
         let vehicle = objects.vehicle { vehicle in
             vehicle.tripId = trip.id

--- a/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/TripStopsTests.swift
@@ -367,13 +367,7 @@ final class TripStopsTests: XCTestCase {
 
         let alert = objects.alert {
             $0.effect = .shuttle
-            $0.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**Shuttle buses** at **Stop C** through end of service"
-            )]
+            $0.summaries = [.init(summary: "**Shuttle buses** at **Stop C** through end of service")]
         }
 
         let vehicle = objects.vehicle { vehicle in
@@ -474,13 +468,7 @@ final class TripStopsTests: XCTestCase {
 
         let alert = objects.alert {
             $0.effect = .stopClosure
-            $0.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Stop closed at Stop C through end of service"
-            )]
+            $0.summaries = [.init(summary: "Stop closed at Stop C through end of service")]
         }
 
         let vehicle = objects.vehicle { vehicle in
@@ -581,13 +569,7 @@ final class TripStopsTests: XCTestCase {
 
         let alert = objects.alert {
             $0.effect = .stopClosure
-            $0.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Stop closed at Stop B"
-            )]
+            $0.summaries = [.init(summary: "Stop closed at Stop B")]
         }
 
         let vehicle = objects.vehicle { vehicle in

--- a/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
+++ b/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
@@ -34,10 +34,6 @@ final class FormattedAlertTests: XCTestCase {
                 recurrence: nil
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "Shuttle buses replace the **12:13\u{202F}PM** train from **Oak Grove** to **Forest Hills**"
             )
         )
@@ -68,10 +64,6 @@ final class FormattedAlertTests: XCTestCase {
                 recurrence: nil
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**"
             )
         )
@@ -92,13 +84,7 @@ final class FormattedAlertTests: XCTestCase {
                 endStopName: "North Station",
                 recurrence: nil
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Shuttle buses replace this train from **Porter** to **North Station**"
-            )
+            alertSummaryEntity: .init(summary: "Shuttle buses replace this train from **Porter** to **North Station**")
         )
         XCTAssertEqual(
             "Shuttle buses replace this train from Porter to North Station",
@@ -138,10 +124,6 @@ final class FormattedAlertTests: XCTestCase {
                 )
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday"
             )
         )
@@ -174,10 +156,6 @@ final class FormattedAlertTests: XCTestCase {
                 )
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "Shuttle buses replace this train from **Porter** to **North Station** daily until Thursday"
             )
         )
@@ -209,10 +187,6 @@ final class FormattedAlertTests: XCTestCase {
                 cause: .weather
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Ruggles** is suspended today due to weather"
             )
         )
@@ -234,13 +208,7 @@ final class FormattedAlertTests: XCTestCase {
                 isToday: true,
                 cause: .weather
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "This train is suspended today due to weather"
-            )
+            alertSummaryEntity: .init(summary: "This train is suspended today due to weather")
         )
         XCTAssertEqual(
             "This train is suspended today due to weather",
@@ -270,10 +238,6 @@ final class FormattedAlertTests: XCTestCase {
                 cause: .weather
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Ruggles** will terminate at South Station today due to weather"
             )
         )
@@ -295,13 +259,7 @@ final class FormattedAlertTests: XCTestCase {
                 isToday: true,
                 cause: .weather
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "This train will terminate at South Station today due to weather"
-            )
+            alertSummaryEntity: .init(summary: "This train will terminate at South Station today due to weather")
         )
         XCTAssertEqual(
             "This train will terminate at South Station today due to weather",
@@ -331,10 +289,6 @@ final class FormattedAlertTests: XCTestCase {
                 cause: .weather
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train to **South Station** will not stop at **Back Bay** and **Ruggles** today due to weather"
             )
         )
@@ -356,13 +310,7 @@ final class FormattedAlertTests: XCTestCase {
                 isToday: true,
                 cause: .weather
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "This ferry will not stop at **Rowes Wharf** today due to weather"
-            )
+            alertSummaryEntity: .init(summary: "This ferry will not stop at **Rowes Wharf** today due to weather")
         )
 
         XCTAssertEqual(
@@ -381,13 +329,7 @@ final class FormattedAlertTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Trains will not stop at **Back Bay** until further notice"
-            )
+            alertSummaryEntity: .init(summary: "Trains will not stop at **Back Bay** until further notice")
         )
         XCTAssertEqual(
             "Trains will not stop at Back Bay until further notice",
@@ -406,10 +348,6 @@ final class FormattedAlertTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "Trains will not stop at **Back Bay** and **Ruggles** until further notice"
             )
         )
@@ -430,10 +368,6 @@ final class FormattedAlertTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "Trains will not stop at **Back Bay**, **Ruggles**, and **Hyde Park** until further notice"
             )
         )
@@ -453,13 +387,7 @@ final class FormattedAlertTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Trains will not stop at **multiple stops** until further notice"
-            )
+            alertSummaryEntity: .init(summary: "Trains will not stop at **multiple stops** until further notice")
         )
         XCTAssertEqual(
             "Trains will not stop at multiple stops until further notice",

--- a/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
+++ b/iosApp/iosAppTests/Utils/FormattedAlertTests.swift
@@ -32,6 +32,13 @@ final class FormattedAlertTests: XCTestCase {
                 startStopName: "Oak Grove",
                 endStopName: "Forest Hills",
                 recurrence: nil
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Shuttle buses replace the **12:13\u{202F}PM** train from **Oak Grove** to **Forest Hills**"
             )
         )
         XCTAssertEqual(
@@ -59,6 +66,13 @@ final class FormattedAlertTests: XCTestCase {
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills",
                 recurrence: nil
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**"
             )
         )
         XCTAssertEqual(
@@ -77,6 +91,13 @@ final class FormattedAlertTests: XCTestCase {
                 startStopName: "Porter",
                 endStopName: "North Station",
                 recurrence: nil
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Shuttle buses replace this train from **Porter** to **North Station**"
             )
         )
         XCTAssertEqual(
@@ -115,6 +136,13 @@ final class FormattedAlertTests: XCTestCase {
                         )
                     )
                 )
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday"
             )
         )
         XCTAssertEqual(
@@ -144,6 +172,13 @@ final class FormattedAlertTests: XCTestCase {
                         )
                     )
                 )
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Shuttle buses replace this train from **Porter** to **North Station** daily until Thursday"
             )
         )
         XCTAssertEqual(
@@ -172,6 +207,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: nil,
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Ruggles** is suspended today due to weather"
             )
         )
         XCTAssertEqual(
@@ -191,6 +233,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: nil,
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "This train is suspended today due to weather"
             )
         )
         XCTAssertEqual(
@@ -219,6 +268,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: ["South Station"],
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Ruggles** will terminate at South Station today due to weather"
             )
         )
         XCTAssertEqual(
@@ -238,6 +294,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: ["South Station"],
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "This train will terminate at South Station today due to weather"
             )
         )
         XCTAssertEqual(
@@ -266,6 +329,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: ["Back Bay", "Ruggles"],
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train to **South Station** will not stop at **Back Bay** and **Ruggles** today due to weather"
             )
         )
         XCTAssertEqual(
@@ -285,6 +355,13 @@ final class FormattedAlertTests: XCTestCase {
                 effectStops: ["Rowes Wharf"],
                 isToday: true,
                 cause: .weather
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "This ferry will not stop at **Rowes Wharf** today due to weather"
             )
         )
 
@@ -303,6 +380,13 @@ final class FormattedAlertTests: XCTestCase {
                 timeframe: AlertSummary.TimeframeUntilFurtherNotice(),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Trains will not stop at **Back Bay** until further notice"
             )
         )
         XCTAssertEqual(
@@ -320,6 +404,13 @@ final class FormattedAlertTests: XCTestCase {
                 timeframe: AlertSummary.TimeframeUntilFurtherNotice(),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Trains will not stop at **Back Bay** and **Ruggles** until further notice"
             )
         )
         XCTAssertEqual(
@@ -337,6 +428,13 @@ final class FormattedAlertTests: XCTestCase {
                 timeframe: AlertSummary.TimeframeUntilFurtherNotice(),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Trains will not stop at **Back Bay**, **Ruggles**, and **Hyde Park** until further notice"
             )
         )
         XCTAssertEqual(
@@ -354,6 +452,13 @@ final class FormattedAlertTests: XCTestCase {
                 timeframe: AlertSummary.TimeframeUntilFurtherNotice(),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Trains will not stop at **multiple stops** until further notice"
             )
         )
         XCTAssertEqual(

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -29,6 +29,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {
@@ -67,6 +68,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Start Stop** to **End Stop** through tomorrow"
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -97,6 +105,13 @@ final class AlertCardTests: XCTestCase {
                 timeframe: .some(AlertSummary.TimeframeEndOfService()),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**No service** at **Single Stop** through end of service"
             ),
             spec: .takeover,
             routeAccents: .init(),
@@ -145,6 +160,13 @@ final class AlertCardTests: XCTestCase {
                 ),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Start Stop** to **Westbound** stops through Apr 16"
             ),
             spec: .takeover,
             routeAccents: .init(),
@@ -195,6 +217,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Westbound** stops to **End Stop** through Wednesday"
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -238,6 +267,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Start Stop** to **End Stop** through 4:00\u{202F}PM"
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -263,6 +299,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .basic,
             routeAccents: .init(),
             onViewDetails: {
@@ -293,6 +330,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Detour** through tomorrow"
+            ),
             spec: .basic,
             routeAccents: .init(),
             onViewDetails: {}
@@ -311,6 +355,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .downstream,
             routeAccents: .init(),
             onViewDetails: {
@@ -338,6 +383,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .elevator,
             routeAccents: .init(),
             onViewDetails: {
@@ -374,6 +420,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .elevator,
             routeAccents: .init(),
             onViewDetails: {
@@ -402,6 +449,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .delay,
             routeAccents: .init(),
             onViewDetails: {}
@@ -444,6 +492,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Delay** on **Red Line** starting **9:00\u{202F}PM** today"
+            ),
             spec: .delay,
             now: time.minus(minutes: 15),
             routeAccents: .init(),
@@ -467,6 +522,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .delay,
             routeAccents: .init(),
             onViewDetails: {}
@@ -488,6 +544,7 @@ final class AlertCardTests: XCTestCase {
         let sut = AlertCard(
             alert: alert,
             alertSummary: nil,
+            alertSummaryEntity: nil,
             spec: .delay,
             routeAccents: .init(),
             onViewDetails: {}
@@ -514,6 +571,13 @@ final class AlertCardTests: XCTestCase {
                         endStopName: "End Stop"
                     )
                 )
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**All clear:** Regular service from **Start Stop** to **End Stop**"
             ),
             spec: .takeover,
             routeAccents: .init(),
@@ -554,6 +618,13 @@ final class AlertCardTests: XCTestCase {
                 timeframe: AlertSummary.TimeframeTomorrow(),
                 recurrence: nil,
                 isUpdate: true
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Update:** Shuttle buses from **Start Stop** to **End Stop** through tomorrow"
             ),
             spec: .takeover,
             routeAccents: .init(),
@@ -600,6 +671,13 @@ final class AlertCardTests: XCTestCase {
                 effect: .cancellation,
                 cause: .mechanicalIssue
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Ruggles** is cancelled today due to mechanical issue"
+            ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
             onViewDetails: {}
@@ -630,6 +708,13 @@ final class AlertCardTests: XCTestCase {
                 tripIdentity: TripSpecificAlertSummary.MultipleTrips.shared,
                 effect: .suspension,
                 cause: .holiday
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Multiple trips are suspended today due to holiday"
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -670,6 +755,13 @@ final class AlertCardTests: XCTestCase {
                 ),
                 startStopName: "Ruggles",
                 endStopName: "Forest Hills"
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**"
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -719,6 +811,13 @@ final class AlertCardTests: XCTestCase {
                 effect: .stationClosure,
                 effectStops: ["Back Bay", "Ruggles"]
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today"
+            ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
             onViewDetails: {}
@@ -763,6 +862,13 @@ final class AlertCardTests: XCTestCase {
                 effect: .cancellation,
                 isToday: false,
                 cause: .mechanicalIssue
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Ruggles** is cancelled tomorrow due to mechanical issue"
             ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
@@ -817,7 +923,13 @@ final class AlertCardTests: XCTestCase {
                     )
                 )
             ),
-
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday"
+            ),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
             onViewDetails: {}
@@ -856,6 +968,13 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Trains will not stop at **Stop 1** until further notice"
+            ),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -885,6 +1004,13 @@ final class AlertCardTests: XCTestCase {
                 timeframe: .some(AlertSummary.TimeframeUntilFurtherNotice()),
                 recurrence: nil,
                 isUpdate: false
+            ),
+            alertSummaryEntity: .init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "Buses will not stop at **Stop 1** and **Stop 2** until further notice"
             ),
             spec: .takeover,
             routeAccents: .init(),

--- a/iosApp/iosAppTests/Views/AlertCardTests.swift
+++ b/iosApp/iosAppTests/Views/AlertCardTests.swift
@@ -69,10 +69,6 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**Shuttle buses** from **Start Stop** to **End Stop** through tomorrow"
             ),
             spec: .takeover,
@@ -106,13 +102,7 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**No service** at **Single Stop** through end of service"
-            ),
+            alertSummaryEntity: .init(summary: "**No service** at **Single Stop** through end of service"),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -162,10 +152,6 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**Shuttle buses** from **Start Stop** to **Westbound** stops through Apr 16"
             ),
             spec: .takeover,
@@ -218,10 +204,6 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**Shuttle buses** from **Westbound** stops to **End Stop** through Wednesday"
             ),
             spec: .takeover,
@@ -268,10 +250,6 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: false
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**Shuttle buses** from **Start Stop** to **End Stop** through 4:00\u{202F}PM"
             ),
             spec: .takeover,
@@ -330,13 +308,7 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**Detour** through tomorrow"
-            ),
+            alertSummaryEntity: .init(summary: "**Detour** through tomorrow"),
             spec: .basic,
             routeAccents: .init(),
             onViewDetails: {}
@@ -492,13 +464,7 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**Delay** on **Red Line** starting **9:00\u{202F}PM** today"
-            ),
+            alertSummaryEntity: .init(summary: "**Delay** on **Red Line** starting **9:00\u{202F}PM** today"),
             spec: .delay,
             now: time.minus(minutes: 15),
             routeAccents: .init(),
@@ -572,13 +538,7 @@ final class AlertCardTests: XCTestCase {
                     )
                 )
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**All clear:** Regular service from **Start Stop** to **End Stop**"
-            ),
+            alertSummaryEntity: .init(summary: "**All clear:** Regular service from **Start Stop** to **End Stop**"),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {
@@ -620,10 +580,6 @@ final class AlertCardTests: XCTestCase {
                 isUpdate: true
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**Update:** Shuttle buses from **Start Stop** to **End Stop** through tomorrow"
             ),
             spec: .takeover,
@@ -672,10 +628,6 @@ final class AlertCardTests: XCTestCase {
                 cause: .mechanicalIssue
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Ruggles** is cancelled today due to mechanical issue"
             ),
             spec: .takeover,
@@ -709,13 +661,7 @@ final class AlertCardTests: XCTestCase {
                 effect: .suspension,
                 cause: .holiday
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Multiple trips are suspended today due to holiday"
-            ),
+            alertSummaryEntity: .init(summary: "Multiple trips are suspended today due to holiday"),
             spec: .takeover,
             routeAccents: .init(type: .commuterRail),
             onViewDetails: {}
@@ -757,10 +703,6 @@ final class AlertCardTests: XCTestCase {
                 endStopName: "Forest Hills"
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills**"
             ),
             spec: .takeover,
@@ -812,10 +754,6 @@ final class AlertCardTests: XCTestCase {
                 effectStops: ["Back Bay", "Ruggles"]
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train to **Stoughton** will not stop at **Back Bay** and **Ruggles** today"
             ),
             spec: .takeover,
@@ -864,10 +802,6 @@ final class AlertCardTests: XCTestCase {
                 cause: .mechanicalIssue
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Ruggles** is cancelled tomorrow due to mechanical issue"
             ),
             spec: .takeover,
@@ -924,10 +858,6 @@ final class AlertCardTests: XCTestCase {
                 )
             ),
             alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
                 summary: "**12:13\u{202F}PM** train from **Oak Grove** is replaced by shuttle buses from **Ruggles** to **Forest Hills** daily until Thursday"
             ),
             spec: .takeover,
@@ -968,13 +898,7 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Trains will not stop at **Stop 1** until further notice"
-            ),
+            alertSummaryEntity: .init(summary: "Trains will not stop at **Stop 1** until further notice"),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}
@@ -1005,13 +929,7 @@ final class AlertCardTests: XCTestCase {
                 recurrence: nil,
                 isUpdate: false
             ),
-            alertSummaryEntity: .init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "Buses will not stop at **Stop 1** and **Stop 2** until further notice"
-            ),
+            alertSummaryEntity: .init(summary: "Buses will not stop at **Stop 1** and **Stop 2** until further notice"),
             spec: .takeover,
             routeAccents: .init(),
             onViewDetails: {}

--- a/iosApp/iosAppTests/Views/AlertListContainerTests.swift
+++ b/iosApp/iosAppTests/Views/AlertListContainerTests.swift
@@ -24,6 +24,13 @@ final class AlertListContainerTests: XCTestCase {
         let highAlert = objects.alert { alert in
             alert.effect = .shuttle
             alert.header = "Test header"
+            alert.summaries = [.init(
+                routeId: nil,
+                stopId: nil,
+                tripId: nil,
+                directionId: nil,
+                summary: "**Shuttle buses** from **Start Stop** to **End Stop** through tomorrow"
+            )]
         }
 
         let highAlertSummary = AlertSummary.Standard(effect: .shuttle,
@@ -48,6 +55,9 @@ final class AlertListContainerTests: XCTestCase {
                                      alertSummaries: [highAlert.id: highAlertSummary, downstreamAlert.id: nil],
                                      now: now,
                                      isAllServiceDisrupted: false,
+                                     routeIdMatcher: MatcherWildcard(),
+                                     stopIdMatcher: MatcherWildcard(),
+                                     directionIdMatcher: MatcherWildcard(),
                                      tripId: nil,
                                      routeAccents: .init(),
                                      onRowTap: { _, _ in })
@@ -67,6 +77,9 @@ final class AlertListContainerTests: XCTestCase {
                                      alertSummaries: [:],
                                      now: now,
                                      isAllServiceDisrupted: false,
+                                     routeIdMatcher: MatcherWildcard(),
+                                     stopIdMatcher: MatcherWildcard(),
+                                     directionIdMatcher: MatcherWildcard(),
                                      tripId: nil,
                                      routeAccents: .init(),
                                      onRowTap: { _, _ in })

--- a/iosApp/iosAppTests/Views/AlertListContainerTests.swift
+++ b/iosApp/iosAppTests/Views/AlertListContainerTests.swift
@@ -24,13 +24,7 @@ final class AlertListContainerTests: XCTestCase {
         let highAlert = objects.alert { alert in
             alert.effect = .shuttle
             alert.header = "Test header"
-            alert.summaries = [.init(
-                routeId: nil,
-                stopId: nil,
-                tripId: nil,
-                directionId: nil,
-                summary: "**Shuttle buses** from **Start Stop** to **End Stop** through tomorrow"
-            )]
+            alert.summaries = [.init(summary: "**Shuttle buses** from **Start Stop** to **End Stop** through tomorrow")]
         }
 
         let highAlertSummary = AlertSummary.Standard(effect: .shuttle,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryEntity.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/AlertSummaryEntity.kt
@@ -11,6 +11,8 @@ public data class AlertSummaryEntity(
     @SerialName("direction_id") val directionId: Int?,
     val summary: String?,
 ) {
+    public constructor(summary: String?) : this(null, null, null, null, summary)
+
     internal companion object {
         fun matching(
             summaries: List<AlertSummaryEntity>,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/phoenix/AlertsChannelTest.kt
@@ -109,15 +109,7 @@ class AlertsChannelTest {
                             ),
                             Alert.Lifecycle.Ongoing,
                             10,
-                            listOf(
-                                AlertSummaryEntity(
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    "Ceci n’est pas un alert",
-                                )
-                            ),
+                            listOf(AlertSummaryEntity("Ceci n’est pas un alert")),
                             EasternTimeInstant(2023, Month.MAY, 26, 16, 46, 13),
                         )
                 ),
@@ -203,15 +195,7 @@ class AlertsChannelTest {
                             ),
                             Alert.Lifecycle.Ongoing,
                             10,
-                            listOf(
-                                AlertSummaryEntity(
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    "Ceci n’est pas un alert",
-                                )
-                            ),
+                            listOf(AlertSummaryEntity("Ceci n’est pas un alert")),
                             EasternTimeInstant(2023, Month.MAY, 26, 16, 46, 13),
                         )
                 ),


### PR DESCRIPTION
### Summary

_Ticket:_ [Alert Summary Consolidation | Make the frontend display backend generated summaries](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1215637601111273?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

Wires everything up without deleting the old path.

iOS
- ~~[ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~~
  - ~~[ ] Add temporary machine translations, marked "Needs Review"~~

android
- ~~[ ] All user-facing strings added to strings resource in alphabetical order~~
- ~~[ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~~

### Testing

Updated unit tests. In testing, asserted that the old value and the new value match, but took that out so it doesn’t break everything at runtime.

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
