### PR TITLE
feat(android.NotificationSettingsWidget): Preserve custom when switching between presets

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidgetTest.kt
@@ -385,4 +385,38 @@ class NotificationSettingsWidgetTest : KoinTest {
         composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
         composeTestRule.onNodeWithText("Midday").assertIsSelected()
     }
+
+    @Test
+    fun testCustomPresetRestoredAfterSelectingAnotherPreset() {
+        loadKoinMocks {
+            settings =
+                MockSettingsRepository(settings = mapOf(Settings.NotificationPresetWindows to true))
+        }
+        composeTestRule.setContent {
+            var settings by remember { mutableStateOf(FavoriteSettings.Notifications.disabled) }
+            NotificationSettingsWidget(
+                settings,
+                setSettings = { settings = it },
+                notificationPermissionState = permissionGranted,
+                hasRequestedPermission = true,
+                now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 4, 30, 0)),
+            )
+        }
+
+        composeTestRule.onNodeWithText("Get disruption notifications").performClick()
+        composeTestRule.waitUntilExactlyOneExistsDefaultTimeout(hasText("Morning"))
+
+        composeTestRule.onNodeWithText("Custom").performClick()
+        composeTestRule.onNodeWithText("Sunday").performClick()
+        composeTestRule.onNodeWithText("Custom").assertIsSelected()
+        composeTestRule.onNodeWithText("Sunday").assertIsOn()
+
+        composeTestRule.onNodeWithText("Morning").performClick()
+        composeTestRule.onNodeWithText("Morning").assertIsSelected()
+        composeTestRule.onNodeWithText("Sunday").assertIsOff()
+
+        composeTestRule.onNodeWithText("Custom").performClick()
+        composeTestRule.onNodeWithText("Custom").assertIsSelected()
+        composeTestRule.onNodeWithText("Sunday").assertIsOn()
+    }
 }

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelectorTest.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelectorTest.kt
@@ -1,7 +1,5 @@
 package com.mbta.tid.mbta_app.android.favorites
 
-import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.junit4.v2.createComposeRule
@@ -24,7 +22,7 @@ class PresetWindowSelectorTest {
 
     @Test
     fun testPresetWindowsVisible() {
-        var selectedWindow: Window? = null
+        var selectedWindows: List<Window>? = null
         composeTestRule.setContent {
             PresetWindowSelector(
                 presetRows =
@@ -43,10 +41,10 @@ class PresetWindowSelectorTest {
                         ),
                     ),
                 selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
-                presetsEnabled = true,
-                onSelect = { window -> selectedWindow = window },
                 now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 4, 30, 0)),
-            )
+            ) { windows ->
+                selectedWindows = windows
+            }
         }
 
         composeTestRule.onNodeWithText("Morning").assertIsNotSelected()
@@ -54,42 +52,12 @@ class PresetWindowSelectorTest {
         composeTestRule.onNodeWithText("Custom").assertIsNotSelected()
 
         composeTestRule.onNodeWithText("Morning").performClick()
-        assertEquals(Window.morningDefault(Window.weekdays), selectedWindow)
-    }
-
-    @Test
-    fun testPresetButtonsDisabled() {
-        composeTestRule.setContent {
-            PresetWindowSelector(
-                presetRows =
-                    listOf(
-                        listOf(
-                            PresetWindow(
-                                window = Window.morningDefault(Window.weekdays),
-                                label = "Morning",
-                            )
-                        ),
-                        listOf(
-                            PresetWindow(
-                                window = Window.middayDefault(Window.weekdays),
-                                label = "Midday",
-                            )
-                        ),
-                    ),
-                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
-                presetsEnabled = false,
-                onSelect = {},
-            )
-        }
-
-        composeTestRule.onNodeWithText("Morning").assertIsNotEnabled()
-        composeTestRule.onNodeWithText("Midday").assertIsNotEnabled()
-        composeTestRule.onNodeWithText("Custom").assertIsEnabled()
+        assertEquals(listOf(Window.morningDefault(Window.weekdays)), selectedWindows)
     }
 
     @Test
     fun testCustomDefaultsToNow() {
-        var selectedWindow: Window? = null
+        var selectedWindows: List<Window>? = null
         composeTestRule.setContent {
             PresetWindowSelector(
                 presetRows =
@@ -108,33 +76,35 @@ class PresetWindowSelectorTest {
                         ),
                     ),
                 selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
-                presetsEnabled = true,
-                onSelect = { window -> selectedWindow = window },
                 now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 4, 30, 0)),
-            )
+            ) { windows ->
+                selectedWindows = windows
+            }
         }
 
         composeTestRule.onNodeWithText("Custom").performClick()
         assertEquals(
-            selectedWindow,
-            Window(
-                startTime = LocalTime(4, 0, 0),
-                endTime = LocalTime(5, 0, 0),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
+            selectedWindows,
+            listOf(
+                Window(
+                    startTime = LocalTime(4, 0, 0),
+                    endTime = LocalTime(5, 0, 0),
+                    daysOfWeek =
+                        setOf(
+                            DayOfWeek.MONDAY,
+                            DayOfWeek.TUESDAY,
+                            DayOfWeek.WEDNESDAY,
+                            DayOfWeek.THURSDAY,
+                            DayOfWeek.FRIDAY,
+                        ),
+                )
             ),
         )
     }
 
     @Test
     fun testCustomDefaultsToNowLateNight() {
-        var selectedWindow: Window? = null
+        var selectedWindows: List<Window>? = null
         composeTestRule.setContent {
             PresetWindowSelector(
                 presetRows =
@@ -153,27 +123,70 @@ class PresetWindowSelectorTest {
                         ),
                     ),
                 selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
-                presetsEnabled = true,
-                onSelect = { window -> selectedWindow = window },
                 now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 23, 30, 0)),
-            )
+            ) { windows ->
+                selectedWindows = windows
+            }
         }
 
         composeTestRule.onNodeWithText("Custom").performClick()
         assertEquals(
-            selectedWindow,
-            Window(
-                startTime = LocalTime(23, 0, 0),
-                endTime = LocalTime(23, 59, 0),
-                daysOfWeek =
-                    setOf(
-                        DayOfWeek.MONDAY,
-                        DayOfWeek.TUESDAY,
-                        DayOfWeek.WEDNESDAY,
-                        DayOfWeek.THURSDAY,
-                        DayOfWeek.FRIDAY,
-                    ),
+            selectedWindows,
+            listOf(
+                Window(
+                    startTime = LocalTime(23, 0, 0),
+                    endTime = LocalTime(23, 59, 0),
+                    daysOfWeek =
+                        setOf(
+                            DayOfWeek.MONDAY,
+                            DayOfWeek.TUESDAY,
+                            DayOfWeek.WEDNESDAY,
+                            DayOfWeek.THURSDAY,
+                            DayOfWeek.FRIDAY,
+                        ),
+                )
             ),
         )
+    }
+
+    @Test
+    fun testCustomUsesProvidedCustomPreset() {
+        var selectedWindows: List<Window>? = null
+        val customPresetWindows =
+            listOf(
+                Window(
+                    startTime = LocalTime(10, 15, 0),
+                    endTime = LocalTime(11, 45, 0),
+                    daysOfWeek = setOf(DayOfWeek.SUNDAY, DayOfWeek.TUESDAY),
+                )
+            )
+
+        composeTestRule.setContent {
+            PresetWindowSelector(
+                presetRows =
+                    listOf(
+                        listOf(
+                            PresetWindow(
+                                window = Window.morningDefault(Window.weekdays),
+                                label = "Morning",
+                            )
+                        ),
+                        listOf(
+                            PresetWindow(
+                                window = Window.middayDefault(Window.weekdays),
+                                label = "Midday",
+                            )
+                        ),
+                    ),
+                selectedPreset = PresetSelection.Preset(rowIndex = 1, columnIndex = 0),
+                now = EasternTimeInstant(LocalDateTime(2026, 8, 27, 4, 30, 0)),
+                customPreset = customPresetWindows,
+            ) { windows ->
+                selectedWindows = windows
+            }
+        }
+
+        composeTestRule.onNodeWithText("Custom").performClick()
+        assertEquals(customPresetWindows, selectedWindows)
     }
 }

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -128,7 +128,7 @@ fun NotificationSettingsWidget(
         )
     val presetSelection: PresetSelection =
         remember(settings) {
-            PresetSelection.selectedPresetFromSettings(settings, presetOptions)
+            PresetSelection.selectedPresetFromWindows(settings.windows, presetOptions)
         }
     var customPreset by remember {
         mutableStateOf(listOf(Window.customFromCurrentTime(now)))

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/NotificationSettingsWidget.kt
@@ -130,6 +130,15 @@ fun NotificationSettingsWidget(
         remember(settings) {
             PresetSelection.selectedPresetFromSettings(settings, presetOptions)
         }
+    var customPreset by remember {
+        mutableStateOf(listOf(Window.customFromCurrentTime(now)))
+    }
+
+    LaunchedEffect(presetSelection, settings.windows) {
+        if (presetSelection is PresetSelection.Custom && settings.windows.isNotEmpty()) {
+            customPreset = settings.windows
+        }
+    }
 
     val presetWindowsEnabled = SettingsCache.get(UserSettings.NotificationPresetWindows)
 
@@ -163,12 +172,10 @@ fun NotificationSettingsWidget(
                     PresetWindowSelector(
                         presetRows = presetOptions,
                         selectedPreset = presetSelection,
-                        presetsEnabled = settings.windows.size <= 1,
-                        onSelect = { window ->
-                            val otherWindows = settings.windows.drop(1)
-                            setSettings(settings.copy(windows = listOf(window) + otherWindows))
-                        },
-                    )
+                        customPreset = customPreset,
+                    ) { windows ->
+                        setSettings(settings.copy(windows = windows))
+                    }
                 }
 
                 for (window in

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/favorites/PresetWindowSelector.kt
@@ -28,9 +28,9 @@ import com.mbta.tid.mbta_app.utils.EasternTimeInstant
 fun PresetWindowSelector(
     presetRows: List<List<PresetWindow>>,
     selectedPreset: PresetSelection,
-    presetsEnabled: Boolean,
     now: EasternTimeInstant = EasternTimeInstant.now(),
-    onSelect: (Window) -> Unit,
+    customPreset: List<Window> = listOf(Window.customFromCurrentTime(now)),
+    onSelect: (List<Window>) -> Unit,
 ) {
     val maxColumnCount = presetRows.firstOrNull()?.size ?: 0
 
@@ -52,9 +52,8 @@ fun PresetWindowSelector(
                             rowIndex == selectedPreset.rowIndex &&
                             presetIndex == selectedPreset.columnIndex
                     PresetButton(
-                        enabled = presetsEnabled,
                         isSelected = isSelected,
-                        onSelect = { onSelect(preset.window) },
+                        onSelect = { onSelect(listOf(preset.window)) },
                         label = preset.label,
                         modifier =
                             Modifier.weight(1f).semantics {
@@ -72,11 +71,9 @@ fun PresetWindowSelector(
         }
         Row() {
             val isSelected = selectedPreset is PresetSelection.Custom
-            val customWindow = Window.customFromCurrentTime(now)
             PresetButton(
-                enabled = true,
                 isSelected = isSelected,
-                onSelect = { onSelect(customWindow) },
+                onSelect = { onSelect(customPreset) },
                 label = stringResource(R.string.custom),
                 modifier =
                     Modifier.weight(1f).semantics {
@@ -95,7 +92,6 @@ fun PresetWindowSelector(
 
 @Composable
 fun PresetButton(
-    enabled: Boolean,
     isSelected: Boolean,
     onSelect: () -> Unit,
     label: String,
@@ -103,7 +99,6 @@ fun PresetButton(
 ) {
     Button(
         onClick = onSelect,
-        enabled = enabled,
         colors =
             ButtonDefaults.buttonColors(
                 containerColor =
@@ -116,7 +111,6 @@ fun PresetButton(
         modifier =
             modifier.selectable(
                 selected = isSelected,
-                enabled = enabled,
                 onClick = onSelect,
                 role = Role.Tab,
             ),

--- a/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
@@ -34,6 +34,8 @@ struct NotificationSettingsWidget: View {
     var authorizationStatus: UNAuthorizationStatus? { notificationPermissionManager.authorizationStatus }
     var now: EasternTimeInstant = .now()
 
+    @State var customPreset: [FavoriteSettings.NotificationsWindow] = []
+
     @EnvironmentObject var settingsCache: SettingsCache
     var presetWindowsEnabled: Bool { settingsCache.get(.notificationPresetWindows) }
 
@@ -66,14 +68,17 @@ struct NotificationSettingsWidget: View {
     }
 
     var presetSelection: PresetSelection {
-        PresetSelection.companion.selectedPresetFromSettings(
-            settings: settings,
+        PresetSelection.companion.selectedPresetFromWindows(
+            windows: settings.windows,
             presetOptions: presetOptions
         )
     }
 
+    let inspection = Inspection<Self>()
+
     var body: some View {
         let permissionDenied = authorizationStatus == .denied
+        let _ = print("HELLO CUSTOM PRESET \(customPreset)")
         VStack(spacing: 8) {
             NotificationSwitch(
                 settings: settings,
@@ -88,16 +93,39 @@ struct NotificationSettingsWidget: View {
                     PresetWindowSelector(
                         presetRows: presetOptions,
                         selectedPreset: presetSelection,
-                        presetsEnabled: settings.windows.count <= 1,
                         now: now,
-                        onSelect: { selectedWindow in
-                            let otherWindows = settings.windows.dropFirst()
+                        customPreset: customPreset,
+                        onSelect: { selectedWindows in
                             setSettings(settings.doCopy(
                                 enabled: settings.enabled,
-                                windows: [selectedWindow] + otherWindows
+                                windows: selectedWindows
                             ))
                         }
                     )
+                    .onAppear {
+                        if presetSelection == PresetSelection.Custom() {
+                            customPreset = settings.windows
+                            print("HELLO A \(customPreset)")
+
+                        } else {
+                            print("HELLO B")
+
+                            customPreset =
+                                [FavoriteSettings.NotificationsWindow.companion.customFromCurrentTime(now: now)]
+                        }
+                    }
+                    .onChange(of: settings.windows) { newWindows in
+                        if PresetSelection.companion.selectedPresetFromWindows(
+                            windows: newWindows,
+                            presetOptions: presetOptions
+                        ) == PresetSelection.Custom() {
+                            print("HELLO C \(newWindows)")
+
+                            customPreset = newWindows
+                        } else {
+                            print("HELLO D \(newWindows)")
+                        }
+                    }
                 }
 
                 ForEach(settings.windows, id: \.id) { window in
@@ -112,10 +140,11 @@ struct NotificationSettingsWidget: View {
                             setSettings(settings.doCopy(enabled: settings.enabled, windows: newWindows))
                         },
                         deleteWindow: settings.windows.count > 1 ? {
+                            let nextWindows = settings.windows.filter { $0.id != window.id }
                             setSettings(
                                 settings.doCopy(
                                     enabled: settings.enabled,
-                                    windows: settings.windows.filter { $0.id != window.id }
+                                    windows: nextWindows
                                 )
                             )
                         } : nil
@@ -133,10 +162,13 @@ struct NotificationSettingsWidget: View {
                         )
                     }
 
-                Button(action: { setSettings(settings.doCopy(
-                    enabled: settings.enabled,
-                    windows: settings.windows + [customWindow]
-                )) }) {
+                Button(action: {
+                    let nextWindows = settings.windows + [customWindow]
+                    setSettings(settings.doCopy(
+                        enabled: settings.enabled,
+                        windows: nextWindows
+                    ))
+                }) {
                     HStack(spacing: 12) {
                         Image(.plus)
                             .resizable()
@@ -155,6 +187,7 @@ struct NotificationSettingsWidget: View {
                 .foregroundStyle(Color.text.opacity(0.6))
             }
         }
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
         .enableInjection()
     }
 

--- a/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/NotificationSettingsWidget.swift
@@ -78,7 +78,6 @@ struct NotificationSettingsWidget: View {
 
     var body: some View {
         let permissionDenied = authorizationStatus == .denied
-        let _ = print("HELLO CUSTOM PRESET \(customPreset)")
         VStack(spacing: 8) {
             NotificationSwitch(
                 settings: settings,
@@ -105,11 +104,7 @@ struct NotificationSettingsWidget: View {
                     .onAppear {
                         if presetSelection == PresetSelection.Custom() {
                             customPreset = settings.windows
-                            print("HELLO A \(customPreset)")
-
                         } else {
-                            print("HELLO B")
-
                             customPreset =
                                 [FavoriteSettings.NotificationsWindow.companion.customFromCurrentTime(now: now)]
                         }
@@ -119,11 +114,7 @@ struct NotificationSettingsWidget: View {
                             windows: newWindows,
                             presetOptions: presetOptions
                         ) == PresetSelection.Custom() {
-                            print("HELLO C \(newWindows)")
-
                             customPreset = newWindows
-                        } else {
-                            print("HELLO D \(newWindows)")
                         }
                     }
                 }

--- a/iosApp/iosApp/Pages/SaveFavorite/PresetWindowSelector.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/PresetWindowSelector.swift
@@ -10,21 +10,21 @@ struct PresetWindowSelector: View {
     @ObserveInjection var inject
     let presetRows: [[PresetWindow]]
     let selectedPreset: PresetSelection
-    let presetsEnabled: Bool
     let now: EasternTimeInstant
-    let onSelect: (FavoriteSettings.NotificationsWindow) -> Void
+    let customPreset: [FavoriteSettings.NotificationsWindow]
+    let onSelect: ([FavoriteSettings.NotificationsWindow]) -> Void
 
     init(
         presetRows: [[PresetWindow]],
         selectedPreset: PresetSelection,
-        presetsEnabled: Bool,
         now: EasternTimeInstant = .now(),
-        onSelect: @escaping (FavoriteSettings.NotificationsWindow) -> Void
+        customPreset: [FavoriteSettings.NotificationsWindow],
+        onSelect: @escaping ([FavoriteSettings.NotificationsWindow]) -> Void
     ) {
         self.presetRows = presetRows
         self.selectedPreset = selectedPreset
-        self.presetsEnabled = presetsEnabled
         self.now = now
+        self.customPreset = customPreset
         self.onSelect = onSelect
     }
 
@@ -40,9 +40,8 @@ struct PresetWindowSelector: View {
                             return false
                         }()
                         PresetButton(
-                            enabled: presetsEnabled,
                             isSelected: isSelected,
-                            onSelect: { onSelect(preset.window) },
+                            onSelect: { onSelect([preset.window]) },
                             label: preset.label
                         )
                         .frame(maxWidth: .infinity)
@@ -52,10 +51,9 @@ struct PresetWindowSelector: View {
 
             HStack {
                 PresetButton(
-                    enabled: true,
                     isSelected: selectedPreset == PresetSelection.Custom(),
                     onSelect: {
-                        onSelect(FavoriteSettings.NotificationsWindow.companion.customFromCurrentTime(now: now))
+                        onSelect(customPreset)
                     },
                     label: NSLocalizedString(
                         "Custom",
@@ -78,7 +76,6 @@ struct PresetWindowSelector: View {
 
 private struct PresetButton: View {
     @ObserveInjection var inject
-    let enabled: Bool
     let isSelected: Bool
     let onSelect: () -> Void
     let label: String
@@ -91,7 +88,6 @@ private struct PresetButton: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
         }
-        .disabled(!enabled)
         .foregroundStyle(isSelected ? Color.fill3 : Color.text.opacity(0.6))
         .background(isSelected ? Color.key : Color.fill1)
         .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/iosApp/iosAppTests/Pages/SaveFavorite/NotificationSettingsWidgetTests.swift
+++ b/iosApp/iosAppTests/Pages/SaveFavorite/NotificationSettingsWidgetTests.swift
@@ -12,6 +12,43 @@ import SwiftUI
 import ViewInspector
 import XCTest
 
+private struct NotificationSettingsWidgetHost: View {
+    @ObserveInjection var inject
+    let now: EasternTimeInstant
+    let notificationPermissionManager: INotificationPermissionManager
+    let onSettingsChange: (FavoriteSettings.Notifications) -> Void
+    @State private var settings: FavoriteSettings.Notifications
+
+    let inspection = Inspection<Self>()
+
+    init(
+        initialSettings: FavoriteSettings.Notifications,
+        notificationPermissionManager: INotificationPermissionManager,
+        now: EasternTimeInstant,
+        onSettingsChange: @escaping (FavoriteSettings.Notifications) -> Void
+    ) {
+        _settings = State(initialValue: initialSettings)
+        self.notificationPermissionManager = notificationPermissionManager
+        self.now = now
+        self.onSettingsChange = onSettingsChange
+    }
+
+    var body: some View {
+        NotificationSettingsWidget(
+            settings: settings,
+            setSettings: { newSettings in
+                settings = newSettings
+                onSettingsChange(newSettings)
+            },
+            notificationPermissionManager: notificationPermissionManager,
+            now: now
+        )
+        .withFixedSettings([.notificationPresetWindows: true])
+        .onReceive(inspection.notice) { inspection.visit(self, $0) }
+        .enableInjection()
+    }
+}
+
 final class NotificationSettingsWidgetTests: XCTestCase {
     @MainActor func testAddTimePeriod() async throws {
         var settings: FavoriteSettings.Notifications = .companion.disabled

--- a/iosApp/iosAppTests/Pages/SaveFavorite/PresetWindowSelectorTests.swift
+++ b/iosApp/iosAppTests/Pages/SaveFavorite/PresetWindowSelectorTests.swift
@@ -14,7 +14,7 @@ import XCTest
 
 final class PresetWindowSelectorTests: XCTestCase {
     func testPresetWindowsVisible() {
-        var selectedWindow: FavoriteSettings.NotificationsWindow?
+        var selectedWindows: [FavoriteSettings.NotificationsWindow]?
 
         let sut = PresetWindowSelector(
             presetRows: [[
@@ -30,8 +30,9 @@ final class PresetWindowSelectorTests: XCTestCase {
                 )
             ]],
             selectedPreset: .Preset(rowIndex: 1, columnIndex: 0),
-            presetsEnabled: true,
-            onSelect: { window in selectedWindow = window }
+            customPreset: [FavoriteSettings.NotificationsWindow.companion
+                .eveningDefault(daysOfWeek: FavoriteSettings.NotificationsWindow.companion.weekend)],
+            onSelect: { windows in selectedWindows = windows }
         )
 
         XCTAssertNotNil(try sut.inspect().find(button: "Morning"))
@@ -41,13 +42,18 @@ final class PresetWindowSelectorTests: XCTestCase {
         try? sut.inspect().find(button: "Morning").tap()
 
         XCTAssertEqual(
-            selectedWindow,
-            .companion.morningDefault(daysOfWeek: FavoriteSettings.NotificationsWindow.companion.weekdays)
+            selectedWindows,
+            [.companion.morningDefault(daysOfWeek: FavoriteSettings.NotificationsWindow.companion.weekdays)]
         )
     }
 
-    func testCustomDefaultsToNow() {
-        var selectedWindow: FavoriteSettings.NotificationsWindow?
+    func testCustomUsesProvidedCustomPreset() {
+        var selectedWindows: [FavoriteSettings.NotificationsWindow] = []
+        let customWindow = FavoriteSettings.NotificationsWindow(
+            startTime: .init(hour: 10, minute: 15, second: 0, nanosecond: 0),
+            endTime: .init(hour: 11, minute: 45, second: 0, nanosecond: 0),
+            daysOfWeek: [.sunday, .tuesday]
+        )
 
         let sut = PresetWindowSelector(
             presetRows: [[
@@ -63,19 +69,11 @@ final class PresetWindowSelectorTests: XCTestCase {
                 )
             ]],
             selectedPreset: .Preset(rowIndex: 1, columnIndex: 0),
-            presetsEnabled: true,
-            now: .init(year: 2026, month: .august, day: 31, hour: 4, minute: 30, second: 0),
-            onSelect: { window in selectedWindow = window }
+            customPreset: [customWindow],
+            onSelect: { windows in selectedWindows = windows }
         )
 
         try? sut.inspect().find(button: "Custom").tap()
-        XCTAssertEqual(
-            selectedWindow,
-            .init(
-                startTime: .init(hour: 4, minute: 0, second: 0, nanosecond: 0),
-                endTime: .init(hour: 5, minute: 0, second: 0, nanosecond: 0),
-                daysOfWeek: [.monday, .tuesday, .wednesday, .thursday, .friday]
-            )
-        )
+        XCTAssertEqual(selectedWindows, [customWindow])
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
@@ -41,13 +41,13 @@ public sealed class PresetSelection {
     public object Custom : PresetSelection()
 
     public companion object {
-        public fun selectedPresetFromSettings(
-            settings: FavoriteSettings.Notifications,
+        public fun selectedPresetFromWindows(
+            windows: List<Window>,
             presetOptions: List<List<PresetWindow>>,
         ): PresetSelection =
             when {
-                settings.windows.size == 1 -> {
-                    val targetWindow: Window = settings.windows[0]
+                windows.size == 1 -> {
+                    val targetWindow: Window = windows[0]
                     presetOptions
                         .asSequence()
                         .mapIndexedNotNull { rowIndex, presets ->


### PR DESCRIPTION
### Summary

_Ticket:_ [Disruption Windows | Preset options UX](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217828663233951?focus=true)

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?

If a user edits a custom window, then selects a preset, going back to custom should preserve their earlier work. 

iOS
- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?
  - [ ] Add temporary machine translations, marked "Needs Review"

android
- [ ] All user-facing strings added to strings resource in alphabetical order
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)

### Testing

What testing have you done?
* Ran locally on iOS & android
* Wrote unit tests - this was straightforward on android, but I really struggled to get something working on iOS. Will add a separate comment to solicit ideas

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
