### PR TITLE
feat(NotificationSettingsViewModel): New VM to hold notification settings state

### DIFF
--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/Favorite.kt
@@ -78,6 +78,11 @@ constructor(val notifications: Notifications = Notifications.disabled) {
             val id: String
                 get() = "$startTime $endTime ${daysOfWeek.joinToString(",")}"
 
+            public constructor(
+                preset: Preset,
+                daysOfWeek: Set<DayOfWeek>,
+            ) : this(preset.startTime, preset.endTime, daysOfWeek)
+
             public companion object {
                 public val weekdays: Set<DayOfWeek> =
                     setOf(
@@ -114,14 +119,14 @@ constructor(val notifications: Notifications = Notifications.disabled) {
                     val daysOfWeek = defaultDaysOfWeek(now)
                     val presets =
                         listOf(
-                            morningDefault(daysOfWeek),
-                            middayDefault(daysOfWeek),
-                            eveningDefault(daysOfWeek),
-                            allDayDefault(daysOfWeek),
+                            Window(Preset.Morning, daysOfWeek),
+                            Window(Preset.Midday, daysOfWeek),
+                            Window(Preset.Evening, daysOfWeek),
+                            Window(Preset.AllDay, daysOfWeek),
                         )
 
                     return presets.firstOrNull { now.local.time in it.startTime..it.endTime }
-                        ?: allDayDefault(daysOfWeek)
+                        ?: Window(Preset.AllDay, daysOfWeek)
                 }
 
                 public fun customFromCurrentTime(now: EasternTimeInstant): Window {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/model/NotificationWindowPresets.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.model
 
 import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
 import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalTime
 
 public class PresetWindow(
     public val label: String,
@@ -12,25 +13,25 @@ public class PresetWindow(
         public fun morningPreset(label: String, daysOfWeek: Set<DayOfWeek>): PresetWindow =
             PresetWindow(
                 label = label,
-                window = Window.morningDefault(daysOfWeek),
+                window = Window(Preset.Morning, daysOfWeek),
             )
 
         public fun middayPreset(label: String, daysOfWeek: Set<DayOfWeek>): PresetWindow =
             PresetWindow(
                 label = label,
-                window = Window.middayDefault(daysOfWeek),
+                window = Window(Preset.Midday, daysOfWeek),
             )
 
         public fun eveningPreset(label: String, daysOfWeek: Set<DayOfWeek>): PresetWindow =
             PresetWindow(
                 label = label,
-                window = Window.eveningDefault(daysOfWeek),
+                window = Window(Preset.Evening, daysOfWeek),
             )
 
         public fun allDayPreset(label: String, daysOfWeek: Set<DayOfWeek>): PresetWindow =
             PresetWindow(
                 label = label,
-                window = Window.allDayDefault(daysOfWeek),
+                window = Window(Preset.AllDay, daysOfWeek),
             )
     }
 }
@@ -55,14 +56,41 @@ public sealed class PresetSelection {
                                 it.window == targetWindow
                             }
                             if (presetMatchIndex != -1) {
-                                Preset(rowIndex, presetMatchIndex)
+                                PresetSelection.Preset(rowIndex, presetMatchIndex)
                             } else {
                                 null
                             }
                         }
-                        .firstOrNull() ?: Custom
+                        .firstOrNull() ?: PresetSelection.Custom
                 }
-                else -> Custom
+                else -> {
+                    PresetSelection.Custom
+                }
             }
+    }
+}
+
+public enum class Preset(public val startTime: LocalTime, public val endTime: LocalTime) {
+    Morning(LocalTime(6, 0), LocalTime(10, 0)),
+    Midday(LocalTime(10, 0), LocalTime(16, 0)),
+    Evening(LocalTime(16, 0), LocalTime(20, 0)),
+    AllDay(LocalTime(0, 0), LocalTime(23, 59));
+
+    public companion object {
+
+        public fun selected(windows: List<Window>): Preset? {
+            if (windows.size == 1) {
+                val targetWindow: Window = windows[0]
+                val presetMatch =
+                    Preset.entries.firstOrNull {
+                        it.startTime == targetWindow.startTime &&
+                            it.endTime == targetWindow.endTime &&
+                            (targetWindow.daysOfWeek == Window.weekend ||
+                                targetWindow.daysOfWeek == Window.weekdays)
+                    }
+                return presetMatch
+            }
+            return null
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
@@ -1,0 +1,219 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.*
+import com.mbta.tid.mbta_app.model.Preset
+import com.mbta.tid.mbta_app.repositories.ISentryRepository
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+public interface INotificationSettingsViewModel {
+    public val models: StateFlow<NotificationSettingsViewModel.State>
+
+    public fun loadSavedSettings(settings: Notifications)
+
+    public fun setEnabled(enabled: Boolean)
+
+    public fun setPresetsEnabledFlag(enabled: Boolean)
+
+    public fun setCustomWindows(windows: List<Window>)
+
+    public fun addPlaceholderWindow()
+
+    public fun setPreset(preset: Preset?)
+
+    public fun setNow(now: EasternTimeInstant)
+}
+
+public class NotificationSettingsViewModel(private val sentryRepository: ISentryRepository) :
+    MoleculeViewModel<NotificationSettingsViewModel.Event, NotificationSettingsViewModel.State>(),
+    INotificationSettingsViewModel {
+    public sealed class Event {
+
+        public data class LoadSavedSettings(val settings: Notifications) : Event()
+
+        public data class SetEnabled(val enabled: Boolean) : Event()
+
+        public data class SetPresetsEnabledFlag(val enabled: Boolean) : Event()
+
+        public data class SetCustomWindows(val windows: List<Notifications.Window>) : Event()
+
+        public data object AddPlaceholderWindow : Event()
+
+        public data class SetPreset(val preset: Preset?) : Event()
+
+        public data class SetNow(val now: EasternTimeInstant) : Event()
+    }
+
+    public data class State(
+        val settings: Notifications?,
+        val selectedPreset: Preset?,
+    ) {
+        public constructor() : this(Notifications.disabled, null)
+    }
+
+    override val models: StateFlow<State>
+        get() = internalModels
+
+    @Composable
+    override fun runLogic(): State {
+        var now: EasternTimeInstant by remember { mutableStateOf(EasternTimeInstant.now()) }
+
+        var settings: Notifications? by remember {
+            mutableStateOf(null)
+        }
+        var customPreset: List<Window>? by remember {
+            mutableStateOf(null)
+        }
+
+        var presetsEnabledFlag: Boolean by remember {
+            mutableStateOf(false)
+        }
+
+        EventSink(eventHandlingTimeout = 1.seconds, sentryRepository = sentryRepository) { event ->
+            val enabled = settings?.enabled ?: false
+
+            when (event) {
+                is Event.SetEnabled -> {
+                    val windows =
+                        if (!enabled && event.enabled) {
+                            (settings?.windows ?: emptyList()).ifEmpty {
+                                listOf(Window.default(emptyList(), presetsEnabledFlag, now))
+                            }
+                        } else {
+                            settings?.windows ?: emptyList()
+                        }
+
+                    settings = Notifications(enabled = event.enabled, windows = windows)
+                }
+
+                is Event.SetCustomWindows -> {
+                    settings = Notifications(enabled = enabled, windows = event.windows)
+                    customPreset = event.windows
+                }
+                is Event.SetNow -> {
+                    now = event.now
+                }
+                is Event.SetPreset -> {
+                    settings =
+                        if (event.preset == null) {
+                            val windows = customPreset ?: listOf(Window.customFromCurrentTime(now))
+                            Notifications(enabled = enabled, windows = windows)
+                        } else {
+                            Notifications(
+                                enabled = enabled,
+                                windows =
+                                    listOf(
+                                        Window(
+                                            event.preset.startTime,
+                                            event.preset.endTime,
+                                            Window.defaultDaysOfWeek(now),
+                                        )
+                                    ),
+                            )
+                        }
+                }
+
+                is Event.SetPresetsEnabledFlag -> presetsEnabledFlag = event.enabled
+                is Event.AddPlaceholderWindow -> {
+                    val existingWindows = settings?.windows ?: emptyList()
+                    settings =
+                        Notifications(
+                            enabled = enabled,
+                            windows =
+                                existingWindows +
+                                    Window.default(existingWindows, presetsEnabledFlag, now),
+                        )
+                }
+
+                is Event.LoadSavedSettings -> {
+                    val loadedWindows = event.settings.windows
+                    if (Preset.selected(loadedWindows) == null && loadedWindows.isNotEmpty()) {
+                        customPreset = loadedWindows
+                    }
+                    settings = event.settings
+                }
+            }
+        }
+
+        val state =
+            remember(settings) {
+                State(settings, Preset.selected(settings?.windows ?: emptyList()))
+            }
+        return state
+    }
+
+    override fun loadSavedSettings(settings: Notifications) {
+        fireEvent(Event.LoadSavedSettings(settings))
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        fireEvent(Event.SetEnabled(enabled))
+    }
+
+    override fun setPresetsEnabledFlag(enabled: Boolean) {
+        fireEvent(Event.SetPresetsEnabledFlag(enabled))
+    }
+
+    override fun setCustomWindows(windows: List<FavoriteSettings.Notifications.Window>) {
+        fireEvent(Event.SetCustomWindows(windows))
+    }
+
+    override fun addPlaceholderWindow() {
+        fireEvent(Event.AddPlaceholderWindow)
+    }
+
+    override fun setPreset(preset: Preset?) {
+        fireEvent(Event.SetPreset(preset))
+    }
+
+    override fun setNow(now: EasternTimeInstant) {
+        fireEvent(Event.SetNow(now))
+    }
+}
+
+public class MockNotificationSettingsViewModel(
+    public val initialState: NotificationSettingsViewModel.State =
+        NotificationSettingsViewModel.State()
+) : INotificationSettingsViewModel {
+    override val models: MutableStateFlow<NotificationSettingsViewModel.State>
+        get() = MutableStateFlow(initialState)
+
+    public var onLoadSavedSettings: (Notifications) -> Unit = {}
+    public var onSetEnabled: (Boolean) -> Unit = {}
+    public var onSetCustomWindows: (List<FavoriteSettings.Notifications.Window>) -> Unit = {}
+    public var onSetPreset: (Preset?) -> Unit = {}
+    public var onSetNow: (EasternTimeInstant) -> Unit = {}
+
+    override fun loadSavedSettings(settings: Notifications) {
+        onLoadSavedSettings(settings)
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        onSetEnabled(enabled)
+    }
+
+    override fun setPresetsEnabledFlag(enabled: Boolean) {}
+
+    override fun setCustomWindows(windows: List<FavoriteSettings.Notifications.Window>) {
+        onSetCustomWindows(windows)
+    }
+
+    override fun addPlaceholderWindow() {}
+
+    override fun setPreset(preset: Preset?) {
+        onSetPreset(preset)
+    }
+
+    override fun setNow(now: EasternTimeInstant) {
+        onSetNow(now)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
@@ -49,6 +49,7 @@ public fun viewModelModule(): Module = module {
         .bind(IMapViewModel::class)
     single { NearbyViewModel(get(), get(), get(named("coroutineDispatcherDefault"))) }
         .bind(INearbyViewModel::class)
+    factory { NotificationSettingsViewModel(get()) }.bind(INotificationSettingsViewModel::class)
     singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
     singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
     singleOf(::SearchViewModel).bind(ISearchViewModel::class)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/FavoriteTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/model/FavoriteTest.kt
@@ -112,26 +112,26 @@ class FavoriteTest {
     @Test
     fun `defaultFromCurrentTime returns the matching preset`() {
         assertEquals(
-            Window.morningDefault(Window.weekdays),
+            Window(Preset.Morning, Window.weekdays),
             Window.defaultFromCurrentTime(EasternTimeInstant(LocalDateTime(2026, 8, 27, 7, 30))),
         )
         assertEquals(
-            Window.middayDefault(Window.weekdays),
+            Window(Preset.Midday, Window.weekdays),
             Window.defaultFromCurrentTime(EasternTimeInstant(LocalDateTime(2026, 8, 27, 12, 30))),
         )
 
         assertEquals(
-            Window.eveningDefault(Window.weekdays),
+            Window(Preset.Evening, Window.weekdays),
             Window.defaultFromCurrentTime(EasternTimeInstant(LocalDateTime(2026, 8, 27, 18, 30))),
         )
 
         assertEquals(
-            Window.allDayDefault(Window.weekdays),
+            Window(Preset.AllDay, Window.weekdays),
             Window.defaultFromCurrentTime(EasternTimeInstant(LocalDateTime(2026, 8, 27, 21, 30))),
         )
 
         assertEquals(
-            Window.allDayDefault(Window.weekend),
+            Window(Preset.AllDay, Window.weekend),
             Window.defaultFromCurrentTime(EasternTimeInstant(LocalDateTime(2026, 8, 30, 21, 30))),
         )
     }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
@@ -1,0 +1,262 @@
+package com.mbta.tid.mbta_app.viewModel
+
+import app.cash.turbine.test
+import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.model.Preset
+import com.mbta.tid.mbta_app.repositories.MockSentryRepository
+import com.mbta.tid.mbta_app.utils.EasternTimeInstant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.Month
+
+class NotificationSettingsViewModelTest {
+    @Test
+    fun initialStateIsNull() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(
+                NotificationSettingsViewModel.State(
+                    null,
+                    selectedPreset = null,
+                ),
+                awaitItem(),
+            )
+        }
+    }
+
+    @Test
+    fun loadSavedSettingsReplacesStateAndSelectsPreset() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val loadedSettings =
+            FavoriteSettings.Notifications(
+                enabled = true,
+                windows =
+                    listOf(
+                        FavoriteSettings.Notifications.Window(
+                            startTime = Preset.Morning.startTime,
+                            endTime = Preset.Morning.endTime,
+                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                        )
+                    ),
+            )
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(null, awaitItem().settings)
+
+            viewModel.loadSavedSettings(loadedSettings)
+
+            val state = awaitItem()
+            assertEquals(loadedSettings, state.settings)
+            assertEquals(Preset.Morning, state.selectedPreset)
+        }
+    }
+
+    @Test
+    fun setEnabledUpdatesNotificationToggle() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            assertEquals(null, awaitItem().settings)
+
+            viewModel.setEnabled(true)
+            assertEquals(true, awaitItem().settings?.enabled)
+
+            viewModel.setEnabled(false)
+            assertEquals(false, awaitItem().settings?.enabled)
+        }
+    }
+
+    @Test
+    fun setEnabledAddsDefaultWeekdayWindowWhenPresetsFeatureDisabled() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+
+            viewModel.setPresetsEnabledFlag(false)
+            viewModel.setEnabled(true)
+
+            val state = awaitItem()
+            assertEquals(true, state.settings?.enabled)
+            assertEquals(
+                listOf(
+                    FavoriteSettings.Notifications.Window(
+                        startTime = LocalTime(8, 0),
+                        endTime = LocalTime(9, 0),
+                        daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                    )
+                ),
+                state.settings?.windows,
+            )
+            assertEquals(null, state.selectedPreset)
+        }
+    }
+
+    @Test
+    fun setEnabledUsesCurrentPresetWindow() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+
+            viewModel.setNow(EasternTimeInstant(2026, Month.SEPTEMBER, 3, 12, 30))
+            viewModel.setPresetsEnabledFlag(true)
+            viewModel.setEnabled(true)
+
+            val state = awaitItem()
+            assertEquals(true, state.settings?.enabled)
+            assertEquals(
+                listOf(
+                    FavoriteSettings.Notifications.Window(
+                        startTime = Preset.Midday.startTime,
+                        endTime = Preset.Midday.endTime,
+                        daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                    )
+                ),
+                state.settings?.windows,
+            )
+            assertEquals(Preset.Midday, state.selectedPreset)
+        }
+    }
+
+    @Test
+    fun testRestoringCustomWindows() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val customWindows =
+            listOf(
+                FavoriteSettings.Notifications.Window(
+                    startTime = LocalTime(9, 0),
+                    endTime = LocalTime(11, 0),
+                    daysOfWeek = setOf(DayOfWeek.MONDAY),
+                )
+            )
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+
+            viewModel.setCustomWindows(customWindows)
+            assertEquals(customWindows, awaitItem().settings?.windows)
+
+            viewModel.setNow(EasternTimeInstant(2026, Month.SEPTEMBER, 2, 8, 0))
+            viewModel.setPreset(Preset.Morning)
+
+            val presetState = awaitItem()
+            assertEquals(
+                listOf(
+                    FavoriteSettings.Notifications.Window(
+                        startTime = Preset.Morning.startTime,
+                        endTime = Preset.Morning.endTime,
+                        daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                    )
+                ),
+                presetState.settings?.windows,
+            )
+            assertEquals(Preset.Morning, presetState.selectedPreset)
+
+            viewModel.setPreset(null)
+            val customState = awaitItem()
+            assertEquals(customWindows, customState.settings?.windows)
+            assertEquals(null, customState.selectedPreset)
+        }
+    }
+
+    @Test
+    fun testDefaultCustomWindows() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val now = EasternTimeInstant(2026, Month.SEPTEMBER, 3, 12, 30)
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+            viewModel.setNow(now)
+            viewModel.setPresetsEnabledFlag(true)
+            viewModel.loadSavedSettings(FavoriteSettings.Notifications.disabled)
+
+            val state = awaitItem()
+            assertEquals(emptyList(), state.settings?.windows)
+            viewModel.setPreset(null)
+            assertEquals(
+                listOf(FavoriteSettings.Notifications.Window.customFromCurrentTime(now)),
+                awaitItem().settings?.windows,
+            )
+        }
+    }
+
+    @Test
+    fun addPlaceholderWindowAppendsWeekendWindowWhenFeatureFlagDisabled() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val customWindows =
+            listOf(
+                FavoriteSettings.Notifications.Window(
+                    startTime = LocalTime(9, 0),
+                    endTime = LocalTime(11, 0),
+                    daysOfWeek = setOf(DayOfWeek.MONDAY),
+                )
+            )
+
+        testViewModelFlow(viewModel).test {
+            awaitItem()
+
+            viewModel.setCustomWindows(customWindows)
+            assertEquals(customWindows, awaitItem().settings?.windows)
+
+            viewModel.addPlaceholderWindow()
+
+            val state = awaitItem()
+            assertEquals(2, state.settings?.windows?.size)
+            assertEquals(
+                customWindows +
+                    FavoriteSettings.Notifications.Window(
+                        startTime = LocalTime(12, 0),
+                        endTime = LocalTime(13, 0),
+                        daysOfWeek = FavoriteSettings.Notifications.Window.weekend,
+                    ),
+                state.settings?.windows,
+            )
+            assertEquals(null, state.selectedPreset)
+        }
+    }
+
+    @Test
+    fun setPresetUsesWeekDaysWhenNowIsWeekday() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            viewModel.setNow(EasternTimeInstant(2026, Month.SEPTEMBER, 3, 8, 0))
+
+            awaitItem()
+
+            viewModel.setPreset(Preset.Evening)
+
+            val weekendPresetState = awaitItem()
+            assertEquals(
+                FavoriteSettings.Notifications.Window.weekdays,
+                weekendPresetState.settings?.windows?.single()?.daysOfWeek,
+            )
+            assertEquals(Preset.Evening, weekendPresetState.selectedPreset)
+        }
+    }
+
+    @Test
+    fun setPresetUsesWeekendDaysWhenNowIsWeekend() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+
+        testViewModelFlow(viewModel).test {
+            viewModel.setNow(EasternTimeInstant(2026, Month.SEPTEMBER, 5, 8, 0))
+
+            awaitItem()
+
+            viewModel.setPreset(Preset.Evening)
+
+            val weekendPresetState = awaitItem()
+            assertEquals(
+                FavoriteSettings.Notifications.Window.weekend,
+                weekendPresetState.settings?.windows?.single()?.daysOfWeek,
+            )
+            assertEquals(Preset.Evening, weekendPresetState.selectedPreset)
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
+++ b/shared/src/iosMain/kotlin/com/mbta/tid/mbta_app/viewModel/ViewModelDI.kt
@@ -8,8 +8,8 @@ public class ViewModelDI : KoinComponent {
     public val errorBanner: ErrorBannerViewModel by inject()
     public val favorites: FavoritesViewModel by inject()
     public val map: MapViewModel by inject()
-
     public val nearby: NearbyViewModel by inject()
+    public val notificationSettings: NotificationSettingsViewModel by inject()
     public val routeCardData: RouteCardDataViewModel by inject()
     public val search: SearchViewModel by inject()
     public val searchRoutes: SearchRoutesViewModel by inject()


### PR DESCRIPTION
### Summary

Ticket: No ticket, follow up to https://github.com/mbta/mobile_app/pull/1971

<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

What is this PR for?
Adds a new NotificationSettingsViewModel for representing the in progress state of notification settings. Overall I'm happier with this simpler model for Preset and think the testability + that pushing more logic into shared is an improvement.

iOS
~- [ ] If you added any user-facing strings on iOS, are they included in Localizable.xcstrings?~
~  - [ ] Add temporary machine translations, marked "Needs Review"~

android
~- [ ] All user-facing strings added to strings resource in alphabetical order~
~- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)~

### Testing

What testing have you done?
* Added unit tests
* Adopted on iOS & android in https://github.com/mbta/mobile_app/pull/1985

<!--
Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
