### PR TITLE
fix(StopDetailsFiltered): Refetch nextScheduleResponse when direction change

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesViewTest.kt
@@ -1,6 +1,9 @@
 package com.mbta.tid.mbta_app.android.stopDetails
 
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -853,6 +856,71 @@ class StopDetailsFilteredDeparturesViewTest {
         composeTestRule
             .onNode(hasTextMatching(Regex("^Next trip on \\w+, (Dec 8|8 Dec)$")))
             .assertCanBeDisplayed()
+    }
+
+    @Test
+    fun testLoadsNextTripAgainWhenSelectedDirectionChanges(): Unit = runBlocking {
+        val objects = ObjectCollectionBuilder()
+        val stop = objects.stop {}
+        val route = objects.route { id = "Red" }
+
+        val lineOrRoute = LineOrRoute.Route(route)
+        val leaf =
+            RouteCardData.Leaf(
+                lineOrRoute,
+                stop,
+                Direction(0, route),
+                emptyList(),
+                setOf(stop.id),
+                emptyList(),
+                emptyList(),
+                true,
+                true,
+                null,
+                emptyList(),
+                RouteCardData.Context.StopDetailsFiltered,
+            )
+
+        val now = EasternTimeInstant.now()
+        val nextSchedule = objects.schedule {
+            departureTime = EasternTimeInstant(now.local.year + 1, Month.DECEMBER, 8, 8, 0)
+        }
+
+        var loadedNextTripForDirection: Int? = null
+
+        loadKoinMocks {
+            schedules =
+                MockScheduleRepository(
+                    nextScheduleResponse = NextScheduleResponse(nextSchedule),
+                    nextScheduleCallback = { _, directionId ->
+                        loadedNextTripForDirection = directionId
+                    },
+                )
+        }
+
+        var selectedDirection by mutableStateOf(Direction(0, route))
+
+        composeTestRule.setContent {
+            StopDetailsFilteredDeparturesView(
+                stopId = stop.id,
+                stopFilter = StopDetailsFilter(route.id, 0),
+                tripFilter = null,
+                leaf = leaf,
+                selectedDirection = selectedDirection,
+                allAlerts = null,
+                now = now,
+                updateTripFilter = {},
+                tileScrollState = rememberScrollState(),
+                isFavorite = false,
+                openModal = {},
+                openSheetRoute = {},
+            )
+        }
+
+        composeTestRule.runOnIdle { selectedDirection = Direction(1, route) }
+        composeTestRule.waitUntilDefaultTimeout { loadedNextTripForDirection == 1 }
+
+        assert(loadedNextTripForDirection == 1)
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -217,7 +217,7 @@ fun StopDetailsFilteredDeparturesView(
             Box(modifier = Modifier.padding(horizontal = 10.dp).padding(bottom = 12.dp)) {
                 val schedulesRepository: ISchedulesRepository = koinInject()
                 var nextScheduleResponse: NextScheduleResponse? by remember { mutableStateOf(null) }
-                LaunchedEffect(noPredictionsStatus, stopFilter) {
+                LaunchedEffect(noPredictionsStatus, selectedDirection) {
                     nextScheduleResponse =
                         if (
                             noPredictionsStatus == UpcomingFormat.NoTripsFormat.NoSchedulesToday ||

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/stopDetails/StopDetailsFilteredDeparturesView.kt
@@ -217,7 +217,7 @@ fun StopDetailsFilteredDeparturesView(
             Box(modifier = Modifier.padding(horizontal = 10.dp).padding(bottom = 12.dp)) {
                 val schedulesRepository: ISchedulesRepository = koinInject()
                 var nextScheduleResponse: NextScheduleResponse? by remember { mutableStateOf(null) }
-                LaunchedEffect(noPredictionsStatus) {
+                LaunchedEffect(noPredictionsStatus, stopFilter) {
                     nextScheduleResponse =
                         if (
                             noPredictionsStatus == UpcomingFormat.NoTripsFormat.NoSchedulesToday ||

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -9,6 +9,11 @@
 import Shared
 import SwiftUI
 
+struct NextScheduleKeys: Equatable {
+    var stopFilter: StopDetailsFilter
+    var noPredictionStatus: UpcomingFormat.NoTripsFormat?
+}
+
 // swiftlint:disable:next type_body_length
 struct StopDetailsFilteredDepartureDetails: View {
     @ObserveInjection var inject
@@ -176,9 +181,9 @@ struct StopDetailsFilteredDepartureDetails: View {
             handleViewportForStatus(noPredictionsStatus)
             loadNextScheduleForStatus(noPredictionsStatus)
         }
-        .onChange(of: noPredictionsStatus) { status in
-            handleViewportForStatus(status)
-            loadNextScheduleForStatus(status)
+        .onChange(of: NextScheduleKeys(stopFilter: stopFilter, noPredictionStatus: noPredictionsStatus)) { keys in
+            handleViewportForStatus(keys.noPredictionStatus)
+            loadNextScheduleForStatus(keys.noPredictionStatus)
         }
         .onChange(of: selectedTripIsCancelled) { if $0 { setViewportToStop() } }
         .onChange(of: tripFilter) { tripFilter in

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -185,7 +185,6 @@ struct StopDetailsFilteredDepartureDetails: View {
             selectedDirection: selectedDirection,
             noPredictionStatus: noPredictionsStatus
         )) { keys in
-            print(selectedDirection)
             handleViewportForStatus(keys.noPredictionStatus)
             loadNextScheduleForStatus(keys.noPredictionStatus, keys.selectedDirection)
         }

--- a/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
+++ b/iosApp/iosApp/Pages/StopDetails/StopDetailsFilteredDepartureDetails.swift
@@ -10,7 +10,7 @@ import Shared
 import SwiftUI
 
 struct NextScheduleKeys: Equatable {
-    var stopFilter: StopDetailsFilter
+    var selectedDirection: Direction
     var noPredictionStatus: UpcomingFormat.NoTripsFormat?
 }
 
@@ -179,11 +179,15 @@ struct StopDetailsFilteredDepartureDetails: View {
         )
         .onAppear {
             handleViewportForStatus(noPredictionsStatus)
-            loadNextScheduleForStatus(noPredictionsStatus)
+            loadNextScheduleForStatus(noPredictionsStatus, selectedDirection)
         }
-        .onChange(of: NextScheduleKeys(stopFilter: stopFilter, noPredictionStatus: noPredictionsStatus)) { keys in
+        .onChange(of: NextScheduleKeys(
+            selectedDirection: selectedDirection,
+            noPredictionStatus: noPredictionsStatus
+        )) { keys in
+            print(selectedDirection)
             handleViewportForStatus(keys.noPredictionStatus)
-            loadNextScheduleForStatus(keys.noPredictionStatus)
+            loadNextScheduleForStatus(keys.noPredictionStatus, keys.selectedDirection)
         }
         .onChange(of: selectedTripIsCancelled) { if $0 { setViewportToStop() } }
         .onChange(of: tripFilter) { tripFilter in
@@ -203,7 +207,7 @@ struct StopDetailsFilteredDepartureDetails: View {
         }
     }
 
-    func loadNextScheduleForStatus(_ status: UpcomingFormat.NoTripsFormat?) {
+    func loadNextScheduleForStatus(_ status: UpcomingFormat.NoTripsFormat?, _ selectedDirection: Direction) {
         Task {
             switch onEnum(of: status) {
             case .serviceEndedToday, .noSchedulesToday:

--- a/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
+++ b/iosApp/iosAppTests/Pages/StopDetails/StopDetailsFilteredDepartureDetailsTests.swift
@@ -821,6 +821,65 @@ final class StopDetailsFilteredDepartureDetailsTests: XCTestCase {
         wait(for: [exp], timeout: 2)
     }
 
+    @MainActor func testLoadsNextTripAgainWhenSelectedDirectionChanges() {
+        let objects = ObjectCollectionBuilder()
+        let stop = objects.stop { _ in }
+        let route = objects.route { route in route.id = "Red" }
+
+        let now = EasternTimeInstant.now()
+        let nextSchedule = objects.schedule { schedule in
+            schedule.departureTime = .init(
+                year: now.local.year + 1,
+                month: .december,
+                day: 8,
+                hour: 8,
+                minute: 0,
+                second: 0
+            )
+        }
+
+        let reloadExp = expectation(description: "Loads next schedule for initial and updated directions")
+        reloadExp.expectedFulfillmentCount = 2
+        var requestedDirections: [Int] = []
+        let directionReloadRepo = MockScheduleRepository(
+            nextScheduleResponse: .init(nextSchedule: nextSchedule),
+            nextScheduleCallback: { _, directionId in
+                requestedDirections.append(Int(directionId))
+                reloadExp.fulfill()
+            }
+        )
+
+        let leaf = makeLeaf(route: route, stop: stop, upcomingTrips: [], objects: objects)
+
+        let sut = StopDetailsFilteredDepartureDetails(
+            stopId: stop.id,
+            stopFilter: .init(routeId: route.id, directionId: 0),
+            tripFilter: nil,
+            setStopFilter: { _ in },
+            setTripFilter: { _ in },
+            leaf: leaf,
+            selectedDirection: .init(name: nil, destination: nil, id: 0),
+            favorite: false,
+            now: now,
+            errorBannerVM: MockErrorBannerViewModel(),
+            mapVM: MockMapViewModel(),
+            stopDetailsVM: MockStopDetailsViewModel(),
+            schedulesRepository: directionReloadRepo,
+            navManager: .init(),
+        )
+
+        let directionChangeExp = sut.inspection.inspect(after: 0.5) { view in
+            try view.find(ViewType.VStack.self).callOnChange(newValue: NextScheduleKeys(
+                selectedDirection: .init(name: nil, destination: nil, id: 1),
+                noPredictionStatus: UpcomingFormat.NoTripsFormatNoSchedulesToday()
+            ))
+        }
+
+        ViewHosting.host(view: sut.environmentObject(ViewportProvider()).withFixedSettings([:]))
+        wait(for: [directionChangeExp, reloadExp], timeout: 2)
+        XCTAssertEqual(requestedDirections, [0, 1])
+    }
+
     func testHidesEarlyMorningCardWhenPredictionExists() {
         let now = EasternTimeInstant(year: 2025, month: .november, day: 17, hour: 3, minute: 30, second: 0)
         let subwayStartTime = EasternTimeInstant(year: 2025, month: .november, day: 17, hour: 9, minute: 44, second: 0)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SchedulesRepository.kt
@@ -155,6 +155,7 @@ public class MockScheduleRepository(
     private val response: ApiResult<ScheduleResponse>,
     private val nextResponse: ApiResult<NextScheduleResponse>,
     private val callback: (stopIds: Set<String>) -> Unit = {},
+    private val nextScheduleCallback: (stopId: String, directionId: Int) -> Unit = { _, _ -> },
 ) : ISchedulesRepository {
 
     @DefaultArgumentInterop.Enabled
@@ -162,7 +163,13 @@ public class MockScheduleRepository(
         scheduleResponse: ScheduleResponse = ScheduleResponse(listOf(), mapOf()),
         nextScheduleResponse: NextScheduleResponse = NextScheduleResponse(null),
         callback: (stopIds: Set<String>) -> Unit = {},
-    ) : this(ApiResult.Ok(scheduleResponse), ApiResult.Ok(nextScheduleResponse), callback)
+        nextScheduleCallback: (stopId: String, directionId: Int) -> Unit = { _, _ -> },
+    ) : this(
+        ApiResult.Ok(scheduleResponse),
+        ApiResult.Ok(nextScheduleResponse),
+        callback,
+        nextScheduleCallback,
+    )
 
     public constructor() :
         this(
@@ -189,6 +196,7 @@ public class MockScheduleRepository(
         directionId: Int,
         now: EasternTimeInstant,
     ): ApiResult<NextScheduleResponse> {
+        nextScheduleCallback(stopId, directionId)
         return nextResponse
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/StopDetailsViewModelTest.kt
@@ -82,7 +82,10 @@ class StopDetailsViewModelTest : KoinTest {
     fun testLoadsSchedules() = runTest {
         var schedulesLoaded = false
         val scheduleRepo =
-            MockScheduleRepository(ScheduleResponse(objects)) { _ -> schedulesLoaded = true }
+            MockScheduleRepository(
+                ScheduleResponse(objects),
+                callback = { _ -> schedulesLoaded = true },
+            )
 
         val dispatcher = StandardTestDispatcher(testScheduler)
         setUpKoin(objects, dispatcher) { schedules = scheduleRepo }


### PR DESCRIPTION
### Summary

_Ticket:_ ["Next trip at" shows time for wrong direction](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217410813479634?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
The issue was we were only refetching the next schule when the `noPredictionStatus` changed, but `noPredictionStatus` is often the same between directions. Now, we also refetch when the selected direction changes.

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests
* Ran locally 

https://github.com/user-attachments/assets/9cebc9d3-be45-472b-933a-0f08ce81c521


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
