### PR TITLE
fix: Don't trim bus route shapes at start and end

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilder.kt
@@ -28,7 +28,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.geojson.Position
+import org.maplibre.spatialk.turf.measurement.length
+import org.maplibre.spatialk.turf.misc.nearestPointTo
 import org.maplibre.spatialk.turf.misc.slice
+import org.maplibre.spatialk.units.Length
 
 public data class RouteLineData
 internal constructor(
@@ -62,7 +66,7 @@ public object RouteFeaturesBuilder {
     ): List<RouteSourceData> =
         generateRouteSources(
             routeData,
-            globalData.stops,
+            globalData,
             globalMapData?.alertsByStop.orEmpty(),
             coroutineDispatcher,
         )
@@ -70,28 +74,38 @@ public object RouteFeaturesBuilder {
     @DefaultArgumentInterop.Enabled
     internal suspend fun generateRouteSources(
         routeData: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,
-        stopsById: Map<String, Stop>,
+        globalData: GlobalResponse,
         alertsByStop: Map<String, AlertAssociatedStop>,
         coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default,
     ): List<RouteSourceData> =
         withContext(coroutineDispatcher) {
-            routeData.map {
-                generateRouteSource(
-                    routeId = it.routeId,
-                    routeShapes = it.segmentedShapes,
-                    stopsById,
-                    alertsByStop,
-                )
+            routeData.mapNotNull {
+                // We can't use getLineOrRoute for Route.Ids, because for the Green Line that will
+                // fetch the Line object even when a Route.Id is passed in
+                val route =
+                    when (it.routeId) {
+                        is Line.Id -> globalData.getLineOrRoute(it.routeId)
+                        is Route.Id ->
+                            globalData.getRoute(it.routeId)?.let { id -> LineOrRoute.Route(id) }
+                    }
+                route?.let { route ->
+                    generateRouteSource(
+                        route,
+                        routeShapes = it.segmentedShapes,
+                        stopsById = globalData.stops,
+                        alertsByStop,
+                    )
+                }
             }
         }
 
     private fun generateRouteSource(
-        routeId: LineOrRoute.Id,
+        route: LineOrRoute,
         routeShapes: List<SegmentedRouteShape>,
         stopsById: Map<String, Stop>,
         alertsByStop: Map<String, AlertAssociatedStop>,
     ): RouteSourceData {
-        val routeLines = generateRouteLines(routeId, routeShapes, stopsById, alertsByStop)
+        val routeLines = generateRouteLines(route.type, routeShapes, stopsById, alertsByStop)
         val routeFeatures = routeLines.map { lineData ->
             Feature(
                 geometry = lineData.line,
@@ -100,7 +114,7 @@ public object RouteFeaturesBuilder {
             )
         }
         val featureCollection = FeatureCollection(routeFeatures)
-        return RouteSourceData(routeId, routeLines, featureCollection)
+        return RouteSourceData(route.id, routeLines, featureCollection)
     }
 
     internal fun shapesWithStopsToMapFriendly(
@@ -143,18 +157,19 @@ public object RouteFeaturesBuilder {
     }
 
     private fun generateRouteLines(
-        routeId: LineOrRoute.Id,
+        routeType: RouteType,
         routeShapes: List<SegmentedRouteShape>,
         stopsById: Map<String, Stop>,
         alertsByStop: Map<String, AlertAssociatedStop>,
     ): List<RouteLineData> {
         return routeShapes.flatMap { routePatternShape ->
-            routeShapeToLineData(routePatternShape, stopsById, alertsByStop)
+            routeShapeToLineData(routePatternShape, routeType, stopsById, alertsByStop)
         }
     }
 
     private fun routeShapeToLineData(
         routePatternShape: SegmentedRouteShape,
+        routeType: RouteType,
         stopsById: Map<String, Stop>?,
         alertsByStop: Map<String, AlertAssociatedStop>?,
     ): List<RouteLineData> {
@@ -168,9 +183,10 @@ public object RouteFeaturesBuilder {
             }
         return alertAwareSegments.mapNotNull { segment ->
             routeSegmentToRouteLineData(
-                segment = segment,
-                fullLineString = fullLineString,
-                stopsById = stopsById,
+                segment,
+                fullLineString,
+                routeType,
+                stopsById,
             )
         }
     }
@@ -178,17 +194,23 @@ public object RouteFeaturesBuilder {
     private fun routeSegmentToRouteLineData(
         segment: AlertAwareRouteSegment,
         fullLineString: LineString,
+        routeType: RouteType,
         stopsById: Map<String, Stop>?,
     ): RouteLineData? {
         val firstStopId = segment.stopIds.firstOrNull() ?: return null
         val firstStop = stopsById?.get(firstStopId) ?: return null
         val lastStopId = segment.stopIds.lastOrNull() ?: return null
         val lastStop = stopsById.get(lastStopId) ?: return null
-        // Loop routes can begin and end at the same stop, but slicing by identical positions
-        // produces an empty line, so if there's a loop, always draw the full shape
         val lineSegment =
-            if (firstStopId == lastStopId) fullLineString
-            else fullLineString.slice(start = firstStop.position, stop = lastStop.position)
+            when {
+                routeType.isSubway() || routeType == RouteType.COMMUTER_RAIL ->
+                    fullLineString.slice(start = firstStop.position, stop = lastStop.position)
+                // For bus and ferry, we want to draw the full shape at the ends of the route
+                segment.isFirst && segment.isLast -> fullLineString
+                segment.isFirst -> firstSlice(fullLineString, lastStop.position)
+                segment.isLast -> lastSlice(fullLineString, firstStop.position)
+                else -> fullLineString.slice(start = firstStop.position, stop = lastStop.position)
+            }
         return RouteLineData(
             id = segment.id,
             sourceRoutePatternId = segment.sourceRoutePatternId,
@@ -197,6 +219,18 @@ public object RouteFeaturesBuilder {
             alertState = segment.alertState,
         )
     }
+
+    private fun lengthAtPosition(lineString: LineString, position: Position): Length =
+        lineString.nearestPointTo(position).properties.location
+
+    private fun firstSlice(lineString: LineString, stopPosition: Position): LineString =
+        lineString.slice(start = Length.Zero, stop = lengthAtPosition(lineString, stopPosition))
+
+    private fun lastSlice(lineString: LineString, startPosition: Position): LineString =
+        lineString.slice(
+            start = lengthAtPosition(lineString, startPosition),
+            stop = lineString.length(),
+        )
 
     public fun forRailAtStop(
         stopShapes: List<MapFriendlyRouteResponse.RouteWithSegmentedShapes>,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/RouteSegment.kt
@@ -49,6 +49,8 @@ public data class RouteSegment(
                 sourceRoutePatternId = sourceRoutePatternId,
                 sourceRouteId = sourceRouteId,
                 stopIds = segmentStops,
+                isFirst = index == 0,
+                isLast = index == alertingSegments.lastIndex,
                 alertState = alertState,
                 otherPatternsByStopId = otherPatternsByStopId.filter { stopIdSet.contains(it.key) },
             )
@@ -177,6 +179,8 @@ internal data class AlertAwareRouteSegment(
     override val sourceRouteId: Route.Id,
     override val stopIds: List<String>,
     override val otherPatternsByStopId: Map<String, List<RoutePatternKey>>,
+    val isFirst: Boolean = false,
+    val isLast: Boolean = false,
     val alertState: SegmentAlertState,
 ) : IRouteSegment
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/RouteFeaturesBuilderTest.kt
@@ -16,10 +16,13 @@ import com.mbta.tid.mbta_app.model.response.ShapeWithStops
 import com.mbta.tid.mbta_app.model.response.StopMapResponse
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.GreenLineTestHelper
+import com.mbta.tid.mbta_app.utils.isRoughlyEqualTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.maplibre.spatialk.geojson.LineString
+import org.maplibre.spatialk.turf.misc.nearestPointTo
 import org.maplibre.spatialk.turf.misc.slice
 
 class RouteFeaturesBuilderTest {
@@ -28,16 +31,7 @@ class RouteFeaturesBuilderTest {
         val routeSources =
             RouteFeaturesBuilder.generateRouteSources(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
-                stopsById =
-                    mapOf(
-                        MapTestDataHelper.stopAlewife.id to MapTestDataHelper.stopAlewife,
-                        MapTestDataHelper.stopDavis.id to MapTestDataHelper.stopDavis,
-                        MapTestDataHelper.stopPorter.id to MapTestDataHelper.stopPorter,
-                        MapTestDataHelper.stopHarvard.id to MapTestDataHelper.stopHarvard,
-                        MapTestDataHelper.stopCentral.id to MapTestDataHelper.stopCentral,
-                        MapTestDataHelper.stopAssembly.id to MapTestDataHelper.stopAssembly,
-                        MapTestDataHelper.stopSullivan.id to MapTestDataHelper.stopSullivan,
-                    ),
+                globalData = MapTestDataHelper.global,
                 alertsByStop = emptyMap(),
             )
 
@@ -131,14 +125,7 @@ class RouteFeaturesBuilderTest {
         val routeSources =
             RouteFeaturesBuilder.generateRouteSources(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
-                stopsById =
-                    mapOf(
-                        MapTestDataHelper.stopAlewife.id to MapTestDataHelper.stopAlewife,
-                        MapTestDataHelper.stopDavis.id to MapTestDataHelper.stopDavis,
-                        MapTestDataHelper.stopPorter.id to MapTestDataHelper.stopPorter,
-                        MapTestDataHelper.stopHarvard.id to MapTestDataHelper.stopHarvard,
-                        MapTestDataHelper.stopCentral.id to MapTestDataHelper.stopCentral,
-                    ),
+                globalData = MapTestDataHelper.global,
                 alertsByStop = alertsByStop,
             )
 
@@ -190,20 +177,19 @@ class RouteFeaturesBuilderTest {
         val loopRouteData =
             listOf(
                 MapFriendlyRouteResponse.RouteWithSegmentedShapes(
-                    routeId = MapTestDataHelper.routeRed.id,
+                    routeId = MapTestDataHelper.route67.id,
                     segmentedShapes =
                         listOf(
                             SegmentedRouteShape(
-                                sourceRoutePatternId = MapTestDataHelper.patternRed10.id,
-                                sourceRouteId = MapTestDataHelper.patternRed10.routeId,
-                                directionId = MapTestDataHelper.patternRed10.directionId,
+                                sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                sourceRouteId = MapTestDataHelper.pattern67.routeId,
+                                directionId = MapTestDataHelper.pattern67.directionId,
                                 routeSegments =
                                     listOf(
                                         RouteSegment(
                                             id = "loop-segment",
-                                            sourceRoutePatternId =
-                                                MapTestDataHelper.patternRed10.id,
-                                            sourceRouteId = MapTestDataHelper.patternRed10.routeId,
+                                            sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                            sourceRouteId = MapTestDataHelper.pattern67.routeId,
                                             stopIds =
                                                 listOf(
                                                     MapTestDataHelper.stopAlewife.id,
@@ -222,11 +208,7 @@ class RouteFeaturesBuilderTest {
         val routeSources =
             RouteFeaturesBuilder.generateRouteSources(
                 routeData = loopRouteData,
-                stopsById =
-                    mapOf(
-                        MapTestDataHelper.stopAlewife.id to MapTestDataHelper.stopAlewife,
-                        MapTestDataHelper.stopDavis.id to MapTestDataHelper.stopDavis,
-                    ),
+                globalData = MapTestDataHelper.global,
                 alertsByStop = emptyMap(),
             )
 
@@ -235,45 +217,165 @@ class RouteFeaturesBuilderTest {
     }
 
     @Test
-    fun `transforms shapes with stops`() {
-        val now = EasternTimeInstant.now()
+    fun `uses full shape for bus route`() = runBlocking {
+        val busRouteData =
+            listOf(
+                MapFriendlyRouteResponse.RouteWithSegmentedShapes(
+                    routeId = MapTestDataHelper.route67.id,
+                    segmentedShapes =
+                        listOf(
+                            SegmentedRouteShape(
+                                sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                sourceRouteId = MapTestDataHelper.pattern67.routeId,
+                                directionId = MapTestDataHelper.pattern67.directionId,
+                                routeSegments =
+                                    listOf(
+                                        RouteSegment(
+                                            id = "bus-segment",
+                                            sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                            sourceRouteId = MapTestDataHelper.pattern67.routeId,
+                                            stopIds =
+                                                listOf(
+                                                    MapTestDataHelper.stopAlewife.id,
+                                                    MapTestDataHelper.stopDavis.id,
+                                                ),
+                                            otherPatternsByStopId = emptyMap(),
+                                        )
+                                    ),
+                                shape = MapTestDataHelper.shapeRedC1,
+                            )
+                        ),
+                )
+            )
 
+        val routeSources =
+            RouteFeaturesBuilder.generateRouteSources(
+                routeData = busRouteData,
+                globalData = MapTestDataHelper.global,
+                alertsByStop = emptyMap(),
+            )
+
+        val geometry = routeSources.single().features.features.single().geometry
+        assertEquals(LineString(Polyline.decode(MapTestDataHelper.shapeRedC1.polyline!!)), geometry)
+    }
+
+    @Test
+    fun `bus alert segments preserve leading and trailing shape tails`() = runBlocking {
+        val now = EasternTimeInstant.now()
         val objects = ObjectCollectionBuilder()
 
-        val redAlert = objects.alert {
-            id = "a1"
+        val busAlert = objects.alert {
+            id = "bus-a1"
             effect = Alert.Effect.Shuttle
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board),
-                route = MapTestDataHelper.routeRed.id.idText,
-                routeType = RouteType.HEAVY_RAIL,
-                stop = MapTestDataHelper.stopAlewife.id,
+                route = MapTestDataHelper.route67.id.idText,
+                routeType = RouteType.BUS,
+                stop = MapTestDataHelper.stopPorter.id,
             )
             informedEntity(
                 listOf(Alert.InformedEntity.Activity.Board),
-                route = MapTestDataHelper.routeRed.id.idText,
-                routeType = RouteType.HEAVY_RAIL,
-                stop = MapTestDataHelper.stopDavis.id,
+                route = MapTestDataHelper.route67.id.idText,
+                routeType = RouteType.BUS,
+                stop = MapTestDataHelper.stopHarvard.id,
             )
         }
+
         val alertsByStop =
-            listOf(
-                MapTestDataHelper.stopAlewife.id to
+            mapOf(
+                MapTestDataHelper.stopPorter.id to
                     AlertAssociatedStop(
-                        stop = MapTestDataHelper.stopAlewife,
-                        relevantAlerts = listOf(redAlert),
-                        stateByRoute = mapOf(MapStopRoute.RED to StopAlertState.Shuttle),
+                        stop = MapTestDataHelper.stopPorter,
+                        relevantAlerts = listOf(busAlert),
+                        stateByRoute = mapOf(MapStopRoute.BUS to StopAlertState.Shuttle),
                         now = now,
                     ),
-                MapTestDataHelper.stopDavis.id to
+                MapTestDataHelper.stopHarvard.id to
                     AlertAssociatedStop(
-                        stop = MapTestDataHelper.stopDavis,
-                        relevantAlerts = listOf(redAlert),
-                        stateByRoute = mapOf(MapStopRoute.RED to StopAlertState.Shuttle),
+                        stop = MapTestDataHelper.stopHarvard,
+                        relevantAlerts = listOf(busAlert),
+                        stateByRoute = mapOf(MapStopRoute.BUS to StopAlertState.Shuttle),
                         now = now,
                     ),
             )
 
+        val busRouteData =
+            listOf(
+                MapFriendlyRouteResponse.RouteWithSegmentedShapes(
+                    routeId = MapTestDataHelper.route67.id,
+                    segmentedShapes =
+                        listOf(
+                            SegmentedRouteShape(
+                                sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                sourceRouteId = MapTestDataHelper.pattern67.routeId,
+                                directionId = MapTestDataHelper.pattern67.directionId,
+                                routeSegments =
+                                    listOf(
+                                        RouteSegment(
+                                            id = "bus-alert-segment",
+                                            sourceRoutePatternId = MapTestDataHelper.pattern67.id,
+                                            sourceRouteId = MapTestDataHelper.pattern67.routeId,
+                                            stopIds =
+                                                listOf(
+                                                    MapTestDataHelper.stopAlewife.id,
+                                                    MapTestDataHelper.stopDavis.id,
+                                                    MapTestDataHelper.stopPorter.id,
+                                                    MapTestDataHelper.stopHarvard.id,
+                                                    MapTestDataHelper.stopCentral.id,
+                                                ),
+                                            otherPatternsByStopId = emptyMap(),
+                                        )
+                                    ),
+                                shape = MapTestDataHelper.shapeRedC1,
+                            )
+                        ),
+                )
+            )
+
+        val routeSources =
+            RouteFeaturesBuilder.generateRouteSources(
+                routeData = busRouteData,
+                globalData = MapTestDataHelper.global,
+                alertsByStop = alertsByStop,
+            )
+
+        val busFeatures = routeSources.single().features.features
+        val fullCoordinates =
+            LineString(Polyline.decode(MapTestDataHelper.shapeRedC1.polyline!!)).coordinates
+        assertEquals(3, busFeatures.size)
+        assertEquals(
+            SegmentAlertState.Normal.name,
+            busFeatures[0].properties[RouteFeaturesBuilder.propAlertStateKey],
+        )
+        assertEquals(
+            SegmentAlertState.Shuttle.name,
+            busFeatures[1].properties[RouteFeaturesBuilder.propAlertStateKey],
+        )
+        assertEquals(
+            SegmentAlertState.Normal.name,
+            busFeatures[2].properties[RouteFeaturesBuilder.propAlertStateKey],
+        )
+
+        val firstSegmentCoordinates = (busFeatures[0].geometry as LineString).coordinates
+        val middleSegmentCoordinates = (busFeatures[1].geometry as LineString).coordinates
+        val lastSegmentCoordinates = (busFeatures[2].geometry as LineString).coordinates
+
+        val shape = LineString(Polyline.decode(MapTestDataHelper.shapeRedC1.polyline))
+        val porterPositionOnLine =
+            shape.nearestPointTo(MapTestDataHelper.stopPorter.position).geometry.coordinates
+        val harvardPositionOnLine =
+            shape.nearestPointTo(MapTestDataHelper.stopHarvard.position).geometry.coordinates
+
+        assertEquals(firstSegmentCoordinates.first(), fullCoordinates.first())
+        assertTrue(firstSegmentCoordinates.last().isRoughlyEqualTo(porterPositionOnLine))
+        assertTrue(middleSegmentCoordinates.first().isRoughlyEqualTo(porterPositionOnLine))
+        assertTrue(middleSegmentCoordinates.last().isRoughlyEqualTo(harvardPositionOnLine))
+        assertTrue(lastSegmentCoordinates.first().isRoughlyEqualTo(harvardPositionOnLine))
+        assertEquals(lastSegmentCoordinates.last(), fullCoordinates.last())
+    }
+
+    @Test
+    fun `transforms shapes with stops`() {
         val shapeWithStops =
             ShapeWithStops(
                 directionId = MapTestDataHelper.patternRed10.directionId,

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/map/StopFeaturesBuilderTest.kt
@@ -4,6 +4,7 @@ import com.mbta.tid.mbta_app.model.MapStop
 import com.mbta.tid.mbta_app.model.MapStopRoute
 import com.mbta.tid.mbta_app.model.StopAlertState
 import com.mbta.tid.mbta_app.utils.TestData
+import io.ktor.client.request.invoke
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -108,7 +109,7 @@ class StopFeaturesBuilderTest {
         val routeLines =
             RouteFeaturesBuilder.generateRouteSources(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
-                stopsById = stops.mapValues { it.value.stop },
+                globalData = MapTestDataHelper.global,
                 alertsByStop = emptyMap(),
             )
         val collection =
@@ -203,7 +204,7 @@ class StopFeaturesBuilderTest {
         val routeLines =
             RouteFeaturesBuilder.generateRouteSources(
                 routeData = MapTestDataHelper.routeResponse.routesWithSegmentedShapes,
-                stopsById = stops.mapValues { it.value.stop },
+                globalData = MapTestDataHelper.global,
                 alertsByStop = emptyMap(),
             )
         val collection =

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/RouteSegmentTest.kt
@@ -438,6 +438,7 @@ class RouteSegmentTest {
                     sourceRoutePatternId = routeSegment.sourceRoutePatternId,
                     sourceRouteId = routeSegment.sourceRouteId,
                     stopIds = listOf("alewife", "davis"),
+                    isFirst = true,
                     otherPatternsByStopId =
                         mapOf(
                             "alewife" to
@@ -463,6 +464,7 @@ class RouteSegmentTest {
                     sourceRoutePatternId = routeSegment.sourceRoutePatternId,
                     sourceRouteId = routeSegment.sourceRouteId,
                     stopIds = listOf("porter", "harvard", "central"),
+                    isLast = true,
                     otherPatternsByStopId = mapOf(),
                     alertState = SegmentAlertState.Normal,
                 ),
@@ -508,6 +510,8 @@ class RouteSegmentTest {
                     sourceRoutePatternId = routeSegment.sourceRoutePatternId,
                     sourceRouteId = routeSegment.sourceRouteId,
                     stopIds = listOf("alewife", "davis", "porter"),
+                    isFirst = true,
+                    isLast = true,
                     otherPatternsByStopId =
                         mapOf(
                             "alewife" to
@@ -555,6 +559,8 @@ class RouteSegmentTest {
                     sourceRoutePatternId = routeSegment.sourceRoutePatternId,
                     sourceRouteId = routeSegment.sourceRouteId,
                     stopIds = listOf("alewife", "davis", "porter"),
+                    isFirst = true,
+                    isLast = true,
                     otherPatternsByStopId =
                         mapOf(
                             "alewife" to


### PR DESCRIPTION
### Summary

_Ticket:_ [Bus route shape cut off at last station](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1210503750238566?focus=true), [Some ferry route shapes don't appear on the map](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1216540341278354?focus=true)

Follow up to #1919, I realized after picking up the bus shape changes that this would not work properly with partial service disruptions. These changes make the shapes work properly with ferry and bus, rail still behaves the same, trimming shapes at the terminals. 

<img width="231" height="500" alt="Screenshot_20260811_191734" src="https://github.com/user-attachments/assets/38ecbf8f-889f-433c-9f3e-35ac0168b20f" />
<img width="231" height="500" alt="Screenshot_20260811_191813" src="https://github.com/user-attachments/assets/0b2acd6c-aedf-42d4-9961-26166d58fcf7" />


### Testing

Added unit tests for new behavior, and tested with dev alerts that bus and ferry alerts for partial suspensions show up properly, with the full shape at terminals.
