### PR TITLE
chore: add translations for all clear summary strings

### DIFF
--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1626,58 +1626,8 @@
       }
     },
     "**All clear:** Normal service has resumed." : {
-      "comment" : "Alert summary in the format of \"All clear: Normal service has resumed.\"",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**All clear:** Normal service has resumed."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Todo despejado:** se ha reanudado el servicio normal."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Alerte levé :** Le service normal a repris."
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "*Tout bagay nòmal:** Sèvis la retounen nan nòmal."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Situação normalizada:** O serviço normal foi retomado."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Đã thông thoáng:** Dịch vụ đã hoạt động trở lại bình thường."
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**运行正常：**服务已恢复正常。"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**運行正常：**服務已恢復正常。"
-          }
-        }
-      }
+      "comment" : "Alert summary in the format of \\\"All clear: Normal service has resumed.\\\"",
+      "extractionState" : "manual"
     },
     "**All clear:** Regular service%1$@" : {
       "comment" : "Alert summary in the format of \"All clear: Regular service[at location]\", ex \"[All clear][Regular service][ from Alewife to Harvard]\"",
@@ -1923,113 +1873,13 @@
         }
       }
     },
-    "**Update:** %1$@ has ended%2$@.": {
-      "comment" : "Alert summary in the format of \"Update: [Alert effect] has ended[ at location].\", ex \"[Update][Stop clousure] has ended[ at Haymarket]." or \"[Update][Service suspension] has ended[ from Alewife to Harvard].",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Update:** %1$@ has ended%2$@."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Actualización:** %1$@ has ended%2$@."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Mise à jour :** %1$@ has ended%2$@."
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Mizajou:** %1$@ has ended%2$@."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Atualização:** %1$@ has ended%2$@."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Cập nhật:** %1$@ has ended%2$@."
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**更新：** %1$@ has ended%2$@."
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**更新：** %1$@ has ended%2$@."
-          }
-        }
-      }
+    "**Update:** %{mode} service has resumed%{summary_location}." : {
+      "comment" : "Alert summary in the format of \\\"Update: [Vehicle type] service has resumed[ at location].\\\", ex \\\"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\\\" or \\\"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\\\"",
+      "extractionState" : "manual"
     },
-    "**Update:** %{mode} service has resumed%{summary_location}.": {
-      "comment" : "Alert summary in the format of \"Update: [Vehicle type] service has resumed[ at location].\", ex \"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\" or \"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\"",
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "**Update:** %1$@ has resumed%2$@."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Actualización:** %1$@ has resumed%2$@."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Mise à jour :** %1$@ has resumed%2$@."
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Mizajou:** %1$@ has resumed%2$@."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Atualização:** %1$@ has resumed%2$@."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**Cập nhật:** %1$@ has resumed%2$@."
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**更新：** %1$@ has resumed%2$@."
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "**更新：** %1$@ has resumed%2$@."
-          }
-        }
-      }
+    "**Update:** %1$@ has ended%2$@." : {
+      "comment" : "Alert summary in the format of \\\"Update: [Alert effect] has ended[ at location].\\\", ex \\\"[Update][Stop clousure] has ended[ at Haymarket].\" or \\\"[Update][Service suspension] has ended[ from Alewife to Harvard].",
+      "extractionState" : "manual"
     },
     "**Update:** %1$@%2$@%3$@%4$@%5$@" : {
       "comment" : "Alert summary in the format of \"Update: [Alert effect][at location][through timeframe][until recurrence][ due to cause], ex \"[Update][Stop closed][ at Haymarket][ through this Friday][]\" or \"[Update][Service suspended][ from Alewife to Harvard][ through end of service][ daily until Friday][due “to maintenance]",
@@ -11369,56 +11219,7 @@
     },
     "Elevator" : {
       "comment" : "Elevator Service",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elevator"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ascensor"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Ascenseur"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Asansè"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Elevador"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Thang máy đóng cửa"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "直梯已关闭"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "直梯已關閉"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Elevator closed" : {
       "comment" : "Possible alert effect",
@@ -14638,48 +14439,48 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " until %@"
+            "value" : "**All clear:** Normal service has resumed."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " hasta %@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " jusqu’à %@"
           }
         },
         "ht" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " jiska %@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " até %@"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " cho đến khi %@"
           }
         },
         "zh-Hans-CN" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " 直至%@"
           }
         },
         "zh-Hant-TW" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : " 直至%@"
           }
         }
@@ -26071,56 +25872,7 @@
     },
     "Train" : {
       "comment" : "Train",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Train"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tren"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Train"
-          }
-        },
-        "ht" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tren"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Trem"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "Tàu"
-          }
-        },
-        "zh-Hans-CN" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "列车"
-          }
-        },
-        "zh-Hant-TW" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : "列車"
-          }
-        }
-      }
+      "extractionState" : "manual"
     },
     "Train cancelled" : {
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1625,6 +1625,60 @@
         }
       }
     },
+    "**All clear:** Normal service has resumed." : {
+      "comment" : "Alert summary in the format of \"All clear: Normal service has resumed.\"",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**All clear:** Normal service has resumed."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Todo despejado:** se ha reanudado el servicio normal."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Alerte levé :** Le service normal a repris."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "*Tout bagay nòmal:** Sèvis la retounen nan nòmal."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Situação normalizada:** O serviço normal foi retomado."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Đã thông thoáng:** Dịch vụ đã hoạt động trở lại bình thường."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**运行正常：**服务已恢复正常。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**運行正常：**服務已恢復正常。"
+          }
+        }
+      }
+    },
     "**All clear:** Regular service%1$@" : {
       "comment" : "Alert summary in the format of \"All clear: Regular service[at location]\", ex \"[All clear][Regular service][ from Alewife to Harvard]\"",
       "extractionState" : "manual",
@@ -1865,6 +1919,114 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "**多個網站**"
+          }
+        }
+      }
+    },
+    "**Update:** %1$@ has ended%2$@.": {
+      "comment" : "Alert summary in the format of \"Update: [Alert effect] has ended[ at location].\", ex \"[Update][Stop clousure] has ended[ at Haymarket]." or \"[Update][Service suspension] has ended[ from Alewife to Harvard].",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Update:** %1$@ has ended%2$@."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Actualización:** %1$@ has ended%2$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Mise à jour :** %1$@ has ended%2$@."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Mizajou:** %1$@ has ended%2$@."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Atualização:** %1$@ has ended%2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Cập nhật:** %1$@ has ended%2$@."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**更新：** %1$@ has ended%2$@."
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**更新：** %1$@ has ended%2$@."
+          }
+        }
+      }
+    },
+    "**Update:** %{mode} service has resumed%{summary_location}.": {
+      "comment" : "Alert summary in the format of \"Update: [Vehicle type] service has resumed[ at location].\", ex \"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\" or \"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\"",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Update:** %1$@ has resumed%2$@."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Actualización:** %1$@ has resumed%2$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Mise à jour :** %1$@ has resumed%2$@."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Mizajou:** %1$@ has resumed%2$@."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Atualização:** %1$@ has resumed%2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**Cập nhật:** %1$@ has resumed%2$@."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**更新：** %1$@ has resumed%2$@."
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "**更新：** %1$@ has resumed%2$@."
           }
         }
       }
@@ -11201,6 +11363,59 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "電力作業"
+          }
+        }
+      }
+    },
+    "Elevator" : {
+      "comment" : "Elevator Service",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elevator"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ascensor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Ascenseur"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Asansè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Elevador"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Thang máy đóng cửa"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "直梯已关闭"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "直梯已關閉"
           }
         }
       }
@@ -25849,6 +26064,59 @@
         "zh-Hant-TW" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "列車"
+          }
+        }
+      }
+    },
+    "Train" : {
+      "comment" : "Train",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Train"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Train"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tren"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Trem"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Tàu"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "列车"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "needs_review",
             "value" : "列車"
           }
         }

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -14439,7 +14439,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "**All clear:** Normal service has resumed."
+            "value" : " until %@"
           }
         },
         "es" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -26814,6 +26814,10 @@
         }
       }
     },
+    "Update: %1$@" : {
+      "comment" : "Example: “Update: Service has ended”",
+      "extractionState" : "manual"
+    },
     "Updated %ld minutes ago" : {
       "comment" : "Displayed when prediction data has not been able to update for an unexpected amount of time",
       "localizations" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1873,12 +1873,12 @@
         }
       }
     },
-    "**Update:** %{mode} service has resumed%{summary_location}." : {
-      "comment" : "Alert summary in the format of \\\"Update: [Vehicle type] service has resumed[ at location].\\\", ex \\\"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\\\" or \\\"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\\\"",
+    "**Update:** %1$@ has ended%2$@." : {
+      "comment" : "Alert summary in the format of \"Update: [Alert effect] has ended[ at location].\", ex \"[Update][Stop closure] has ended[ at Haymarket].\" or \\\"[Update][Service suspension] has ended[ from Alewife to Harvard]”.",
       "extractionState" : "manual"
     },
-    "**Update:** %1$@ has ended%2$@." : {
-      "comment" : "Alert summary in the format of \\\"Update: [Alert effect] has ended[ at location].\\\", ex \\\"[Update][Stop clousure] has ended[ at Haymarket].\" or \\\"[Update][Service suspension] has ended[ from Alewife to Harvard].",
+    "**Update:** %1$@ service has resumed%2$@." : {
+      "comment" : "Alert summary in the format of \"Update: [Vehicle type] service has resumed[ at location].\", ex \"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\" or \"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\"",
       "extractionState" : "manual"
     },
     "**Update:** %1$@%2$@%3$@%4$@%5$@" : {

--- a/iosApp/iosApp/Localizable.xcstrings
+++ b/iosApp/iosApp/Localizable.xcstrings
@@ -1627,7 +1627,51 @@
     },
     "**All clear:** Normal service has resumed." : {
       "comment" : "Alert summary in the format of \\\"All clear: Normal service has resumed.\\\"",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Todo despejado:** El servicio normal se reanudó."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Voie libre :** Le service normal a repris."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**out bagay klè:** sèvis nòmal has resumed."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**tudo normal:** o serviço normal foi retomado."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**tất cả ổn thỏa:** dịch vụ bình thường đã được tiếp tục."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**通行正常：**服务已恢复正常。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**通行正常：**服務已恢復正常。"
+          }
+        }
+      }
     },
     "**All clear:** Regular service%1$@" : {
       "comment" : "Alert summary in the format of \"All clear: Regular service[at location]\", ex \"[All clear][Regular service][ from Alewife to Harvard]\"",
@@ -1875,11 +1919,99 @@
     },
     "**Update:** %1$@ has ended%2$@." : {
       "comment" : "Alert summary in the format of \"Update: [Alert effect] has ended[ at location].\", ex \"[Update][Stop closure] has ended[ at Haymarket].\" or \\\"[Update][Service suspension] has ended[ from Alewife to Harvard]”.",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Actualización:** %1$@ terminó%2$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Mise à jour :** %1$@ est terminée%2$@."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Mizajou:** %1$@ fini%2$@."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Atualização:** %1$@ terminou%2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Cập nhật:** %1$@ đã kết thúc%2$@."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**更新：** %1$@ 已结束%2$@。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**更新：** %1$@ 已結束%2$@。"
+          }
+        }
+      }
     },
     "**Update:** %1$@ service has resumed%2$@." : {
       "comment" : "Alert summary in the format of \"Update: [Vehicle type] service has resumed[ at location].\", ex \"Update: [Train] service has resumed[ from Riverside to Newton Highlands].\" or \"Update: [Bus] service has resumed[ at Market St @ Lothrop St].\"",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Actualización:** %1$@ servicio se reanudó%2$@."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Mise à jour :** %1$@ service a repris%2$@."
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Mizajou:** Sèvis %1$@ la rekòmanse%2$@."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Atualização:** o serviço %1$@ foi retomado%2$@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**Cập nhật:** Dịch vụ %1$@ đã hoạt động trở lại%2$@."
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**更新：**%1$@ 服务已恢复%2$@。"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**更新：**%1$@ 服務已恢復%2$@。"
+          }
+        }
+      }
     },
     "**Update:** %1$@%2$@%3$@%4$@%5$@" : {
       "comment" : "Alert summary in the format of \"Update: [Alert effect][at location][through timeframe][until recurrence][ due to cause], ex \"[Update][Stop closed][ at Haymarket][ through this Friday][]\" or \"[Update][Service suspended][ from Alewife to Harvard][ through end of service][ daily until Friday][due “to maintenance]",
@@ -11219,7 +11351,51 @@
     },
     "Elevator" : {
       "comment" : "Elevator Service",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascensor"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ascenseur"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Asansè"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elevador"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thang máy"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "电梯"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "電梯"
+          }
+        }
+      }
     },
     "Elevator closed" : {
       "comment" : "Possible alert effect",
@@ -25872,7 +26048,51 @@
     },
     "Train" : {
       "comment" : "Train",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tren"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "train"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tren"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "trem"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tàu"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列车"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "列車"
+          }
+        }
+      }
     },
     "Train cancelled" : {
       "localizations" : {
@@ -26816,7 +27036,51 @@
     },
     "Update: %1$@" : {
       "comment" : "Example: “Update: Service has ended”",
-      "extractionState" : "manual"
+      "extractionState" : "manual",
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualización: %1$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise à jour : %1$@"
+          }
+        },
+        "ht" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mizajou: %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Atualização: %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cập nhật: %1$@"
+          }
+        },
+        "zh-Hans-CN" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新：%1$@"
+          }
+        },
+        "zh-Hant-TW" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更新：%1$@"
+          }
+        }
+      }
     },
     "Updated %ld minutes ago" : {
       "comment" : "Displayed when prediction data has not been able to update for an unexpected amount of time",


### PR DESCRIPTION
### Summary

_Ticket:_ [All Clear | All clear template updates](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217410813479640?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Adds strings for all clear message summaries. https://github.com/mbta/mobile_app_backend/pull/711

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
