### PR TITLE
feat(android): Notification window preset UX

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
@@ -6,11 +6,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
@@ -21,18 +25,26 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionStatus
+import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.android.testUtils.hasTextMatching
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilDefaultTimeout
+import com.mbta.tid.mbta_app.android.testUtils.waitUntilExactlyOneExistsDefaultTimeout
 import com.mbta.tid.mbta_app.android.util.ConstantPermissionState
 import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
+import com.mbta.tid.mbta_app.repositories.Settings
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.test.assertEquals
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import org.junit.Rule
 import org.junit.Test
+import org.koin.test.KoinTest
 
-@OptIn(ExperimentalPermissionsApi::class)
-class NotificationSettingsWidgetTest {
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalTestApi::class)
+class NotificationSettingsWidgetTest : KoinTest {
     @get:Rule val composeTestRule = createComposeRule()
 
     private val permissionGranted =
@@ -43,6 +55,13 @@ class NotificationSettingsWidgetTest {
 
     @Test
     fun testAddTimePeriod() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(
+                    settings = mapOf(Settings.NotificationPresetWindows to false)
+                )
+        }
+
         lateinit var settings: MutableState<FavoriteSettings.Notifications>
         composeTestRule.setContent {
             settings = remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
@@ -56,10 +75,10 @@ class NotificationSettingsWidgetTest {
         }
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
-        assertEquals(1, settings.value.windows.size)
-        composeTestRule
-            .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
-            .assertExists()
+        composeTestRule.waitUntilDefaultTimeout { 1 == settings.value.windows.size }
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            (hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
+        )
         composeTestRule
             .onNode(hasTextMatching(Regex("9:00\\sAM", RegexOption.IGNORE_CASE)))
             .assertExists()
@@ -73,9 +92,9 @@ class NotificationSettingsWidgetTest {
         composeTestRule.onNodeWithContentDescription("Delete").assertDoesNotExist()
         composeTestRule.onNodeWithText("Add another time period").performClick()
         assertEquals(2, settings.value.windows.size)
-        composeTestRule
-            .onNode(hasTextMatching(Regex("12:00\\sPM", RegexOption.IGNORE_CASE)))
-            .assertExists()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            (hasTextMatching(Regex("12:00\\sPM", RegexOption.IGNORE_CASE)))
+        )
         composeTestRule
             .onNode(hasTextMatching(Regex("1:00\\sPM", RegexOption.IGNORE_CASE)))
             .assertExists()
@@ -91,6 +110,13 @@ class NotificationSettingsWidgetTest {
 
     @Test
     fun testChangeTime() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(
+                    settings = mapOf(Settings.NotificationPresetWindows to false)
+                )
+        }
+
         lateinit var settings: MutableState<FavoriteSettings.Notifications>
         composeTestRule.setContent {
             settings = remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
@@ -104,6 +130,12 @@ class NotificationSettingsWidgetTest {
         }
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            hasText("Get disruption notifications").and(isEnabled())
+        )
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE))
+        )
         composeTestRule
             .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
             .performClick()
@@ -151,6 +183,12 @@ class NotificationSettingsWidgetTest {
 
     @Test
     fun testValidatesTime() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(
+                    settings = mapOf(Settings.NotificationPresetWindows to false)
+                )
+        }
         lateinit var settings: MutableState<FavoriteSettings.Notifications>
         composeTestRule.setContent {
             settings = remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
@@ -164,6 +202,12 @@ class NotificationSettingsWidgetTest {
         }
 
         composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            hasText("Get disruption notifications").and(isEnabled())
+        )
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(
+            hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE))
+        )
         composeTestRule
             .onNode(hasTextMatching(Regex("8:00\\sAM", RegexOption.IGNORE_CASE)))
             .performClick()
@@ -205,5 +249,140 @@ class NotificationSettingsWidgetTest {
         hasRequestedPermission.value = true
 
         composeTestRule.onNodeWithText("Allow Notifications in Settings").assertCanBeDisplayed()
+    }
+
+    @Test
+    fun testPresetButtonsAreNotVisibleWhenFeatureFlagDisabled() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(
+                    settings = mapOf(Settings.NotificationPresetWindows to false)
+                )
+        }
+        composeTestRule.setContent {
+            var settings by remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            NotificationSettingsWidget(
+                settings,
+                setSettings = { settings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+
+        composeTestRule.onNodeWithText("Morning").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Midday").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Evening").assertDoesNotExist()
+        composeTestRule.onNodeWithText("All day").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Custom").assertDoesNotExist()
+    }
+
+    @Test
+    fun testPresetButtonsAreVisibleWhenFeatureFlagEnabled() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(settings = mapOf(Settings.NotificationPresetWindows to true))
+        }
+        composeTestRule.setContent {
+            var settings by remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            NotificationSettingsWidget(
+                settings,
+                setSettings = { settings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Midday"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Evening"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("All day"))
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Custom"))
+    }
+
+    @Test
+    fun testEditingPresetTimeSelectsCustom() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(settings = mapOf(Settings.NotificationPresetWindows to true))
+        }
+        composeTestRule.setContent {
+            var settings by remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            NotificationSettingsWidget(
+                settings,
+                setSettings = { settings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
+        composeTestRule.onNodeWithText("Morning").performClick()
+        composeTestRule.onNodeWithText("Morning").assertIsSelected()
+
+        composeTestRule
+            .onNode(hasTextMatching(Regex("6:00\\sAM", RegexOption.IGNORE_CASE)))
+            .performClick()
+        composeTestRule.onNodeWithContentDescription("7 o'clock").performClick()
+        composeTestRule.onNodeWithContentDescription("Select minutes").performClick()
+        composeTestRule.onNodeWithContentDescription("15 minutes").performClick()
+        composeTestRule.onNodeWithText("Okay").performClick()
+
+        composeTestRule.onNodeWithText("Custom").assertIsSelected()
+    }
+
+    @Test
+    fun testAddingWindowSelectsCustom() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(settings = mapOf(Settings.NotificationPresetWindows to true))
+        }
+        composeTestRule.setContent {
+            var settings by remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            NotificationSettingsWidget(
+                settings,
+                setSettings = { settings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
+        composeTestRule.onNodeWithText("Midday").performClick()
+        composeTestRule.onNodeWithText("Midday").assertIsSelected()
+
+        composeTestRule.onNodeWithText("Add another time period").performClick()
+
+        composeTestRule.onNodeWithText("Custom").assertIsSelected()
+    }
+
+    @Test
+    fun testSelectsPresetMatchingCurrentTime() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(settings = mapOf(Settings.NotificationPresetWindows to true))
+        }
+        lateinit var settings: MutableState<FavoriteSettings.Notifications>
+        composeTestRule.setContent {
+            settings = remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            var notificationSettings by settings
+            NotificationSettingsWidget(
+                notificationSettings,
+                setSettings = { notificationSettings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+                now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 12, 30, 0)),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
+        composeTestRule.onNodeWithText("Midday").assertIsSelected()
     }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelectorTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelectorTest.kt
@@ -1,0 +1,138 @@
+package com.mbta.tid.mbta_app.android.favorites
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
+import com.mbta.tid.mbta_app.model.PresetSelection
+import com.mbta.tid.mbta_app.model.PresetWindow
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.assertEquals
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import org.junit.Rule
+import org.junit.Test
+
+class PresetWindowSelectorTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun testPresetWindowsVisible() {
+        var selectedWindow: Window? = null
+        composeTestRule.setContent {
+            PresetWindowSelector(
+                presetRows =
+                    listOf(
+                        listOf(PresetWindow(window = Window.morningDefault, label = "Morning")),
+                        listOf(PresetWindow(window = Window.middayDefault, label = "Midday")),
+                    ),
+                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
+                presetsEnabled = true,
+                onSelect = { window -> selectedWindow = window },
+            )
+        }
+
+        composeTestRule.onNodeWithText("Morning").assertIsNotSelected()
+        composeTestRule.onNodeWithText("Midday").assertIsSelected()
+        composeTestRule.onNodeWithText("Custom").assertIsNotSelected()
+
+        composeTestRule.onNodeWithText("Morning").performClick()
+        assertEquals(Window.morningDefault, selectedWindow)
+    }
+
+    @Test
+    fun testPresetButtonsDisabled() {
+        composeTestRule.setContent {
+            PresetWindowSelector(
+                presetRows =
+                    listOf(
+                        listOf(PresetWindow(window = Window.morningDefault, label = "Morning")),
+                        listOf(PresetWindow(window = Window.middayDefault, label = "Midday")),
+                    ),
+                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
+                presetsEnabled = false,
+                onSelect = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Morning").assertIsNotEnabled()
+        composeTestRule.onNodeWithText("Midday").assertIsNotEnabled()
+        composeTestRule.onNodeWithText("Custom").assertIsEnabled()
+    }
+
+    @Test
+    fun testCustomDefaultsToNow() {
+        var selectedWindow: Window? = null
+        composeTestRule.setContent {
+            PresetWindowSelector(
+                presetRows =
+                    listOf(
+                        listOf(PresetWindow(window = Window.morningDefault, label = "Morning")),
+                        listOf(PresetWindow(window = Window.middayDefault, label = "Midday")),
+                    ),
+                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
+                presetsEnabled = true,
+                onSelect = { window -> selectedWindow = window },
+                now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 4, 30, 0)),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Custom").performClick()
+        assertEquals(
+            selectedWindow,
+            Window(
+                startTime = LocalTime(4, 0, 0),
+                endTime = LocalTime(5, 0, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+        )
+    }
+
+    @Test
+    fun testCustomDefaultsToNowLateNight() {
+        var selectedWindow: Window? = null
+        composeTestRule.setContent {
+            PresetWindowSelector(
+                presetRows =
+                    listOf(
+                        listOf(PresetWindow(window = Window.morningDefault, label = "Morning")),
+                        listOf(PresetWindow(window = Window.middayDefault, label = "Midday")),
+                    ),
+                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
+                presetsEnabled = true,
+                onSelect = { window -> selectedWindow = window },
+                now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 23, 30, 0)),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Custom").performClick()
+        assertEquals(
+            selectedWindow,
+            Window(
+                startTime = LocalTime(23, 0, 0),
+                endTime = LocalTime(23, 59, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+        )
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -100,6 +100,7 @@ fun NotificationSettingsWidget(
     setSettings: (FavoriteSettings.Notifications) -> Unit,
     notificationPermissionState: PermissionState,
     hasRequestedPermission: Boolean,
+    now: EasternTimeInstant = EasternTimeInstant.now(),
 ) {
     val permissionStatus = notificationPermissionState.status
     val permissionDenied = !permissionStatus.isGranted
@@ -150,6 +151,7 @@ fun NotificationSettingsWidget(
                 notificationPermissionState = notificationPermissionState,
                 enabled = !showPermissionSettingsLink,
                 presetWindowsEnabled = presetWindowsEnabled,
+                now = now,
             )
             AnimatedVisibility(showPermissionSettingsLink) { PermissionSettingsLink() }
         }
@@ -169,7 +171,7 @@ fun NotificationSettingsWidget(
 
                 for (window in
                     settings.windows.ifEmpty {
-                        setOf(defaultWindow(emptyList(), presetWindowsEnabled))
+                        setOf(defaultWindow(emptyList(), presetWindowsEnabled, now))
                     }) {
                     WindowWidget(
                         window,
@@ -189,9 +191,9 @@ fun NotificationSettingsWidget(
 
                 val customWindow =
                     if (presetWindowsEnabled) {
-                        Window.customFromCurrentTime(EasternTimeInstant.now())
+                        Window.customFromCurrentTime(now)
                     } else {
-                        Window.customFromCurrentTime(EasternTimeInstant.now())
+                        defaultWindow(settings.windows, presetWindowsEnabled, now)
                     }
                 Surface(
                     onClick = {
@@ -230,9 +232,10 @@ fun NotificationSettingsWidget(
 private fun defaultWindow(
     existingWindows: List<Window> = emptyList(),
     presetsEnabled: Boolean,
+    now: EasternTimeInstant,
 ): Window {
     if (presetsEnabled) {
-        return Window.customFromCurrentTime(EasternTimeInstant.now())
+        return Window.defaultFromCurrentTime(now)
     } else {
         if (existingWindows.isEmpty()) {
             return Window(
@@ -291,7 +294,7 @@ private fun WindowWidget(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TimeInput(
-                    stringResource(R.string.from),
+                    stringResource(R.string.select_start_time),
                     window.startTime,
                     setTime = {
                         setWindow(
@@ -502,6 +505,7 @@ private fun NotificationSwitch(
     notificationPermissionState: PermissionState,
     enabled: Boolean,
     presetWindowsEnabled: Boolean,
+    now: EasternTimeInstant = EasternTimeInstant.now(),
 ) {
 
     LabeledSwitch(
@@ -534,7 +538,7 @@ private fun NotificationSwitch(
                     enabled = it,
                     windows =
                         settings.windows.ifEmpty {
-                            listOf(defaultWindow(emptyList(), presetWindowsEnabled))
+                            listOf(defaultWindow(emptyList(), presetWindowsEnabled, now))
                         },
                 )
             )
@@ -599,7 +603,7 @@ private fun NotificationSettingsWidgetPreview() {
         mutableStateOf(
             FavoriteSettings.Notifications(
                 enabled = true,
-                windows = listOf(defaultWindow(emptyList(), true)),
+                windows = listOf(defaultWindow(emptyList(), true, EasternTimeInstant.now())),
             )
         )
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -1,7 +1,6 @@
 package com.mbta.tid.mbta_app.android.favorites
 
 import android.Manifest
-import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
@@ -23,7 +22,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialogDefaults
@@ -83,11 +81,17 @@ import com.mbta.tid.mbta_app.android.util.formattedTime
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.FavoriteSettings
 import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
+import com.mbta.tid.mbta_app.model.PresetSelection
+import com.mbta.tid.mbta_app.model.PresetWindow
+import com.mbta.tid.mbta_app.repositories.MockSettingsRepository
 import com.mbta.tid.mbta_app.repositories.Settings as UserSettings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalTime
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatformTools
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalPermissionsApi::class)
 @Composable
@@ -112,31 +116,16 @@ fun NotificationSettingsWidget(
 
     val presetOptions =
         listOf(
-            listOf(morningPreset(context), middayPreset(context), eveningPreset(context)),
-            listOf(allDayPreset(context)),
+            listOf(
+                PresetWindow.morningPreset(stringResource(R.string.morning)),
+                PresetWindow.middayPreset(stringResource(R.string.midday)),
+                PresetWindow.eveningPreset(stringResource(R.string.evening)),
+            ),
+            listOf(PresetWindow.allDayPreset(stringResource(R.string.all_day))),
         )
-    val selectedPreset =
+    val presetSelection: PresetSelection =
         remember(settings) {
-            when {
-                settings.windows.isEmpty() -> PresetSelection.Preset(1, 0)
-                settings.windows.size == 1 -> {
-                    val targetWindow: Window = settings.windows[0]
-                    presetOptions
-                        .asSequence()
-                        .mapIndexedNotNull { rowIndex, presets ->
-                            val presetMatchIndex = presets.indexOfFirst {
-                                it.window == targetWindow
-                            }
-                            if (presetMatchIndex != -1) {
-                                PresetSelection.Preset(rowIndex, presetMatchIndex)
-                            } else {
-                                null
-                            }
-                        }
-                        .firstOrNull() ?: PresetSelection.Custom
-                }
-                else -> PresetSelection.Custom
-            }
+            PresetSelection.selectedPresetFromSettings(settings, presetOptions)
         }
 
     val presetWindowsEnabled = SettingsCache.get(UserSettings.NotificationPresetWindows)
@@ -160,24 +149,16 @@ fun NotificationSettingsWidget(
                 setSettings = setSettings,
                 notificationPermissionState = notificationPermissionState,
                 enabled = !showPermissionSettingsLink,
+                presetWindowsEnabled = presetWindowsEnabled,
             )
             AnimatedVisibility(showPermissionSettingsLink) { PermissionSettingsLink() }
         }
         AnimatedVisibility(settings.enabled && !permissionDenied) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 if (presetWindowsEnabled) {
-
-                    PresetWindowWidget(
-                        presetRows =
-                            listOf(
-                                listOf(
-                                    morningPreset(context),
-                                    middayPreset(context),
-                                    eveningPreset(context),
-                                ),
-                                listOf(allDayPreset(context)),
-                            ),
-                        selectedPreset = selectedPreset,
+                    PresetWindowSelector(
+                        presetRows = presetOptions,
+                        selectedPreset = presetSelection,
                         presetsEnabled = settings.windows.size <= 1,
                         onSelect = { window ->
                             val otherWindows = settings.windows.drop(1)
@@ -185,7 +166,11 @@ fun NotificationSettingsWidget(
                         },
                     )
                 }
-                for (window in settings.windows.ifEmpty { setOf(defaultWindow()) }) {
+
+                for (window in
+                    settings.windows.ifEmpty {
+                        setOf(defaultWindow(emptyList(), presetWindowsEnabled))
+                    }) {
                     WindowWidget(
                         window,
                         setWindow = { newWindow ->
@@ -201,13 +186,16 @@ fun NotificationSettingsWidget(
                                 .takeIf { settings.windows.size > 1 },
                     )
                 }
+
+                val customWindow =
+                    if (presetWindowsEnabled) {
+                        Window.customFromCurrentTime(EasternTimeInstant.now())
+                    } else {
+                        Window.customFromCurrentTime(EasternTimeInstant.now())
+                    }
                 Surface(
                     onClick = {
-                        setSettings(
-                            settings.copy(
-                                windows = settings.windows + defaultWindow(settings.windows)
-                            )
-                        )
+                        setSettings(settings.copy(windows = settings.windows + customWindow))
                     },
                     Modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(8.dp),
@@ -239,197 +227,34 @@ fun NotificationSettingsWidget(
     }
 }
 
-sealed class PresetSelection {
-    data class Preset(val rowIndex: Int, val columnIndex: Int) : PresetSelection()
-
-    object Custom : PresetSelection()
-}
-
-@Composable
-fun PresetWindowWidget(
-    presetRows: List<List<PresetWindow>>,
-    selectedPreset: PresetSelection,
+private fun defaultWindow(
+    existingWindows: List<Window> = emptyList(),
     presetsEnabled: Boolean,
-    onSelect: (Window) -> Unit,
-) {
-
-    // TODO: Accessibility of this segmented control
-
-    Column() {
-        presetRows.forEachIndexed { rowIndex, windows ->
-            Row() {
-                windows.forEachIndexed { presetIndex, preset ->
-                    val isSelected =
-                        selectedPreset is PresetSelection.Preset &&
-                            rowIndex == selectedPreset.rowIndex &&
-                            presetIndex == selectedPreset.columnIndex
-                    Button(
-                        onClick = { onSelect(preset.window) },
-                        enabled = presetsEnabled,
-                        modifier =
-                            Modifier.selectable(
-                                    enabled = presetsEnabled,
-                                    selected = isSelected,
-                                    onClick = { onSelect(preset.window) },
-                                )
-                                .weight(1f),
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor =
-                                    if (isSelected) colorResource(R.color.key)
-                                    else colorResource(R.color.fill1),
-                                contentColor =
-                                    if (isSelected) colorResource(R.color.fill3)
-                                    else colorResource(R.color.text).copy(alpha = 0.6f),
-                            ),
-                        shape = RoundedCornerShape(8.dp),
-                    ) {
-                        Text(preset.label)
-                    }
-                }
-            }
-        }
-        Row() {
-            val isSelected = selectedPreset is PresetSelection.Custom
-            // TODO: Base selection on current time
-            val window =
-                Window(
-                    startTime = LocalTime(8, 0),
-                    endTime = LocalTime(9, 0),
-                    daysOfWeek =
-                        setOf(
-                            DayOfWeek.MONDAY,
-                            DayOfWeek.TUESDAY,
-                            DayOfWeek.WEDNESDAY,
-                            DayOfWeek.THURSDAY,
-                            DayOfWeek.FRIDAY,
-                        ),
-                )
-            Button(
-                modifier =
-                    Modifier.selectable(
-                            selected = isSelected,
-                            onClick = { onSelect(window) },
-                        )
-                        .weight(1f),
-                onClick = { onSelect(window) },
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor =
-                            if (isSelected) colorResource(R.color.key)
-                            else colorResource(R.color.fill1),
-                        contentColor =
-                            if (isSelected) colorResource(R.color.fill3)
-                            else colorResource(R.color.text).copy(alpha = 0.6f),
+): Window {
+    if (presetsEnabled) {
+        return Window.customFromCurrentTime(EasternTimeInstant.now())
+    } else {
+        if (existingWindows.isEmpty()) {
+            return Window(
+                startTime = LocalTime(8, 0),
+                endTime = LocalTime(9, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
                     ),
-                shape = RoundedCornerShape(8.dp),
-            ) {
-                Text(stringResource(R.string.custom))
-            }
+            )
         }
-    }
-}
-
-private fun defaultWindow(existingWindows: List<Window> = emptyList()): Window {
-    if (existingWindows.isEmpty()) {
         return Window(
-            startTime = LocalTime(8, 0),
-            endTime = LocalTime(9, 0),
-            daysOfWeek =
-                setOf(
-                    DayOfWeek.MONDAY,
-                    DayOfWeek.TUESDAY,
-                    DayOfWeek.WEDNESDAY,
-                    DayOfWeek.THURSDAY,
-                    DayOfWeek.FRIDAY,
-                ),
+            startTime = LocalTime(12, 0),
+            endTime = LocalTime(13, 0),
+            setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
         )
     }
-    return Window(
-        startTime = LocalTime(12, 0),
-        endTime = LocalTime(13, 0),
-        setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
-    )
 }
-
-class PresetWindow(
-    val label: String,
-    val window: Window,
-    val selected: Boolean = false,
-)
-
-fun morningPreset(context: Context) =
-    PresetWindow(
-        label = context.getString(R.string.morning),
-        window =
-            Window(
-                startTime = LocalTime(6, 0),
-                endTime = LocalTime(10, 0),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
-            ),
-    )
-
-fun middayPreset(context: Context) =
-    PresetWindow(
-        label = context.getString(R.string.midday),
-        window =
-            Window(
-                startTime = LocalTime(10, 0),
-                endTime = LocalTime(16, 0),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
-            ),
-    )
-
-fun eveningPreset(context: Context) =
-    PresetWindow(
-        label = context.getString(R.string.evening),
-        window =
-            Window(
-                startTime = LocalTime(16, 0),
-                endTime = LocalTime(20, 0),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
-            ),
-    )
-
-fun allDayPreset(context: Context) =
-    PresetWindow(
-        label = context.getString(R.string.all_day),
-        window =
-            // TODO: Handle default that crosses midnight boundary
-            Window(
-                startTime = LocalTime(0, 0),
-                endTime = LocalTime(23, 59),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
-            ),
-    )
 
 @Composable
 private fun WindowWidget(
@@ -676,7 +501,9 @@ private fun NotificationSwitch(
     setSettings: (FavoriteSettings.Notifications) -> Unit,
     notificationPermissionState: PermissionState,
     enabled: Boolean,
+    presetWindowsEnabled: Boolean,
 ) {
+
     LabeledSwitch(
         Modifier.haloContainer(
                 outlineColor = Color.Transparent,
@@ -705,7 +532,10 @@ private fun NotificationSwitch(
             setSettings(
                 settings.copy(
                     enabled = it,
-                    windows = settings.windows.ifEmpty { listOf(defaultWindow()) },
+                    windows =
+                        settings.windows.ifEmpty {
+                            listOf(defaultWindow(emptyList(), presetWindowsEnabled))
+                        },
                 )
             )
         },
@@ -749,11 +579,27 @@ private fun PermissionSettingsLink() {
 @Preview
 @Composable
 private fun NotificationSettingsWidgetPreview() {
+
+    if (KoinPlatformTools.defaultContext().getOrNull() == null) {
+        startKoin {
+            modules(
+                module {
+                    single {
+                        SettingsCache(
+                            MockSettingsRepository(
+                                mapOf(UserSettings.NotificationPresetWindows to true)
+                            )
+                        )
+                    }
+                }
+            )
+        }
+    }
     var settings by remember {
         mutableStateOf(
             FavoriteSettings.Notifications(
                 enabled = true,
-                windows = listOf(defaultWindow(), defaultWindow(listOf(defaultWindow()))),
+                windows = listOf(defaultWindow(emptyList(), true)),
             )
         )
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -1,5 +1,7 @@
 package com.mbta.tid.mbta_app.android.favorites
 
+import android.Manifest
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.provider.Settings
@@ -21,6 +23,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialogDefaults
@@ -79,6 +82,7 @@ import com.mbta.tid.mbta_app.android.util.formattedFull
 import com.mbta.tid.mbta_app.android.util.formattedTime
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
 import com.mbta.tid.mbta_app.repositories.Settings as UserSettings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.uuid.ExperimentalUuidApi
@@ -106,6 +110,35 @@ fun NotificationSettingsWidget(
         }
     }
 
+    val presetOptions =
+        listOf(
+            listOf(morningPreset(context), middayPreset(context), eveningPreset(context)),
+            listOf(allDayPreset(context)),
+        )
+    val selectedPreset =
+        remember(settings) {
+            when {
+                settings.windows.isEmpty() -> PresetSelection.Preset(1, 0)
+                settings.windows.size == 1 -> {
+                    val targetWindow: Window = settings.windows[0]
+                    presetOptions
+                        .asSequence()
+                        .mapIndexedNotNull { rowIndex, presets ->
+                            val presetMatchIndex = presets.indexOfFirst {
+                                it.window == targetWindow
+                            }
+                            if (presetMatchIndex != -1) {
+                                PresetSelection.Preset(rowIndex, presetMatchIndex)
+                            } else {
+                                null
+                            }
+                        }
+                        .firstOrNull() ?: PresetSelection.Custom
+                }
+                else -> PresetSelection.Custom
+            }
+        }
+
     val presetWindowsEnabled = SettingsCache.get(UserSettings.NotificationPresetWindows)
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -132,6 +165,26 @@ fun NotificationSettingsWidget(
         }
         AnimatedVisibility(settings.enabled && !permissionDenied) {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (presetWindowsEnabled) {
+
+                    PresetWindowWidget(
+                        presetRows =
+                            listOf(
+                                listOf(
+                                    morningPreset(context),
+                                    middayPreset(context),
+                                    eveningPreset(context),
+                                ),
+                                listOf(allDayPreset(context)),
+                            ),
+                        selectedPreset = selectedPreset,
+                        presetsEnabled = settings.windows.size <= 1,
+                        onSelect = { window ->
+                            val otherWindows = settings.windows.drop(1)
+                            setSettings(settings.copy(windows = listOf(window) + otherWindows))
+                        },
+                    )
+                }
                 for (window in settings.windows.ifEmpty { setOf(defaultWindow()) }) {
                     WindowWidget(
                         window,
@@ -186,11 +239,100 @@ fun NotificationSettingsWidget(
     }
 }
 
-private fun defaultWindow(
-    existingWindows: List<FavoriteSettings.Notifications.Window> = emptyList()
-): FavoriteSettings.Notifications.Window {
+sealed class PresetSelection {
+    data class Preset(val rowIndex: Int, val columnIndex: Int) : PresetSelection()
+
+    object Custom : PresetSelection()
+}
+
+@Composable
+fun PresetWindowWidget(
+    presetRows: List<List<PresetWindow>>,
+    selectedPreset: PresetSelection,
+    presetsEnabled: Boolean,
+    onSelect: (Window) -> Unit,
+) {
+
+    // TODO: Accessibility of this segmented control
+
+    Column() {
+        presetRows.forEachIndexed { rowIndex, windows ->
+            Row() {
+                windows.forEachIndexed { presetIndex, preset ->
+                    val isSelected =
+                        selectedPreset is PresetSelection.Preset &&
+                            rowIndex == selectedPreset.rowIndex &&
+                            presetIndex == selectedPreset.columnIndex
+                    Button(
+                        onClick = { onSelect(preset.window) },
+                        enabled = presetsEnabled,
+                        modifier =
+                            Modifier.selectable(
+                                    enabled = presetsEnabled,
+                                    selected = isSelected,
+                                    onClick = { onSelect(preset.window) },
+                                )
+                                .weight(1f),
+                        colors =
+                            ButtonDefaults.buttonColors(
+                                containerColor =
+                                    if (isSelected) colorResource(R.color.key)
+                                    else colorResource(R.color.fill1),
+                                contentColor =
+                                    if (isSelected) colorResource(R.color.fill3)
+                                    else colorResource(R.color.text).copy(alpha = 0.6f),
+                            ),
+                        shape = RoundedCornerShape(8.dp),
+                    ) {
+                        Text(preset.label)
+                    }
+                }
+            }
+        }
+        Row() {
+            val isSelected = selectedPreset is PresetSelection.Custom
+            // TODO: Base selection on current time
+            val window =
+                Window(
+                    startTime = LocalTime(8, 0),
+                    endTime = LocalTime(9, 0),
+                    daysOfWeek =
+                        setOf(
+                            DayOfWeek.MONDAY,
+                            DayOfWeek.TUESDAY,
+                            DayOfWeek.WEDNESDAY,
+                            DayOfWeek.THURSDAY,
+                            DayOfWeek.FRIDAY,
+                        ),
+                )
+            Button(
+                modifier =
+                    Modifier.selectable(
+                            selected = isSelected,
+                            onClick = { onSelect(window) },
+                        )
+                        .weight(1f),
+                onClick = { onSelect(window) },
+                colors =
+                    ButtonDefaults.buttonColors(
+                        containerColor =
+                            if (isSelected) colorResource(R.color.key)
+                            else colorResource(R.color.fill1),
+                        contentColor =
+                            if (isSelected) colorResource(R.color.fill3)
+                            else colorResource(R.color.text).copy(alpha = 0.6f),
+                    ),
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text(stringResource(R.string.custom))
+            }
+        }
+    }
+}
+
+private fun defaultWindow(existingWindows: List<Window> = emptyList()): Window {
     if (existingWindows.isEmpty()) {
-        return FavoriteSettings.Notifications.Window(
+        return Window(
             startTime = LocalTime(8, 0),
             endTime = LocalTime(9, 0),
             daysOfWeek =
@@ -203,17 +345,96 @@ private fun defaultWindow(
                 ),
         )
     }
-    return FavoriteSettings.Notifications.Window(
+    return Window(
         startTime = LocalTime(12, 0),
         endTime = LocalTime(13, 0),
         setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY),
     )
 }
 
+class PresetWindow(
+    val label: String,
+    val window: Window,
+    val selected: Boolean = false,
+)
+
+fun morningPreset(context: Context) =
+    PresetWindow(
+        label = context.getString(R.string.morning),
+        window =
+            Window(
+                startTime = LocalTime(6, 0),
+                endTime = LocalTime(10, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+    )
+
+fun middayPreset(context: Context) =
+    PresetWindow(
+        label = context.getString(R.string.midday),
+        window =
+            Window(
+                startTime = LocalTime(10, 0),
+                endTime = LocalTime(16, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+    )
+
+fun eveningPreset(context: Context) =
+    PresetWindow(
+        label = context.getString(R.string.evening),
+        window =
+            Window(
+                startTime = LocalTime(16, 0),
+                endTime = LocalTime(20, 0),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+    )
+
+fun allDayPreset(context: Context) =
+    PresetWindow(
+        label = context.getString(R.string.all_day),
+        window =
+            // TODO: Handle default that crosses midnight boundary
+            Window(
+                startTime = LocalTime(0, 0),
+                endTime = LocalTime(23, 59),
+                daysOfWeek =
+                    setOf(
+                        DayOfWeek.MONDAY,
+                        DayOfWeek.TUESDAY,
+                        DayOfWeek.WEDNESDAY,
+                        DayOfWeek.THURSDAY,
+                        DayOfWeek.FRIDAY,
+                    ),
+            ),
+    )
+
 @Composable
 private fun WindowWidget(
-    window: FavoriteSettings.Notifications.Window,
-    setWindow: (FavoriteSettings.Notifications.Window) -> Unit,
+    window: Window,
+    setWindow: (Window) -> Unit,
     deleteWindow: (() -> Unit)?,
 ) {
     Row(
@@ -326,8 +547,8 @@ private fun TimeInput(
     modalTitle: String,
     time: LocalTime,
     setTime: (LocalTime) -> Unit,
-    minimumTime: LocalTime? = null,
     modifier: Modifier = Modifier,
+    minimumTime: LocalTime? = null,
 ) {
     var isPicking by rememberSaveable { mutableStateOf(false) }
     Row(
@@ -546,7 +767,7 @@ private fun NotificationSettingsWidgetPreview() {
                 settings,
                 { settings = it },
                 ConstantPermissionState(
-                    android.Manifest.permission.POST_NOTIFICATIONS,
+                    Manifest.permission.POST_NOTIFICATIONS,
                     PermissionStatus.Granted,
                 ),
                 true,
@@ -556,7 +777,7 @@ private fun NotificationSettingsWidgetPreview() {
                 FavoriteSettings.Notifications.disabled,
                 {},
                 ConstantPermissionState(
-                    android.Manifest.permission.POST_NOTIFICATIONS,
+                    Manifest.permission.POST_NOTIFICATIONS,
                     PermissionStatus.Denied(false),
                 ),
                 true,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -72,12 +72,14 @@ import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.android.component.HaloSeparator
 import com.mbta.tid.mbta_app.android.component.LabeledSwitch
 import com.mbta.tid.mbta_app.android.util.ConstantPermissionState
+import com.mbta.tid.mbta_app.android.util.SettingsCache
 import com.mbta.tid.mbta_app.android.util.Typography
 import com.mbta.tid.mbta_app.android.util.formattedAbbr
 import com.mbta.tid.mbta_app.android.util.formattedFull
 import com.mbta.tid.mbta_app.android.util.formattedTime
 import com.mbta.tid.mbta_app.android.util.modifiers.haloContainer
 import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.repositories.Settings as UserSettings
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.datetime.DayOfWeek
@@ -103,6 +105,8 @@ fun NotificationSettingsWidget(
             setSettings(FavoriteSettings.Notifications.disabled)
         }
     }
+
+    val presetWindowsEnabled = SettingsCache.get(UserSettings.NotificationPresetWindows)
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Column(
@@ -235,32 +239,38 @@ private fun WindowWidget(
             }
         }
         Column(Modifier.background(colorResource(R.color.fill3), RoundedCornerShape(8.dp))) {
-            LabeledTimeInput(
-                stringResource(R.string.from),
-                stringResource(R.string.select_start_time),
-                window.startTime,
-                setTime = {
-                    setWindow(
-                        window.copy(
-                            startTime = it,
-                            endTime =
-                                if (window.endTime > it) window.endTime
-                                else
-                                    LocalTime.fromSecondOfDay(
-                                        minOf(it.toSecondOfDay() + 60 * 60, (24 * 60 - 1) * 60)
-                                    ),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TimeInput(
+                    stringResource(R.string.from),
+                    window.startTime,
+                    setTime = {
+                        setWindow(
+                            window.copy(
+                                startTime = it,
+                                endTime =
+                                    if (window.endTime > it) window.endTime
+                                    else
+                                        LocalTime.fromSecondOfDay(
+                                            minOf(it.toSecondOfDay() + 60 * 60, (24 * 60 - 1) * 60)
+                                        ),
+                            )
                         )
-                    )
-                },
-            )
-            HaloSeparator()
-            LabeledTimeInput(
-                stringResource(R.string.to),
-                stringResource(R.string.select_end_time),
-                window.endTime,
-                setTime = { setWindow(window.copy(endTime = it)) },
-                minimumTime = window.startTime,
-            )
+                    },
+                    modifier = Modifier.weight(1f),
+                )
+                Text(stringResource(R.string.to_lowercase))
+                TimeInput(
+                    stringResource(R.string.select_end_time),
+                    window.endTime,
+                    setTime = { setWindow(window.copy(endTime = it)) },
+                    minimumTime = window.startTime,
+                    modifier = Modifier.weight(1f),
+                )
+            }
             DaysOfWeekInput(
                 window.daysOfWeek,
                 setDaysOfWeek = { setWindow(window.copy(daysOfWeek = it)) },
@@ -312,20 +322,19 @@ fun AdvancedTimePickerDialog(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun LabeledTimeInput(
-    label: String,
+private fun TimeInput(
     modalTitle: String,
     time: LocalTime,
     setTime: (LocalTime) -> Unit,
     minimumTime: LocalTime? = null,
+    modifier: Modifier = Modifier,
 ) {
     var isPicking by rememberSaveable { mutableStateOf(false) }
     Row(
-        Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+        modifier.padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(label, Modifier.weight(1f))
         Button(
             onClick = { isPicking = true },
             shape = RoundedCornerShape(6.dp),
@@ -335,6 +344,7 @@ private fun LabeledTimeInput(
                     contentColor = colorResource(R.color.text),
                 ),
             contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
                 EasternTimeInstant(EasternTimeInstant.now().local.date, time).formattedTime(),

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -1,0 +1,3 @@
+package com.mbta.tid.mbta_app.android.favorites
+
+class PresetWindowSelector {}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -3,7 +3,6 @@ package com.mbta.tid.mbta_app.android.favorites
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -12,6 +11,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CollectionInfo
+import androidx.compose.ui.semantics.CollectionItemInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.collectionInfo
+import androidx.compose.ui.semantics.collectionItemInfo
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.mbta.tid.mbta_app.android.R
 import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
@@ -27,9 +32,19 @@ fun PresetWindowSelector(
     now: EasternTimeInstant = EasternTimeInstant.now(),
     onSelect: (Window) -> Unit,
 ) {
+    val maxColumnCount = presetRows.firstOrNull()?.size ?: 0
 
     // TODO: Accessibility of this segmented control
-    Column(modifier = Modifier.selectableGroup()) {
+    Column(
+        modifier =
+            Modifier.semantics {
+                collectionInfo =
+                    CollectionInfo(
+                        rowCount = presetRows.size + 1, // +1 for Custom
+                        columnCount = maxColumnCount,
+                    )
+            }
+    ) {
         presetRows.forEachIndexed { rowIndex, windows ->
             Row() {
                 windows.forEachIndexed { presetIndex, preset ->
@@ -42,7 +57,16 @@ fun PresetWindowSelector(
                         isSelected = isSelected,
                         onSelect = { onSelect(preset.window) },
                         label = preset.label,
-                        modifier = Modifier.weight(1f),
+                        modifier =
+                            Modifier.weight(1f).semantics {
+                                collectionItemInfo =
+                                    CollectionItemInfo(
+                                        rowIndex = rowIndex,
+                                        rowSpan = 1,
+                                        columnIndex = presetIndex,
+                                        columnSpan = 1,
+                                    )
+                            },
                     )
                 }
             }
@@ -55,7 +79,16 @@ fun PresetWindowSelector(
                 isSelected = isSelected,
                 onSelect = { onSelect(customWindow) },
                 label = stringResource(R.string.custom),
-                modifier = Modifier.weight(1f),
+                modifier =
+                    Modifier.weight(1f).semantics {
+                        collectionItemInfo =
+                            CollectionItemInfo(
+                                rowIndex = presetRows.size,
+                                rowSpan = 1,
+                                columnIndex = 0,
+                                columnSpan = maxColumnCount,
+                            )
+                    },
             )
         }
     }
@@ -82,7 +115,12 @@ fun PresetButton(
             ),
         shape = RoundedCornerShape(8.dp),
         modifier =
-            modifier.selectable(selected = isSelected, enabled = enabled, onClick = onSelect),
+            modifier.selectable(
+                selected = isSelected,
+                enabled = enabled,
+                onClick = onSelect,
+                role = Role.Tab,
+            ),
     ) {
         Text(label)
     }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -34,7 +34,6 @@ fun PresetWindowSelector(
 ) {
     val maxColumnCount = presetRows.firstOrNull()?.size ?: 0
 
-    // TODO: Accessibility of this segmented control
     Column(
         modifier =
             Modifier.semantics {

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -1,3 +1,88 @@
 package com.mbta.tid.mbta_app.android.favorites
 
-class PresetWindowSelector {}
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.mbta.tid.mbta_app.android.R
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
+import com.mbta.tid.mbta_app.model.PresetSelection
+import com.mbta.tid.mbta_app.model.PresetWindow
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+
+@Composable
+fun PresetWindowSelector(
+    presetRows: List<List<PresetWindow>>,
+    selectedPreset: PresetSelection,
+    presetsEnabled: Boolean,
+    onSelect: (Window) -> Unit,
+) {
+
+    // TODO: Accessibility of this segmented control
+    Column(modifier = Modifier.selectableGroup()) {
+        presetRows.forEachIndexed { rowIndex, windows ->
+            Row() {
+                windows.forEachIndexed { presetIndex, preset ->
+                    val isSelected =
+                        selectedPreset is PresetSelection.Preset &&
+                            rowIndex == selectedPreset.rowIndex &&
+                            presetIndex == selectedPreset.columnIndex
+                    PresetButton(
+                        enabled = presetsEnabled,
+                        isSelected = isSelected,
+                        onSelect = { onSelect(preset.window) },
+                        label = preset.label,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+        Row() {
+            val isSelected = selectedPreset is PresetSelection.Custom
+            val customWindow = Window.customFromCurrentTime(EasternTimeInstant.now())
+            PresetButton(
+                enabled = true,
+                isSelected = isSelected,
+                onSelect = { onSelect(customWindow) },
+                label = stringResource(R.string.custom),
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+@Composable
+fun PresetButton(
+    enabled: Boolean,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+    label: String,
+    modifier: Modifier,
+) {
+    Button(
+        onClick = onSelect,
+        enabled = enabled,
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor =
+                    if (isSelected) colorResource(R.color.key) else colorResource(R.color.fill1),
+                contentColor =
+                    if (isSelected) colorResource(R.color.fill3)
+                    else colorResource(R.color.text).copy(alpha = 0.6f),
+            ),
+        shape = RoundedCornerShape(8.dp),
+        modifier =
+            modifier.selectable(selected = isSelected, enabled = enabled, onClick = onSelect),
+    ) {
+        Text(label)
+    }
+}

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -24,6 +24,7 @@ fun PresetWindowSelector(
     presetRows: List<List<PresetWindow>>,
     selectedPreset: PresetSelection,
     presetsEnabled: Boolean,
+    now: EasternTimeInstant = EasternTimeInstant.now(),
     onSelect: (Window) -> Unit,
 ) {
 
@@ -48,7 +49,7 @@ fun PresetWindowSelector(
         }
         Row() {
             val isSelected = selectedPreset is PresetSelection.Custom
-            val customWindow = Window.customFromCurrentTime(EasternTimeInstant.now())
+            val customWindow = Window.customFromCurrentTime(now)
             PresetButton(
                 enabled = true,
                 isSelected = isSelected,

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/MorePage.kt
@@ -147,6 +147,7 @@ fun MorePage(
                                             }
                                             Settings.DevDebugMode,
                                             Settings.HideMaps,
+                                            Settings.NotificationPresetWindows,
                                             Settings.SearchRouteResults -> {}
                                         }
                                     },

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/util/SharedStringLocalization.kt
@@ -22,6 +22,7 @@ val SharedString.value: String
             SharedString.MapDisplay -> stringResource(R.string.setting_toggle_map_display)
             SharedString.MTicketApp -> stringResource(R.string.resources_link_mticket_note)
             SharedString.Notifications -> stringResource(R.string.notifications_beta_toggle_label)
+            SharedString.NotificationPresetWindows -> "Notification preset windows"
             SharedString.PrivacyPolicy -> stringResource(R.string.other_link_privacy_policy)
             SharedString.ResourcesSection -> stringResource(R.string.more_section_resources)
             SharedString.RouteSearch -> stringResource(R.string.feature_flag_route_search)

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -413,8 +413,9 @@
     <string name="tie_replacement">Tie Replacement</string>
     <string name="tie_replacement_lowercase">tie replacement</string>
     <string name="time_picker_type_toggle">Time picker type toggle</string>
-    <string name="to">To</string>
     <string name="toast_tip_prefix">Tip: %1$s</string>
+    <string name="to">To</string>
+    <string name="to_lowercase">to</string>
     <string name="toggle_direction">toggle direction</string>
     <string name="track_change">Track Change</string>
     <string name="track_change_sentence_case">Track change</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -493,4 +493,9 @@
     <string name="weekends">Weekends</string>
     <string name="westbound">Westbound</string>
     <string name="x_and_y">%1$s and %2$s</string>
+    <string name="morning">Morning</string>
+    <string name="midday">Midday</string>
+    <string name="evening">Evening</string>
+    <string name="all_day">All day</string>
+    <string name="custom">Custom</string>
 </resources>

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -5766,44 +5766,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "Todo el día"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Toute la journée"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Tout lajounen"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "O dia todo"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Cả ngày"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "全天"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "全天"
           }
         }
       }
@@ -9467,44 +9467,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "Costumbres"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Coutumes"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Personnalisé"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "Personalizado"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Phong tục"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "风俗"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "風俗"
           }
         }
       }
@@ -11681,44 +11681,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "Noche"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Soirée"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Aswè"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "Noite"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Buổi tối"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "晚上"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "晚上"
           }
         }
       }
@@ -16011,44 +16011,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "Mediodía"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Midi"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Midi"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "Meio-dia"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Giữa trưa"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "正午"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "正午"
           }
         }
       }
@@ -16246,44 +16246,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "Buenos días"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Bonjour"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Maten"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "Manhã"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Buổi sáng"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "早晨"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "早晨"
           }
         }
       }
@@ -25389,44 +25389,44 @@
       "localizations" : {
         "es" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"es\")"
+            "state" : "translated",
+            "value" : "A"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"fr\")"
+            "state" : "translated",
+            "value" : "Jusqu’à"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"ht\")"
+            "state" : "translated",
+            "value" : "Pou"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"pt-BR\")"
+            "state" : "translated",
+            "value" : "Para"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"vi\")"
+            "state" : "translated",
+            "value" : "Đến"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"zh-CN\")"
+            "state" : "translated",
+            "value" : "目的地"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"zh-TW\")"
+            "state" : "translated",
+            "value" : "目的地"
           }
         }
       }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -5761,6 +5761,53 @@
         }
       }
     },
+    "All day" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"All day\", \"en\", \"zh-TW\")"
+          }
+        }
+      }
+    },
     "All routes" : {
       "comment" : "VoiceOver label for the button to clear\nselected route to display all routes at a station\"",
       "localizations" : {
@@ -9414,6 +9461,54 @@
         }
       }
     },
+    "Custom" : {
+      "comment" : "Button text for selecting custom time range for notifications",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Custom\", \"en\", \"zh-TW\")"
+          }
+        }
+      }
+    },
     "Daily" : {
       "comment" : "Label for the days of a recurring alert",
       "localizations" : {
@@ -11577,6 +11672,53 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "自動扶梯關閉"
+          }
+        }
+      }
+    },
+    "Evening" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Evening\", \"en\", \"zh-TW\")"
           }
         }
       }
@@ -15864,6 +16006,53 @@
         }
       }
     },
+    "Midday" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Midday\", \"en\", \"zh-TW\")"
+          }
+        }
+      }
+    },
     "Modified service" : {
       "comment" : "Possible alert effect",
       "localizations" : {
@@ -16048,6 +16237,53 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更多"
+          }
+        }
+      }
+    },
+    "Morning" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"Morning\", \"en\", \"zh-TW\")"
           }
         }
       }
@@ -25143,6 +25379,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "提示：%1$@"
+          }
+        }
+      }
+    },
+    "to" : {
+      "comment" : "Displayed between two time pickers. Ex: [8:00AM] to [9:00AM]",
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"es\")"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"fr\")"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"ht\")"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"pt-BR\")"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"vi\")"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"zh-CN\")"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "=GOOGLETRANSLATE(\"to\", \"en\", \"zh-TW\")"
           }
         }
       }

--- a/iosApp/iosApp/Pages/More/MorePage.swift
+++ b/iosApp/iosApp/Pages/More/MorePage.swift
@@ -96,7 +96,7 @@ struct MorePage: View {
                                         }
                                     case .notifications:
                                         await reloadPendingOnboarding()
-                                    case .devDebugMode, .hideMaps, .searchRouteResults:
+                                    case .devDebugMode, .hideMaps, .notificationPresetWindows, .searchRouteResults:
                                         break
                                     }
                                 }

--- a/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
+++ b/iosApp/iosApp/Utils/Extensions/SharedStringLocalization.swift
@@ -59,6 +59,8 @@ extension SharedString {
                 "Disruption Notifications",
                 comment: "A setting on the More page to enable the disruption notification beta"
             )
+        case .notificationPresetWindows:
+            "Notification preset windows" // dev only, no i18n
         case .privacyPolicy:
             NSLocalizedString(
                 "Privacy Policy",

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.model
 
 import co.touchlab.skie.configuration.annotations.DefaultArgumentInterop
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import kotlin.experimental.ExperimentalObjCName
 import kotlin.native.ObjCName
 import kotlinx.datetime.DayOfWeek
@@ -73,7 +74,97 @@ constructor(val notifications: Notifications = Notifications.disabled) {
             val startTime: LocalTime,
             val endTime: LocalTime,
             val daysOfWeek: Set<DayOfWeek>,
-        )
+        ) {
+            public companion object {
+
+                public val morningDefault: Window =
+                    Window(
+                        startTime = LocalTime(6, 0),
+                        endTime = LocalTime(10, 0),
+                        daysOfWeek =
+                            setOf(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,
+                                DayOfWeek.FRIDAY,
+                            ),
+                    )
+
+                public val middayDefault: Window =
+                    Window(
+                        startTime = LocalTime(10, 0),
+                        endTime = LocalTime(16, 0),
+                        daysOfWeek =
+                            setOf(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,
+                                DayOfWeek.FRIDAY,
+                            ),
+                    )
+
+                public val eveningDefault: Window =
+                    Window(
+                        startTime = LocalTime(16, 0),
+                        endTime = LocalTime(20, 0),
+                        daysOfWeek =
+                            setOf(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,
+                                DayOfWeek.FRIDAY,
+                            ),
+                    )
+                // TODO: Handle default that crosses midnight boundary
+                public val allDayDefault: Window =
+                    Window(
+                        startTime = LocalTime(0, 0),
+                        endTime = LocalTime(23, 59),
+                        daysOfWeek =
+                            setOf(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,
+                                DayOfWeek.FRIDAY,
+                            ),
+                    )
+
+                public fun defaultFromCurrentTime(now: EasternTimeInstant): Window {
+                    val presets =
+                        listOf(morningDefault, middayDefault, eveningDefault, allDayDefault)
+
+                    return presets.firstOrNull { now.local.time in it.startTime..it.endTime }
+                        ?: allDayDefault
+                }
+
+                public fun customFromCurrentTime(now: EasternTimeInstant): Window {
+                    val startTime = LocalTime(now.local.time.hour, 0)
+                    val endTime =
+                        if (startTime.hour == 23) LocalTime(now.local.time.hour, 59)
+                        else
+                            LocalTime(
+                                now.local.time.hour + 1,
+                                0,
+                            )
+                    return Window(
+                        startTime = startTime,
+                        endTime = endTime,
+                        daysOfWeek =
+                            setOf(
+                                DayOfWeek.MONDAY,
+                                DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY,
+                                DayOfWeek.THURSDAY,
+                                DayOfWeek.FRIDAY,
+                            ),
+                    )
+                }
+            }
+        }
 
         public companion object {
             public val disabled: Notifications =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
@@ -5,7 +5,6 @@ import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
 public class PresetWindow(
     public val label: String,
     public val window: Window,
-    public val selected: Boolean = false,
 ) {
     public companion object {
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
@@ -45,7 +45,6 @@ public sealed class PresetSelection {
             presetOptions: List<List<PresetWindow>>,
         ): PresetSelection =
             when {
-                settings.windows.isEmpty() -> Preset(1, 0)
                 settings.windows.size == 1 -> {
                     val targetWindow: Window = settings.windows[0]
                     presetOptions

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
@@ -1,0 +1,69 @@
+package com.mbta.tid.mbta_app.model
+
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
+
+public class PresetWindow(
+    public val label: String,
+    public val window: Window,
+    public val selected: Boolean = false,
+) {
+    public companion object {
+
+        public fun morningPreset(label: String): PresetWindow =
+            PresetWindow(
+                label = label,
+                window = Window.morningDefault,
+            )
+
+        public fun middayPreset(label: String): PresetWindow =
+            PresetWindow(
+                label = label,
+                window = Window.middayDefault,
+            )
+
+        public fun eveningPreset(label: String): PresetWindow =
+            PresetWindow(
+                label = label,
+                window = Window.eveningDefault,
+            )
+
+        public fun allDayPreset(label: String): PresetWindow =
+            PresetWindow(
+                label = label,
+                window = Window.allDayDefault,
+            )
+    }
+}
+
+public sealed class PresetSelection {
+    public data class Preset(val rowIndex: Int, val columnIndex: Int) : PresetSelection()
+
+    public object Custom : PresetSelection()
+
+    public companion object {
+        public fun selectedPresetFromSettings(
+            settings: FavoriteSettings.Notifications,
+            presetOptions: List<List<PresetWindow>>,
+        ): PresetSelection =
+            when {
+                settings.windows.isEmpty() -> Preset(1, 0)
+                settings.windows.size == 1 -> {
+                    val targetWindow: Window = settings.windows[0]
+                    presetOptions
+                        .asSequence()
+                        .mapIndexedNotNull { rowIndex, presets ->
+                            val presetMatchIndex = presets.indexOfFirst {
+                                it.window == targetWindow
+                            }
+                            if (presetMatchIndex != -1) {
+                                Preset(rowIndex, presetMatchIndex)
+                            } else {
+                                null
+                            }
+                        }
+                        .firstOrNull() ?: Custom
+                }
+                else -> Custom
+            }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepository.kt
@@ -42,6 +42,7 @@ public enum class Settings(
     DevDebugMode(booleanPreferencesKey("dev_debug_mode")),
     HideMaps(booleanPreferencesKey("hide_maps")),
     Notifications(booleanPreferencesKey("notifications")),
+    NotificationPresetWindows(booleanPreferencesKey("notifications_window_changes")),
     SearchRouteResults(booleanPreferencesKey("searchRouteResults_featureFlag")),
     StationAccessibility(booleanPreferencesKey("elevator_accessibility")),
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/utils/SharedString.kt
@@ -12,6 +12,7 @@ public enum class SharedString {
     MapDisplay,
     MTicketApp,
     Notifications,
+    NotificationPresetWindows,
     PrivacyPolicy,
     ResourcesSection,
     RouteSearch,

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/MoreViewModel.kt
@@ -118,6 +118,10 @@ public class MoreViewModel(
                                 }
                             },
                         ),
+                        MoreItem.Toggle(
+                            label = SharedString.NotificationPresetWindows,
+                            settings = Settings.NotificationPresetWindows,
+                        ),
                         MoreItem.Action(
                             label = SharedString.Crash,
                             action = {

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/FavoriteTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/FavoriteTest.kt
@@ -1,10 +1,12 @@
 package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.json
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 import com.mbta.tid.mbta_app.utils.buildFavorites
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.addJsonObject
@@ -16,6 +18,7 @@ import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
 
 class FavoriteTest {
+
     @Test
     fun `parses pre-notifications format`() {
         val oldFavorites = buildJsonObject {
@@ -102,5 +105,75 @@ class FavoriteTest {
         }
         assertEquals(serialized, json.encodeToJsonElement(favorites))
         assertEquals(favorites, json.decodeFromJsonElement(serialized))
+    }
+
+    @Test
+    fun `defaultFromCurrentTime returns the matching preset`() {
+        assertEquals(
+            FavoriteSettings.Notifications.Window.morningDefault,
+            FavoriteSettings.Notifications.Window.defaultFromCurrentTime(
+                EasternTimeInstant(LocalDateTime(2026, 8, 27, 7, 30))
+            ),
+        )
+        assertEquals(
+            FavoriteSettings.Notifications.Window.middayDefault,
+            FavoriteSettings.Notifications.Window.defaultFromCurrentTime(
+                EasternTimeInstant(LocalDateTime(2026, 8, 27, 12, 30))
+            ),
+        )
+
+        assertEquals(
+            FavoriteSettings.Notifications.Window.eveningDefault,
+            FavoriteSettings.Notifications.Window.defaultFromCurrentTime(
+                EasternTimeInstant(LocalDateTime(2026, 8, 27, 18, 30))
+            ),
+        )
+
+        assertEquals(
+            FavoriteSettings.Notifications.Window.allDayDefault,
+            FavoriteSettings.Notifications.Window.defaultFromCurrentTime(
+                EasternTimeInstant(LocalDateTime(2026, 8, 27, 21, 30))
+            ),
+        )
+    }
+
+    @Test
+    fun `customFromCurrentTime rounds to the current hour`() {
+        val now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 9, 30))
+
+        assertEquals(
+            FavoriteSettings.Notifications.Window(
+                LocalTime(9, 0),
+                LocalTime(10, 0),
+                setOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                ),
+            ),
+            FavoriteSettings.Notifications.Window.customFromCurrentTime(now),
+        )
+    }
+
+    @Test
+    fun `customFromCurrentTime maxes out before midnight`() {
+        val now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 23, 30))
+
+        assertEquals(
+            FavoriteSettings.Notifications.Window(
+                LocalTime(23, 0),
+                LocalTime(23, 59),
+                setOf(
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.WEDNESDAY,
+                    DayOfWeek.THURSDAY,
+                    DayOfWeek.FRIDAY,
+                ),
+            ),
+            FavoriteSettings.Notifications.Window.customFromCurrentTime(now),
+        )
     }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/repositories/SettingsRepositoryTest.kt
@@ -40,6 +40,7 @@ internal class SettingsRepositoryTest : KoinTest {
                 Settings.Notifications to false,
                 Settings.SearchRouteResults to false,
                 Settings.StationAccessibility to false,
+                Settings.NotificationPresetWindows to false,
             ),
             repo.getSettings(),
         )


### PR DESCRIPTION
### Summary

_Ticket:_ [Disruption Windows | Preset options UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217828663233951?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Adds the preset notification window UX on android behind a feature flag. 
This does not address creating windows that cross the midnight boundary. 


iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Added unit tests
* Ran locally in android, with and without TalkBack

https://github.com/user-attachments/assets/ca7b2612-c5c4-45c3-9b84-32abef1cccdf


<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
