### PR TITLE
Feat: Group Android notifications by alert id + Overwrite update noti…

### DIFF
--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
@@ -1,12 +1,14 @@
 package com.mbta.tid.mbta_app.android.notification
 
 import android.Manifest
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Intent
 import android.media.AudioAttributes
 import android.media.RingtoneManager
+import android.service.notification.StatusBarNotification
 import androidx.annotation.RequiresPermission
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -48,18 +50,8 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
                 intent,
                 PendingIntent.FLAG_IMMUTABLE,
             )
-
         val channelId = getString(R.string.alerts_channel)
         val defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-        val notificationBuilder =
-            NotificationCompat.Builder(applicationContext, channelId)
-                .setSmallIcon(R.drawable.app_icon_monochrome)
-                .setContentTitle(message.notification?.title)
-                .setContentText(message.notification?.body)
-                .setAutoCancel(true)
-                .setSound(defaultSoundUri)
-                .setContentIntent(pendingIntent)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
         val notificationManager = NotificationManagerCompat.from(applicationContext)
 
@@ -76,6 +68,97 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
 
         notificationManager.createNotificationChannel(channel)
 
-        notificationManager.notify(Random.nextInt(), notificationBuilder.build())
+        val notificationBuilder =
+            NotificationCompat.Builder(applicationContext, channelId)
+                .setSmallIcon(R.drawable.app_icon_monochrome)
+                .setAutoCancel(true)
+                .setSound(defaultSoundUri)
+                .setContentIntent(pendingIntent)
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+
+        // A message having alert_id in the body means it is a data only notification to help
+        // Android notifications group together. It will update the previous notification with the
+        // same tag
+        if (message.data.containsKey("alert_id")) {
+            val alertId = message.data["alert_id"]
+            val prevNotification =
+                findPreviousNotification(notificationManager, message.data["tag"]) ?: return
+
+            updateNotification(
+                notificationManager,
+                notificationBuilder,
+                prevNotification,
+                alertId,
+                channelId,
+                message,
+            )
+        } else {
+            notificationBuilder
+                .setContentTitle(message.notification?.title)
+                .setContentText(message.notification?.body)
+            notificationManager.notify(
+                message.notification?.tag,
+                0,
+                notificationBuilder.build(),
+            )
+        }
+    }
+
+    @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
+    private fun updateNotification(
+        notificationManager: NotificationManagerCompat,
+        notificationBuilder: NotificationCompat.Builder,
+        prevNotification: StatusBarNotification,
+        alertId: String?,
+        channelId: String,
+        message: RemoteMessage,
+    ) {
+        // Try using the title and body from the previous notification, if they exist.
+        // Otherwise, use the title and body from the new message.
+        val title =
+            prevNotification.notification.extras.getString(Notification.EXTRA_TITLE)
+                ?: message.data.getOrDefault("title", null)
+        val body =
+            prevNotification.notification.extras.getString(Notification.EXTRA_TEXT)
+                ?: message.data.getOrDefault("body", null)
+        notificationBuilder
+            .setContentTitle(title)
+            .setContentText(body)
+            .setOnlyAlertOnce(true)
+            .setGroup(alertId)
+
+        notificationManager.notify(
+            prevNotification.tag,
+            prevNotification.id,
+            notificationBuilder.build(),
+        )
+
+        // A notification summary is required, using latest notification title and body.
+        val summaryNotification =
+            NotificationCompat.Builder(applicationContext, channelId)
+                .setSmallIcon(R.drawable.app_icon_monochrome)
+                .setContentTitle(title)
+                .setContentText(body)
+                .setGroup(alertId)
+                .setGroupSummary(true)
+                .build()
+
+        notificationManager.notify(
+            "summary-${alertId}",
+            prevNotification.id,
+            summaryNotification,
+        )
+    }
+
+    private fun findPreviousNotification(
+        notificationManager: NotificationManagerCompat,
+        tag: String?,
+    ): StatusBarNotification? {
+        val activeNotifications = notificationManager.activeNotifications
+        // Finding notification by filtering out all the ones that already have a group
+        // and then checking if the tag matches the one we are looking for
+        return activeNotifications.find { notification ->
+            !notification.isGroup && notification.tag != null && notification.tag == tag
+        }
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/notification/MBTAGoMessagingService.kt
@@ -77,17 +77,17 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
 
         // A message having alert_id in the body means it is a data only notification to help
-        // Android notifications group together. It will update the previous notification with the
+        // Android notifications group together. It will update the ungrouped notification with the
         // same tag
         if (message.data.containsKey("alert_id")) {
             val alertId = message.data["alert_id"]
-            val prevNotification =
-                findPreviousNotification(notificationManager, message.data["tag"]) ?: return
+            val ungroupedNotification =
+                findUngroupedNotification(notificationManager, message.data["tag"]) ?: return
 
             updateNotification(
                 notificationManager,
                 notificationBuilder,
-                prevNotification,
+                ungroupedNotification,
                 alertId,
                 channelId,
                 message,
@@ -108,7 +108,7 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
     private fun updateNotification(
         notificationManager: NotificationManagerCompat,
         notificationBuilder: NotificationCompat.Builder,
-        prevNotification: StatusBarNotification,
+        ungroupedNotification: StatusBarNotification,
         alertId: String?,
         channelId: String,
         message: RemoteMessage,
@@ -116,10 +116,10 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
         // Try using the title and body from the previous notification, if they exist.
         // Otherwise, use the title and body from the new message.
         val title =
-            prevNotification.notification.extras.getString(Notification.EXTRA_TITLE)
+            ungroupedNotification.notification.extras.getString(Notification.EXTRA_TITLE)
                 ?: message.data.getOrDefault("title", null)
         val body =
-            prevNotification.notification.extras.getString(Notification.EXTRA_TEXT)
+            ungroupedNotification.notification.extras.getString(Notification.EXTRA_TEXT)
                 ?: message.data.getOrDefault("body", null)
         notificationBuilder
             .setContentTitle(title)
@@ -128,8 +128,8 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
             .setGroup(alertId)
 
         notificationManager.notify(
-            prevNotification.tag,
-            prevNotification.id,
+            ungroupedNotification.tag,
+            ungroupedNotification.id,
             notificationBuilder.build(),
         )
 
@@ -145,12 +145,12 @@ class MBTAGoMessagingService : FirebaseMessagingService() {
 
         notificationManager.notify(
             "summary-${alertId}",
-            prevNotification.id,
+            ungroupedNotification.id,
             summaryNotification,
         )
     }
 
-    private fun findPreviousNotification(
+    private fun findUngroupedNotification(
         notificationManager: NotificationManagerCompat,
         tag: String?,
     ): StatusBarNotification? {


### PR DESCRIPTION
…fications that have the same title and body

### Summary

_Ticket:_ [All Clear | Investigate tagging notifications for grouping by OS](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217410813479642?focus=true)

Backend PR: https://github.com/mbta/mobile_app_backend/pull/698
<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Group Notifications for Android devices by alert id

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
I ran a few tests
- Create alert and received notification on the background => Update it while app on the foreground => Update it again while phone app on the background => Clear notification while app on the foreground
- Create alert and received notification on the foreground => Update it while app on the background => Update it again while phone app on the foreground => Clear notification while app on the background
<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
