### PR TITLE
fix: Move Sentry beforeSend check to platform code

### DIFF
--- a/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.android.kt
+++ b/shared/src/androidMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.android.kt
@@ -1,0 +1,16 @@
+package com.mbta.tid.mbta_app.utils
+
+import io.sentry.kotlin.multiplatform.SentryEvent
+import io.sentry.protocol.OperatingSystem
+
+// In shared code we can't access Sentry SDK classes outside of io.sentry.kotlin.multiplatform, so
+// in order to cast to the OperatingSystem class we need to implement this in platform-specific code
+internal class AndroidSentryBeforeSend : SentryBeforeSend {
+    override fun processEvent(event: SentryEvent): SentryEvent? {
+        val osContext = event.contexts["os"] as? OperatingSystem
+        val isGoogleCI = osContext?.kernelVersion?.contains("android-build") ?: false
+        return if (isGoogleCI) null else event
+    }
+}
+
+internal actual fun getSentryBeforeSend(): SentryBeforeSend = AndroidSentryBeforeSend()

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/AppSetup.kt
@@ -1,22 +1,16 @@
 package com.mbta.tid.mbta_app
 
+import com.mbta.tid.mbta_app.utils.getSentryBeforeSend
 import io.sentry.kotlin.multiplatform.Sentry
-import io.sentry.kotlin.multiplatform.SentryEvent
 import io.sentry.kotlin.multiplatform.SentryOptions
 
 public fun initializeSentry(dsn: String, environment: String) {
+    val beforeSend = getSentryBeforeSend()
     val configuration: (SentryOptions) -> Unit = {
         it.dsn = dsn
         it.environment = environment
         it.beforeBreadcrumb = { breadcrumb -> breadcrumb }
-        it.beforeSend = { event -> if (shouldSkipEvent(event)) null else event }
+        it.beforeSend = beforeSend::processEvent
     }
     Sentry.init(configuration)
-}
-
-private fun shouldSkipEvent(event: SentryEvent): Boolean {
-    val osContext = event.contexts["os"] as? Map<*, *>
-    val kernelVersion = osContext?.get("kernel_version") as? String
-    val isGoogleCI = kernelVersion?.contains("android-build") ?: false
-    return isGoogleCI
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.utils
+
+import io.sentry.kotlin.multiplatform.SentryEvent
+
+internal interface SentryBeforeSend {
+    fun processEvent(event: SentryEvent): SentryEvent?
+}
+
+internal expect fun getSentryBeforeSend(): SentryBeforeSend

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.ios.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.ios.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.utils
+
+import io.sentry.kotlin.multiplatform.SentryEvent
+
+internal class IOSSentryBeforeSend : SentryBeforeSend {
+    override fun processEvent(event: SentryEvent): SentryEvent? = event
+}
+
+internal actual fun getSentryBeforeSend(): SentryBeforeSend = IOSSentryBeforeSend()

--- a/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.jvm.kt
+++ b/shared/src/jvmMain/kotlin/com/mbta/tid/mbta_app/utils/SentryBeforeSend.jvm.kt
@@ -1,0 +1,9 @@
+package com.mbta.tid.mbta_app.utils
+
+import io.sentry.kotlin.multiplatform.SentryEvent
+
+internal class JVMSentryBeforeSend : SentryBeforeSend {
+    override fun processEvent(event: SentryEvent): SentryEvent? = event
+}
+
+internal actual fun getSentryBeforeSend(): SentryBeforeSend = JVMSentryBeforeSend()


### PR DESCRIPTION


### Summary

_Ticket:_ [Reduce Sentry noise](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217331237724271?focus=true)

Follow up to #1947 

The docs are really vague and apparently you can't just cast the OS context as a map, it's a specific type of object, but we have no access to that object unless we're on Android. In shared code we can't use any libraries outside of `io.sentry.kotlin.multiplatform`, so I needed to move the check into the platform specific code so that the OS context can be cast into the right type.

This works out since the check is platform specific for Android, if we want shared checks for both platforms in the future, we can just implement something directly on `SentryBeforeSend`.

### Testing

Ran locally with Sentry enabled and printed values to verify that the kernel version was populated
