### PR TITLE
feat: Enable R8

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -72,7 +72,11 @@ android {
     packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
     buildTypes {
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            optimization {
+                enable = true
+            }
             if (runLocalReleaseBuild) {
                 signingConfig = signingConfigs.getByName("debug")
             }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/nearbyTransit/MapAndSheetPageTest.kt
@@ -32,6 +32,7 @@ import com.mbta.tid.mbta_app.android.location.MockFusedLocationProviderClient
 import com.mbta.tid.mbta_app.android.location.MockLocationDataManager
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.map.IMapboxConfigManager
+import com.mbta.tid.mbta_app.android.map.ManageMapboxConfig
 import com.mbta.tid.mbta_app.android.pages.MapAndSheetPage
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
@@ -315,6 +316,7 @@ class MapAndSheetPageTest : KoinTest {
             CompositionLocalProvider(
                 LocalLocationClient provides MockFusedLocationProviderClient()
             ) {
+                ManageMapboxConfig()
                 MapAndSheetPage(
                     Modifier,
                     NearbyTransit(
@@ -442,6 +444,7 @@ class MapAndSheetPageTest : KoinTest {
             CompositionLocalProvider(
                 LocalLocationClient provides MockFusedLocationProviderClient()
             ) {
+                ManageMapboxConfig(mapboxConfigManager = mockConfigManager)
                 MapAndSheetPage(
                     Modifier,
                     NearbyTransit(
@@ -471,7 +474,7 @@ class MapAndSheetPageTest : KoinTest {
         )
 
         composeTestRule.waitUntilDefaultTimeout { mockConfigManager.loadConfigCalledCount == 1 }
-        mockConfigManager.mutableLastErrorTimestamp.value = EasternTimeInstant.now()
+        mockConfigManager.mutableLastErrorTimestamp.tryEmit(EasternTimeInstant.now())
 
         composeTestRule.waitUntilDefaultTimeout { mockConfigManager.loadConfigCalledCount == 2 }
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/ContentView.kt
@@ -31,6 +31,7 @@ import com.mbta.tid.mbta_app.android.component.sheet.rememberBottomSheetScaffold
 import com.mbta.tid.mbta_app.android.component.sheet.rememberStandardBottomSheetState
 import com.mbta.tid.mbta_app.android.location.ViewportProvider
 import com.mbta.tid.mbta_app.android.location.rememberLocationDataManager
+import com.mbta.tid.mbta_app.android.map.ManageMapboxConfig
 import com.mbta.tid.mbta_app.android.pages.MapAndSheetPage
 import com.mbta.tid.mbta_app.android.pages.MorePage
 import com.mbta.tid.mbta_app.android.pages.NearbyTransit
@@ -104,6 +105,8 @@ fun ContentView(
     val pendingOnboarding = viewModel.pendingOnboarding.collectAsState().value
     val pendingFeaturePromos = viewModel.pendingFeaturePromos.collectAsState().value
     val currentLocale = stringResource(R.string.current_locale)
+
+    ManageMapboxConfig()
 
     LaunchedEffect(fcmToken, notificationsEnabled) {
         fcmToken?.let {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/HomeMapView.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mapbox.common.MapboxOptions
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraBoundsOptions
 import com.mapbox.maps.ViewAnnotationAnchor
@@ -161,7 +162,7 @@ fun HomeMapView(
         /* Whether loading the config succeeds or not we show the Mapbox Map in case
          * the user has cached tiles on their device.
          */
-        if (!configLoadAttempted) {
+        if (!configLoadAttempted || MapboxOptions.accessToken.isBlank()) {
             Image(
                 painterResource(R.drawable.empty_map_grid),
                 null,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/ManageMapboxConfig.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/map/ManageMapboxConfig.kt
@@ -1,0 +1,15 @@
+package com.mbta.tid.mbta_app.android.map
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.compose.koinInject
+
+@Composable
+fun ManageMapboxConfig(mapboxConfigManager: IMapboxConfigManager = koinInject()) {
+    val lastErrorTimestamp by
+        mapboxConfigManager.lastMapboxErrorTimestamp.collectAsStateWithLifecycle(null)
+
+    LaunchedEffect(lastErrorTimestamp) { mapboxConfigManager.loadConfig() }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MapAndSheetPage.kt
@@ -497,11 +497,6 @@ fun MapAndSheetPage(
         onPauseOrDispose { backgroundTimestamp = clock.now().toEpochMilliseconds() }
     }
 
-    LaunchedEffect(
-        mapboxConfigManager.lastMapboxErrorTimestamp.collectAsStateWithLifecycle(null).value
-    ) {
-        mapboxConfigManager.loadConfig()
-    }
     LaunchedEffect(nearbyTransit.alertData) { mapViewModel.alertsChanged(nearbyTransit.alertData) }
 
     LaunchedEffect(sheetNavEntrypoint) {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
@@ -14,6 +14,7 @@ val SharedString.value: String
             SharedString.BetaSection -> stringResource(R.string.more_section_public_beta)
             SharedString.CommuterRailAndFerryTickets ->
                 stringResource(R.string.resources_link_mticket)
+            SharedString.Crash -> "Crash the app"
             SharedString.DebugMode -> stringResource(R.string.feature_flag_debug_mode)
             SharedString.FareInformation -> stringResource(R.string.resources_link_fare_info)
             SharedString.FavoritesByStop -> "Group favorites by stop"

--- a/androidApp/src/main/keepRules/custom-rules.keep
+++ b/androidApp/src/main/keepRules/custom-rules.keep
@@ -1,0 +1,1 @@
+-keep enum com.mbta.tid.mbta_app.** { *;}

--- a/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
+++ b/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
@@ -27,6 +27,7 @@ extension SharedString {
                 "Commuter Rail and Ferry Tickets",
                 comment: "Label for a More page link to the MBTA mTicket app"
             )
+        case .crash: "Crash the app" // dev only, no i18n
         case .debugMode:
             NSLocalizedString(
                 "Debug Mode",

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
@@ -4,6 +4,7 @@ public enum class SharedString {
     BetaEarlyAccessNote,
     BetaSection,
     CommuterRailAndFerryTickets,
+    Crash,
     DebugMode,
     FareInformation,
     FavoritesByStop,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
@@ -122,6 +122,12 @@ public class MoreViewModel(
                             label = SharedString.FavoritesByStop,
                             settings = Settings.FavoritesByStop,
                         ),
+                        MoreItem.Action(
+                            label = SharedString.Crash,
+                            action = {
+                                throw RuntimeException("Crash button pressed")
+                            },
+                        ),
                     ),
             ),
             MoreSection(


### PR DESCRIPTION
### Summary

_Ticket:_ [Set up R8 app optimization](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217431846650038?focus=true)

Enable R8 for release builds (this will be run for dev orange and staging releases as well). I'm pretty sure that the deobfuscation files will be uploaded to Sentry properly, but I'll double check on dev orange.

I needed to add one keep rule for enums, because the values were being changed and it was causing crashes, I believe the serialized onboarding enums couldn't be parsed because the obfuscated value was different.

### Testing

Verified that R8 was running during the release build process
[Confirmed in Sentry](https://mbtace.sentry.io/issues/7684941654/?project=4508416340983808&query=is%3Aunresolved&referrer=issue-stream&sort=recommended) that mapping is working and stack traces still display with the right class names