### PR TITLE
fix: Use departure time for CR and ferry trips

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -87,7 +87,7 @@ public sealed class TripInstantDisplay {
             isScheduledDeparture: Boolean,
             now: EasternTimeInstant,
         ): EasternTimeInstant? =
-            if (isScheduledDeparture) stopTime?.scheduleBasedStopTime
+            if (isScheduledDeparture) stopTime?.departureBasedStopTime
             else stopTime?.stopTimeAfter(now)
 
         internal fun from(

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplay.kt
@@ -82,6 +82,14 @@ public sealed class TripInstantDisplay {
     public companion object {
         public val delayStatuses: Set<String> = setOf("Delay", "Delayed", "Late")
 
+        private fun timeFor(
+            stopTime: TripStopTime?,
+            isScheduledDeparture: Boolean,
+            now: EasternTimeInstant,
+        ): EasternTimeInstant? =
+            if (isScheduledDeparture) stopTime?.scheduleBasedStopTime
+            else stopTime?.stopTimeAfter(now)
+
         internal fun from(
             prediction: Prediction?,
             schedule: Schedule?,
@@ -96,9 +104,9 @@ public sealed class TripInstantDisplay {
             val scheduleBasedRouteType =
                 routeType == RouteType.COMMUTER_RAIL || routeType == RouteType.FERRY
             val forceAsTime = context == Context.TripDetails || scheduleBasedRouteType
-            val showTimeAsHeadline = scheduleBasedRouteType && context != Context.TripDetails
-            val predictionTime = prediction?.stopTimeAfter(now)
-            val scheduleTime = schedule?.stopTimeAfter(now)
+            val isScheduledDeparture = scheduleBasedRouteType && context != Context.TripDetails
+            val predictionTime = timeFor(prediction, isScheduledDeparture, now)
+            val scheduleTime = timeFor(schedule, isScheduledDeparture, now)
             val isScheduleUpcoming = scheduleTime?.let { it >= now } ?: false
             scheduleTime
                 ?.takeIf {
@@ -127,22 +135,22 @@ public sealed class TripInstantDisplay {
                                 predictionTime,
                                 prediction.status,
                                 lastTrip,
-                                showTimeAsHeadline,
+                                isScheduledDeparture,
                             )
                         predictionTime != null ->
-                            return Time(predictionTime, lastTrip, showTimeAsHeadline)
+                            return Time(predictionTime, lastTrip, isScheduledDeparture)
                         scheduleTime != null &&
                             (context == Context.StopDetailsFiltered || lastTrip) ->
                             return ScheduleTimeWithStatusColumn(
                                 scheduleTime,
                                 prediction.status,
                                 lastTrip,
-                                showTimeAsHeadline,
+                                isScheduledDeparture,
                             )
                         scheduleTime != null && scheduleTime < now ->
                             return ScheduleTimeWithStatusRow(scheduleTime, prediction.status)
                         scheduleTime != null ->
-                            return ScheduleTime(scheduleTime, lastTrip, showTimeAsHeadline)
+                            return ScheduleTime(scheduleTime, lastTrip, isScheduledDeparture)
                     }
                 }
                 return Overridden(prediction.status, lastTrip)
@@ -167,7 +175,7 @@ public sealed class TripInstantDisplay {
                         scheduleMinutesRemaining >=
                             SCHEDULE_CLOCK_CUTOFF.toDouble(DurationUnit.MINUTES) || forceAsTime
                     ) {
-                        ScheduleTime(scheduleTime, lastTrip, headline = showTimeAsHeadline)
+                        ScheduleTime(scheduleTime, lastTrip, headline = isScheduledDeparture)
                     } else {
                         ScheduleMinutes(scheduleMinutesRemaining, lastTrip)
                     }
@@ -195,10 +203,10 @@ public sealed class TripInstantDisplay {
                         predictionTime,
                         scheduleTime,
                         lastTrip,
-                        headline = showTimeAsHeadline,
+                        headline = isScheduledDeparture,
                     )
                 } else {
-                    Time(predictionTime, lastTrip, headline = showTimeAsHeadline)
+                    Time(predictionTime, lastTrip, headline = isScheduledDeparture)
                 }
             }
 

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -13,7 +13,7 @@ public interface TripStopTime : Comparable<TripStopTime> {
      * For Ferry and Commuter Rail, the departure time is the primary time that should be displayed,
      * but if arrival is the only time that exists, we should still fall back to that.
      */
-    public val scheduleBasedStopTime: EasternTimeInstant?
+    public val departureBasedStopTime: EasternTimeInstant?
         get() = departureTime ?: arrivalTime
 
     public fun stopTimeAfter(now: EasternTimeInstant): EasternTimeInstant? =

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/TripStopTime.kt
@@ -9,6 +9,13 @@ public interface TripStopTime : Comparable<TripStopTime> {
     public val stopTime: EasternTimeInstant?
         get() = arrivalTime ?: departureTime
 
+    /**
+     * For Ferry and Commuter Rail, the departure time is the primary time that should be displayed,
+     * but if arrival is the only time that exists, we should still fall back to that.
+     */
+    public val scheduleBasedStopTime: EasternTimeInstant?
+        get() = departureTime ?: arrivalTime
+
     public fun stopTimeAfter(now: EasternTimeInstant): EasternTimeInstant? =
         arrivalTime?.takeUnless { it < now } ?: departureTime
 

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/TripInstantDisplayTest.kt
@@ -1204,4 +1204,50 @@ class TripInstantDisplayTest {
             ),
         )
     }
+
+    @Test
+    fun `departure times are shown instead of arrival times for Ferry and Commuter Rail`() =
+        parametricTest {
+            val now = EasternTimeInstant.now()
+            val lastTrip = anyBoolean()
+            assertEquals(
+                TripInstantDisplay.Time(now + 15.minutes, lastTrip, true),
+                TripInstantDisplay.from(
+                    prediction =
+                        ObjectCollectionBuilder.Single.prediction {
+                            arrivalTime = now + 10.minutes
+                            departureTime = now + 15.minutes
+                        },
+                    schedule = null,
+                    vehicle = null,
+                    routeType = RouteType.COMMUTER_RAIL,
+                    now = now,
+                    context = nonTripDetails(),
+                    lastTrip = lastTrip,
+                ),
+            )
+        }
+
+    @Test
+    fun `arrival times are show instead of departure times for Ferry and Commuter Rail on trip details`() =
+        parametricTest {
+            val now = EasternTimeInstant.now()
+            val lastTrip = anyBoolean()
+            assertEquals(
+                TripInstantDisplay.Time(now + 10.minutes, lastTrip),
+                TripInstantDisplay.from(
+                    prediction =
+                        ObjectCollectionBuilder.Single.prediction {
+                            arrivalTime = now + 10.minutes
+                            departureTime = now + 15.minutes
+                        },
+                    schedule = null,
+                    vehicle = null,
+                    routeType = RouteType.COMMUTER_RAIL,
+                    now = now,
+                    context = TripInstantDisplay.Context.TripDetails,
+                    lastTrip = lastTrip,
+                ),
+            )
+        }
 }


### PR DESCRIPTION
### Summary

_Ticket:_ [Use departure_time for Commuter Rail and Ferry](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217793966475173?focus=true)

On nearby transit and stop details, show the departure times for schedule based modes, instead of arrivals. Times in trip details are still the arrival times.

<img height="600" alt="Screenshot_20260901_143640" src="https://github.com/user-attachments/assets/036e9aba-7c0c-4b27-9766-9bc5752b8a9d" />

### Testing

Updated tests to check for new behavior