### PR TITLE
fix(android): Import missing translations

### DIFF
--- a/androidApp/src/main/res/values-es/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-es/strings_ios_converted.xml
@@ -25,6 +25,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020hasta las %1$s</string>
+    <string name="all_day">Todo el día</string>
     <string name="alternative_path">Camino alternativo</string>
     <string name="amber_alert">Alerta Amber</string>
     <string name="amber_alert_sentence_case">Alerta Amber</string>
@@ -77,6 +78,7 @@
     <string name="crowding_some_crowding">Algo de gente</string>
     <string name="crowding_unknown">Nivel de ocupación desconocido</string>
     <string name="current_locale">es</string>
+    <string name="custom">Costumbres</string>
     <string name="daily">A diario</string>
     <string name="delay">Demora</string>
     <string name="delays_due_to_cause">Retrasos debido a &lt;b>%1$s&lt;/b></string>
@@ -132,6 +134,7 @@
     <string name="error_loading_data">Error al cargar datos</string>
     <string name="escalator_closed_sentence_case">Escalera mecánica cerrada</string>
     <string name="escalator_closure">Escalera mecánica fuera de servicio</string>
+    <string name="evening">Noche</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b> h</string>
     <string name="expand_remaining_stops">ampliar las paradas restantes</string>
     <string name="expand_stops">ampliar paradas</string>
@@ -221,6 +224,7 @@
     <string name="mechanical_problem_lowercase">problema mecánico</string>
     <string name="medical_emergency">Emergencia médica</string>
     <string name="medical_emergency_lowercase">emergencia médica</string>
+    <string name="midday">Mediodía</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="modified_service">Servicio modificado</string>
     <string name="modified_service_sentence_case">Servicio modificado</string>
@@ -237,6 +241,7 @@
     <string name="more_section_support_note_accessibility">711 para usuarios de TTY; VRS para usuarios de ASL</string>
     <string name="more_section_support_note_hours">De lunes a viernes de 6:30 a. m. a 8:00 p. m.</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">Buenos días</string>
     <string name="nearby_transit">Tránsito cercano</string>
     <string name="nearby_transit_link">Cerca</string>
     <string name="new_feature_screen_reader_header_prefix">Nueva función. %1$s</string>
@@ -415,6 +420,7 @@
     <string name="tie_replacement_lowercase">reemplazo de traviesas</string>
     <string name="time_picker_type_toggle">Alternar el tipo de selector de hora</string>
     <string name="to">A</string>
+    <string name="to_lowercase">A</string>
     <string name="toast_tip_prefix">Consejo: %1$s</string>
     <string name="toggle_direction">alternar dirección</string>
     <string name="track_change">Cambio de pista</string>

--- a/androidApp/src/main/res/values-fr/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-fr/strings_ios_converted.xml
@@ -25,6 +25,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> à &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020jusqu’au %1$s</string>
+    <string name="all_day">Toute la journée</string>
     <string name="alternative_path">Trajet alternatif</string>
     <string name="amber_alert">Alerte Amber</string>
     <string name="amber_alert_sentence_case">Alerte Amber</string>
@@ -77,6 +78,7 @@
     <string name="crowding_some_crowding">Affluence modérée</string>
     <string name="crowding_unknown">Foule inconnue</string>
     <string name="current_locale">fr</string>
+    <string name="custom">Coutumes</string>
     <string name="daily">Tous les jours</string>
     <string name="delay">Retard</string>
     <string name="delays_due_to_cause">Retards dus à &lt;b>%1$s&lt;/b></string>
@@ -132,6 +134,7 @@
     <string name="error_loading_data">Erreur dans le chargement des données</string>
     <string name="escalator_closed_sentence_case">Escalator hors service</string>
     <string name="escalator_closure">Escalator hors service</string>
+    <string name="evening">Soirée</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b> h</string>
     <string name="expand_remaining_stops">étendre les arrêts restants</string>
     <string name="expand_stops">afficher les arrêts</string>
@@ -221,6 +224,7 @@
     <string name="mechanical_problem_lowercase">problème mécanique</string>
     <string name="medical_emergency">Urgence médicale</string>
     <string name="medical_emergency_lowercase">urgence médicale</string>
+    <string name="midday">Midi</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="modified_service">Service modifié</string>
     <string name="modified_service_sentence_case">Service modifié</string>
@@ -237,6 +241,7 @@
     <string name="more_section_support_note_accessibility">711 pour le service TTY; VRS pour la langue des signes</string>
     <string name="more_section_support_note_hours">Du lundi au vendredi : de 6 h 30 à 20 h</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">Bonjour</string>
     <string name="nearby_transit">Transports à proximité</string>
     <string name="nearby_transit_link">Proche</string>
     <string name="new_feature_screen_reader_header_prefix">Nouvelle fonctionnalité. %1$s</string>
@@ -415,6 +420,7 @@
     <string name="tie_replacement_lowercase">remplacement de traverses</string>
     <string name="time_picker_type_toggle">Changer le mode de sélection de l’heure</string>
     <string name="to">Jusqu’à</string>
+    <string name="to_lowercase">Jusqu’à</string>
     <string name="toast_tip_prefix">Astuce : %1$s</string>
     <string name="toggle_direction">inverser la direction</string>
     <string name="track_change">Changement de voie</string>

--- a/androidApp/src/main/res/values-ht/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-ht/strings_ios_converted.xml
@@ -28,6 +28,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020soti nan &lt;b>%1$s&lt;/b> a &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020jiska %1$s</string>
+    <string name="all_day">Tout lajounen</string>
     <string name="alternative_path">Lòt chemen</string>
     <string name="amber_alert">Avètisman Amber</string>
     <string name="amber_alert_sentence_case">Avètisman amber</string>
@@ -80,6 +81,7 @@
     <string name="crowding_some_crowding">Gen kèk moun ki te twò chaje</string>
     <string name="crowding_unknown">Foul moun enkoni</string>
     <string name="current_locale">ht</string>
+    <string name="custom">Personnalisé</string>
     <string name="daily">Chak jou</string>
     <string name="delay">Reta</string>
     <string name="delays_due_to_cause">Reta akòz &lt;b>%1$s&lt;/b></string>
@@ -141,6 +143,7 @@
     <string name="error_loading_data">Erè nan chajman done</string>
     <string name="escalator_closed_sentence_case">Fèmti eskalye</string>
     <string name="escalator_closure">Fèmti Eskalye</string>
+    <string name="evening">Aswè</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b> èdtan</string>
     <string name="expand_remaining_stops">elaji arè ki rete yo</string>
     <string name="expand_stops">elaji arè yo</string>
@@ -230,6 +233,7 @@
     <string name="mechanical_problem_lowercase">pwoblèm mekanik</string>
     <string name="medical_emergency">Ijans Medikal</string>
     <string name="medical_emergency_lowercase">ijans medikal</string>
+    <string name="midday">Midi</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> minit</string>
     <string name="modified_service">Sèvis Modifye</string>
     <string name="modified_service_sentence_case">Sèvis modifye</string>
@@ -246,6 +250,7 @@
     <string name="more_section_support_note_accessibility">711 pou moun ki rele TTY; VRS pou moun kap rele ASL</string>
     <string name="more_section_support_note_hours">Lendi rive vandredi: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">Maten</string>
     <string name="nearby_transit">Transpò piblik ki toupre</string>
     <string name="nearby_transit_link">Toupre</string>
     <string name="new_feature_screen_reader_header_prefix">Nouvo karakteristik. %1$s</string>
@@ -427,6 +432,7 @@
     <string name="tie_replacement_lowercase">ranplasman mare</string>
     <string name="time_picker_type_toggle">Chanje/dezaktive kalite seleksyon tan an</string>
     <string name="to">Pou</string>
+    <string name="to_lowercase">Pou</string>
     <string name="toast_tip_prefix">Konsèy: %1$s</string>
     <string name="toggle_direction">baskile direksyon</string>
     <string name="track_change">Suiv Chanjman</string>

--- a/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-pt-rBR/strings_ios_converted.xml
@@ -25,6 +25,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020de &lt;b>%1$s&lt;/b> até &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020até %1$s</string>
+    <string name="all_day">O dia todo</string>
     <string name="alternative_path">Caminho alternativo</string>
     <string name="amber_alert">Alerta amarelo</string>
     <string name="amber_alert_sentence_case">Alerta amarelo</string>
@@ -77,6 +78,7 @@
     <string name="crowding_some_crowding">Lotação moderada</string>
     <string name="crowding_unknown">Lotação desconhecida</string>
     <string name="current_locale">pt-BR</string>
+    <string name="custom">Personalizado</string>
     <string name="daily">Diariamente</string>
     <string name="delay">Atraso</string>
     <string name="delays_due_to_cause">Atrasos devido a &lt;b>%1$s&lt;/b></string>
@@ -132,6 +134,7 @@
     <string name="error_loading_data">Erro ao carregar dados</string>
     <string name="escalator_closed_sentence_case">Escada rolante fechada</string>
     <string name="escalator_closure">Fechamento de escada rolante</string>
+    <string name="evening">Noite</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b> h</string>
     <string name="expand_remaining_stops">expandir as paradas restantes</string>
     <string name="expand_stops">expandir paradas</string>
@@ -221,6 +224,7 @@
     <string name="mechanical_problem_lowercase">problema mecânico</string>
     <string name="medical_emergency">Emergência médica</string>
     <string name="medical_emergency_lowercase">emergência médica</string>
+    <string name="midday">Meio-dia</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> min</string>
     <string name="modified_service">Serviço modificado</string>
     <string name="modified_service_sentence_case">Serviço modificado</string>
@@ -237,6 +241,7 @@
     <string name="more_section_support_note_accessibility">711 para usuários de TTY e VRS para usuários de ASL</string>
     <string name="more_section_support_note_hours">De segunda a sexta: 6:30 AM - 8 PM</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">Manhã</string>
     <string name="nearby_transit">Trânsito próximo</string>
     <string name="nearby_transit_link">Próximo</string>
     <string name="new_feature_screen_reader_header_prefix">Novo recurso. %1$s</string>
@@ -415,6 +420,7 @@
     <string name="tie_replacement_lowercase">substituição de dormentes</string>
     <string name="time_picker_type_toggle">Alternar modo de entrada do horário</string>
     <string name="to">Para</string>
+    <string name="to_lowercase">Para</string>
     <string name="toast_tip_prefix">Dica: %1$s</string>
     <string name="toggle_direction">alternar direção</string>
     <string name="track_change">Alteração de trilho</string>

--- a/androidApp/src/main/res/values-vi/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-vi/strings_ios_converted.xml
@@ -23,6 +23,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020từ &lt;b>%1$s&lt;/b> đến &lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020đến %1$s</string>
+    <string name="all_day">Cả ngày</string>
     <string name="alternative_path">Đường đi thay thế</string>
     <string name="amber_alert">Cảnh báo Amber</string>
     <string name="amber_alert_sentence_case">Cảnh báo Amber</string>
@@ -75,6 +76,7 @@
     <string name="crowding_some_crowding">Một số chỗ chật chội</string>
     <string name="crowding_unknown">Tình trạng đông đúc chưa rõ</string>
     <string name="current_locale">vi</string>
+    <string name="custom">Phong tục</string>
     <string name="daily">Hằng ngày</string>
     <string name="delay">Trễ</string>
     <string name="delays_due_to_cause">Trì hoãn do &lt;b>%1$s&lt;/b></string>
@@ -115,7 +117,7 @@
     <string name="elevator_closed_sentence_case">Thang máy đóng cửa</string>
     <string name="elevator_closure">Đóng thang máy</string>
     <plurals name="elevator_closure_count">
-        <item quantity="other">%1$d elevators đã đóng</item>
+        <item quantity="other">%1$d thang máy đã đóng</item>
     </plurals>
     <plurals name="elevator_closure_count_accessibility_description">
         <item quantity="other">Điểm dừng này có %1$d thang máy đã đóng</item>
@@ -126,6 +128,7 @@
     <string name="error_loading_data">Lỗi khi tải dữ liệu</string>
     <string name="escalator_closed_sentence_case">Thang cuốn đóng cửa</string>
     <string name="escalator_closure">Thang cuốn đóng cửa</string>
+    <string name="evening">Buổi tối</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b> giờ</string>
     <string name="expand_remaining_stops">mở rộng các điểm dừng còn lại</string>
     <string name="expand_stops">mở rộng các điểm dừng</string>
@@ -215,6 +218,7 @@
     <string name="mechanical_problem_lowercase">vấn đề cơ khí</string>
     <string name="medical_emergency">Cấp cứu y tế</string>
     <string name="medical_emergency_lowercase">cấp cứu y tế</string>
+    <string name="midday">Giữa trưa</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b> phút</string>
     <string name="modified_service">Dịch vụ đã sửa đổi</string>
     <string name="modified_service_sentence_case">Dịch vụ đã sửa đổi</string>
@@ -231,6 +235,7 @@
     <string name="more_section_support_note_accessibility">711 với người gọi TTY; VRS với người gọi ASL</string>
     <string name="more_section_support_note_hours">Từ thứ Hai đến thứ Sáu: 6:30 sáng - 8:00 tối</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">Buổi sáng</string>
     <string name="nearby_transit">Phương tiện công cộng ở gần</string>
     <string name="nearby_transit_link">Ở gần</string>
     <string name="new_feature_screen_reader_header_prefix">Tính năng mới. %1$s</string>
@@ -407,6 +412,7 @@
     <string name="tie_replacement_lowercase">thay tà vẹt</string>
     <string name="time_picker_type_toggle">Công tắc chọn loại thời gian</string>
     <string name="to">Đến</string>
+    <string name="to_lowercase">Đến</string>
     <string name="toast_tip_prefix">Mẹo: %1$s</string>
     <string name="toggle_direction">chuyển hướng</string>
     <string name="track_change">Thay đổi đường ray</string>

--- a/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rCN/strings_ios_converted.xml
@@ -23,6 +23,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020从&lt;b>%1$s&lt;/b>到&lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020至%1$s</string>
+    <string name="all_day">全天</string>
     <string name="alternative_path">备选路线</string>
     <string name="amber_alert">安珀警报</string>
     <string name="amber_alert_sentence_case">安珀警报</string>
@@ -75,6 +76,7 @@
     <string name="crowding_some_crowding">略有拥挤</string>
     <string name="crowding_unknown">拥挤度未知</string>
     <string name="current_locale">zh-Hans-CN</string>
+    <string name="custom">风俗</string>
     <string name="daily">每日</string>
     <string name="delay">延误</string>
     <string name="delays_due_to_cause">由于 &lt;b>%1$s&lt;/b> 造成延误</string>
@@ -126,6 +128,7 @@
     <string name="error_loading_data">加载数据时出错</string>
     <string name="escalator_closed_sentence_case">自动扶梯已关闭</string>
     <string name="escalator_closure">自动扶梯关闭</string>
+    <string name="evening">晚上</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b>小时</string>
     <string name="expand_remaining_stops">展开剩余站点</string>
     <string name="expand_stops">展开站点</string>
@@ -215,6 +218,7 @@
     <string name="mechanical_problem_lowercase">机械故障</string>
     <string name="medical_emergency">医疗急救</string>
     <string name="medical_emergency_lowercase">医疗急救</string>
+    <string name="midday">正午</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b>分钟</string>
     <string name="modified_service">调整后的服务</string>
     <string name="modified_service_sentence_case">调整后的服务</string>
@@ -231,6 +235,7 @@
     <string name="more_section_support_note_accessibility">TTY呼叫者请拨打711；ASL呼叫者请使用VRS</string>
     <string name="more_section_support_note_hours">周一至周五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">早晨</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
     <string name="new_feature_screen_reader_header_prefix">新增功能。%1$s</string>
@@ -407,6 +412,7 @@
     <string name="tie_replacement_lowercase">更换轨枕</string>
     <string name="time_picker_type_toggle">时间选择器类型切换</string>
     <string name="to">目的地</string>
+    <string name="to_lowercase">目的地</string>
     <string name="toast_tip_prefix">提示：%1$s</string>
     <string name="toggle_direction">切换方向</string>
     <string name="track_change">轨道变更</string>

--- a/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
+++ b/androidApp/src/main/res/values-zh-rTW/strings_ios_converted.xml
@@ -23,6 +23,7 @@
     <string name="alert_summary">&lt;b>%1$s&lt;/b>%2$s%3$s%4$s</string>
     <string name="alert_summary_location_successive">\u0020從&lt;b>%1$s&lt;/b>到&lt;b>%2$s&lt;/b></string>
     <string name="alert_summary_timeframe_this_week">\u0020至%1$s</string>
+    <string name="all_day">全天</string>
     <string name="alternative_path">替代路徑</string>
     <string name="amber_alert">安珀警報</string>
     <string name="amber_alert_sentence_case">安珀警報</string>
@@ -75,6 +76,7 @@
     <string name="crowding_some_crowding">略有擁擠</string>
     <string name="crowding_unknown">擁擠度不明</string>
     <string name="current_locale">zh-Hant-TW</string>
+    <string name="custom">風俗</string>
     <string name="daily">每日</string>
     <string name="delay">延誤</string>
     <string name="delays_due_to_cause">因 &lt;b>%1$s&lt;/b> 造成延誤</string>
@@ -126,6 +128,7 @@
     <string name="error_loading_data">載入資料時發生錯誤</string>
     <string name="escalator_closed_sentence_case">自動扶梯已關閉</string>
     <string name="escalator_closure">自動扶梯關閉</string>
+    <string name="evening">晚上</string>
     <string name="exact_hours_format_abbr">&lt;b>%1$d&lt;/b>小時</string>
     <string name="expand_remaining_stops">展開剩餘站點</string>
     <string name="expand_stops">展開網站</string>
@@ -215,6 +218,7 @@
     <string name="mechanical_problem_lowercase">機械故障</string>
     <string name="medical_emergency">醫療急救</string>
     <string name="medical_emergency_lowercase">醫療急救</string>
+    <string name="midday">正午</string>
     <string name="minutes_abbr">&lt;b>%1$d&lt;/b>分鐘</string>
     <string name="modified_service">調整後的服務</string>
     <string name="modified_service_sentence_case">調整後的服務</string>
@@ -231,6 +235,7 @@
     <string name="more_section_support_note_accessibility">TTY呼叫者請致電711；ASL呼叫者請使用VRS</string>
     <string name="more_section_support_note_hours">週一至週五：上午6:30至晚上8:00</string>
     <string name="more_title">MBTA Go</string>
+    <string name="morning">早晨</string>
     <string name="nearby_transit">附近的交通</string>
     <string name="nearby_transit_link">附近</string>
     <string name="new_feature_screen_reader_header_prefix">新增功能。%1$s</string>
@@ -407,6 +412,7 @@
     <string name="tie_replacement_lowercase">更換軌枕</string>
     <string name="time_picker_type_toggle">時間選擇器類型切換</string>
     <string name="to">目的地</string>
+    <string name="to_lowercase">目的地</string>
     <string name="toast_tip_prefix">提示：%1$s</string>
     <string name="toggle_direction">切換方向</string>
     <string name="track_change">軌道變更</string>


### PR DESCRIPTION
### Summary

_Ticket:_ [Name](URL)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
