### PR TITLE
feat: Filter and tag noisy Sentry errors

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app
 
 import io.sentry.kotlin.multiplatform.Sentry
+import io.sentry.kotlin.multiplatform.SentryEvent
 import io.sentry.kotlin.multiplatform.SentryOptions
 
 public fun initializeSentry(dsn: String, environment: String) {
@@ -8,6 +9,14 @@ public fun initializeSentry(dsn: String, environment: String) {
         it.dsn = dsn
         it.environment = environment
         it.beforeBreadcrumb = { breadcrumb -> breadcrumb }
+        it.beforeSend = { event -> if (shouldSkipEvent(event)) null else event }
     }
     Sentry.init(configuration)
+}
+
+private fun shouldSkipEvent(event: SentryEvent): Boolean {
+    val osContext = event.contexts["os"] as? Map<*, *>
+    val kernelVersion = osContext?.get("kernel_version") as? String
+    val isGoogleCI = kernelVersion?.contains("android-build") ?: false
+    return isGoogleCI
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Reduce Sentry noise](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217331237724271?focus=true)

This filters out any exceptions that are only happening within Google Android CI by checking if the kernel version has "android-build" in the name, which is only true for their specific runners. This should cut down on a certain class of Android errors, including the majority of 504s.

There were two other error types called out in the ticket, the first was ANRs. I didn't make any code changes to deal with these, but went through and determined that they all seem to be coming from very low spec or very old phones, and I don't think there's much that we're able to do about them. I tried updating the [fingerprint rules](https://mbtace.sentry.io/settings/projects/mobile_app_android/issue-grouping/) for the android project to better group them into the same issue (I split them up into foreground and background ANRs, we can group those too if we decide this distinction isn't useful).

The other was `EXC_BAD_ACCESS` and `SIGABRT` errors on iOS. A significant portion of these seemed to be coming from either internal mapbox code, or internal Phoenix channel code. I added fingerprinting rules for these two, but I couldn't find any throughline to tie the other events together. Most are one offs that never happen again. We could try grouping them, but that might cause us to miss real issues that are surfaced as one of those exceptions.

### Testing

I'm not totally certain this will work without deploying to prod and seeing what happens.