### PR TITLE
feat(SaveFavoritesPage): Default to last saved notification settings within session

### DIFF
--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.rule.GrantPermissionRule
+import com.mapbox.maps.extension.style.expressions.dsl.generated.not
 import com.mbta.tid.mbta_app.android.loadKoinMocks
 import com.mbta.tid.mbta_app.android.testUtils.assertCanBeDisplayed
 import com.mbta.tid.mbta_app.model.FavoriteSettings
@@ -37,12 +38,26 @@ class SaveFavoritePageTests {
     @Test
     fun testCloses() {
         var backCalled = false
+        var savedSettingsCleared = false
 
         val objects = TestData.clone()
         val route = objects.getRoute("Red")
         val stop = objects.getStop("70069")
 
         loadKoinMocks(objects)
+
+        val notificationSettingsVM =
+            MockNotificationSettingsViewModel(
+                NotificationSettingsViewModel.State(
+                    FavoriteSettings.Notifications(false, emptyList()),
+                    null,
+                )
+            )
+        notificationSettingsVM.onLoadSavedSettings = {
+            if (it == null) {
+                savedSettingsCleared = true
+            }
+        }
 
         composeTestRule.setContent {
             SaveFavoritePage(
@@ -51,12 +66,14 @@ class SaveFavoritePageTests {
                 1,
                 EditFavoritesContext.StopDetails,
                 { backCalled = true },
+                notificationSettingsViewModel = notificationSettingsVM,
             )
         }
         composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText("Cancel").performClick()
         composeTestRule.waitForIdle()
         assert(backCalled)
+        assert(savedSettingsCleared)
     }
 
     @Test

--- a/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
+++ b/androidApp/src/androidTest/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePageTests.kt
@@ -1,6 +1,7 @@
 package com.mbta.tid.mbta_app.android.pages
 
 import android.os.Build
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -16,12 +17,15 @@ import com.mbta.tid.mbta_app.repositories.MockFavoritesRepository
 import com.mbta.tid.mbta_app.usecases.EditFavoritesContext
 import com.mbta.tid.mbta_app.utils.TestData
 import com.mbta.tid.mbta_app.utils.buildFavorites
+import com.mbta.tid.mbta_app.viewModel.MockNotificationSettingsViewModel
+import com.mbta.tid.mbta_app.viewModel.NotificationSettingsViewModel
 import kotlin.test.assertEquals
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalTime
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalTestApi::class)
 class SaveFavoritePageTests {
     @get:Rule val composeTestRule = createComposeRule()
     @get:Rule
@@ -243,6 +247,42 @@ class SaveFavoritePageTests {
         composeTestRule.waitForIdle()
         assertEquals(Favorites(), favoritesSet)
         assert(closed)
+    }
+
+    @Test
+    fun testCallsSavedNotificationVM() {
+        var savedSettings = false
+
+        val notificationSettingsVM =
+            MockNotificationSettingsViewModel(
+                NotificationSettingsViewModel.State(
+                    FavoriteSettings.Notifications(false, emptyList()),
+                    null,
+                )
+            )
+        notificationSettingsVM.onSavedSettings = { savedSettings = true }
+
+        val objects = TestData.clone()
+        val route = objects.getRoute("Orange")
+        val stop = objects.getStop("place-welln")
+        loadKoinMocks(objects) {
+            favorites = MockFavoritesRepository()
+        }
+
+        composeTestRule.setContent {
+            SaveFavoritePage(
+                route.id,
+                stop.id,
+                0,
+                EditFavoritesContext.StopDetails,
+                {},
+                notificationSettingsViewModel = notificationSettingsVM,
+            )
+        }
+
+        composeTestRule.onNodeWithText("Add Favorite").assertCanBeDisplayed()
+        composeTestRule.onNodeWithText("Save").performClick()
+        assert(savedSettings)
     }
 
     @Test

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
@@ -127,10 +127,10 @@ fun SaveFavoritePage(
 
     LaunchedEffect(isFavorite, favorites) { if (favorites != null && !isFavorite) wasAdding = true }
 
-    val existingSettings = favorites?.get(selectedRouteStopDirection) ?: FavoriteSettings()
+    val existingSettings = favorites?.get(selectedRouteStopDirection)
     var updatedSettings by
         rememberSaveable(saver = stateJsonSaver()) { mutableStateOf<FavoriteSettings?>(null) }
-    val settings = updatedSettings ?: existingSettings
+    val settings = updatedSettings ?: existingSettings ?: FavoriteSettings()
 
     var hasRequestedPermission by rememberSaveable { mutableStateOf(false) }
     val notificationPermissionState = notificationPermissionState { hasRequestedPermission = true }
@@ -149,7 +149,7 @@ fun SaveFavoritePage(
     val notificationSettingsState by notificationSettingsViewModel.models.collectAsState()
 
     LaunchedEffect(existingSettings) {
-        notificationSettingsViewModel.loadSavedSettings(existingSettings.notifications)
+        notificationSettingsViewModel.loadSavedSettings(existingSettings?.notifications)
     }
 
     LaunchedEffect(notificationSettingsState) {
@@ -171,6 +171,7 @@ fun SaveFavoritePage(
             fcmToken,
             currentLocale,
         )
+        notificationSettingsViewModel.savedSettings()
     }
 
     val updateToastSingleText = stringResource(R.string.favorites_toast_add)

--- a/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
+++ b/androidApp/src/main/java/com/mbta/tid/mbta_app/android/pages/SaveFavoritePage.kt
@@ -127,10 +127,10 @@ fun SaveFavoritePage(
 
     LaunchedEffect(isFavorite, favorites) { if (favorites != null && !isFavorite) wasAdding = true }
 
-    val existingSettings = favorites?.get(selectedRouteStopDirection)
+    val existingSettings = favorites?.get(selectedRouteStopDirection) ?: FavoriteSettings()
     var updatedSettings by
         rememberSaveable(saver = stateJsonSaver()) { mutableStateOf<FavoriteSettings?>(null) }
-    val settings = updatedSettings ?: existingSettings ?: FavoriteSettings()
+    val settings = updatedSettings ?: existingSettings
 
     var hasRequestedPermission by rememberSaveable { mutableStateOf(false) }
     val notificationPermissionState = notificationPermissionState { hasRequestedPermission = true }
@@ -149,7 +149,7 @@ fun SaveFavoritePage(
     val notificationSettingsState by notificationSettingsViewModel.models.collectAsState()
 
     LaunchedEffect(existingSettings) {
-        notificationSettingsViewModel.loadSavedSettings(existingSettings?.notifications)
+        notificationSettingsViewModel.loadSavedSettings(existingSettings.notifications)
     }
 
     LaunchedEffect(notificationSettingsState) {
@@ -260,7 +260,10 @@ fun SaveFavoritePage(
                             containerColor = Color.Transparent,
                             contentColor = colorResource(R.color.key),
                         ),
-                    action = goBack,
+                    action = {
+                        goBack()
+                        notificationSettingsViewModel.loadSavedSettings(null)
+                    },
                 )
                 NavTextButton(stringResource(R.string.save), colors = ButtonDefaults.key()) {
                     updateCloseAndToast(mapOf(selectedRouteStopDirection to settings))

--- a/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
@@ -23,7 +23,7 @@ struct SaveFavoritePage: View {
 
     @State var globalResponse: GlobalResponse?
     @State var favorites: Favorites = .init(routeStopDirection: [:])
-    @State var pendingSettings: FavoriteSettings
+    @State var pendingSettings: FavoriteSettings?
     @State var selectedDirection: Int32
     @State var favoritesLoaded: Bool = false
     @State var wasAdding: Bool = false
@@ -94,11 +94,12 @@ struct SaveFavoritePage: View {
 
     func resetPendingSettings() {
         pendingSettings = favorites
-            .routeStopDirection[selectedRouteStopDirection] ?? .init(notifications: .companion.disabled)
+            .routeStopDirection[selectedRouteStopDirection]
     }
 
     func updateCloseAndToast(_ rsd: RouteStopDirection, _ setting: FavoriteSettings?) {
         updateFavorites([rsd: setting])
+        notificationSettingsVM.savedSettings()
 
         navCallbacks.onBack?()
 
@@ -186,7 +187,9 @@ struct SaveFavoritePage: View {
                         NotificationSettingsWidget(
                             vm: notificationSettingsVM,
                             onUpdate: { newNotificationSettings in
-                                pendingSettings = pendingSettings.doCopy(notifications: newNotificationSettings)
+                                pendingSettings =
+                                    (pendingSettings ?? FavoriteSettings(notifications: .companion.disabled))
+                                        .doCopy(notifications: newNotificationSettings)
                             },
                             notificationPermissionManager: notificationPermissionManager,
                         )
@@ -203,10 +206,10 @@ struct SaveFavoritePage: View {
             }
         }
         .onAppear { resetPendingSettings()
-            notificationSettingsVM.loadSavedSettings(settings: pendingSettings.notifications)
+            notificationSettingsVM.loadSavedSettings(settings: pendingSettings?.notifications)
         }
         .onChange(of: pendingSettings) { newSettings in
-            notificationSettingsVM.loadSavedSettings(settings: newSettings.notifications)
+            notificationSettingsVM.loadSavedSettings(settings: newSettings?.notifications)
         }
         .onChange(of: selectedDirection) { _ in resetPendingSettings() }
         .onChange(of: favorites) { _ in

--- a/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
+++ b/iosApp/iosApp/Pages/SaveFavorite/SaveFavoritePage.swift
@@ -23,7 +23,7 @@ struct SaveFavoritePage: View {
 
     @State var globalResponse: GlobalResponse?
     @State var favorites: Favorites = .init(routeStopDirection: [:])
-    @State var pendingSettings: FavoriteSettings?
+    @State var pendingSettings: FavoriteSettings
     @State var selectedDirection: Int32
     @State var favoritesLoaded: Bool = false
     @State var wasAdding: Bool = false
@@ -94,7 +94,7 @@ struct SaveFavoritePage: View {
 
     func resetPendingSettings() {
         pendingSettings = favorites
-            .routeStopDirection[selectedRouteStopDirection]
+            .routeStopDirection[selectedRouteStopDirection] ?? FavoriteSettings(notifications: .companion.disabled)
     }
 
     func updateCloseAndToast(_ rsd: RouteStopDirection, _ setting: FavoriteSettings?) {
@@ -170,7 +170,10 @@ struct SaveFavoritePage: View {
         VStack(alignment: .leading, spacing: 0) {
             SaveFavoriteHeader(
                 isFavorite: isFavorite,
-                onCancel: { navCallbacks.onBack?() },
+                onCancel: { navCallbacks.onBack?()
+                    notificationSettingsVM.loadSavedSettings(settings: nil)
+
+                },
                 onSave: { updateCloseAndToast(selectedRouteStopDirection, pendingSettings) },
             )
             HaloScrollView(alwaysShowHalo: true) {
@@ -187,9 +190,7 @@ struct SaveFavoritePage: View {
                         NotificationSettingsWidget(
                             vm: notificationSettingsVM,
                             onUpdate: { newNotificationSettings in
-                                pendingSettings =
-                                    (pendingSettings ?? FavoriteSettings(notifications: .companion.disabled))
-                                        .doCopy(notifications: newNotificationSettings)
+                                pendingSettings = pendingSettings.doCopy(notifications: newNotificationSettings)
                             },
                             notificationPermissionManager: notificationPermissionManager,
                         )
@@ -206,10 +207,10 @@ struct SaveFavoritePage: View {
             }
         }
         .onAppear { resetPendingSettings()
-            notificationSettingsVM.loadSavedSettings(settings: pendingSettings?.notifications)
+            notificationSettingsVM.loadSavedSettings(settings: pendingSettings.notifications)
         }
         .onChange(of: pendingSettings) { newSettings in
-            notificationSettingsVM.loadSavedSettings(settings: newSettings?.notifications)
+            notificationSettingsVM.loadSavedSettings(settings: newSettings.notifications)
         }
         .onChange(of: selectedDirection) { _ in resetPendingSettings() }
         .onChange(of: favorites) { _ in

--- a/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
+++ b/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
@@ -180,4 +180,39 @@ final class SaveFavoritePageTests: XCTestCase {
 
         wait(for: [exp1], timeout: 5)
     }
+
+    @MainActor func testClearsLoadedSettingsOnCancel() {
+        let objects = TestData.clone()
+        let route = objects.getRoute(id: "Orange")
+        let stop = objects.getStop(id: "place-welln")
+
+        loadKoinMocks(objects: objects)
+
+        var savedSettingsCleared = false
+
+        let notificationSettingsVM: MockNotificationSettingsViewModel = .init(initialState: .init(
+            settings: FavoriteSettings.Notifications.companion.disabled,
+            selectedPreset: nil
+        ))
+        notificationSettingsVM.onLoadSavedSettings = { savedSettingsCleared = $0 == nil }
+
+        let sut = SaveFavoritePage(
+            routeId: route.id,
+            stopId: stop.id,
+            initialSelectedDirection: 0,
+            context: .stopDetails,
+            updateFavorites: { _ in },
+            navCallbacks: .init(onBack: nil, onClose: nil, backButtonPresentation: .floating),
+            notificationSettingsVM: notificationSettingsVM
+        )
+
+        let exp1 = sut.inspection.inspect(after: 1) { view in
+            try view.find(button: "Cancel").tap()
+            XCTAssertTrue(savedSettingsCleared)
+        }
+
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+
+        wait(for: [exp1], timeout: 5)
+    }
 }

--- a/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
+++ b/iosApp/iosAppTests/Pages/SaveFavorite/SaveFavoritePageTests.swift
@@ -145,4 +145,39 @@ final class SaveFavoritePageTests: XCTestCase {
 
         wait(for: [exp1], timeout: 5)
     }
+
+    @MainActor func testCallsSavedSettingsOnSave() {
+        let objects = TestData.clone()
+        let route = objects.getRoute(id: "Orange")
+        let stop = objects.getStop(id: "place-welln")
+
+        loadKoinMocks(objects: objects)
+
+        var savedSettings = false
+
+        let notificationSettingsVM: MockNotificationSettingsViewModel = .init(initialState: .init(
+            settings: FavoriteSettings.Notifications.companion.disabled,
+            selectedPreset: nil
+        ))
+        notificationSettingsVM.onSavedSettings = { savedSettings = true }
+
+        let sut = SaveFavoritePage(
+            routeId: route.id,
+            stopId: stop.id,
+            initialSelectedDirection: 0,
+            context: .stopDetails,
+            updateFavorites: { _ in },
+            navCallbacks: .init(onBack: nil, onClose: nil, backButtonPresentation: .floating),
+            notificationSettingsVM: notificationSettingsVM
+        )
+
+        let exp1 = sut.inspection.inspect(after: 1) { view in
+            try view.find(button: "Save").tap()
+            XCTAssertTrue(savedSettings)
+        }
+
+        ViewHosting.host(view: sut.withFixedSettings([:]))
+
+        wait(for: [exp1], timeout: 5)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
@@ -18,7 +18,9 @@ import kotlinx.coroutines.flow.StateFlow
 public interface INotificationSettingsViewModel {
     public val models: StateFlow<NotificationSettingsViewModel.State>
 
-    public fun loadSavedSettings(settings: Notifications)
+    public fun loadSavedSettings(settings: Notifications?)
+
+    public fun savedSettings()
 
     public fun setEnabled(enabled: Boolean)
 
@@ -33,12 +35,21 @@ public interface INotificationSettingsViewModel {
     public fun setNow(now: EasternTimeInstant)
 }
 
+/**
+ * ViewModel for editing notification settings per route/stop/direction. This VM is not responsible
+ * for persisting those settings, only for managing the state of the settings while the user is
+ * editing them. These settings are persisted by [FavoritesViewModel]
+ *
+ * Intended to be used as a singleton across the app, so that the state of the recently saved window
+ * persists through a user session.
+ */
 public class NotificationSettingsViewModel(private val sentryRepository: ISentryRepository) :
     MoleculeViewModel<NotificationSettingsViewModel.Event, NotificationSettingsViewModel.State>(),
     INotificationSettingsViewModel {
     public sealed class Event {
+        public data class LoadSavedSettings(val settings: Notifications?) : Event()
 
-        public data class LoadSavedSettings(val settings: Notifications) : Event()
+        public data object SavedSettings : Event()
 
         public data class SetEnabled(val enabled: Boolean) : Event()
 
@@ -70,6 +81,10 @@ public class NotificationSettingsViewModel(private val sentryRepository: ISentry
         var settings: Notifications? by remember {
             mutableStateOf(null)
         }
+
+        var lastSavedSettings: Notifications? by remember {
+            mutableStateOf(null)
+        }
         var customPreset: List<Window>? by remember {
             mutableStateOf(null)
         }
@@ -85,9 +100,13 @@ public class NotificationSettingsViewModel(private val sentryRepository: ISentry
                 is Event.SetEnabled -> {
                     val windows =
                         if (!enabled && event.enabled) {
-                            (settings?.windows ?: emptyList()).ifEmpty {
-                                listOf(Window.default(emptyList(), presetsEnabledFlag, now))
-                            }
+                            (settings?.windows ?: emptyList())
+                                .ifEmpty {
+                                    lastSavedSettings?.windows ?: emptyList()
+                                }
+                                .ifEmpty {
+                                    listOf(Window.default(emptyList(), presetsEnabledFlag, now))
+                                }
                         } else {
                             settings?.windows ?: emptyList()
                         }
@@ -135,11 +154,24 @@ public class NotificationSettingsViewModel(private val sentryRepository: ISentry
                 }
 
                 is Event.LoadSavedSettings -> {
-                    val loadedWindows = event.settings.windows
-                    if (Preset.selected(loadedWindows) == null && loadedWindows.isNotEmpty()) {
-                        customPreset = loadedWindows
+                    val newSettings =
+                        event.settings ?: (lastSavedSettings ?: Notifications.disabled)
+
+                    if (
+                        Preset.selected(newSettings.windows) == null &&
+                            newSettings.windows.isNotEmpty()
+                    ) {
+                        customPreset = newSettings.windows
                     }
-                    settings = event.settings
+
+                    settings = newSettings
+                }
+
+                Event.SavedSettings -> {
+                    if (settings?.enabled == true) {
+                        lastSavedSettings = settings
+                    }
+                    settings = null
                 }
             }
         }
@@ -151,8 +183,12 @@ public class NotificationSettingsViewModel(private val sentryRepository: ISentry
         return state
     }
 
-    override fun loadSavedSettings(settings: Notifications) {
+    override fun loadSavedSettings(settings: Notifications?) {
         fireEvent(Event.LoadSavedSettings(settings))
+    }
+
+    override fun savedSettings() {
+        fireEvent(Event.SavedSettings)
     }
 
     override fun setEnabled(enabled: Boolean) {
@@ -187,15 +223,17 @@ public class MockNotificationSettingsViewModel(
     override val models: MutableStateFlow<NotificationSettingsViewModel.State>
         get() = MutableStateFlow(initialState)
 
-    public var onLoadSavedSettings: (Notifications) -> Unit = {}
+    public var onLoadSavedSettings: (Notifications?) -> Unit = {}
     public var onSetEnabled: (Boolean) -> Unit = {}
     public var onSetCustomWindows: (List<FavoriteSettings.Notifications.Window>) -> Unit = {}
     public var onSetPreset: (Preset?) -> Unit = {}
     public var onSetNow: (EasternTimeInstant) -> Unit = {}
 
-    override fun loadSavedSettings(settings: Notifications) {
+    override fun loadSavedSettings(settings: Notifications?) {
         onLoadSavedSettings(settings)
     }
+
+    override fun savedSettings() {}
 
     override fun setEnabled(enabled: Boolean) {
         onSetEnabled(enabled)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
@@ -224,6 +224,7 @@ public class MockNotificationSettingsViewModel(
         get() = MutableStateFlow(initialState)
 
     public var onLoadSavedSettings: (Notifications?) -> Unit = {}
+    public var onSavedSettings: () -> Unit = {}
     public var onSetEnabled: (Boolean) -> Unit = {}
     public var onSetCustomWindows: (List<FavoriteSettings.Notifications.Window>) -> Unit = {}
     public var onSetPreset: (Preset?) -> Unit = {}
@@ -233,7 +234,9 @@ public class MockNotificationSettingsViewModel(
         onLoadSavedSettings(settings)
     }
 
-    override fun savedSettings() {}
+    override fun savedSettings() {
+        onSavedSettings()
+    }
 
     override fun setEnabled(enabled: Boolean) {
         onSetEnabled(enabled)

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModel.kt
@@ -154,17 +154,11 @@ public class NotificationSettingsViewModel(private val sentryRepository: ISentry
                 }
 
                 is Event.LoadSavedSettings -> {
-                    val newSettings =
-                        event.settings ?: (lastSavedSettings ?: Notifications.disabled)
-
-                    if (
-                        Preset.selected(newSettings.windows) == null &&
-                            newSettings.windows.isNotEmpty()
-                    ) {
-                        customPreset = newSettings.windows
+                    val loadedWindows = event.settings?.windows ?: emptyList()
+                    if (Preset.selected(loadedWindows) == null && loadedWindows.isNotEmpty()) {
+                        customPreset = loadedWindows
                     }
-
-                    settings = newSettings
+                    settings = event.settings
                 }
 
                 Event.SavedSettings -> {

--- a/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
+++ b/shared/src/commonMain/kotlin/com/mbta/tid/mbta_app/viewModel/viewModelModule.kt
@@ -49,7 +49,7 @@ public fun viewModelModule(): Module = module {
         .bind(IMapViewModel::class)
     single { NearbyViewModel(get(), get(), get(named("coroutineDispatcherDefault"))) }
         .bind(INearbyViewModel::class)
-    factory { NotificationSettingsViewModel(get()) }.bind(INotificationSettingsViewModel::class)
+    single { NotificationSettingsViewModel(get()) }.bind(INotificationSettingsViewModel::class)
     singleOf(::RouteCardDataViewModel).bind(IRouteCardDataViewModel::class)
     singleOf(::SearchRoutesViewModel).bind(ISearchRoutesViewModel::class)
     singleOf(::SearchViewModel).bind(ISearchViewModel::class)

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
@@ -259,4 +259,97 @@ class NotificationSettingsViewModelTest {
             assertEquals(Preset.Evening, weekendPresetState.selectedPreset)
         }
     }
+
+    @Test
+    fun usesLastSavedSettingsWhenLoadingNull() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val savedSettings =
+            FavoriteSettings.Notifications(
+                enabled = true,
+                windows =
+                    listOf(
+                        FavoriteSettings.Notifications.Window(
+                            startTime = Preset.Morning.startTime,
+                            endTime = Preset.Morning.endTime,
+                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                        )
+                    ),
+            )
+
+        testViewModelFlow(viewModel).test {
+            viewModel.loadSavedSettings(savedSettings)
+            awaitItem()
+
+            viewModel.savedSettings()
+            viewModel.loadSavedSettings(null)
+            val state = awaitItem()
+            assertEquals(savedSettings, state.settings)
+            assertEquals(Preset.Morning, state.selectedPreset)
+        }
+    }
+
+    @Test
+    fun doesNotUseLastSavedDisabledSettings() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val savedSettings =
+            FavoriteSettings.Notifications(
+                enabled = false,
+                windows =
+                    listOf(
+                        FavoriteSettings.Notifications.Window(
+                            startTime = Preset.Morning.startTime,
+                            endTime = Preset.Morning.endTime,
+                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                        )
+                    ),
+            )
+
+        testViewModelFlow(viewModel).test {
+            viewModel.loadSavedSettings(savedSettings)
+            awaitItem()
+            viewModel.savedSettings()
+            viewModel.loadSavedSettings(null)
+            val state = awaitItem()
+            assertEquals(emptyList(), state.settings?.windows)
+        }
+    }
+
+    @Test
+    fun doesNotUseLastSavedWhenLoadingExistingSettings() = runTest {
+        val viewModel = NotificationSettingsViewModel(MockSentryRepository())
+        val lastSavedSettings =
+            FavoriteSettings.Notifications(
+                enabled = true,
+                windows =
+                    listOf(
+                        FavoriteSettings.Notifications.Window(
+                            startTime = Preset.Morning.startTime,
+                            endTime = Preset.Morning.endTime,
+                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                        )
+                    ),
+            )
+        val newSettings =
+            FavoriteSettings.Notifications(
+                enabled = true,
+                windows =
+                    listOf(
+                        FavoriteSettings.Notifications.Window(
+                            startTime = Preset.Evening.startTime,
+                            endTime = Preset.Evening.endTime,
+                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                        )
+                    ),
+            )
+
+        testViewModelFlow(viewModel).test {
+            viewModel.loadSavedSettings(lastSavedSettings)
+            awaitItem()
+            viewModel.savedSettings()
+            viewModel.loadSavedSettings(newSettings)
+            val state = awaitItem()
+            assertEquals(newSettings, state.settings)
+            assertEquals(Preset.Evening, state.selectedPreset)
+        }
+    }
 }

--- a/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/mbta/tid/mbta_app/viewModel/NotificationSettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.mbta.tid.mbta_app.viewModel
 
 import app.cash.turbine.test
 import com.mbta.tid.mbta_app.model.FavoriteSettings
+import com.mbta.tid.mbta_app.model.FavoriteSettings.Notifications.Window
 import com.mbta.tid.mbta_app.model.Preset
 import com.mbta.tid.mbta_app.repositories.MockSentryRepository
 import com.mbta.tid.mbta_app.utils.EasternTimeInstant
@@ -261,7 +262,7 @@ class NotificationSettingsViewModelTest {
     }
 
     @Test
-    fun usesLastSavedSettingsWhenLoadingNull() = runTest {
+    fun usesLastSavedSettingsWhenEnabled() = runTest {
         val viewModel = NotificationSettingsViewModel(MockSentryRepository())
         val savedSettings =
             FavoriteSettings.Notifications(
@@ -281,7 +282,7 @@ class NotificationSettingsViewModelTest {
             awaitItem()
 
             viewModel.savedSettings()
-            viewModel.loadSavedSettings(null)
+            viewModel.setEnabled(true)
             val state = awaitItem()
             assertEquals(savedSettings, state.settings)
             assertEquals(Preset.Morning, state.selectedPreset)
@@ -290,6 +291,8 @@ class NotificationSettingsViewModelTest {
 
     @Test
     fun doesNotUseLastSavedDisabledSettings() = runTest {
+        val now = EasternTimeInstant(2026, Month.SEPTEMBER, 3, 12, 30)
+
         val viewModel = NotificationSettingsViewModel(MockSentryRepository())
         val savedSettings =
             FavoriteSettings.Notifications(
@@ -299,23 +302,28 @@ class NotificationSettingsViewModelTest {
                         FavoriteSettings.Notifications.Window(
                             startTime = Preset.Morning.startTime,
                             endTime = Preset.Morning.endTime,
-                            daysOfWeek = FavoriteSettings.Notifications.Window.weekdays,
+                            daysOfWeek = Window.weekdays,
                         )
                     ),
             )
 
         testViewModelFlow(viewModel).test {
+            viewModel.setNow(now)
+            viewModel.setPresetsEnabledFlag(true)
             viewModel.loadSavedSettings(savedSettings)
             awaitItem()
             viewModel.savedSettings()
-            viewModel.loadSavedSettings(null)
+            viewModel.setEnabled(true)
             val state = awaitItem()
-            assertEquals(emptyList(), state.settings?.windows)
+            assertEquals(
+                listOf(Window(Preset.Midday, Window.weekdays)),
+                state.settings?.windows,
+            )
         }
     }
 
     @Test
-    fun doesNotUseLastSavedWhenLoadingExistingSettings() = runTest {
+    fun doesNotUseLastSavedWhenExistingSettingsLoaded() = runTest {
         val viewModel = NotificationSettingsViewModel(MockSentryRepository())
         val lastSavedSettings =
             FavoriteSettings.Notifications(


### PR DESCRIPTION
### Summary

_Ticket:_ [Disruption Windows | Recently Used Presets](https://app.asana.com/1/15492006741476/project/1205732265579288/task/1217828663233953?focus=true)
<!--
Community contributors: see our [Community Contributions](https://github.com/mbta/mobile_app?tab=readme-ov-file#Community-Contributions) documentation
-->

<!-- What is this PR for? -->

As suspected in https://github.com/mbta/mobile_app/pull/1993, making the NotificationSettingsViewModel a singleton did most of the work of defaulting to the recently used notification window. 

There was just some additional minor work to ensure that we only used the last *saved* window rather than just the last window from an opened editor.


> [!NOTE]
> **AI Usage:** VM test boilerplate
>


#### Localization
- [ ] If you added any user-facing strings, have they been included in Localizable.xcstrings and/or the android resource files?

#### Performance
- [ ] Expensive calculations are run in `withContext(Dispatchers.Default)` where possible (ideally in shared code)


### Testing
* Added unit tests
* Ran locally and confirmed that the last saved settings were used when adding favorites and not when editing favorites.

<!-- What testing have you done?

Automated tests are expected with every code change.

For UI changes, include tests for the accessibility of elements. This can include:
* Run the application locally with accessibility features such as VoiceOver/TalkBack enabled.
* Write UI tests that find elements by their accessible label
    * assert that elements have the expected properties - isEnabled, isSelected, etc.
* Run accessibility audit using XCode Accessibility Inspector or Android Accessibility Scanner
-->
